### PR TITLE
Add landing page for DotAgents

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,1012 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>dotagents — One dot. Every agent.</title>
+<meta name="description" content="The operating system for AI agents. Give your agents memory, skills, and tools — orchestrate them from one place.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Mono:ital,wght@0,300;0,400;0,500;1,400&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --bg: #000000;
+  --fg: #FCFCFC;
+  --fg-muted: #888888;
+  --fg-dim: #555555;
+  --accent: #3B82F6;
+  --accent-glow: rgba(59, 130, 246, 0.4);
+  --accent-subtle: rgba(59, 130, 246, 0.08);
+  --surface: #0A0A0A;
+  --surface-border: #1A1A1A;
+  --surface-hover: #111111;
+  --radius: 12px;
+  --font-display: 'Outfit', sans-serif;
+  --font-mono: 'DM Mono', monospace;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-display);
+  font-weight: 400;
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+/* --- Dot grid background --- */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.03) 1px, transparent 1px);
+  background-size: 32px 32px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* --- Scroll reveal --- */
+.reveal {
+  opacity: 0;
+  transform: translateY(28px);
+  transition: opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1), transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.reveal-delay-1 { transition-delay: 0.1s; }
+.reveal-delay-2 { transition-delay: 0.2s; }
+.reveal-delay-3 { transition-delay: 0.3s; }
+.reveal-delay-4 { transition-delay: 0.4s; }
+.reveal-delay-5 { transition-delay: 0.5s; }
+
+/* --- Layout --- */
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 24px;
+  position: relative;
+  z-index: 1;
+}
+
+section {
+  padding: 120px 0;
+}
+
+/* --- Nav --- */
+nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 16px 0;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.logo {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.logo-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  background: var(--accent);
+  border-radius: 50%;
+  margin-right: 2px;
+  box-shadow: 0 0 12px var(--accent-glow), 0 0 4px var(--accent);
+  animation: dot-pulse 3s ease-in-out infinite;
+}
+
+@keyframes dot-pulse {
+  0%, 100% { box-shadow: 0 0 12px var(--accent-glow), 0 0 4px var(--accent); }
+  50% { box-shadow: 0 0 20px var(--accent-glow), 0 0 8px var(--accent), 0 0 30px rgba(59,130,246,0.15); }
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  list-style: none;
+}
+
+.nav-links a {
+  color: var(--fg-muted);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 400;
+  transition: color 0.2s;
+}
+
+.nav-links a:hover {
+  color: var(--fg);
+}
+
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 18px;
+  background: var(--fg);
+  color: var(--bg);
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: opacity 0.2s;
+}
+
+.nav-cta:hover {
+  opacity: 0.85;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--fg);
+  margin: 5px 0;
+  transition: 0.3s;
+}
+
+/* --- Hero --- */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  padding-top: 80px;
+  position: relative;
+}
+
+.hero-glow {
+  position: absolute;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(circle, rgba(59,130,246,0.07) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-content {
+  text-align: center;
+  max-width: 800px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 16px;
+  background: var(--accent-subtle);
+  border: 1px solid rgba(59,130,246,0.15);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent);
+  margin-bottom: 32px;
+}
+
+.hero-badge-dot {
+  width: 6px;
+  height: 6px;
+  background: var(--accent);
+  border-radius: 50%;
+  animation: dot-pulse 3s ease-in-out infinite;
+}
+
+h1 {
+  font-size: clamp(48px, 8vw, 88px);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.035em;
+  margin-bottom: 24px;
+}
+
+h1 .dot-accent {
+  color: var(--accent);
+  text-shadow: 0 0 40px var(--accent-glow);
+}
+
+.hero-sub {
+  font-size: clamp(16px, 2vw, 20px);
+  color: var(--fg-muted);
+  line-height: 1.6;
+  max-width: 560px;
+  margin: 0 auto 40px;
+  font-weight: 300;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 28px;
+  background: var(--fg);
+  color: var(--bg);
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  text-decoration: none;
+  font-family: var(--font-display);
+  transition: transform 0.2s, box-shadow 0.2s;
+  border: none;
+  cursor: pointer;
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 24px rgba(255,255,255,0.08);
+}
+
+.btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 28px;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--surface-border);
+  border-radius: 10px;
+  font-size: 15px;
+  font-weight: 500;
+  text-decoration: none;
+  font-family: var(--font-display);
+  transition: background 0.2s, border-color 0.2s;
+  cursor: pointer;
+}
+
+.btn-secondary:hover {
+  background: var(--surface);
+  border-color: #333;
+}
+
+.hero-keys {
+  margin-top: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg-dim);
+}
+
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1;
+}
+
+/* --- Section headers --- */
+.section-label {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.section-title {
+  font-size: clamp(32px, 5vw, 48px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+  margin-bottom: 16px;
+}
+
+.section-desc {
+  font-size: 17px;
+  color: var(--fg-muted);
+  max-width: 560px;
+  font-weight: 300;
+  line-height: 1.6;
+}
+
+.section-header {
+  margin-bottom: 64px;
+}
+
+/* --- Triad cards (What is DotAgents) --- */
+.triad {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+
+.triad-card {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  padding: 36px 28px;
+  transition: border-color 0.3s, background 0.3s;
+  position: relative;
+  overflow: hidden;
+}
+
+.triad-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.triad-card:hover {
+  border-color: #2a2a2a;
+  background: var(--surface-hover);
+}
+
+.triad-card:hover::before {
+  opacity: 0.6;
+}
+
+.triad-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--accent-subtle);
+  border: 1px solid rgba(59,130,246,0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+  font-size: 18px;
+}
+
+.triad-card h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 10px;
+  letter-spacing: -0.01em;
+}
+
+.triad-card p {
+  font-size: 14px;
+  color: var(--fg-muted);
+  line-height: 1.6;
+  font-weight: 300;
+}
+
+/* --- Features grid --- */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--surface-border);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.feature-cell {
+  background: var(--bg);
+  padding: 36px 28px;
+  transition: background 0.3s;
+}
+
+.feature-cell:hover {
+  background: var(--surface);
+}
+
+.feature-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  margin-bottom: 12px;
+}
+
+.feature-cell h3 {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  letter-spacing: -0.01em;
+}
+
+.feature-cell p {
+  font-size: 13px;
+  color: var(--fg-muted);
+  line-height: 1.6;
+  font-weight: 300;
+}
+
+/* --- How it works --- */
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  position: relative;
+}
+
+.steps::before {
+  content: '';
+  position: absolute;
+  top: 40px;
+  left: 15%;
+  right: 15%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--surface-border) 20%, var(--surface-border) 80%, transparent);
+}
+
+.step {
+  text-align: center;
+  position: relative;
+}
+
+.step-num {
+  width: 80px;
+  height: 80px;
+  margin: 0 auto 24px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 28px;
+  font-weight: 500;
+  color: var(--fg-muted);
+  position: relative;
+  z-index: 1;
+  transition: border-color 0.3s, color 0.3s;
+}
+
+.step:hover .step-num {
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: 0 0 24px rgba(59,130,246,0.1);
+}
+
+.step h3 {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  letter-spacing: -0.01em;
+}
+
+.step p {
+  font-size: 14px;
+  color: var(--fg-muted);
+  font-weight: 300;
+  max-width: 260px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+/* --- Protocol section --- */
+.protocol-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: center;
+}
+
+.protocol-text .section-desc {
+  margin-bottom: 32px;
+}
+
+.protocol-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tool-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg-muted);
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.tool-tag:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+}
+
+.protocol-code {
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.code-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--surface-border);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+.code-dots {
+  display: flex;
+  gap: 6px;
+  margin-right: 8px;
+}
+
+.code-dots span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #333;
+}
+
+.code-body {
+  padding: 24px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 2;
+  color: var(--fg-muted);
+}
+
+.code-body .dir {
+  color: var(--accent);
+}
+
+.code-body .file {
+  color: var(--fg-dim);
+}
+
+.code-body .comment {
+  color: #444;
+  font-style: italic;
+}
+
+.indent-1 { padding-left: 24px; }
+.indent-2 { padding-left: 48px; }
+
+/* --- CTA banner --- */
+.cta-section {
+  padding: 80px 0 120px;
+}
+
+.cta-banner {
+  text-align: center;
+  padding: 80px 40px;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  position: relative;
+  overflow: hidden;
+}
+
+.cta-banner::before {
+  content: '';
+  position: absolute;
+  top: -100px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 400px;
+  height: 400px;
+  background: radial-gradient(circle, rgba(59,130,246,0.06) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.cta-banner h2 {
+  font-size: clamp(28px, 4vw, 40px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin-bottom: 12px;
+  position: relative;
+}
+
+.cta-banner p {
+  color: var(--fg-muted);
+  font-size: 16px;
+  font-weight: 300;
+  margin-bottom: 32px;
+  position: relative;
+}
+
+.cta-banner .hero-actions {
+  position: relative;
+}
+
+/* --- Footer --- */
+footer {
+  border-top: 1px solid var(--surface-border);
+  padding: 40px 0;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer-links {
+  display: flex;
+  gap: 24px;
+  list-style: none;
+}
+
+.footer-links a {
+  color: var(--fg-dim);
+  text-decoration: none;
+  font-size: 13px;
+  font-family: var(--font-mono);
+  transition: color 0.2s;
+}
+
+.footer-links a:hover {
+  color: var(--fg);
+}
+
+.footer-copy {
+  font-size: 13px;
+  color: var(--fg-dim);
+  font-family: var(--font-mono);
+}
+
+/* --- SVG icons inline --- */
+.icon-svg {
+  width: 20px;
+  height: 20px;
+  stroke: var(--accent);
+  stroke-width: 1.5;
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* --- Responsive --- */
+@media (max-width: 900px) {
+  .triad {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .steps {
+    grid-template-columns: 1fr;
+    gap: 48px;
+  }
+  .steps::before {
+    display: none;
+  }
+  .protocol-layout {
+    grid-template-columns: 1fr;
+    gap: 40px;
+  }
+  .nav-links {
+    display: none;
+  }
+  .nav-toggle {
+    display: block;
+  }
+  section {
+    padding: 80px 0;
+  }
+}
+
+@media (max-width: 600px) {
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+  .hero-actions {
+    flex-direction: column;
+    align-items: center;
+  }
+  .btn-primary, .btn-secondary {
+    width: 100%;
+    justify-content: center;
+    max-width: 300px;
+  }
+  .footer-inner {
+    flex-direction: column;
+    gap: 16px;
+    text-align: center;
+  }
+  .cta-banner {
+    padding: 48px 24px;
+  }
+}
+</style>
+</head>
+<body>
+
+<!-- Nav -->
+<nav>
+  <div class="container nav-inner">
+    <a href="#" class="logo"><span class="logo-dot"></span>dotagents</a>
+    <ul class="nav-links">
+      <li><a href="#what">About</a></li>
+      <li><a href="#features">Features</a></li>
+      <li><a href="#protocol">Protocol</a></li>
+      <li><a href="https://github.com/aj47/dotagents-mono" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="https://github.com/aj47/dotagents-mono/releases/latest" class="nav-cta">Download</a></li>
+    </ul>
+    <button class="nav-toggle" aria-label="Menu" onclick="this.classList.toggle('active')">
+      <span></span><span></span><span></span>
+    </button>
+  </div>
+</nav>
+
+<!-- Hero -->
+<section class="hero">
+  <div class="hero-glow"></div>
+  <div class="container hero-content">
+    <div class="hero-badge reveal">
+      <span class="hero-badge-dot"></span>
+      the agent operating system
+    </div>
+    <h1 class="reveal reveal-delay-1">One dot<span class="dot-accent">.</span><br>Every agent<span class="dot-accent">.</span></h1>
+    <p class="hero-sub reveal reveal-delay-2">The operating system for AI agents. Give them memory, skills, and tools &mdash; orchestrate everything from one place. Built on the <code style="color:var(--accent);background:var(--accent-subtle);padding:2px 8px;border-radius:4px;font-family:var(--font-mono);font-size:0.9em;">.agents</code> open standard.</p>
+    <div class="hero-actions reveal reveal-delay-3">
+      <a href="https://github.com/aj47/dotagents-mono/releases/latest" class="btn-primary">
+        <svg class="icon-svg" viewBox="0 0 24 24" style="stroke:var(--bg);width:18px;height:18px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        Download
+      </a>
+      <a href="https://discord.gg/cK9WeQ7jPq" class="btn-secondary" target="_blank" rel="noopener">Join Discord</a>
+    </div>
+    <div class="hero-keys reveal reveal-delay-4">
+      <span class="kbd">Ctrl+Alt</span> agent mode
+      <span style="margin: 0 8px;color:#333">|</span>
+      <span class="kbd">Ctrl</span> voice input
+      <span style="margin: 0 8px;color:#333">|</span>
+      <span class="kbd">Ctrl+T</span> text input
+    </div>
+  </div>
+</section>
+
+<!-- What is DotAgents -->
+<section id="what">
+  <div class="container">
+    <div class="section-header reveal">
+      <p class="section-label">What is dotagents</p>
+      <h2 class="section-title">Three things in one<span class="dot-accent">.</span></h2>
+    </div>
+    <div class="triad">
+      <div class="triad-card reveal reveal-delay-1">
+        <div class="triad-icon">
+          <svg class="icon-svg" viewBox="0 0 24 24"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+        </div>
+        <h3>The App</h3>
+        <p>A unified control plane for your AI agents. Manage profiles, delegate tasks, and watch agents execute tools in real time.</p>
+      </div>
+      <div class="triad-card reveal reveal-delay-2">
+        <div class="triad-icon">
+          <svg class="icon-svg" viewBox="0 0 24 24"><path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><polyline points="13 2 13 9 20 9"/></svg>
+        </div>
+        <h3>The Protocol</h3>
+        <p>An open standard for agent skills, memories, and commands. Define once in <code style="color:var(--accent);font-family:var(--font-mono);font-size:0.9em">.agents/</code>, works everywhere.</p>
+      </div>
+      <div class="triad-card reveal reveal-delay-3">
+        <div class="triad-icon">
+          <svg class="icon-svg" viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+        </div>
+        <h3>Agent Skills</h3>
+        <p>Reusable capabilities your agents can learn. Portable, shareable, and composable &mdash; not locked into any single vendor.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Features -->
+<section id="features">
+  <div class="container">
+    <div class="section-header reveal">
+      <p class="section-label">Capabilities</p>
+      <h2 class="section-title">Everything you need<span class="dot-accent">.</span></h2>
+      <p class="section-desc">A complete operating system for AI agents with real tool execution.</p>
+    </div>
+    <div class="features-grid reveal">
+      <div class="feature-cell">
+        <p class="feature-label">orchestration</p>
+        <h3>Agent Profiles</h3>
+        <p>Specialized AI personas with distinct skills. Skill-based delegation, persistent memory, and ACP multi-agent coordination.</p>
+      </div>
+      <div class="feature-cell">
+        <p class="feature-label">mcp tools</p>
+        <h3>Real Execution</h3>
+        <p>Tool execution via Model Context Protocol. OAuth 2.1 auth, real-time progress tracking, and conversation context.</p>
+      </div>
+      <div class="feature-cell">
+        <p class="feature-label">memory</p>
+        <h3>Persistent Context</h3>
+        <p>Agents remember across sessions. Project context, user preferences, and learned patterns stored in the open <code style="color:var(--accent);font-family:var(--font-mono);font-size:0.85em">.agents/</code> format.</p>
+      </div>
+      <div class="feature-cell">
+        <p class="feature-label">voice + tts</p>
+        <h3>Voice Interface</h3>
+        <p>Hold-to-record in 30+ languages with auto-insert. 50+ AI voices via OpenAI, Groq, and Gemini for spoken output.</p>
+      </div>
+      <div class="feature-cell">
+        <p class="feature-label">observability</p>
+        <h3>Langfuse Tracing</h3>
+        <p>Built-in LLM observability. Trace calls, monitor token usage, and debug agent behavior with Langfuse.</p>
+      </div>
+      <div class="feature-cell">
+        <p class="feature-label">multi-provider</p>
+        <h3>Any Model</h3>
+        <p>Bring your own provider &mdash; OpenAI, Groq, or Gemini. Switch models per agent. Rate limit handling built in.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- How it works -->
+<section id="how">
+  <div class="container">
+    <div class="section-header" style="text-align:center">
+      <p class="section-label reveal">How it works</p>
+      <h2 class="section-title reveal reveal-delay-1">Three steps<span class="dot-accent">.</span></h2>
+    </div>
+    <div class="steps">
+      <div class="step reveal reveal-delay-1">
+        <div class="step-num">1</div>
+        <h3>Define your agents</h3>
+        <p>Create agent profiles with specific skills, tools, and memory. Each agent is a specialist in its domain.</p>
+      </div>
+      <div class="step reveal reveal-delay-2">
+        <div class="step-num">2</div>
+        <h3>Agents think & act</h3>
+        <p>Give a task via voice or text. The right agent picks it up, reasons through it, and executes tools in real time.</p>
+      </div>
+      <div class="step reveal reveal-delay-3">
+        <div class="step-num">3</div>
+        <h3>Results delivered</h3>
+        <p>Output flows back to you &mdash; inserted into your app, spoken aloud, or displayed. Skills persist for next time.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Protocol -->
+<section id="protocol">
+  <div class="container">
+    <div class="protocol-layout">
+      <div class="protocol-text">
+        <p class="section-label reveal">The .agents protocol</p>
+        <h2 class="section-title reveal reveal-delay-1">Define once<span class="dot-accent">.</span><br>Run everywhere<span class="dot-accent">.</span></h2>
+        <p class="section-desc reveal reveal-delay-2">Skills you create for DotAgents work across every tool that adopts the protocol. Protocol first, product second.</p>
+        <div class="protocol-tools reveal reveal-delay-3">
+          <span class="tool-tag">Claude Code</span>
+          <span class="tool-tag">Cursor</span>
+          <span class="tool-tag">Codex</span>
+          <span class="tool-tag">OpenCode</span>
+          <span class="tool-tag">+ more</span>
+        </div>
+      </div>
+      <div class="protocol-code reveal reveal-delay-2">
+        <div class="code-header">
+          <div class="code-dots"><span></span><span></span><span></span></div>
+          .agents/
+        </div>
+        <div class="code-body">
+          <div><span class="dir">.agents/</span></div>
+          <div class="indent-1"><span class="dir">skills/</span> <span class="comment"># reusable agent capabilities</span></div>
+          <div class="indent-2"><span class="file">web-search.md</span></div>
+          <div class="indent-2"><span class="file">code-review.md</span></div>
+          <div class="indent-2"><span class="file">deploy.md</span></div>
+          <div class="indent-1"><span class="dir">memory/</span> <span class="comment"># persistent context</span></div>
+          <div class="indent-2"><span class="file">project.md</span></div>
+          <div class="indent-1"><span class="dir">commands/</span> <span class="comment"># custom commands</span></div>
+          <div class="indent-1"><span class="file">config.yaml</span> <span class="comment"># profiles & settings</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- CTA -->
+<section class="cta-section">
+  <div class="container">
+    <div class="cta-banner reveal">
+      <h2>Your agents need an OS<span class="dot-accent">.</span></h2>
+      <p>Download DotAgents and orchestrate your AI agents from one place.</p>
+      <div class="hero-actions">
+        <a href="https://github.com/aj47/dotagents-mono/releases/latest" class="btn-primary">
+          <svg class="icon-svg" viewBox="0 0 24 24" style="stroke:var(--bg);width:18px;height:18px"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          Download
+        </a>
+        <a href="https://github.com/aj47/dotagents-mono" class="btn-secondary" target="_blank" rel="noopener">
+          <svg class="icon-svg" viewBox="0 0 24 24" style="stroke:var(--fg);width:18px;height:18px"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+          GitHub
+        </a>
+        <a href="https://discord.gg/cK9WeQ7jPq" class="btn-secondary" target="_blank" rel="noopener">Discord</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Footer -->
+<footer>
+  <div class="container footer-inner">
+    <a href="#" class="logo" style="font-size:15px"><span class="logo-dot" style="width:6px;height:6px"></span>dotagents</a>
+    <ul class="footer-links">
+      <li><a href="https://github.com/aj47/dotagents-mono" target="_blank" rel="noopener">GitHub</a></li>
+      <li><a href="https://discord.gg/cK9WeQ7jPq" target="_blank" rel="noopener">Discord</a></li>
+      <li><a href="https://dotagents.app">Website</a></li>
+    </ul>
+    <span class="footer-copy">AGPL-3.0</span>
+  </div>
+</footer>
+
+<script>
+// Scroll reveal
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('visible');
+    }
+  });
+}, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a single-file landing page at `apps/web/index.html`
- Dark theme with dot grid background, scroll reveal animations, and responsive layout
- Positions DotAgents as "the operating system for AI agents" rather than voice-first
- Sections: Hero, What is DotAgents (3 cards), Features grid, How it works, .agents Protocol, CTA, Footer
- Self-contained — no build step, no dependencies, just HTML/CSS/JS

## Test plan
- [ ] Open `apps/web/index.html` in a browser and verify all sections render
- [ ] Check responsive layout on mobile viewport
- [ ] Verify all links (Download, Discord, GitHub) point to correct URLs
- [ ] Confirm scroll animations trigger on scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)