### PR TITLE
Fix unnecessary main-agent delegation for simple repo tasks

### DIFF
--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
+const mockAgentProfileService = {
+  getByRole: vi.fn(() => []),
+  getCurrentProfile: vi.fn(() => undefined),
+}
+
 // Avoid pulling in real ACP/services (can have side effects / require Electron runtime)
 vi.mock("./acp/acp-smart-router", () => ({
   acpSmartRouter: {
@@ -21,15 +26,15 @@ vi.mock("./acp/internal-agent", () => ({
 }))
 
 vi.mock("./agent-profile-service", () => ({
-  agentProfileService: {
-    getByRole: () => [],
-    getCurrentProfile: () => undefined,
-  },
+  agentProfileService: mockAgentProfileService,
 }))
 
 describe("constructSystemPrompt", () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.clearAllMocks()
+    mockAgentProfileService.getByRole.mockReturnValue([])
+    mockAgentProfileService.getCurrentProfile.mockReturnValue(undefined)
   })
 
   it("injects skillsInstructions only once", async () => {
@@ -39,5 +44,26 @@ describe("constructSystemPrompt", () => {
     const prompt = constructSystemPrompt([], undefined, true, undefined, undefined, skills)
 
     expect(prompt.split(skills).length - 1).toBe(1)
+  })
+
+  it("prefers direct execution over mandatory delegation for simple tasks", async () => {
+    mockAgentProfileService.getByRole.mockReturnValue([
+      {
+        id: "augustus",
+        enabled: true,
+        displayName: "augustus",
+        description: "Augment Code's AI coding assistant with native ACP support",
+      },
+    ])
+
+    const { getAgentsPromptAddition } = await import("./system-prompts")
+
+    const prompt = getAgentsPromptAddition()
+
+    expect(prompt).toContain("Prefer doing the work directly")
+    expect(prompt).toContain("Delegate when the user explicitly asks for a specific agent")
+    expect(prompt).toContain("incorporate the result into a complete answer")
+    expect(prompt).not.toContain("ALWAYS delegate")
+    expect(prompt).not.toContain("Only respond directly if NO agent matches")
   })
 })

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -187,11 +187,11 @@ export function getAgentsPromptAddition(excludeAgentId?: string): string {
 
   return `
 DELEGATION RULES (PRIORITY — check BEFORE responding):
-- ALWAYS delegate to a matching agent BEFORE responding or asking for clarification
-- When the user's request matches an agent's description/specialty, delegate immediately
-- When user mentions an agent by name, delegate to that agent
-- Match user intent to agent capabilities — e.g., web browsing tasks go to a web browsing agent
-- Only respond directly if NO agent matches the request
+  - Prefer doing the work directly when you can answer well with your own available tools, especially for simple questions, local lookups, and small tasks
+  - Delegate when the user explicitly asks for a specific agent or when an agent has a clear specialty advantage for the task
+  - Use delegation for substantial specialized work or for independent subtasks that can run in parallel
+  - Match user intent to agent capabilities — e.g., web browsing tasks go to a web browsing agent
+  - After delegating, incorporate the result into a complete answer instead of stopping at raw delegate output
 
 AVAILABLE AGENTS (${delegationTargets.length}):
 ${agentsList}

--- a/langfuse-bug-fix.md
+++ b/langfuse-bug-fix.md
@@ -1,0 +1,31 @@
+# Langfuse Bug Fix Loop Ledger
+
+## Purpose
+Track recent Langfuse sessions/traces inspected so this loop does not repeat the same evidence without new signals.
+
+## Recently inspected
+| Date | Session ID | Trace ID | Outcome | Notes |
+| --- | --- | --- | --- | --- |
+| 2026-03-09 | `conv_1773024143793_v7qtjonjy` | `session_1773024143795_wrbpe7lkn` | Not a product bug | `discord-recap-tweeter-v3` skill file was created after the failed run, so no code fix justified. |
+| 2026-03-09 | `conv_1773028533776_ldsjpjgh5` | `session_1773028533777_0ya0av86q` | Fixed | Main agent over-delegated a simple repo question to `augustus`; user had to correct the system. |
+
+## Iteration notes
+
+### 2026-03-09 - Prompt over-delegation fix
+- Started by reviewing `apps/desktop/OBSERVABILITY.md` and `apps/desktop/DEBUGGING.md`.
+- Dismissed one false lead where a skill genuinely did not exist yet.
+- Chosen issue: mandatory delegation guidance caused a poor first run on a simple repo question.
+
+#### Evidence
+- Scope: Reduce unnecessary delegation in ACP main-agent runs when the task is simple enough to answer directly with available tools.
+- Before evidence: Langfuse trace `session_1773028533777_0ya0av86q` shows the user asked `how does the QA agent work in aloops. will it work for any loop`; the first model step immediately called `delegate_to_agent` for `augustus`. In the same conversation (`conv_1773028533776_ldsjpjgh5`), the user later had to send `Use available tools directly via native function-calling, or provide a complete final answer.` The injected prompt in `apps/desktop/src/main/system-prompts.ts` explicitly said `ALWAYS delegate to a matching agent BEFORE responding` and `Only respond directly if NO agent matches the request`.
+- Change: Updated `apps/desktop/src/main/system-prompts.ts` so delegation guidance prefers direct execution for simple/local tasks, reserves delegation for explicit/specialized/parallel cases, and tells the agent to incorporate delegated results into a complete answer. Added `apps/desktop/src/main/system-prompts.test.ts` coverage for the new wording.
+- After evidence: The delegation prompt no longer contains the mandatory `ALWAYS delegate` / `Only respond directly if NO agent matches` rules, and now contains direct-answer preference plus delegation-result synthesis guidance. Regression test passes against the updated prompt builder.
+- Verification commands/run results: `NODE_PATH="$HOME/Development/dotagents-mono/node_modules" "$HOME/Development/dotagents-mono/node_modules/.bin/vitest" run apps/desktop/src/main/system-prompts.test.ts` → passed (`2 tests`). Initial `pnpm --filter @dotagents/desktop test -- src/main/system-prompts.test.ts` was blocked because this worktree has no local `node_modules`.
+- Blockers/remaining uncertainty: I did not perform a live desktop repro because this iteration only changed prompt text and the worktree lacks a local dependency install. Remaining lead: inspect whether delegated-run output selection should prefer explicit `respond_to_user` content more aggressively when sub-agents do run.
+
+## Next promising leads
+- Sessions where delegated sub-agent output was low quality or not synthesized cleanly by the parent agent
+- Recent traces with tool/generation errors that map to app behavior instead of external provider/network failures
+- Runs that ended without satisfying the user in a single agent execution
+


### PR DESCRIPTION
## Summary
- ship the QA-approved follow-up from `langfuse-bug-fix-loop`
- relax the main-agent system prompt so simple local/repo tasks can be handled directly instead of forcing a specialist handoff first
- add targeted regression coverage for the revised prompt guidance

## Before evidence
- Langfuse trace `session_1773028533777_0ya0av86q` showed a simple repo question about the aloops QA agent being immediately delegated to `augustus`
- the user had to explicitly tell the system to use available tools directly / provide a complete answer
- the detailed investigation notes and trace references are captured in `langfuse-bug-fix.md`

## After evidence
- `apps/desktop/src/main/system-prompts.ts` no longer instructs the main agent to always delegate before responding
- the prompt now prefers direct handling for simple/local tasks while preserving delegation for specialized or parallel work and requiring delegated results to be synthesized into the final answer
- targeted prompt coverage was added in `apps/desktop/src/main/system-prompts.test.ts`

## Verification
- `NODE_PATH="$HOME/Development/dotagents-mono/node_modules" "$HOME/Development/dotagents-mono/node_modules/.bin/vitest" run apps/desktop/src/main/system-prompts.test.ts` ✅
- supporting trace-backed evidence and notes are recorded in `langfuse-bug-fix.md`

## Screenshots / visual evidence
- not applicable for this prompt/runtime behavior change

---
Pull Request prepared from the QA-approved overnight snapshot by Augment Code.
