### PR TITLE
desktop: improve session tile chat density, maximize action, and title handling

### DIFF
--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -224,7 +224,7 @@ async function processWithAgentMode(
     logLLM(`[processWithAgentMode] ACP mode enabled, routing to agent: ${config.mainAgentName}`)
 
     // Create conversation title for session tracking
-    const conversationTitle = text.length > 50 ? text.substring(0, 50) + "..." : text
+    const conversationTitle = text
 
     // Start tracking this agent session (or reuse existing one)
     const sessionId = existingSessionId || agentSessionTracker.startSession(conversationId, conversationTitle, startSnoozed)
@@ -284,7 +284,7 @@ async function processWithAgentMode(
   }
 
   // Start tracking this agent session (or reuse existing one)
-  let conversationTitle = text.length > 50 ? text.substring(0, 50) + "..." : text
+  let conversationTitle = text
   // When creating a new session from keybind/UI, start unsnoozed so panel shows immediately
   const sessionId = existingSessionId || agentSessionTracker.startSession(conversationId, conversationTitle, startSnoozed, profileSnapshot)
 
@@ -1848,7 +1848,7 @@ export const router = {
       }
 
       // Update session with actual conversation ID and title after transcription
-      const conversationTitle = transcript.length > 50 ? transcript.substring(0, 50) + "..." : transcript
+      const conversationTitle = transcript
       agentSessionTracker.updateSession(sessionId, {
         conversationId,
         conversationTitle,

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -335,14 +335,6 @@ const CompactMessage: React.FC<{
     }
   }
 
-  const getRoleIcon = () => {
-    switch (message.role) {
-      case "user": return <span className="i-mingcute-user-3-line h-3 w-3 text-blue-500" />
-      case "assistant": return <span className="i-mingcute-android-2-line h-3 w-3 text-gray-500" />
-      case "tool": return <span className="i-mingcute-tool-line h-3 w-3 text-orange-500" />
-    }
-  }
-
   const handleToggleExpand = () => {
     if (shouldCollapse) {
       onToggleExpand()
@@ -362,10 +354,9 @@ const CompactMessage: React.FC<{
       shouldCollapse && "cursor-pointer"
     )}>
       <div
-        className="flex items-start gap-2 px-2 py-1 text-left"
+        className="flex items-start px-2 py-1 text-left"
         onClick={handleToggleExpand}
       >
-        <span className="opacity-60 mt-0.5 flex-shrink-0">{getRoleIcon()}</span>
         <div className="flex-1 min-w-0">
           <div className={cn(
             "leading-relaxed text-left",
@@ -643,10 +634,6 @@ const ToolExecutionBubble: React.FC<{
               )}
               onClick={handleToggleExpand}
             >
-              <span className={cn(
-                "i-mingcute-tool-line h-2.5 w-2.5 flex-shrink-0",
-                callIsPending ? "text-blue-500" : callSuccess ? "text-green-500" : "text-red-500"
-              )} />
               {execCmdDisplay ? (
                 <>
                   <span className="font-mono font-medium truncate" title={call.arguments?.command}>{execCmdDisplay.displayCommand}</span>
@@ -812,10 +799,9 @@ const AssistantWithToolsBubble: React.FC<{
     )}>
       {/* Thought content section */}
       <div
-        className="flex items-start gap-2 px-2 py-1 text-left"
+        className="flex items-start px-2 py-1 text-left"
         onClick={handleToggleExpand}
       >
-        <span className="i-mingcute-android-2-line h-3 w-3 text-gray-500 mt-0.5 flex-shrink-0" />
         <div className="flex-1 min-w-0">
           {hasThought && (
             <div className={cn(
@@ -851,10 +837,6 @@ const AssistantWithToolsBubble: React.FC<{
                   )}
                   onClick={handleToggleToolDetails}
                 >
-                  <span className={cn(
-                    "i-mingcute-tool-line h-2.5 w-2.5 flex-shrink-0",
-                    callIsPending ? "text-blue-500" : callSuccess ? "text-green-500" : "text-red-500"
-                  )} />
                   {execCmdDisplay ? (
                     <>
                       <span className="font-mono font-medium truncate" title={call.arguments?.command}>{execCmdDisplay.displayCommand}</span>
@@ -2623,14 +2605,23 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
 
   // Get title for tile variant
   const getTitle = () => {
+    const firstUserMsg = conversationHistory?.find(m => m.role === "user")
+    const firstUserContent = firstUserMsg?.content
+      ? (typeof firstUserMsg.content === "string" ? firstUserMsg.content : JSON.stringify(firstUserMsg.content))
+      : undefined
+
     if (progress.conversationTitle) {
+      const isLikelyCappedTitle = progress.conversationTitle.endsWith("...") || progress.conversationTitle.endsWith("…")
+      if (isLikelyCappedTitle && firstUserContent && firstUserContent.length > progress.conversationTitle.length) {
+        return firstUserContent
+      }
       return progress.conversationTitle
     }
-    const firstUserMsg = conversationHistory?.find(m => m.role === "user")
-    if (firstUserMsg?.content) {
-      const content = typeof firstUserMsg.content === "string" ? firstUserMsg.content : JSON.stringify(firstUserMsg.content)
-      return content.length > 50 ? content.substring(0, 50) + "..." : content
+
+    if (firstUserContent) {
+      return firstUserContent
     }
+
     return `Session ${progress.sessionId?.substring(0, 8) || "..."}`
   }
 
@@ -2689,6 +2680,21 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             <Button variant="ghost" size="icon" className="h-6 w-6" onClick={handleToggleCollapse} title={isCollapsed ? "Expand panel" : "Collapse panel"}>
               {isCollapsed ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
             </Button>
+
+            {onExpand && !isExpanded && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onExpand()
+                }}
+                title="Maximize tile"
+              >
+                <Maximize2 className="h-3 w-3" />
+              </Button>
+            )}
 
             {!isComplete && !isSnoozed && (
               <Button variant="ghost" size="icon" className="h-6 w-6" onClick={(e) => { e.stopPropagation(); handleSnooze(e); }} title="Minimize">

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -9,7 +9,6 @@ import { AgentProgress } from "@renderer/components/agent-progress"
 import { MessageCircle, Mic, Plus, CheckCircle2, LayoutGrid, Maximize2, Grid2x2, Keyboard, Clock } from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
 import { AgentProgressUpdate } from "@shared/types"
-import { cn } from "@renderer/lib/utils"
 import { toast } from "sonner"
 
 import { logUI } from "@renderer/lib/debug"
@@ -482,10 +481,20 @@ export function Component() {
     setTileResetKey(prev => prev + 1)
   }, [])
 
+  const handleMaximizeSingleTile = useCallback(() => {
+    if (tileLayoutMode === "1x1") return
+    clearPersistedSize("session-tile")
+    setTileLayoutMode("1x1")
+    setTileResetKey(prev => prev + 1)
+  }, [tileLayoutMode])
+
   // Count inactive (completed) sessions
   const inactiveSessionCount = useMemo(() => {
     return allProgressEntries.filter(([_, progress]) => progress?.isComplete).length
   }, [allProgressEntries])
+
+  const visibleTileCount = allProgressEntries.length + (pendingProgress ? 1 : 0)
+  const showSingleTileMaximize = visibleTileCount === 1 && tileLayoutMode !== "1x1"
 
   const hasSessions = allProgressEntries.length > 0 || !!pendingProgress
 
@@ -593,6 +602,8 @@ export function Component() {
                     onDismiss={handleDismissPendingContinuation}
                     isCollapsed={collapsedSessions[pendingSessionId] ?? false}
                     onCollapsedChange={(collapsed) => handleCollapsedChange(pendingSessionId, collapsed)}
+                    onExpand={showSingleTileMaximize ? handleMaximizeSingleTile : undefined}
+                    isExpanded={tileLayoutMode === "1x1"}
 
                   />
                 </SessionTileWrapper>
@@ -624,6 +635,8 @@ export function Component() {
                         onDismiss={() => handleDismissSession(sessionId)}
                         isCollapsed={isCollapsed}
                         onCollapsedChange={(collapsed) => handleCollapsedChange(sessionId, collapsed)}
+                        onExpand={showSingleTileMaximize ? handleMaximizeSingleTile : undefined}
+                        isExpanded={tileLayoutMode === "1x1"}
 
                       />
                     </SessionTileWrapper>


### PR DESCRIPTION
## What changed
- Removed role glyph icons from compact chat bubbles in session tiles to free horizontal space.
- Removed extra tool glyph icons in compact tool-call rows (status icons remain).
- Reintroduced singular-session tile maximize action in the tile header (when only one tile is visible and layout is not `1x1`).
- Improved tile title behavior:
  - Stops hard-capping session titles to 50 chars for newly created sessions.
  - If stored `conversationTitle` appears capped (`...`), tile title now prefers full first user message content when available.

## Files
- `apps/desktop/src/renderer/src/components/agent-progress.tsx`
- `apps/desktop/src/renderer/src/pages/sessions.tsx`
- `apps/desktop/src/main/tipc.ts`

## Verification
- Manual UI verification for tile chat density and single-tile maximize behavior.
- `pnpm --filter @dotagents/desktop typecheck:web` currently fails due pre-existing repo-wide React type incompatibilities unrelated to this change.

---
Generated with Augment Code

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author