### PR TITLE
fix: preserve unlimited agent loops and final delegation output

### DIFF
--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -12,6 +12,7 @@ import type {
 import { acpBackgroundNotifier } from './acp-background-notifier';
 import { configStore } from '../config';
 import { acpService, ACPContentBlock } from '../acp-service';
+import { getPreferredDelegationOutput } from '../agent-run-utils';
 import { emitAgentProgress } from '../emit-agent-progress';
 import { agentSessionStateManager } from '../state';
 import type { ACPDelegationProgress, ACPSubAgentMessage } from '../../shared/types';
@@ -140,12 +141,13 @@ function createCompletedResult(
   conversation: ACPSubAgentMessage[]
 ): DelegationResult {
   subAgentState.status = 'completed';
+  const resolvedOutput = getPreferredDelegationOutput(output, conversation);
   return {
     success: true,
     runId: subAgentState.runId,
     agentName: subAgentState.agentName,
     status: 'completed',
-    output,
+    output: resolvedOutput,
     duration: Date.now() - subAgentState.startTime,
     conversation,
   };

--- a/apps/desktop/src/main/acp/internal-agent.ts
+++ b/apps/desktop/src/main/acp/internal-agent.ts
@@ -21,6 +21,7 @@ import { agentSessionTracker } from '../agent-session-tracker';
 import { emitAgentProgress } from '../emit-agent-progress';
 import { skillsService } from '../skills-service';
 import { agentProfileService, createSessionSnapshotFromProfile } from '../agent-profile-service';
+import { getPreferredDelegationOutput } from '../agent-run-utils';
 import { configStore } from '../config';
 import type { AgentProgressUpdate, SessionProfileSnapshot, ACPDelegationProgress, ACPSubAgentMessage, ConversationMessage, AgentProfile } from '../../shared/types';
 import type { MCPToolCall, MCPToolResult } from '../mcp-service';
@@ -622,18 +623,19 @@ export async function runInternalSubSession(
     const wasCancelled = currentSubSession?.status === 'cancelled';
     
     if (currentSubSession && !wasCancelled) {
+      const resolvedResultContent = getPreferredDelegationOutput(result.content, subSession.conversationHistory);
       currentSubSession.status = 'completed';
       currentSubSession.endTime = Date.now();
-      currentSubSession.result = result.content;
+      currentSubSession.result = resolvedResultContent;
 
       // Add final assistant message to conversation history only for completed runs (not cancelled)
       const existingFinal = subSession.conversationHistory.find(
-        m => m.role === 'assistant' && m.content === result.content
+        m => m.role === 'assistant' && m.content === resolvedResultContent
       );
       if (!existingFinal) {
         subSession.conversationHistory.push({
           role: 'assistant',
-          content: result.content,
+          content: resolvedResultContent,
           timestamp: Date.now(),
         });
       }
@@ -675,7 +677,7 @@ export async function runInternalSubSession(
     return {
       success: true,
       subSessionId,
-      result: result.content,
+      result: getPreferredDelegationOutput(result.content, subSession.conversationHistory),
       conversationHistory: subSession.conversationHistory,
       duration: Date.now() - subSession.startTime,
     };

--- a/apps/desktop/src/main/agent-run-utils.test.ts
+++ b/apps/desktop/src/main/agent-run-utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import {
+  AGENT_STOP_NOTE,
+  DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+  appendAgentStopNote,
+  getPreferredDelegationOutput,
+  resolveAgentIterationLimits,
+} from "./agent-run-utils"
+
+describe("agent-run-utils", () => {
+  describe("resolveAgentIterationLimits", () => {
+    it("preserves finite iteration limits", () => {
+      expect(resolveAgentIterationLimits(25)).toEqual({
+        loopMaxIterations: 25,
+        guardrailBudget: 25,
+      })
+    })
+
+    it("keeps unlimited loops unlimited while capping guardrails", () => {
+      expect(resolveAgentIterationLimits(Number.POSITIVE_INFINITY)).toEqual({
+        loopMaxIterations: Number.POSITIVE_INFINITY,
+        guardrailBudget: DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+      })
+    })
+
+    it("falls back to a safe finite budget for invalid values", () => {
+      expect(resolveAgentIterationLimits(Number.NaN)).toEqual({
+        loopMaxIterations: DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+        guardrailBudget: DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+      })
+      expect(resolveAgentIterationLimits(-4)).toEqual({
+        loopMaxIterations: 1,
+        guardrailBudget: 1,
+      })
+    })
+  })
+
+  describe("appendAgentStopNote", () => {
+    it("appends the stop note once to existing content", () => {
+      expect(appendAgentStopNote("Done")).toBe(`Done\n\n${AGENT_STOP_NOTE}`)
+      expect(appendAgentStopNote(`Done\n\n${AGENT_STOP_NOTE}`)).toBe(
+        `Done\n\n${AGENT_STOP_NOTE}`,
+      )
+    })
+
+    it("returns only the stop note when no content exists", () => {
+      expect(appendAgentStopNote("")).toBe(AGENT_STOP_NOTE)
+    })
+  })
+
+  describe("getPreferredDelegationOutput", () => {
+    it("prefers the latest assistant message over stale output", () => {
+      expect(
+        getPreferredDelegationOutput("I'll start by loading the page", [
+          { role: "user", content: "Do the task" },
+          { role: "assistant", content: "I'll start by loading the page" },
+          { role: "assistant", content: "Finished the task successfully" },
+        ]),
+      ).toBe("Finished the task successfully")
+    })
+
+    it("falls back to the provided output when no assistant message exists", () => {
+      expect(
+        getPreferredDelegationOutput("Final output", [
+          { role: "user", content: "Do the task" },
+          { role: "tool", content: "tool result" },
+        ]),
+      ).toBe("Final output")
+    })
+
+    it("ignores blank assistant messages when choosing the final output", () => {
+      expect(
+        getPreferredDelegationOutput("Final output", [
+          { role: "assistant", content: "   " },
+          { role: "assistant", content: "Real final output" },
+        ]),
+      ).toBe("Real final output")
+    })
+  })
+})

--- a/apps/desktop/src/main/agent-run-utils.ts
+++ b/apps/desktop/src/main/agent-run-utils.ts
@@ -1,0 +1,80 @@
+export const DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET = 60
+export const AGENT_STOP_NOTE =
+  "(Agent mode was stopped by emergency kill switch)"
+
+export interface AgentIterationLimits {
+  loopMaxIterations: number
+  guardrailBudget: number
+}
+
+interface ConversationMessageLike {
+  role: string
+  content?: string | null
+}
+
+export function resolveAgentIterationLimits(
+  requestedMaxIterations: number,
+): AgentIterationLimits {
+  if (requestedMaxIterations === Number.POSITIVE_INFINITY) {
+    return {
+      loopMaxIterations: Number.POSITIVE_INFINITY,
+      guardrailBudget: DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+    }
+  }
+
+  if (!Number.isFinite(requestedMaxIterations)) {
+    return {
+      loopMaxIterations: DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+      guardrailBudget: DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET,
+    }
+  }
+
+  const normalizedMaxIterations = Math.max(
+    1,
+    Math.floor(requestedMaxIterations),
+  )
+  return {
+    loopMaxIterations: normalizedMaxIterations,
+    guardrailBudget: normalizedMaxIterations,
+  }
+}
+
+export function appendAgentStopNote(content: string): string {
+  const normalizedContent = typeof content === "string" ? content.trimEnd() : ""
+  if (normalizedContent.includes(AGENT_STOP_NOTE)) {
+    return normalizedContent
+  }
+
+  return normalizedContent.length > 0
+    ? `${normalizedContent}\n\n${AGENT_STOP_NOTE}`
+    : AGENT_STOP_NOTE
+}
+
+export function getLatestAssistantMessageContent(
+  conversation?: ConversationMessageLike[],
+): string | undefined {
+  if (!Array.isArray(conversation)) return undefined
+
+  for (let index = conversation.length - 1; index >= 0; index--) {
+    const message = conversation[index]
+    if (message?.role !== "assistant") continue
+    if (typeof message.content !== "string") continue
+
+    const trimmedContent = message.content.trim()
+    if (trimmedContent.length > 0) {
+      return message.content
+    }
+  }
+
+  return undefined
+}
+
+export function getPreferredDelegationOutput(
+  output: string | undefined,
+  conversation?: ConversationMessageLike[],
+): string {
+  return (
+    getLatestAssistantMessageContent(conversation) ??
+    (typeof output === "string" ? output : "")
+  )
+}

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -41,6 +41,10 @@ import {
   RESPOND_TO_USER_TOOL,
   INTERNAL_COMPLETION_NUDGE_TEXT,
 } from "../shared/builtin-tool-names"
+import {
+  appendAgentStopNote,
+  resolveAgentIterationLimits,
+} from "./agent-run-utils"
 import { filterEphemeralMessages } from "./conversation-history-utils"
 import {
   filterNamedItemsToAllowedTools,
@@ -446,6 +450,8 @@ export async function processTranscriptWithAgentMode(
   runId?: number,
 ): Promise<AgentModeResponse> {
   const config = configStore.get()
+  const { loopMaxIterations, guardrailBudget } = resolveAgentIterationLimits(maxIterations)
+  maxIterations = loopMaxIterations
 
   // Store IDs for use in progress updates
   const currentConversationId = conversationId
@@ -997,6 +1003,30 @@ export async function processTranscriptWithAgentMode(
       }))
   }
 
+  const finalizeEmergencyStop = (steps: AgentProgressStep[]) => {
+    finalContent = appendAgentStopNote(finalContent)
+
+    const lastMessage = conversationHistory[conversationHistory.length - 1]
+    if (
+      !lastMessage ||
+      lastMessage.role !== "assistant" ||
+      lastMessage.content !== finalContent
+    ) {
+      addMessage("assistant", finalContent)
+    }
+
+    emit({
+      currentIteration: iteration,
+      maxIterations,
+      steps,
+      isComplete: true,
+      finalContent,
+      conversationHistory: formatConversationForProgress(conversationHistory),
+    })
+
+    wasAborted = true
+  }
+
   // Helper to check if content is just a tool call placeholder (not real content)
   const isToolCallPlaceholder = (content: string): boolean => {
     const trimmed = content.trim()
@@ -1274,14 +1304,7 @@ Return ONLY JSON per schema.`,
   // give up too early on recoverable tasks (e.g. tool-heavy flows that need
   // several correction nudges before converging).
   const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value))
-  const effectiveIterationBudget = Number.isFinite(maxIterations)
-    ? Math.max(1, Math.floor(maxIterations))
-    : 60
-
-  // Keep loop behavior aligned with guardrails by normalizing non-finite limits
-  // to the same fallback budget. This avoids cases where the main loop could
-  // skip entirely (NaN) or run unbounded (Infinity) while guardrails are capped.
-  maxIterations = effectiveIterationBudget
+  const effectiveIterationBudget = guardrailBudget
 
   // Verification failure limit - after this many failed completion checks, end as incomplete.
   // Scales with iteration budget instead of a fixed low constant.
@@ -1535,20 +1558,7 @@ Return ONLY JSON per schema.`,
       )
       progressSteps.push(stopStep)
 
-      // Emit final progress (ensure final output is saved in history)
-      const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-      const finalOutput = (finalContent || "") + killNote
-      conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-      emit({
-        currentIteration: iteration,
-        maxIterations,
-        steps: progressSteps.slice(-3),
-        isComplete: true,
-        finalContent: finalOutput,
-        conversationHistory: formatConversationForProgress(conversationHistory),
-      })
-
-      wasAborted = true
+      finalizeEmergencyStop(progressSteps.slice(-3))
       break
     }
 
@@ -1649,18 +1659,7 @@ Return ONLY JSON per schema.`,
       thinkingStep.status = "completed"
       thinkingStep.title = "Agent stopped"
       thinkingStep.description = "Emergency stop triggered"
-      const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-      const finalOutput = (finalContent || "") + killNote
-      conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-      emit({
-        currentIteration: iteration,
-        maxIterations,
-        steps: progressSteps.slice(-3),
-        isComplete: true,
-        finalContent: finalOutput,
-        conversationHistory: formatConversationForProgress(conversationHistory),
-      })
-      wasAborted = true
+      finalizeEmergencyStop(progressSteps.slice(-3))
       break
     }
 
@@ -1717,18 +1716,7 @@ Return ONLY JSON per schema.`,
         thinkingStep.status = "completed"
         thinkingStep.title = "Agent stopped"
         thinkingStep.description = "Emergency stop triggered"
-        const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-        const finalOutput = (finalContent || "") + killNote
-        conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-        emit({
-          currentIteration: iteration,
-          maxIterations,
-          steps: progressSteps.slice(-3),
-          isComplete: true,
-          finalContent: finalOutput,
-          conversationHistory: formatConversationForProgress(conversationHistory),
-        })
-        wasAborted = true
+        finalizeEmergencyStop(progressSteps.slice(-3))
         break
       }
     } catch (error: any) {
@@ -1737,19 +1725,7 @@ Return ONLY JSON per schema.`,
         thinkingStep.status = "completed"
         thinkingStep.title = "Agent stopped"
         thinkingStep.description = "Emergency stop triggered"
-        // Ensure final output appears in saved conversation on abort
-        const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-        const finalOutput = (finalContent || "") + killNote
-        conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-        emit({
-          currentIteration: iteration,
-          maxIterations,
-          steps: progressSteps.slice(-3),
-          isComplete: true,
-          finalContent: finalOutput,
-          conversationHistory: formatConversationForProgress(conversationHistory),
-        })
-        wasAborted = true
+        finalizeEmergencyStop(progressSteps.slice(-3))
         break
       }
 
@@ -2272,18 +2248,7 @@ Return ONLY JSON per schema.`,
     // Check for stop signal before starting tool execution
     if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
       logLLM(`Agent session ${currentSessionId} stopped before tool execution`)
-      const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-      const finalOutput = (finalContent || "") + killNote
-      conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-      emit({
-        currentIteration: iteration,
-        maxIterations,
-        steps: progressSteps.slice(-3),
-        isComplete: true,
-        finalContent: finalOutput,
-        conversationHistory: formatConversationForProgress(conversationHistory),
-      })
-      wasAborted = true
+      finalizeEmergencyStop(progressSteps.slice(-3))
       break
     }
 
@@ -2380,18 +2345,7 @@ Return ONLY JSON per schema.`,
       // Check if any tool was cancelled by kill switch
       const anyCancelled = executionResults.some(r => r.cancelledByKill)
       if (anyCancelled) {
-        const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-        const finalOutput = (finalContent || "") + killNote
-        conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-        emit({
-          currentIteration: iteration,
-          maxIterations,
-          steps: progressSteps.slice(-Math.min(toolCallsArray.length * 2, 6)),
-          isComplete: true,
-          finalContent: finalOutput,
-          conversationHistory: formatConversationForProgress(conversationHistory),
-        })
-        wasAborted = true
+        finalizeEmergencyStop(progressSteps.slice(-Math.min(toolCallsArray.length * 2, 6)))
         break
       }
 
@@ -2427,18 +2381,7 @@ Return ONLY JSON per schema.`,
         // Check for stop signal before executing each tool
         if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
           logLLM(`Agent session ${currentSessionId} stopped during tool execution`)
-          const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-          const finalOutput = (finalContent || "") + killNote
-          conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-          emit({
-            currentIteration: iteration,
-            maxIterations,
-            steps: progressSteps.slice(-3),
-            isComplete: true,
-            finalContent: finalOutput,
-            conversationHistory: formatConversationForProgress(conversationHistory),
-          })
-          wasAborted = true
+          finalizeEmergencyStop(progressSteps.slice(-3))
           break
         }
 
