### PR TITLE
Fix mobile ACP main-agent settings and runtime flow

### DIFF
--- a/apps/desktop/src/main/main-agent-selection.test.ts
+++ b/apps/desktop/src/main/main-agent-selection.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { resolveMainAcpAgentSelection } from "./main-agent-selection"
+
+describe("resolveMainAcpAgentSelection", () => {
+  it("resolves ACP profile display names to canonical profile names", () => {
+    const result = resolveMainAcpAgentSelection("Claude Code", [
+      {
+        name: "claude-code",
+        displayName: "Claude Code",
+        enabled: true,
+        connection: { type: "acp", command: "claude-code-acp" },
+      } as any,
+    ])
+
+    expect(result).toEqual({ resolvedName: "claude-code" })
+  })
+
+  it("repairs stale selections when exactly one ACP-capable agent is available", () => {
+    const result = resolveMainAcpAgentSelection("missing-agent", [
+      {
+        name: "augustus",
+        displayName: "augustus",
+        enabled: true,
+        connection: { type: "acp", command: "auggie", args: ["--acp"] },
+      } as any,
+    ])
+
+    expect(result).toEqual({ resolvedName: "augustus", repairedName: "augustus" })
+  })
+
+  it("returns a helpful error when multiple ACP-capable agents are available", () => {
+    const result = resolveMainAcpAgentSelection("missing-agent", [
+      {
+        name: "agent-one",
+        displayName: "Agent One",
+        enabled: true,
+        connection: { type: "acp", command: "agent-one" },
+      } as any,
+      {
+        name: "agent-two",
+        displayName: "Agent Two",
+        enabled: true,
+        connection: { type: "stdio", command: "agent-two" },
+      } as any,
+    ])
+
+    expect(result).toEqual({
+      error: 'ACP main agent "missing-agent" is not available. Configure mainAgentName to one of: agent-one, agent-two',
+    })
+  })
+})

--- a/apps/desktop/src/main/main-agent-selection.ts
+++ b/apps/desktop/src/main/main-agent-selection.ts
@@ -1,0 +1,65 @@
+import type { ACPAgentConfig, AgentProfile } from "../shared/types"
+
+export type MainAcpAgentSelection =
+  | { resolvedName: string; repairedName?: string }
+  | { error: string }
+
+export function resolveMainAcpAgentSelection(
+  configuredName: string,
+  profileAgents: AgentProfile[] = [],
+  legacyAgents: ACPAgentConfig[] = []
+): MainAcpAgentSelection {
+  const normalizedMainAgentName = configuredName.trim().toLowerCase()
+
+  const spawnableProfileCandidates = profileAgents.filter((profile) =>
+    profile.enabled !== false
+    && (profile.connection.type === "acp" || profile.connection.type === "stdio")
+  )
+
+  const fallbackLegacyAgents = legacyAgents.filter((agent) =>
+    agent.enabled !== false && agent.connection.type === "stdio"
+  )
+
+  const configuredProfile = spawnableProfileCandidates.find((profile) =>
+    profile.name.trim().toLowerCase() === normalizedMainAgentName
+    || profile.displayName.trim().toLowerCase() === normalizedMainAgentName
+  )
+
+  const legacyAgentMatch = fallbackLegacyAgents.find((agent) =>
+    agent.name.trim().toLowerCase() === normalizedMainAgentName
+    || agent.displayName.trim().toLowerCase() === normalizedMainAgentName
+  )
+
+  if (configuredProfile) {
+    return { resolvedName: configuredProfile.name }
+  }
+
+  if (legacyAgentMatch) {
+    return { resolvedName: legacyAgentMatch.name }
+  }
+
+  const fallbackNames = new Set<string>()
+  const fallbackExternalAgents = [
+    ...spawnableProfileCandidates.map((profile) => ({ name: profile.name })),
+    ...fallbackLegacyAgents.map((agent) => ({ name: agent.name })),
+  ].filter((agent) => {
+    const dedupeKey = agent.name.trim().toLowerCase()
+    if (fallbackNames.has(dedupeKey)) return false
+    fallbackNames.add(dedupeKey)
+    return true
+  })
+
+  if (fallbackExternalAgents.length === 1) {
+    return {
+      resolvedName: fallbackExternalAgents[0].name,
+      repairedName: fallbackExternalAgents[0].name,
+    }
+  }
+
+  const availableNames = fallbackExternalAgents.map((profile) => profile.name)
+  return {
+    error: availableNames.length > 0
+      ? `ACP main agent "${configuredName}" is not available. Configure mainAgentName to one of: ${availableNames.join(", ")}`
+      : `ACP main agent "${configuredName}" is not available and no enabled ACP/stdio agents were found.`,
+  }
+}

