### PR TITLE
Fix copy buttons on Wayland via Electron clipboard fallback

### DIFF
--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1189,6 +1189,13 @@ export const router = {
       return { success: true }
     }),
 
+  writeClipboard: t.procedure
+    .input<{ text: string }>()
+    .action(async ({ input }) => {
+      clipboard.writeText(input.text ?? "")
+      return { success: true }
+    }),
+
   showContextMenu: t.procedure
     .input<{
       x: number

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -7,6 +7,7 @@ import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
 import { tipcClient } from "@renderer/lib/tipc-client"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { useAgentStore, useConversationStore, useMessageQueue, useIsQueuePaused } from "@renderer/stores"
 import { AudioPlayer } from "@renderer/components/audio-player"
 import { useConfigQuery } from "@renderer/lib/queries"
@@ -248,7 +249,7 @@ const CompactMessage: React.FC<{
   const handleCopyResponse = async (e: React.MouseEvent) => {
     e.stopPropagation()
     try {
-      await navigator.clipboard.writeText(message.content)
+      await copyTextToClipboard(message.content)
       setIsCopied(true)
       // Clear any existing timeout before setting a new one
       if (copyTimeoutRef.current) {
@@ -687,7 +688,7 @@ const ToolExecutionBubble: React.FC<{
 }> = ({ execution, isExpanded, onToggleExpand }) => {
   const copy = async (text: string) => {
     try {
-      await navigator.clipboard?.writeText(text)
+      await copyTextToClipboard(text)
     } catch {}
   }
 
@@ -1385,7 +1386,7 @@ const SubAgentConversationMessage: React.FC<{
   const handleCopy = async (e: React.MouseEvent) => {
     e.stopPropagation()
     try {
-      await navigator.clipboard.writeText(message.content)
+      await copyTextToClipboard(message.content)
       setIsCopied(true)
       if (copyTimeoutRef.current) {
         clearTimeout(copyTimeoutRef.current)
@@ -1525,7 +1526,7 @@ const SubAgentConversationPanel: React.FC<{
       return `[${role}]\n${msg.content}`
     }).join('\n\n---\n\n')
     try {
-      await navigator.clipboard.writeText(fullConversation)
+      await copyTextToClipboard(fullConversation)
     } catch (err) {
       console.error("Failed to copy conversation:", err)
     }

--- a/apps/desktop/src/renderer/src/components/bundle-publish-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/bundle-publish-dialog.tsx
@@ -10,6 +10,7 @@ import { Textarea } from "@renderer/components/ui/textarea"
 import { Badge } from "@renderer/components/ui/badge"
 import { Loader2, Copy, Download, Globe, User, Tag, Info, AlertTriangle, FileJson } from "lucide-react"
 import { tipcClient } from "@renderer/lib/tipc-client"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { buildHubBundleArtifactUrl, slugifyHubCatalogId, type HubPublishSubmission } from "@dotagents/shared"
 import { toast } from "sonner"
 import {
@@ -75,7 +76,7 @@ export function BundlePublishDialog({ open, onOpenChange }: PublishDialogProps) 
     onOpenChange(v)
   }
   const ok = !!(form.name.trim() && form.summary.trim() && form.authorName.trim() && exportableItemsQuery.data)
-  const copy = async (t: string, l: string) => { try { await navigator.clipboard.writeText(t); toast.success(`${l} copied`) } catch { toast.error("Copy failed") } }
+  const copy = async (t: string, l: string) => { try { await copyTextToClipboard(t); toast.success(`${l} copied`) } catch { toast.error("Copy failed") } }
   const generate = async () => {
     setLoading(true)
     try {

--- a/apps/desktop/src/renderer/src/components/session-tile.tsx
+++ b/apps/desktop/src/renderer/src/components/session-tile.tsx
@@ -28,6 +28,7 @@ import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { MessageQueuePanel } from "@renderer/components/message-queue-panel"
 import { useMessageQueue, useIsQueuePaused } from "@renderer/stores"
 import { tipcClient } from "@renderer/lib/tipc-client"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { AudioPlayer } from "@renderer/components/audio-player"
 import { useConfigQuery } from "@renderer/lib/queries"
 import { ttsManager } from "@renderer/lib/tts-manager"
@@ -129,7 +130,7 @@ export function SessionTile({
   const handleCopyMessage = async (e: React.MouseEvent, content: string, messageId: string) => {
     e.stopPropagation()
     try {
-      await navigator.clipboard.writeText(content)
+      await copyTextToClipboard(content)
       setCopiedMessageId(messageId)
       // Clear any existing timeout before setting a new one
       if (copyTimeoutRef.current) {

--- a/apps/desktop/src/renderer/src/lib/clipboard.ts
+++ b/apps/desktop/src/renderer/src/lib/clipboard.ts
@@ -1,0 +1,25 @@
+import { tipcClient } from "@renderer/lib/tipc-client"
+
+/**
+ * Clipboard writes via the renderer API can fail on some Wayland setups.
+ * Fallback to Electron main-process clipboard to keep copy actions working.
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+  let rendererError: unknown = null
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+      return
+    }
+  } catch (error) {
+    rendererError = error
+  }
+
+  try {
+    await tipcClient.writeClipboard({ text })
+  } catch (error) {
+    throw error ?? rendererError ?? new Error("Failed to copy text to clipboard")
+  }
+}
+

--- a/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select"
 import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import type { Config } from "@shared/types"
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
@@ -272,7 +273,12 @@ export function RemoteServerSettingsGroups({
                     size="sm"
                     disabled={streamerMode}
                     title={streamerMode ? "Disabled in Streamer Mode" : undefined}
-                    onClick={() => cfg.remoteServerApiKey && !streamerMode && navigator.clipboard.writeText(cfg.remoteServerApiKey)}
+                    onClick={() => {
+                      if (!cfg.remoteServerApiKey || streamerMode) return
+                      void copyTextToClipboard(cfg.remoteServerApiKey).catch((err) => {
+                        console.error("Failed to copy remote server API key", err)
+                      })
+                    }}
                   >
                     {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy"}
                   </Button>
@@ -390,7 +396,9 @@ export function RemoteServerSettingsGroups({
                             onClick={() => {
                               if (streamerMode) return
                               const deepLink = `dotagents://config?baseUrl=${encodeURIComponent(baseUrl)}&apiKey=${encodeURIComponent(cfg.remoteServerApiKey || "")}`
-                              navigator.clipboard.writeText(deepLink)
+                              void copyTextToClipboard(deepLink).catch((err) => {
+                                console.error("Failed to copy deep link", err)
+                              })
                             }}
                           >
                             {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy Deep Link"}
@@ -653,7 +661,12 @@ export function RemoteServerSettingsGroups({
                           size="sm"
                           disabled={streamerMode}
                           title={streamerMode ? "Disabled in Streamer Mode" : undefined}
-                          onClick={() => !streamerMode && navigator.clipboard.writeText(`${tunnelStatus.url}/v1`)}
+                          onClick={() => {
+                            if (streamerMode) return
+                            void copyTextToClipboard(`${tunnelStatus.url}/v1`).catch((err) => {
+                              console.error("Failed to copy tunnel URL", err)
+                            })
+                          }}
                         >
                           {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy"}
                         </Button>
@@ -693,7 +706,9 @@ export function RemoteServerSettingsGroups({
                               onClick={() => {
                                 if (streamerMode) return
                                 const deepLink = `dotagents://config?baseUrl=${encodeURIComponent(`${tunnelStatus.url}/v1`)}&apiKey=${encodeURIComponent(cfg.remoteServerApiKey || "")}`
-                                navigator.clipboard.writeText(deepLink)
+                                void copyTextToClipboard(deepLink).catch((err) => {
+                                  console.error("Failed to copy tunnel deep link", err)
+                                })
                               }}
                             >
                               {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy Deep Link"}


### PR DESCRIPTION
## What
- Add a new `writeClipboard` tipc route in desktop main process that writes via Electron `clipboard.writeText`
- Add `copyTextToClipboard` helper in renderer that:
  - tries `navigator.clipboard.writeText` first
  - falls back to `tipcClient.writeClipboard` when renderer clipboard is unavailable/fails (common on some Wayland setups)
- Migrate renderer copy actions to use the helper in:
  - `agent-progress.tsx`
  - `session-tile.tsx`
  - `bundle-publish-dialog.tsx`
  - `settings-remote-server.tsx`

## Why
On Wayland, renderer clipboard APIs can fail depending on compositor/permission behavior. Using Electron main-process clipboard as a fallback makes copy buttons reliable.

## Validation
- `pnpm --filter @dotagents/desktop typecheck`

## Files
- `apps/desktop/src/main/tipc.ts`
- `apps/desktop/src/renderer/src/lib/clipboard.ts`
- `apps/desktop/src/renderer/src/components/agent-progress.tsx`
- `apps/desktop/src/renderer/src/components/session-tile.tsx`
- `apps/desktop/src/renderer/src/components/bundle-publish-dialog.tsx`
- `apps/desktop/src/renderer/src/pages/settings-remote-server.tsx`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author