@@ -2500,18 +2443,7 @@ Return ONLY JSON per schema.`,
           )
           toolResultStep.toolResult = toolCallStep.toolResult
           progressSteps.push(toolResultStep)
-          const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-          const finalOutput = (finalContent || "") + killNote
-          conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-          emit({
-            currentIteration: iteration,
-            maxIterations,
-            steps: progressSteps.slice(-3),
-            isComplete: true,
-            finalContent: finalOutput,
-            conversationHistory: formatConversationForProgress(conversationHistory),
-          })
-          wasAborted = true
+          finalizeEmergencyStop(progressSteps.slice(-3))
           break
         }
 
@@ -2558,19 +2490,7 @@ Return ONLY JSON per schema.`,
 
     // If stop was requested during tool execution, exit the agent loop now
     if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
-      // Emit final progress with complete status
-      const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-      const finalOutput = (finalContent || "") + killNote
-      addMessage("assistant", finalOutput)
-      emit({
-        currentIteration: iteration,
-        maxIterations,
-        steps: progressSteps.slice(-3),
-        isComplete: true,
-        finalContent: finalOutput,
-        conversationHistory: formatConversationForProgress(conversationHistory),
-      })
-      wasAborted = true
+      finalizeEmergencyStop(progressSteps.slice(-3))
       break
     }
 
