### PR TITLE
Fix macOS Cmd+Tab app switcher behavior

### DIFF
--- a/apps/desktop/src/main/app-switcher.test.ts
+++ b/apps/desktop/src/main/app-switcher.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const appMock = {
+  dock: {
+    isVisible: vi.fn(() => false),
+    show: vi.fn(),
+  },
+  show: vi.fn(),
+  setActivationPolicy: vi.fn(),
+}
+
+let mockConfig = { hideDockIcon: false }
+
+vi.mock("electron", () => ({ app: appMock }))
+vi.mock("./config", () => ({ configStore: { get: () => mockConfig } }))
+vi.mock("./debug", () => ({ logApp: vi.fn() }))
+
+describe("ensureAppSwitcherPresence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockConfig = { hideDockIcon: false }
+    process.env.IS_MAC = true
+  })
+
+  it("restores regular activation policy when dock icon is enabled", async () => {
+    const { ensureAppSwitcherPresence } = await import("./app-switcher")
+
+    ensureAppSwitcherPresence("test")
+
+    expect(appMock.setActivationPolicy).toHaveBeenCalledWith("regular")
+    expect(appMock.dock.show).toHaveBeenCalled()
+  })
+
+  it("respects the hideDockIcon preference", async () => {
+    mockConfig = { hideDockIcon: true }
+    const { ensureAppSwitcherPresence } = await import("./app-switcher")
+
+    ensureAppSwitcherPresence("test")
+
+    expect(appMock.setActivationPolicy).not.toHaveBeenCalled()
+    expect(appMock.dock.show).not.toHaveBeenCalled()
+  })
+
+  it("shows and focuses the main window when activating the app", async () => {
+    const { showAndFocusMainWindow } = await import("./app-switcher")
+    const win = {
+      isMinimized: vi.fn(() => true),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+    }
+
+    showAndFocusMainWindow(win, "test")
+
+    expect(appMock.setActivationPolicy).toHaveBeenCalledWith("regular")
+    expect(appMock.dock.show).toHaveBeenCalled()
+    expect(appMock.show).toHaveBeenCalled()
+    expect(win.restore).toHaveBeenCalled()
+    expect(win.show).toHaveBeenCalled()
+    expect(win.focus).toHaveBeenCalled()
+  })
+
+  it("focuses the main window even when it is not minimized", async () => {
+    const { showAndFocusMainWindow } = await import("./app-switcher")
+    const win = {
+      isMinimized: vi.fn(() => false),
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+    }
+
+    showAndFocusMainWindow(win, "test")
+
+    expect(win.restore).not.toHaveBeenCalled()
+    expect(win.show).toHaveBeenCalled()
+    expect(win.focus).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/app-switcher.ts
+++ b/apps/desktop/src/main/app-switcher.ts
@@ -1,0 +1,46 @@
+import { app } from "electron"
+import type { BrowserWindow } from "electron"
+import { configStore } from "./config"
+import { logApp } from "./debug"
+
+export function ensureAppSwitcherPresence(reason: string): void {
+  if (!process.env.IS_MAC) return
+
+  try {
+    const cfg = configStore.get()
+    if (cfg.hideDockIcon === true) return
+
+    app.setActivationPolicy("regular")
+    if (!app.dock?.isVisible?.()) {
+      app.dock?.show()
+    }
+  } catch (error) {
+    logApp(`[${reason}] Failed to ensure app switcher visibility:`, error)
+  }
+}
+
+export function showAndFocusMainWindow(
+  win: Pick<BrowserWindow, "isMinimized" | "restore" | "show" | "focus">,
+  reason: string,
+): void {
+  ensureAppSwitcherPresence(reason)
+
+  try {
+    if (process.env.IS_MAC) {
+      app.show()
+    }
+  } catch (error) {
+    logApp(`[${reason}] Failed to show app before focusing main window:`, error)
+  }
+
+  try {
+    if (win.isMinimized()) {
+      win.restore()
+    }
+  } catch (error) {
+    logApp(`[${reason}] Failed to restore minimized main window:`, error)
+  }
+
+  win.show()
+  win.focus()
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -5,6 +5,7 @@ import {
   createPanelWindow,
   createSetupWindow,
   makePanelWindowClosable,
+  showMainWindow,
   setAppQuitting,
   WINDOWS,
 } from "./window"
@@ -19,6 +20,7 @@ import { mcpService } from "./mcp-service"
 import { initDebugFlags, logApp } from "./debug"
 import { initializeDeepLinkHandling } from "./oauth-deeplink-handler"
 import { diagnosticsService } from "./diagnostics"
+import { ensureAppSwitcherPresence } from "./app-switcher"
 
 import { configStore } from "./config"
 import { startRemoteServer, printQRCodeToTerminal, startRemoteServerForced } from "./remote-server"
@@ -457,18 +459,13 @@ app.whenReady().then(async () => {
     const cfg = configStore.get()
 
     if (process.platform === "darwin" && !cfg.hideDockIcon) {
-      // Ensure Cmd+Tab presence and a visible dock icon when app is activated.
-      // This recovers from rare activation-policy drift to "accessory".
-      app.setActivationPolicy("regular")
-      if (!app.dock?.isVisible?.()) {
-        app.dock?.show()
-      }
+      ensureAppSwitcherPresence("app.activate")
     }
 
     if (accessibilityGranted) {
       if (mainWin) {
-        // Window exists (may be hidden on macOS close-to-hide) — just show it
-        mainWin.show()
+        // Window exists (may be hidden/minimized/behind another app) — restore and focus it
+        showMainWindow()
       } else {
         // Check if onboarding has been completed
         // Skip for existing users who have already configured models (pre-onboarding installs)

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -9,6 +9,7 @@ import path from "path"
 import { getRendererHandlers } from "@egoist/tipc/main"
 import { RendererHandlers } from "./renderer-handlers"
 import { logApp, logUI } from "./debug"
+import { ensureAppSwitcherPresence, showAndFocusMainWindow } from "./app-switcher"
 import { configStore } from "./config"
 import { getFocusedAppInfo } from "./keyboard"
 import { state, agentProcessManager, suppressPanelAutoShow, isHeadlessMode } from "./state"
@@ -270,10 +271,7 @@ export function createMainWindow({ url }: { url?: string } = {}): BrowserWindow 
       )
 
       try {
-        app.setActivationPolicy("regular")
-        if (!app.dock?.isVisible?.()) {
-          app.dock?.show()
-        }
+        ensureAppSwitcherPresence("main.hide.recover")
       } catch {
         // best-effort recovery
       }
@@ -317,12 +315,7 @@ export function createMainWindow({ url }: { url?: string } = {}): BrowserWindow 
           app.setActivationPolicy("accessory")
           app.dock.hide()
         } else {
-          // Defensive recovery: if activation policy drifted to accessory for any
-          // reason, restore regular policy so the app remains Cmd+Tab-able.
-          app.setActivationPolicy("regular")
-          if (!app.dock.isVisible()) {
-            app.dock.show()
-          }
+          ensureAppSwitcherPresence("main.close")
         }
         return
       }
@@ -378,7 +371,7 @@ export function showMainWindow(url?: string) {
   const win = WINDOWS.get("main")
 
   if (win) {
-    win.show()
+    showAndFocusMainWindow(win, "showMainWindow")
     if (url) {
       getRendererHandlers<RendererHandlers>(win.webContents).navigate.send(url)
     }
@@ -721,11 +714,13 @@ export function createPanelWindow(): BrowserWindow | undefined {
 
   win.on("hide", () => {
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()
+    ensureAppSwitcherPresence("panel.hide")
   })
 
   // Reassert z-order on lifecycle changes and reset stale focus-hide flag
   win.on("show", () => {
     ensurePanelZOrder(win)
+    ensureAppSwitcherPresence("panel.show")
     // Clear the flag when panel becomes visible through any means.
     // This prevents stale state if user manually shows panel while main is focused.
     clearPanelHiddenByMainFocus()


### PR DESCRIPTION
## Summary
- centralize macOS app switcher / Dock recovery into a dedicated helper
- ensure app activation and window show/hide paths restore regular activation policy when appropriate
- improve main window restore/focus behavior and add focused tests

## Validation
- `pnpm exec vitest run src/main/app-switcher.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.node.json --composite false`

## Notes
- respects `hideDockIcon` and leaves unrelated local workspace files untouched

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author