### PR TITLE
Fix follow-up startup and agent UI issue batch (#37, #34, #39, #23)

### DIFF
--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -103,7 +103,6 @@ class AgentSessionTracker {
       startTime: Date.now(),
       currentIteration: 0,
       maxIterations: 10,
-      lastActivity: "Starting agent session...",
       isSnoozed: startSnoozed, // Start snoozed by default - no floating panel auto-show
       profileSnapshot, // Capture profile settings at session creation for isolation
     }

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -434,8 +434,9 @@ async function processWithAgentMode(
       return await mcpService.executeToolCall(toolCall, onProgress, true, sessionId, profileSnapshot?.mcpServerConfig)
     }
 
-    // Load previous conversation history if continuing a conversation
-    // IMPORTANT: Load this BEFORE emitting initial progress to ensure consistency
+    // Load previous conversation history if continuing a conversation.
+    // IMPORTANT: Load this BEFORE emitting initial progress to ensure consistency.
+    // Do not block follow-up startup on lazy conversation compaction.
     let previousConversationHistory:
       | Array<{
           role: "user" | "assistant" | "tool"
@@ -448,10 +449,7 @@ async function processWithAgentMode(
 
     if (conversationId) {
       logLLM(`[tipc.ts processWithAgentMode] Loading conversation history for conversationId: ${conversationId}`)
-      // Use loadConversationWithCompaction to automatically compact old conversations on load
-      // Pass sessionId so that compaction summarization can be cancelled by emergency stop
-      const conversation =
-        await conversationService.loadConversationWithCompaction(conversationId, sessionId)
+      const conversation = await conversationService.loadConversation(conversationId)
 
       if (conversation && conversation.messages.length > 0) {
         logLLM(`[tipc.ts processWithAgentMode] Loaded conversation with ${conversation.messages.length} messages`)

--- a/apps/desktop/src/renderer/src/components/agent-processing-view.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-processing-view.tsx
@@ -92,11 +92,6 @@ export function AgentProcessingView({
 
           <Spinner aria-hidden="true" />
           <span className="sr-only">Processing</span>
-
-          {/* Help text showing keyboard shortcut - visually subtle */}
-          <div className="text-[10px] text-muted-foreground/50">
-            Ctrl+Shift+Escape to stop
-          </div>
         </div>
       )}
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1288,12 +1288,16 @@ const formatDelegationStatus = (status: ACPDelegationProgress["status"]): string
 
 const getDelegationSubtitle = (delegation: ACPDelegationProgress, maxLength: number): string => {
   const source = delegation.status === "failed"
-    ? delegation.error ?? delegation.progressMessage ?? delegation.task
+    ? delegation.error ?? delegation.progressMessage
     : delegation.status === "completed"
-      ? delegation.resultSummary ?? delegation.progressMessage ?? delegation.task
-      : delegation.progressMessage ?? delegation.task
+      ? delegation.resultSummary ?? delegation.progressMessage
+      : delegation.progressMessage
 
-  return truncatePreview(source, maxLength) || truncatePreview(delegation.task, maxLength)
+  const conversationPreview = delegation.conversation?.length
+    ? getConversationPreview(delegation.conversation, delegation.agentName, maxLength)
+    : ""
+
+  return truncatePreview(source, maxLength) || conversationPreview || truncatePreview(delegation.task, maxLength)
 }
 
 const getConversationPreview = (
@@ -1622,7 +1626,7 @@ const DelegationBubble: React.FC<{
   delegation: ACPDelegationProgress
   isExpanded?: boolean
   onToggleExpand?: () => void
-}> = ({ delegation, isExpanded = true, onToggleExpand }) => {
+}> = ({ delegation, isExpanded = false, onToggleExpand }) => {
   const { ref: containerRef, isCompact } = useCompactWidth<HTMLDivElement>()
   const [isConversationOpen, setIsConversationOpen] = useState(false)
   const isRunning = delegation.status === 'running' || delegation.status === 'pending' || delegation.status === 'spawning'
@@ -1768,6 +1772,17 @@ const DelegationBubble: React.FC<{
       {/* Content - only shown when expanded */}
       {isExpanded && (
         <div className="px-3 py-3 space-y-3">
+          {/* Collapsible conversation panel - persists after completion */}
+          {hasConversation && (
+            <SubAgentConversationPanel
+              conversation={delegation.conversation!}
+              agentName={delegation.agentName}
+              isOpen={isConversationOpen}
+              onToggle={() => setIsConversationOpen(!isConversationOpen)}
+              isCompact={isCompact}
+            />
+          )}
+
           <div className="space-y-1">
             <div className={cn("text-[11px] font-semibold uppercase tracking-wide", mutedTextColor)}>
               Task
@@ -1811,17 +1826,6 @@ const DelegationBubble: React.FC<{
                 {delegation.error}
               </p>
             </div>
-          )}
-
-          {/* Collapsible conversation panel - persists after completion */}
-          {hasConversation && (
-            <SubAgentConversationPanel
-              conversation={delegation.conversation!}
-              agentName={delegation.agentName}
-              isOpen={isConversationOpen}
-              onToggle={() => setIsConversationOpen(!isConversationOpen)}
-              isCompact={isCompact}
-            />
           )}
 
           {/* Status footer */}
@@ -3206,13 +3210,13 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                           />
                         )
                       } else if (item.kind === "delegation") {
-                        const delegationExpanded = expandedItems[itemKey] ?? true
+                        const delegationExpanded = expandedItems[itemKey] ?? false
                         return (
                           <DelegationBubble
                             key={itemKey}
                             delegation={item.data}
                             isExpanded={delegationExpanded}
-                            onToggleExpand={() => toggleItemExpansion(itemKey, true)}
+                            onToggleExpand={() => toggleItemExpansion(itemKey, false)}
                           />
                         )
                       } else {
@@ -3228,8 +3232,9 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     })}
                   </div>
                 ) : (
-                  <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-                    Initializing...
+                  <div className="flex h-full items-center justify-center">
+                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground/70" aria-hidden="true" />
+                    <span className="sr-only">Loading agent activity</span>
                   </div>
                 )}
               </div>
@@ -3590,13 +3595,13 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     />
                   )
                 } else if (item.kind === "delegation") {
-                  const delegationExpanded = expandedItems[itemKey] ?? true
+                  const delegationExpanded = expandedItems[itemKey] ?? false
                   return (
                     <DelegationBubble
                       key={itemKey}
                       delegation={item.data}
                       isExpanded={delegationExpanded}
-                      onToggleExpand={() => toggleItemExpansion(itemKey, true)}
+                      onToggleExpand={() => toggleItemExpansion(itemKey, false)}
                     />
                   )
                 } else {
@@ -3612,8 +3617,9 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               })}
             </div>
           ) : (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-              Initializing...
+            <div className="flex h-full items-center justify-center">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground/70" aria-hidden="true" />
+              <span className="sr-only">Loading agent activity</span>
             </div>
           )}
         </div>