@@ -2808,18 +2728,7 @@ Return ONLY JSON per schema.`,
           // Check if stop was requested during summary generation
           if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
             logLLM(`Agent session ${currentSessionId} stopped during summary generation`)
-            const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-            const finalOutput = (finalContent || "") + killNote
-            conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-            emit({
-              currentIteration: iteration,
-              maxIterations,
-              steps: progressSteps.slice(-3),
-              isComplete: true,
-              finalContent: finalOutput,
-              conversationHistory: formatConversationForProgress(conversationHistory),
-            })
-            wasAborted = true
+            finalizeEmergencyStop(progressSteps.slice(-3))
             break
           }
 
@@ -2896,18 +2805,7 @@ Return ONLY JSON per schema.`,
 	        // Check if stop was requested during verification
 	        if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
 	          logLLM(`Agent session ${currentSessionId} stopped during verification`)
-	          const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-	          const finalOutput = (finalContent || "") + killNote
-	          conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-	          emit({
-	            currentIteration: iteration,
-	            maxIterations,
-	            steps: progressSteps.slice(-3),
-	            isComplete: true,
-	            finalContent: finalOutput,
-	            conversationHistory: formatConversationForProgress(conversationHistory),
-	          })
-	          wasAborted = true
+	          finalizeEmergencyStop(progressSteps.slice(-3))
 	          break
 	        }
 
