### PR TITLE
Fix ACP workspace dir changes for new sessions

### DIFF
--- a/apps/desktop/src/main/acp-service.test.ts
+++ b/apps/desktop/src/main/acp-service.test.ts
@@ -375,6 +375,90 @@ describe("ACP Service", () => {
     })
   })
 
+  describe("getOrCreateSession", () => {
+    it("restarts a ready agent when configured cwd changes before creating a new session", async () => {
+      const workspaceDir = mkdtempSync(join(tmpdir(), "acp-workspace-"))
+      const firstDir = "repo/feature-a"
+      const secondDir = "repo/feature-b"
+      const expectedFirstCwd = join(workspaceDir, firstDir)
+      const expectedSecondCwd = join(workspaceDir, secondDir)
+      mkdirSync(expectedFirstCwd, { recursive: true })
+      mkdirSync(expectedSecondCwd, { recursive: true })
+
+      process.env.DOTAGENTS_WORKSPACE_DIR = workspaceDir
+      ;(mockConfig.acpAgents[0].connection as { cwd?: string }).cwd = firstDir
+
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      ;(mockConfig.acpAgents[0].connection as { cwd?: string }).cwd = secondDir
+
+      const stopSpy = vi.spyOn(acpService, "stopAgent").mockResolvedValue()
+      vi.spyOn(acpService as any, "initializeAgent").mockResolvedValue(undefined)
+      vi.spyOn(acpService as any, "createSession").mockResolvedValue("session-updated-cwd")
+
+      const sessionId = await acpService.getOrCreateSession("test-agent", true)
+
+      expect(sessionId).toBe("session-updated-cwd")
+      expect(stopSpy).toHaveBeenCalledWith("test-agent")
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        2,
+        "test-command",
+        ["--test"],
+        expect.objectContaining({ cwd: expectedSecondCwd })
+      )
+
+      rmSync(workspaceDir, { recursive: true, force: true })
+    })
+  })
+
+  describe("runTask", () => {
+    it("restarts a ready agent when configured cwd changes before forcing a new session", async () => {
+      const workspaceDir = mkdtempSync(join(tmpdir(), "acp-workspace-"))
+      const firstDir = "repo/feature-a"
+      const secondDir = "repo/feature-b"
+      const expectedFirstCwd = join(workspaceDir, firstDir)
+      const expectedSecondCwd = join(workspaceDir, secondDir)
+      mkdirSync(expectedFirstCwd, { recursive: true })
+      mkdirSync(expectedSecondCwd, { recursive: true })
+
+      process.env.DOTAGENTS_WORKSPACE_DIR = workspaceDir
+      ;(mockConfig.acpAgents[0].connection as { cwd?: string }).cwd = firstDir
+
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      ;(mockConfig.acpAgents[0].connection as { cwd?: string }).cwd = secondDir
+
+      const stopSpy = vi.spyOn(acpService, "stopAgent").mockResolvedValue()
+      vi.spyOn(acpService as any, "initializeAgent").mockResolvedValue(undefined)
+      vi.spyOn(acpService as any, "createSession").mockResolvedValue("session-updated-cwd")
+      vi.spyOn(acpService as any, "sendRequest").mockResolvedValue({
+        content: [{ type: "text", text: "done" }],
+      })
+
+      const result = await acpService.runTask({
+        agentName: "test-agent",
+        input: "hello",
+        forceNewSession: true,
+      })
+
+      expect(result).toEqual(expect.objectContaining({
+        success: true,
+        result: "done",
+      }))
+      expect(stopSpy).toHaveBeenCalledWith("test-agent")
+      expect(mockSpawn).toHaveBeenNthCalledWith(
+        2,
+        "test-command",
+        ["--test"],
+        expect.objectContaining({ cwd: expectedSecondCwd })
+      )
+
+      rmSync(workspaceDir, { recursive: true, force: true })
+    })
+  })
+
   describe("getAgentStatus", () => {
     it("should return stopped for unspawned agent", async () => {
       const { acpService } = await import("./acp-service")

--- a/apps/desktop/src/main/acp-service.ts
+++ b/apps/desktop/src/main/acp-service.ts
@@ -1775,18 +1775,15 @@ class ACPService extends EventEmitter {
   async runTask(request: ACPRunRequest): Promise<ACPRunResponse> {
     const { agentName, input, context, workingDirectory, forceNewSession } = request
 
-    // Ensure agent is running
+    // Ensure agent is running and reconcile any updated working-directory config.
     let instance = this.agents.get(agentName)
-    if (!instance || instance.status !== "ready" || !!workingDirectory) {
-      // Try to spawn it
-      try {
-        await this.spawnAgent(agentName, { workingDirectory })
-        instance = this.agents.get(agentName)
-      } catch (error) {
-        return {
-          success: false,
-          error: `Failed to start agent: ${error instanceof Error ? error.message : String(error)}`,
-        }
+    try {
+      await this.spawnAgent(agentName, { workingDirectory })
+      instance = this.agents.get(agentName)
+    } catch (error) {
+      return {
+        success: false,
+        error: `Failed to start agent: ${error instanceof Error ? error.message : String(error)}`,
       }
     }
 
@@ -1938,16 +1935,14 @@ class ACPService extends EventEmitter {
    * Throws with a descriptive error if the agent cannot be started or no session can be created.
    */
   async getOrCreateSession(agentName: string, forceNew?: boolean, workingDirectory?: string): Promise<string> {
-    // Ensure agent is spawned and ready
+    // Ensure agent is spawned, ready, and reconciled with the latest working-directory config.
     let instance = this.agents.get(agentName)
-    if (!instance || instance.status !== "ready" || !!workingDirectory) {
-      try {
-        await this.spawnAgent(agentName, { workingDirectory })
-        instance = this.agents.get(agentName)
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error)
-        throw new Error(`Failed to start ACP agent ${agentName}: ${message}`)
-      }
+    try {
+      await this.spawnAgent(agentName, { workingDirectory })
+      instance = this.agents.get(agentName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to start ACP agent ${agentName}: ${message}`)
     }
 
     if (!instance || instance.status !== "ready") {


### PR DESCRIPTION
## Summary
- reconcile ACP agent startup through `spawnAgent()` before creating or running sessions
- pick up updated configured working directories for later new sessions on the same agent
- add regression coverage for `getOrCreateSession()` and `runTask()` after cwd config changes

## Validation
- `pnpm exec vitest run src/main/acp-service.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.node.json --composite false`

## Notes
- leaves unrelated local workspace files untouched

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author