### PR TITLE
Scale agent completion guardrails with iteration budget

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1249,6 +1249,11 @@ Return ONLY JSON per schema.`,
     ? Math.max(1, Math.floor(maxIterations))
     : 60
 
+  // Keep loop behavior aligned with guardrails by normalizing non-finite limits
+  // to the same fallback budget. This avoids cases where the main loop could
+  // skip entirely (NaN) or run unbounded (Infinity) while guardrails are capped.
+  maxIterations = effectiveIterationBudget
+
   // Verification failure limit - after this many failed completion checks, end as incomplete.
   // Scales with iteration budget instead of a fixed low constant.
   const VERIFICATION_FAIL_LIMIT = clamp(Math.ceil(effectiveIterationBudget * 0.8), 5, 60)


### PR DESCRIPTION
## What
- Replace fixed completion-loop guardrail limits in `apps/desktop/src/main/llm.ts` with iteration-budget-based values.
- `VERIFICATION_FAIL_LIMIT`: now `ceil(0.8 * effectiveIterationBudget)` clamped to `5..60`.
- `MAX_NUDGES`: now `ceil(0.6 * effectiveIterationBudget)` clamped to `3..40`.
- Keep existing behavior shape, but allow longer recovery on tool-heavy flows before fallback.

## Why
Recent sessions were failing early with the fallback message even though issuing a follow-up "continue" often led to eventual success. This change reduces premature termination by making budgets scale with configured iteration limits.

## Validation
- `pnpm -C apps/desktop exec tsc --noEmit -p tsconfig.json`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author