@@ -2933,17 +2831,7 @@ Return ONLY JSON per schema.`,
           try {
             const result = await generatePostVerifySummary(finalContent, true, activeTools)
             if (result.stopped) {
-              const killNote = "\n\n(Agent mode was stopped by emergency kill switch)"
-              const finalOutput = (finalContent || "") + killNote
-              conversationHistory.push({ role: "assistant", content: finalOutput, timestamp: Date.now() })
-              emit({
-                currentIteration: iteration,
-                maxIterations,
-                steps: progressSteps.slice(-3),
-                isComplete: true,
-                finalContent: finalOutput,
-                conversationHistory: formatConversationForProgress(conversationHistory),
-              })
+              finalizeEmergencyStop(progressSteps.slice(-3))
               break
             }
             finalContent = result.content


### PR DESCRIPTION
## What changed
- preserve `Infinity` agent iteration limits for the main loop while still capping guardrail-derived retry budgets
- centralize emergency-stop finalization so the stop note is appended once and the final assistant message is always persisted/emitted
- prefer the latest assistant transcript message when returning delegated/internal sub-agent results so callers receive the real final output
- add targeted tests for iteration-limit normalization, stop-note handling, and delegation output selection

## Validation
- `pnpm --dir apps/desktop run typecheck:node`
- `pnpm --dir apps/desktop exec vitest run src/main/agent-run-utils.test.ts`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author