### PR TITLE
fix(desktop): infer delegation role for external agent profiles

### DIFF
--- a/apps/desktop/src/main/agents-files/agent-profiles.test.ts
+++ b/apps/desktop/src/main/agents-files/agent-profiles.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import type { AgentProfileConnectionType, AgentProfileRole } from "@shared/types"
+import { getAgentsLayerPaths, type AgentsLayerPaths } from "./modular-config"
+import {
+  AGENTS_PROFILE_CANONICAL_FILENAME,
+  getAgentProfilesDir,
+  loadAgentProfilesLayer,
+} from "./agent-profiles"
+
+function mkTempLayer(prefix: string): AgentsLayerPaths {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  return getAgentsLayerPaths(path.join(dir, ".agents"))
+}
+
+function writeAgentProfileMarkdown(
+  layer: AgentsLayerPaths,
+  options: {
+    id: string
+    connectionType: AgentProfileConnectionType
+    role?: AgentProfileRole
+  },
+): void {
+  const profileDir = path.join(getAgentProfilesDir(layer), options.id)
+  fs.mkdirSync(profileDir, { recursive: true })
+
+  const roleLine = options.role ? `role: ${options.role}\n` : ""
+  const markdown = `---\nid: ${options.id}\nname: ${options.id}\ndisplayName: ${options.id}\nenabled: true\nconnection-type: ${options.connectionType}\n${roleLine}---\n\nPrompt\n`
+
+  fs.writeFileSync(path.join(profileDir, AGENTS_PROFILE_CANONICAL_FILENAME), markdown, "utf8")
+}
+
+describe("agent-profiles role inference", () => {
+  it.each(["acp", "stdio", "remote"] as const)(
+    "infers delegation-target for %s profiles missing role",
+    (connectionType) => {
+      const layer = mkTempLayer("dotagents-agent-profiles-ext-")
+      writeAgentProfileMarkdown(layer, {
+        id: `ext-${connectionType}`,
+        connectionType,
+      })
+
+      const { profiles } = loadAgentProfilesLayer(layer)
+      expect(profiles).toHaveLength(1)
+      expect(profiles[0].connection.type).toBe(connectionType)
+      expect(profiles[0].role).toBe("delegation-target")
+      expect(profiles[0].isAgentTarget).toBe(true)
+    },
+  )
+
+  it("does not infer delegation-target for internal profiles missing role", () => {
+    const layer = mkTempLayer("dotagents-agent-profiles-internal-")
+    writeAgentProfileMarkdown(layer, {
+      id: "internal-no-role",
+      connectionType: "internal",
+    })
+
+    const { profiles } = loadAgentProfilesLayer(layer)
+    expect(profiles).toHaveLength(1)
+    expect(profiles[0].connection.type).toBe("internal")
+    expect(profiles[0].role).toBeUndefined()
+    expect(profiles[0].isAgentTarget).toBeUndefined()
+  })
+
+  it("preserves explicit external-agent role", () => {
+    const layer = mkTempLayer("dotagents-agent-profiles-explicit-")
+    writeAgentProfileMarkdown(layer, {
+      id: "explicit-external-agent",
+      connectionType: "acp",
+      role: "external-agent",
+    })
+
+    const { profiles } = loadAgentProfilesLayer(layer)
+    expect(profiles).toHaveLength(1)
+    expect(profiles[0].role).toBe("external-agent")
+    expect(profiles[0].isAgentTarget).toBe(true)
+  })
+})
+

--- a/apps/desktop/src/main/agents-files/agent-profiles.ts
+++ b/apps/desktop/src/main/agents-files/agent-profiles.ts
@@ -233,6 +233,9 @@ function assembleAgentProfile(
     type: mdPartial.connection?.type ?? "internal",
   }
 
+  const isExternalConnection = connection.type === "acp" || connection.type === "stdio" || connection.type === "remote"
+  const role = mdPartial.role ?? (isExternalConnection ? "delegation-target" : undefined)
+
   return {
     id: mdPartial.id,
     name: mdPartial.name ?? mdPartial.id,
@@ -241,13 +244,13 @@ function assembleAgentProfile(
     systemPrompt: mdPartial.systemPrompt,
     guidelines: mdPartial.guidelines,
     connection,
-    role: mdPartial.role,
+    role,
     enabled: mdPartial.enabled ?? true,
     isBuiltIn: mdPartial.isBuiltIn,
     isDefault: mdPartial.isDefault,
     isStateful: mdPartial.isStateful,
     autoSpawn: mdPartial.autoSpawn,
-    isAgentTarget: mdPartial.role === "delegation-target" || mdPartial.role === "external-agent" || undefined,
+    isAgentTarget: role === "delegation-target" || role === "external-agent" || isExternalConnection || undefined,
     createdAt: mdPartial.createdAt ?? Date.now(),
     updatedAt: mdPartial.updatedAt ?? Date.now(),
     // From config.json


### PR DESCRIPTION
## What this fixes
External ACP/stdio/remote agent profiles loaded from `agent.md` without an explicit `role` were not consistently recognized as delegation targets.

This happened because role-less profiles relied on legacy `isAgentTarget`, but that flag was not inferred from connection type when assembling profile data.

## Changes
- In `agents-files/agent-profiles.ts`:
  - infer `role: "delegation-target"` when `connection.type` is `acp`, `stdio`, or `remote` and role is missing
  - infer `isAgentTarget` for external connection types
- Added regression tests in `agents-files/agent-profiles.test.ts`:
  - infers delegation-target for role-less `acp`, `stdio`, and `remote` profiles
  - does not infer delegation-target for role-less `internal` profiles
  - preserves explicit `external-agent` role

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/main/agents-files/agent-profiles.test.ts`
- `pnpm --filter @dotagents/desktop typecheck:node`

Refs: https://github.com/aj47/SpeakMCP/issues/1110


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author