--- a/apps/desktop/src/main/remote-server.routes.test.ts
+++ b/apps/desktop/src/main/remote-server.routes.test.ts
@@ -34,4 +34,11 @@ describe("remote-server route registration", () => {
 
     expect(duplicates).toEqual([])
   })
+
+  it("routes mobile chat requests through ACP main-agent handling when configured", () => {
+    const source = getRemoteServerSource()
+
+    expect(source).toContain('cfg.mainAgentMode === "acp" && cfg.mainAgentName')
+    expect(source).toContain("processTranscriptWithACPAgent")
+  })
 })

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -10,6 +10,8 @@ import { diagnosticsService } from "./diagnostics"
 import { getErrorMessage } from "./error-utils"
 import { mcpService, MCPToolResult, handleWhatsAppToggle } from "./mcp-service"
 import { processTranscriptWithAgentMode } from "./llm"
+import { processTranscriptWithACPAgent } from "./acp-main-agent"
+import { resolveMainAcpAgentSelection } from "./main-agent-selection"
 import { state, agentProcessManager, agentSessionStateManager } from "./state"
 import { conversationService } from "./conversation-service"
 import { AgentProgressUpdate, SessionProfileSnapshot, LoopConfig } from "../shared/types"
@@ -588,7 +590,71 @@ async function runAgent(options: RunAgentOptions): Promise<{
   const conversationTitle = prompt.length > 50 ? prompt.substring(0, 50) + "..." : prompt
   const sessionId = existingSessionId || agentSessionTracker.startSession(conversationId, conversationTitle, startSnoozed, profileSnapshot)
 
+  const loadFormattedConversationHistory = async () => {
+    const latestConversation = await conversationService.loadConversation(conversationId)
+    return formatConversationHistoryForApi(latestConversation?.messages || [])
+  }
+
   try {
+    if (cfg.mainAgentMode === "acp" && cfg.mainAgentName) {
+      const mainAgentSelection = resolveMainAcpAgentSelection(
+        cfg.mainAgentName,
+        agentProfileService.getAll(),
+        cfg.acpAgents || []
+      )
+
+      if ("error" in mainAgentSelection) {
+        diagnosticsService.logWarning("remote-server", mainAgentSelection.error)
+        return {
+          content: mainAgentSelection.error,
+          conversationId,
+          conversationHistory: await loadFormattedConversationHistory(),
+        }
+      }
+
+      const resolvedMainAgentName = mainAgentSelection.resolvedName
+      if (mainAgentSelection.repairedName && mainAgentSelection.repairedName !== cfg.mainAgentName) {
+        configStore.save({ ...cfg, mainAgentName: resolvedMainAgentName })
+        diagnosticsService.logInfo(
+          "remote-server",
+          `ACP main agent \"${cfg.mainAgentName}\" not found. Auto-switched to \"${resolvedMainAgentName}\".`
+        )
+      }
+
+      const runId = agentSessionStateManager.startSessionRun(sessionId, profileSnapshot)
+
+      try {
+        const result = await processTranscriptWithACPAgent(prompt, {
+          agentName: resolvedMainAgentName,
+          conversationId,
+          sessionId,
+          runId,
+          onProgress,
+        })
+
+        if (result.response) {
+          await conversationService.addMessageToConversation(conversationId, result.response, "assistant")
+        }
+
+        if (result.success) {
+          agentSessionTracker.completeSession(sessionId, "ACP agent completed successfully")
+        } else {
+          agentSessionTracker.errorSession(sessionId, result.error || "Unknown error")
+        }
+
+        const formattedHistory = await loadFormattedConversationHistory()
+        notifyConversationHistoryChanged()
+
+        return {
+          content: result.response || result.error || "No response from agent",
+          conversationId,
+          conversationHistory: formattedHistory,
+        }
+      } finally {
+        agentSessionStateManager.cleanupSession(sessionId)
+      }
+    }
+
     await mcpService.initialize()
 
     mcpService.registerExistingProcessesWithAgentManager()

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -70,6 +70,7 @@ import { emitAgentProgress } from "./emit-agent-progress"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { messageQueueService } from "./message-queue-service"
 import { agentProfileService, createSessionSnapshotFromProfile, toolConfigToMcpServerConfig } from "./agent-profile-service"
+import { resolveMainAcpAgentSelection } from "./main-agent-selection"
 import { acpService, ACPRunRequest } from "./acp-service"
 import { processTranscriptWithACPAgent } from "./acp-main-agent"
 import { fetchModelsDevData, getModelFromModelsDevByProviderId, findBestModelMatch, refreshModelsDevCache } from "./models-dev-service"
@@ -227,65 +228,25 @@ async function processWithAgentMode(
 
   // Check if ACP main agent mode is enabled - route to ACP agent instead of LLM API
   if (config.mainAgentMode === "acp" && config.mainAgentName) {
-    const normalizedMainAgentName = config.mainAgentName.trim().toLowerCase()
-    const spawnableProfileCandidates = agentProfileService
-      .getAll()
-      .filter((profile) =>
-        profile.enabled !== false
-        && (profile.connection.type === "acp" || profile.connection.type === "stdio")
-      )
-
-    let resolvedMainAgentName = config.mainAgentName
-
-    // Resolve to a canonical configured ACP/stdio agent name.
-    // This protects against stale settings after profile migrations/renames.
-    const configuredProfile = spawnableProfileCandidates.find((profile) =>
-      profile.name.trim().toLowerCase() === normalizedMainAgentName
-      || profile.displayName.trim().toLowerCase() === normalizedMainAgentName
+    const mainAgentSelection = resolveMainAcpAgentSelection(
+      config.mainAgentName,
+      agentProfileService.getAll(),
+      config.acpAgents || []
     )
 
-    const legacyAgentMatch = (config.acpAgents || []).find((agent) =>
-      (agent.name.trim().toLowerCase() === normalizedMainAgentName
-        || agent.displayName.trim().toLowerCase() === normalizedMainAgentName)
-      && agent.enabled !== false
-      && agent.connection.type === "stdio"
-    )
+    if ("error" in mainAgentSelection) {
+      logLLM(`[processWithAgentMode] ${mainAgentSelection.error}`)
+      return mainAgentSelection.error
+    }
 
-    if (configuredProfile) {
-      resolvedMainAgentName = configuredProfile.name
-    } else if (legacyAgentMatch) {
-      resolvedMainAgentName = legacyAgentMatch.name
-    } else {
-      const fallbackLegacyAgents = (config.acpAgents || []).filter((agent) =>
-        agent.enabled !== false && agent.connection.type === "stdio"
+    const resolvedMainAgentName = mainAgentSelection.resolvedName
+    if (mainAgentSelection.repairedName && mainAgentSelection.repairedName !== config.mainAgentName) {
+      // Persist the repaired selection so future runs don't fail on stale names.
+      configStore.save({ ...config, mainAgentName: resolvedMainAgentName })
+      logLLM(
+        `[processWithAgentMode] ACP main agent \"${config.mainAgentName}\" not found. ` +
+        `Auto-switched to \"${resolvedMainAgentName}\".`
       )
-
-      const fallbackNames = new Set<string>()
-      const fallbackExternalAgents = [
-        ...spawnableProfileCandidates,
-        ...fallbackLegacyAgents.map((agent) => ({ name: agent.name })),
-      ].filter((agent) => {
-        if (fallbackNames.has(agent.name)) return false
-        fallbackNames.add(agent.name)
-        return true
-      })
-
-      if (fallbackExternalAgents.length === 1) {
-        resolvedMainAgentName = fallbackExternalAgents[0].name
-        // Persist the repaired selection so future runs don't fail on stale names.
-        configStore.save({ ...config, mainAgentName: resolvedMainAgentName })
-        logLLM(
-          `[processWithAgentMode] ACP main agent \"${config.mainAgentName}\" not found. ` +
-          `Auto-switched to \"${resolvedMainAgentName}\".`
-        )
-      } else {
-        const availableNames = fallbackExternalAgents.map((profile) => profile.name)
-        const errorMessage = availableNames.length > 0
-          ? `ACP main agent \"${config.mainAgentName}\" is not available. Configure mainAgentName to one of: ${availableNames.join(", ")}`
-          : `ACP main agent \"${config.mainAgentName}\" is not available and no enabled ACP/stdio agents were found.`
-        logLLM(`[processWithAgentMode] ${errorMessage}`)
-        return errorMessage
-      }
     }
 
     logLLM(`[processWithAgentMode] ACP mode enabled, routing to agent: ${resolvedMainAgentName}`)

--- a/apps/desktop/src/shared/connection-recovery.test.ts
+++ b/apps/desktop/src/shared/connection-recovery.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { normalizeApiBaseUrl } from "@dotagents/shared"
+
+describe("normalizeApiBaseUrl", () => {
+  it("adds scheme and /v1 for bare local remote-server URLs", () => {
+    expect(normalizeApiBaseUrl("127.0.0.1:3210")).toBe("http://127.0.0.1:3210/v1")
+  })
+
+  it("preserves existing /v1 paths", () => {
+    expect(normalizeApiBaseUrl("http://127.0.0.1:3210/v1")).toBe("http://127.0.0.1:3210/v1")
+  })
+
+  it("keeps explicit non-root paths unchanged", () => {
+    expect(normalizeApiBaseUrl("api.example.com/custom-root")).toBe("https://api.example.com/custom-root")
+  })
+})

--- a/apps/mobile/src/lib/mainAgentOptions.ts
+++ b/apps/mobile/src/lib/mainAgentOptions.ts
@@ -1,0 +1,40 @@
+import type { AgentProfile, Profile, Settings } from './settingsApi';
+
+export interface MainAgentOption {
+  name: string;
+  displayName: string;
+}
+
+export function getAcpMainAgentOptions(
+  settings?: Settings | null,
+  agentProfiles: AgentProfile[] = []
+): MainAgentOption[] {
+  const seen = new Set<string>();
+  const options: MainAgentOption[] = [];
+
+  for (const profile of agentProfiles) {
+    if (!profile.enabled) continue;
+    if (profile.connectionType !== 'acp' && profile.connectionType !== 'stdio') continue;
+    const key = profile.name.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    options.push({ name: profile.name, displayName: profile.displayName || profile.name });
+  }
+
+  for (const agent of settings?.acpAgents || []) {
+    const key = agent.name.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    options.push({ name: agent.name, displayName: agent.displayName || agent.name });
+  }
+
+  return options;
+}
+
+export function toMainAgentProfile(option: MainAgentOption): Profile {
+  return {
+    id: `main-agent:${option.name}`,
+    name: option.displayName,
+    guidelines: 'ACP main agent',
+  };
+}

--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -4,6 +4,7 @@ import type {
   ConversationHistoryMessage,
   ChatApiResponse
 } from '@dotagents/shared';
+import { normalizeApiBaseUrl } from '@dotagents/shared';
 import { Platform } from 'react-native';
 import EventSource from 'react-native-sse';
 import {
@@ -96,11 +97,11 @@ export class OpenAIClient {
   }
 
   private normalizeBaseUrl(raw: string): string {
-    const trimmed = (raw ?? '').trim();
-    if (!trimmed) {
+    const normalized = normalizeApiBaseUrl(raw ?? '');
+    if (!normalized) {
       throw new Error('OpenAIClient requires a baseUrl');
     }
-    return trimmed.replace(/\/+$/, '');
+    return normalized;
   }
 
   private authHeaders() {

--- a/apps/mobile/src/lib/settingsApi.ts
+++ b/apps/mobile/src/lib/settingsApi.ts
@@ -32,6 +32,7 @@ export type {
   Loop,
   LoopsResponse,
 } from '@dotagents/shared';
+import { normalizeApiBaseUrl } from '@dotagents/shared';
 
 // Re-export agent profile types with backward-compatible names
 // The shared package uses Api* prefix to avoid conflicts with desktop's AgentProfile
@@ -117,7 +118,7 @@ export class SettingsApiClient {
   private apiKey: string;
 
   constructor(baseUrl: string, apiKey: string) {
-    this.baseUrl = baseUrl.replace(/\/+$/, '');
+    this.baseUrl = normalizeApiBaseUrl(baseUrl);
     this.apiKey = apiKey;
   }
 

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -7,6 +7,7 @@ import { spacing, radius } from '../ui/theme';
 import { useProfile } from '../store/profile';
 import { usePushNotifications } from '../lib/pushNotifications';
 import { ExtendedSettingsApiClient, Profile, MCPServer, Settings, ModelInfo, SettingsUpdate, Skill, Memory, AgentProfile, Loop } from '../lib/settingsApi';
+import { getAcpMainAgentOptions } from '../lib/mainAgentOptions';
 import { TTSSettings } from '../ui/TTSSettings';
 import Slider from '@react-native-community/slider';
 
@@ -187,6 +188,10 @@ export default function SettingsScreen({ navigation }: any) {
   const [isLoadingMemories, setIsLoadingMemories] = useState(false);
   const [isLoadingAgentProfiles, setIsLoadingAgentProfiles] = useState(false);
   const [isLoadingLoops, setIsLoadingLoops] = useState(false);
+  const availableAcpMainAgents = useMemo(
+    () => getAcpMainAgentOptions(remoteSettings, agentProfiles),
+    [remoteSettings, agentProfiles]
+  );
 
   // Profile import/export state
   const [isExportingProfile, setIsExportingProfile] = useState(false);
@@ -1675,9 +1680,9 @@ export default function SettingsScreen({ navigation }: any) {
                 {remoteSettings.mainAgentMode === 'acp' && (
                   <>
                     <Text style={styles.label}>ACP Agent</Text>
-                    {remoteSettings.acpAgents && remoteSettings.acpAgents.length > 0 ? (
+                    {availableAcpMainAgents.length > 0 ? (
                       <View style={styles.providerSelector}>
-                        {remoteSettings.acpAgents.map((agent) => (
+                        {availableAcpMainAgents.map((agent) => (
                           <Pressable
                             key={agent.name}
                             style={[

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { normalizeApiBaseUrl } from '@dotagents/shared';
 
 export type AppConfig = {
   apiKey: string;
@@ -28,18 +29,25 @@ const DEFAULTS: AppConfig = {
 
 const STORAGE_KEY = 'app_config_v1';
 
+function normalizeStoredConfig(cfg: AppConfig): AppConfig {
+  return {
+    ...cfg,
+    baseUrl: cfg.baseUrl ? normalizeApiBaseUrl(cfg.baseUrl) : cfg.baseUrl,
+  };
+}
+
 export async function loadConfig(): Promise<AppConfig> {
   const raw = await AsyncStorage.getItem(STORAGE_KEY);
   if (!raw) return DEFAULTS;
   try {
     const parsed = JSON.parse(raw);
-    return { ...DEFAULTS, ...parsed } as AppConfig;
+    return normalizeStoredConfig({ ...DEFAULTS, ...parsed } as AppConfig);
   } catch {}
   return DEFAULTS;
 }
 
 export async function saveConfig(cfg: AppConfig) {
-  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(cfg));
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(normalizeStoredConfig(cfg)));
 }
 
 export function useConfig() {

--- a/apps/mobile/src/store/profile.ts
+++ b/apps/mobile/src/store/profile.ts
@@ -7,6 +7,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
 import { SettingsApiClient, Profile } from '../lib/settingsApi';
+import { getAcpMainAgentOptions, toMainAgentProfile } from '../lib/mainAgentOptions';
 
 export interface ProfileContextValue {
   /** Current profile from the server */
@@ -63,6 +64,16 @@ export function useProfileProvider(baseUrl: string, apiKey: string): ProfileCont
     
     try {
       const client = new SettingsApiClient(baseUrl, apiKey);
+      const settings = await client.getSettings();
+
+      if (settings.mainAgentMode === 'acp' && settings.mainAgentName) {
+        const options = getAcpMainAgentOptions(settings);
+        const selectedOption = options.find((option) => option.name === settings.mainAgentName)
+          || { name: settings.mainAgentName, displayName: settings.mainAgentName };
+        setCurrentProfile(toMainAgentProfile(selectedOption));
+        return;
+      }
+
       const profile = await client.getCurrentProfile();
       setCurrentProfile(profile);
     } catch (err: any) {

--- a/apps/mobile/src/ui/AgentSelectorSheet.tsx
+++ b/apps/mobile/src/ui/AgentSelectorSheet.tsx
@@ -18,8 +18,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from './ThemeProvider';
 import { spacing, radius, Theme } from './theme';
 import { useConfigContext } from '../store/config';
-import { SettingsApiClient, Profile } from '../lib/settingsApi';
+import { ExtendedSettingsApiClient, SettingsApiClient, Profile } from '../lib/settingsApi';
 import { useProfile } from '../store/profile';
+import { getAcpMainAgentOptions, toMainAgentProfile } from '../lib/mainAgentOptions';
+
+interface SelectableProfile extends Profile {
+  selectorMode?: 'profile' | 'acp';
+  selectionValue?: string;
+}
 
 interface AgentSelectorSheetProps {
   visible: boolean;
@@ -35,10 +41,11 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
   const hasApiConfig = Boolean(config.baseUrl && config.apiKey);
   const missingConfigError = 'Configure server URL and API key to switch agents';
 
-  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [profiles, setProfiles] = useState<SelectableProfile[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isSwitching, setIsSwitching] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [selectorMode, setSelectorMode] = useState<'profile' | 'acp'>('profile');
 
   const fetchProfiles = useCallback(async () => {
     if (!hasApiConfig) {
@@ -52,9 +59,27 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
     setError(null);
 
     try {
-      const client = new SettingsApiClient(config.baseUrl, config.apiKey);
-      const res = await client.getProfiles();
-      setProfiles(res.profiles || []);
+      const client = new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
+      const settings = await client.getSettings();
+
+      if (settings.mainAgentMode === 'acp') {
+        setSelectorMode('acp');
+        const agentProfilesResponse = await client.getAgentProfiles().catch(() => ({ profiles: [] }));
+        const mainAgentOptions = getAcpMainAgentOptions(settings, agentProfilesResponse.profiles || []);
+        setProfiles(mainAgentOptions.map((option) => ({
+          ...toMainAgentProfile(option),
+          selectorMode: 'acp',
+          selectionValue: option.name,
+        })));
+      } else {
+        setSelectorMode('profile');
+        const res = await client.getProfiles();
+        setProfiles((res.profiles || []).map((profile) => ({
+          ...profile,
+          selectorMode: 'profile',
+          selectionValue: profile.id,
+        })));
+      }
     } catch (err: any) {
       console.warn('[AgentSelectorSheet] Failed to fetch profiles:', err);
       setError(err?.message || 'Failed to load agents');
@@ -69,7 +94,7 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
     }
   }, [visible, fetchProfiles]);
 
-  const handleSelectProfile = async (profile: Profile) => {
+  const handleSelectProfile = async (profile: SelectableProfile) => {
     if (!hasApiConfig) {
       setProfiles([]);
       setError(missingConfigError);
@@ -83,8 +108,13 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
     setIsSwitching(true);
     try {
       const client = new SettingsApiClient(config.baseUrl, config.apiKey);
-      await client.setCurrentProfile(profile.id);
-      setCurrentProfile(profile);
+      if (profile.selectorMode === 'acp' && profile.selectionValue) {
+        await client.updateSettings({ mainAgentName: profile.selectionValue });
+        setCurrentProfile(toMainAgentProfile({ name: profile.selectionValue, displayName: profile.name }));
+      } else {
+        await client.setCurrentProfile(profile.id);
+        setCurrentProfile(profile);
+      }
       onClose();
     } catch (err: any) {
       console.error('[AgentSelectorSheet] Failed to switch profile:', err);
@@ -94,7 +124,7 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
     }
   };
 
-  const renderProfile = ({ item }: { item: Profile }) => {
+  const renderProfile = ({ item }: { item: SelectableProfile }) => {
     const isSelected = currentProfile?.id === item.id;
     return (
       <TouchableOpacity
@@ -132,7 +162,7 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
       </Pressable>
       <View style={[styles.sheet, { paddingBottom: insets.bottom + spacing.md }]}>
         <View style={styles.handle} />
-        <Text style={styles.title}>Select Agent</Text>
+        <Text style={styles.title}>{selectorMode === 'acp' ? 'Select Main Agent' : 'Select Agent'}</Text>
 
         {isLoading ? (
           <View style={styles.loadingContainer}>
@@ -147,7 +177,9 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
             </TouchableOpacity>
           </View>
         ) : profiles.length === 0 ? (
-          <Text style={styles.emptyText}>No agents available</Text>
+          <Text style={styles.emptyText}>
+            {selectorMode === 'acp' ? 'No ACP agents available' : 'No agents available'}
+          </Text>
         ) : (
           <FlatList
             data={profiles}

--- a/packages/shared/src/connection-recovery.ts
+++ b/packages/shared/src/connection-recovery.ts
@@ -107,6 +107,31 @@ export function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export function normalizeApiBaseUrl(baseUrl: string): string {
+  let normalizedUrl = baseUrl.trim();
+  if (!normalizedUrl) return '';
+
+  const hasScheme = normalizedUrl.startsWith('http://') || normalizedUrl.startsWith('https://');
+  const isLocalAddress = /^(localhost|127\.|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i.test(
+    normalizedUrl.replace(/^https?:\/\//, '')
+  );
+
+  if (!hasScheme) {
+    normalizedUrl = isLocalAddress ? `http://${normalizedUrl}` : `https://${normalizedUrl}`;
+  }
+
+  normalizedUrl = normalizedUrl.replace(/\/+$/, '');
+
+  try {
+    const parsedUrl = new URL(normalizedUrl);
+    const trimmedPath = parsedUrl.pathname.replace(/\/+$/, '');
+    parsedUrl.pathname = !trimmedPath || trimmedPath === '/' ? '/v1' : trimmedPath;
+    return parsedUrl.toString().replace(/\/+$/, '');
+  } catch {
+    return normalizedUrl;
+  }
+}
+
 export type ConnectionCheckResult = {
   success: boolean;
   error?: string;
@@ -160,24 +185,8 @@ export async function checkServerConnection(
   // Trim the API key for use in requests
   const trimmedApiKey = apiKey.trim();
 
-  // Normalize the base URL
-  let normalizedUrl = baseUrl.trim();
-
-  // Check if scheme is already provided
-  const hasScheme = normalizedUrl.startsWith('http://') || normalizedUrl.startsWith('https://');
-
-  // Determine if this is a local address (localhost, 127.x.x.x, 192.168.x.x, 10.x.x.x, etc.)
-  const isLocalAddress = /^(localhost|127\.|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.)/i.test(
-    normalizedUrl.replace(/^https?:\/\//, '')
-  );
-
-  if (!hasScheme) {
-    // Default to http:// for local addresses, https:// for external
-    normalizedUrl = isLocalAddress ? `http://${normalizedUrl}` : `https://${normalizedUrl}`;
-  }
-
-  // Remove trailing slash
-  normalizedUrl = normalizedUrl.replace(/\/+$/, '');
+  // Normalize the base URL, including adding /v1 for root-level OpenAI-compatible endpoints
+  const normalizedUrl = normalizeApiBaseUrl(baseUrl);
 
   // Try the /models endpoint first (OpenAI-compatible)
   const modelsUrl = `${normalizedUrl}/models`;


### PR DESCRIPTION
## Summary
- honor ACP main-agent mode in the mobile remote-server execution path
- normalize mobile remote server base URLs to use the `/v1` API root
- surface ACP main-agent choices consistently in mobile settings, profile context, and the quick selector

## Validation
- `pnpm build:shared`
- `pnpm --filter @dotagents/desktop exec vitest run src/shared/connection-recovery.test.ts src/main/main-agent-selection.test.ts src/main/remote-server.routes.test.ts`
- `pnpm --filter @dotagents/mobile exec tsc --noEmit`
- verified in Expo web that ACP settings are visible/configurable and sending a message works with ACP main mode enabled

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author