--- a/apps/desktop/src/renderer/src/components/agent-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-selector.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from "./ui/button"
 
 const STORAGE_KEY = "dotagents-selected-agent"
+const STORAGE_EVENT = "dotagents-selected-agent-changed"
 
 function loadSelectedAgentId(): string | null {
   try {
@@ -36,10 +37,37 @@ function saveSelectedAgentId(agentId: string | null): void {
       localStorage.removeItem(STORAGE_KEY)
     }
   } catch {}
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent<string | null>(STORAGE_EVENT, { detail: agentId }))
+  }
 }
 
 export function useSelectedAgentId(): [string | null, (id: string | null) => void] {
   const [selectedId, setSelectedId] = React.useState<string | null>(() => loadSelectedAgentId())
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return undefined
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) {
+        setSelectedId(event.newValue)
+      }
+    }
+
+    const handleSelectedAgentChanged = (event: Event) => {
+      const customEvent = event as CustomEvent<string | null>
+      setSelectedId(customEvent.detail ?? null)
+    }
+
+    window.addEventListener("storage", handleStorage)
+    window.addEventListener(STORAGE_EVENT, handleSelectedAgentChanged as EventListener)
+
+    return () => {
+      window.removeEventListener("storage", handleStorage)
+      window.removeEventListener(STORAGE_EVENT, handleSelectedAgentChanged as EventListener)
+    }
+  }, [])
 
   const setAndPersist = React.useCallback((id: string | null) => {
     setSelectedId(id)

--- a/apps/desktop/src/renderer/src/components/session-input.tsx
+++ b/apps/desktop/src/renderer/src/components/session-input.tsx
@@ -3,7 +3,9 @@ import { cn } from "@renderer/lib/utils"
 import { Button } from "@renderer/components/ui/button"
 import { Textarea } from "@renderer/components/ui/textarea"
 import { Mic, Send, X, Plus } from "lucide-react"
+import { AgentSelector, useSelectedAgentId } from "./agent-selector"
 import { tipcClient } from "@renderer/lib/tipc-client"
+import type { AgentProfile } from "@shared/types"
 
 interface SessionInputProps {
   onTextSubmit: (text: string) => void
@@ -25,6 +27,7 @@ export function SessionInput({
   onShowTextInputChange,
 }: SessionInputProps) {
   const [internalShowTextInput, setInternalShowTextInput] = useState(false)
+  const [selectedAgentId, setSelectedAgentId] = useSelectedAgentId()
 
   const showTextInput = controlledShowTextInput ?? internalShowTextInput
   const setShowTextInput = (show: boolean) => {
@@ -34,8 +37,41 @@ export function SessionInput({
   const [text, setText] = useState("")
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
-  const handleSubmit = () => {
+  const applySelectedAgentToNextSession = async () => {
+    try {
+      const agents = await tipcClient.getAgentProfiles()
+      const enabledAgents = (agents as AgentProfile[]).filter((agent) => agent.enabled)
+
+      let agentIdToApply: string | null = selectedAgentId
+      if (agentIdToApply) {
+        const selectedAgent = enabledAgents.find((agent) => agent.id === agentIdToApply)
+        if (!selectedAgent) {
+          setSelectedAgentId(null)
+          agentIdToApply = null
+        }
+      }
+
+      if (!agentIdToApply) {
+        const defaultAgent =
+          enabledAgents.find((agent) => agent.isDefault)
+          ?? enabledAgents.find((agent) => agent.name === "main-agent")
+          ?? enabledAgents[0]
+        agentIdToApply = defaultAgent?.id ?? null
+      }
+
+      if (!agentIdToApply) return true
+
+      const result = await tipcClient.setCurrentAgentProfile({ id: agentIdToApply })
+      return !!result?.success
+    } catch {
+      return false
+    }
+  }
+
+  const handleSubmit = async () => {
     if (text.trim() && !isProcessing) {
+      const applied = await applySelectedAgentToNextSession()
+      if (!applied) return
       onTextSubmit(text.trim())
       setText("")
       setShowTextInput(false)
@@ -45,7 +81,7 @@ export function SessionInput({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault()
-      handleSubmit()
+      void handleSubmit()
     } else if (e.key === "Escape") {
       e.preventDefault()
       setText("")
@@ -59,12 +95,22 @@ export function SessionInput({
   }
 
   const handleVoiceClick = async () => {
+    const applied = await applySelectedAgentToNextSession()
+    if (!applied) return
     onVoiceStart()
   }
 
   if (showTextInput) {
     return (
       <div className={cn("flex items-center gap-2 p-3 bg-card border-b", className)}>
+        <div className="flex items-center gap-2 self-start pt-1">
+          <span className="text-[11px] uppercase tracking-wide text-muted-foreground">Agent</span>
+          <AgentSelector
+            selectedAgentId={selectedAgentId}
+            onSelectAgent={setSelectedAgentId}
+            compact
+          />
+        </div>
         <Textarea
           ref={textareaRef}
           value={text}
@@ -78,7 +124,7 @@ export function SessionInput({
         <div className="flex flex-col gap-1">
           <Button
             size="sm"
-            onClick={handleSubmit}
+            onClick={() => { void handleSubmit() }}
             disabled={!text.trim() || isProcessing}
             className="h-8"
           >
@@ -122,8 +168,15 @@ export function SessionInput({
           <span>{isRecording ? "Recording..." : "Voice"}</span>
         </Button>
       </div>
-      <div className="text-sm text-muted-foreground">
-        Start a new agent session
+      <div className="flex items-center gap-2">
+        <div className="text-sm text-muted-foreground">
+          Start a new agent session
+        </div>
+        <AgentSelector
+          selectedAgentId={selectedAgentId}
+          onSelectAgent={setSelectedAgentId}
+          compact
+        />
       </div>
     </div>
   )

--- a/apps/desktop/src/renderer/src/components/text-input-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/text-input-panel.tsx
@@ -6,6 +6,7 @@ import { AgentProcessingView } from "./agent-processing-view"
 import { AgentProgressUpdate } from "../../../shared/types"
 import { useTheme } from "@renderer/contexts/theme-context"
 import { PredefinedPromptsMenu } from "./predefined-prompts-menu"
+import { AgentSelector } from "./agent-selector"
 import { ImagePlus, X } from "lucide-react"
 import {
   buildMessageWithImages,
@@ -16,6 +17,8 @@ import {
 
 interface TextInputPanelProps {
   onSubmit: (text: string) => void
+  selectedAgentId: string | null
+  onSelectAgent: (agentId: string | null) => void
   onCancel: () => void
   isProcessing?: boolean
   agentProgress?: AgentProgressUpdate | null
@@ -30,6 +33,8 @@ export interface TextInputPanelRef {
 
 export const TextInputPanel = forwardRef<TextInputPanelRef, TextInputPanelProps>(({
   onSubmit,
+  selectedAgentId,
+  onSelectAgent,
   onCancel,
   isProcessing = false,
   agentProgress,
@@ -168,12 +173,22 @@ export const TextInputPanel = forwardRef<TextInputPanelRef, TextInputPanelProps>
         />
       ) : (
         <div className="flex flex-1 flex-col gap-2">
-          {continueConversationTitle && (
-            <div className="flex items-center gap-1 px-2 py-0.5 rounded bg-blue-500/10 dark:bg-blue-400/10 text-blue-600 dark:text-blue-400 text-xs">
-              <span className="opacity-70">Continuing:</span>
-              <span className="font-medium truncate max-w-[200px]">{continueConversationTitle}</span>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <span className="modern-text-muted text-[11px] uppercase tracking-wide">Agent</span>
+              <AgentSelector
+                selectedAgentId={selectedAgentId}
+                onSelectAgent={onSelectAgent}
+                compact
+              />
             </div>
-          )}
+            {continueConversationTitle && (
+              <div className="flex items-center gap-1 px-2 py-0.5 rounded bg-blue-500/10 dark:bg-blue-400/10 text-blue-600 dark:text-blue-400 text-xs">
+                <span className="opacity-70">Continuing:</span>
+                <span className="font-medium truncate max-w-[200px]">{continueConversationTitle}</span>
+              </div>
+            )}
+          </div>
           <div className="modern-text-muted flex items-center justify-between text-xs">
             <span>Type your message • Enter to send • Shift+Enter for new line • Esc to cancel</span>
             <div className="flex items-center gap-1">

--- a/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
+++ b/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
@@ -319,8 +319,8 @@ export function TileFollowUpInput({
           variant="ghost"
           className="h-6 w-6 flex-shrink-0"
           disabled={!hasMessageContent || isDisabled}
-          title={isInitializingSession ? "Starting agent session" : isSessionActive && isQueueEnabled ? "Queue message" : "Send follow-up message"}
-          aria-label={isInitializingSession ? "Starting agent session" : isSessionActive && isQueueEnabled ? "Queue message" : "Send follow-up message"}
+          title={isInitializingSession ? "Starting follow-up" : isSessionActive && isQueueEnabled ? "Queue message" : "Send follow-up message"}
+          aria-label={isInitializingSession ? "Starting follow-up" : isSessionActive && isQueueEnabled ? "Queue message" : "Send follow-up message"}
         >
           {isInitializingSession ? (
             <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />

--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -91,7 +91,7 @@ export function Component() {
   const endConversation = useConversationStore((s) => s.endConversation)
 
   // Get currently selected agent for display in waveform recording UI
-  const [selectedAgentId] = useSelectedAgentId()
+  const [selectedAgentId, setSelectedAgentId] = useSelectedAgentId()
   const { data: agents = [] } = useQuery<AgentProfile[]>({
     queryKey: ["agentProfilesPanel"],
     queryFn: () => tipcClient.getAgentProfiles(),
@@ -747,6 +747,40 @@ export function Component() {
   }, [])
 
   const handleTextSubmit = async (text: string) => {
+    try {
+      const agentProfiles = agents.length > 0
+        ? agents
+        : ((await tipcClient.getAgentProfiles()) as AgentProfile[])
+      const enabledAgents = agentProfiles.filter((agent) => agent.enabled)
+
+      let agentIdToApply: string | null = selectedAgentId
+      if (agentIdToApply) {
+        const selectedAgent = enabledAgents.find((agent) => agent.id === agentIdToApply)
+        if (!selectedAgent) {
+          setSelectedAgentId(null)
+          agentIdToApply = null
+        }
+      }
+
+      if (!agentIdToApply) {
+        const defaultAgent =
+          enabledAgents.find((agent) => agent.isDefault)
+          ?? enabledAgents.find((agent) => agent.name === "main-agent")
+          ?? enabledAgents[0]
+        agentIdToApply = defaultAgent?.id ?? null
+      }
+
+      if (agentIdToApply) {
+        const result = await tipcClient.setCurrentAgentProfile({ id: agentIdToApply })
+        if (!result?.success) {
+          throw new Error("setCurrentAgentProfile returned success=false")
+        }
+      }
+    } catch (error) {
+      logUI("[Panel] Failed to apply selected agent before text submit", { selectedAgentId, error })
+      return
+    }
+
     // Capture the conversation ID at submit time - if user explicitly continued a conversation
     // from history, currentConversationId will be set. Otherwise it's null for new inputs.
     const conversationIdForMcp = currentConversationId
@@ -1115,6 +1149,8 @@ export function Component() {
           <TextInputPanel
             ref={textInputPanelRef}
             onSubmit={handleTextSubmit}
+            selectedAgentId={selectedAgentId}
+            onSelectAgent={setSelectedAgentId}
             onCancel={() => {
               setShowTextInput(false)
               tipcClient.clearTextInputState({})

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -231,7 +231,7 @@ export function Component() {
 
   // Auto-dismiss the pending tile synchronously via derived state:
   // When a real session starts for the pending conversation, clear the pending state
-  // so we don't briefly show two tiles (the old pending + the new "Initializing..." session).
+  // so we don't briefly show two tiles for the same conversation.
   useEffect(() => {
     if (hasRealActiveSessionForPending) {
       setPendingConversationId(null)
@@ -245,7 +245,7 @@ export function Component() {
       // completed progress entry for the same conversation to avoid showing
       // duplicate tiles (one pending, one completed) for the same conversation.
       // Also hide new active sessions for the same conversation while pending tile
-      // is still visible, to prevent a phantom "Initializing..." tile alongside
+      // is still visible, to prevent a duplicate loading tile alongside
       // the pending tile that already shows conversation history.
       .filter(([_, progress]) => {
         if (pendingConversationId && progress?.conversationId === pendingConversationId) {
@@ -396,8 +396,8 @@ export function Component() {
         ? [{
             id: `pending-start-${pendingConversationId}`,
             type: "thinking",
-            title: "Initializing session",
-            description: "Starting agent session...",
+            title: "Starting follow-up",
+            description: "Waiting for session updates...",
             status: "in_progress",
             timestamp: pendingContinuationStartedAt,
           }]

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -254,6 +254,7 @@ export default function ChatScreen({ route, navigation }: any) {
   const connectionManager = useConnectionManager();
   const { connectionInfo } = useTunnelConnection();
   const { currentProfile } = useProfile();
+  const currentAgentLabel = currentProfile?.name || 'Default Agent';
   const handsFree = !!config.handsFree;
   const messageQueueEnabled = config.messageQueueEnabled !== false; // default true
   const handsFreeRef = useRef<boolean>(handsFree);
@@ -424,7 +425,7 @@ export default function ChatScreen({ route, navigation }: any) {
           style={{ flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}
           onPress={() => setAgentSelectorVisible(true)}
           accessibilityRole="button"
-          accessibilityLabel={`Current agent: ${currentProfile?.name || 'Default'}. Tap to change.`}
+          accessibilityLabel={`Current agent: ${currentAgentLabel}. Tap to change.`}
           accessibilityHint="Opens agent selection menu"
         >
           <Text style={{ fontSize: 17, fontWeight: '600', color: theme.colors.foreground }}>Chat</Text>
@@ -442,7 +443,7 @@ export default function ChatScreen({ route, navigation }: any) {
               color: theme.colors.primary,
               fontWeight: '500',
             }}>
-              {currentProfile?.name || 'Default'} ▼
+              {currentAgentLabel} ▼
             </Text>
           </View>
         </TouchableOpacity>
@@ -3248,6 +3249,21 @@ export default function ChatScreen({ route, navigation }: any) {
 	              ))}
 	            </ScrollView>
 	          )}
+		          <View style={styles.agentSelectorRow}>
+		            <TouchableOpacity
+		              style={styles.agentSelectorChip}
+		              onPress={() => setAgentSelectorVisible(true)}
+		              activeOpacity={0.8}
+		              accessibilityRole="button"
+		              accessibilityLabel={`Current agent: ${currentAgentLabel}. Tap to change.`}
+		              accessibilityHint="Opens agent selection menu"
+		            >
+		              <Text style={styles.agentSelectorChipLabel}>🤖 Agent</Text>
+		              <Text style={styles.agentSelectorChipValue} numberOfLines={1}>
+		                {currentAgentLabel} ▼
+		              </Text>
+		            </TouchableOpacity>
+		          </View>
 	          {/* Top row: TTS toggle, text input, send button */}
 	          <View style={styles.inputRow}>
 	            <TouchableOpacity
@@ -3425,6 +3441,34 @@ function createStyles(theme: Theme, screenHeight: number) {
       borderTopWidth: theme.hairline,
       borderColor: theme.colors.border,
       backgroundColor: theme.colors.card,
+    },
+    agentSelectorRow: {
+      paddingHorizontal: spacing.sm,
+      paddingTop: spacing.xs,
+      paddingBottom: 2,
+    },
+    agentSelectorChip: {
+      alignSelf: 'flex-start',
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 6,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      backgroundColor: theme.colors.muted,
+    },
+    agentSelectorChipLabel: {
+      fontSize: 11,
+      color: theme.colors.mutedForeground,
+      fontWeight: '600',
+      marginRight: 6,
+    },
+    agentSelectorChipValue: {
+      fontSize: 12,
+      color: theme.colors.primary,
+      fontWeight: '600',
+      maxWidth: 220,
     },
     pendingImagesRow: {
       paddingHorizontal: spacing.sm,


### PR DESCRIPTION
## Summary
- fix follow-up startup so conversation history loads without waiting on compaction first
- clean up remaining misleading desktop loading/initialization copy in the scoped issue surfaces
- make delegated-agent bubbles start more compact/collapsed with recent activity emphasized
- add missing in-flow agent selector / indicator affordances on the remaining desktop and mobile surfaces

## Issue scope
- Targets #37
- Targets #34
- Targets #39
- Targets #23
- Explicitly excludes #25 from this batch

## Current PR status
- PR is open for review
- GitHub currently reports this branch as mergeable clean against `main`
- Static review/verifier pass: the diff looks cohesive for this grouped batch

## Validation status
- Automated desktop checks in this workspace are blocked because local dependencies/tooling are missing (`node_modules`, `@electron-toolkit/tsconfig`, `tsup`)
- Desktop manual runtime validation is still blocked in this workspace because the only live target is stuck on a disconnected settings screen
- Closest accessible mobile validation: `#32` looks ready to close; `#26` and `#33` look good but still ideally want one direct branch-local confirmation before closure

## Remaining before final completion
- complete honest desktop runtime validation for #37 / #34 / #39 / #23
- decide issue closures separately once validation is complete

## Notes
- The PR is intentionally open for review even though validation is incomplete, so reviewers can assess the code while the runtime-validation gap is tracked separately.
- The current implementation branch changes desktop main/runtime surfaces, desktop renderer surfaces, and one mobile chat surface required for the scoped issue batch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author