### PR TITLE
fix(desktop): resume async delegated ACP runs

### DIFF
--- a/apps/desktop/src/main/acp-main-agent.test.ts
+++ b/apps/desktop/src/main/acp-main-agent.test.ts
@@ -7,6 +7,7 @@ const mockOn = vi.fn()
 const mockOff = vi.fn()
 const mockEmitAgentProgress = vi.fn(() => Promise.resolve())
 const mockLoadConversation = vi.fn()
+const mockAddMessageToConversation = vi.fn(() => Promise.resolve())
 let sessionUpdateHandler: ((event: any) => void) | undefined
 
 vi.mock("./acp-service", () => ({
@@ -34,6 +35,7 @@ vi.mock("./emit-agent-progress", () => ({
 vi.mock("./conversation-service", () => ({
   conversationService: {
     loadConversation: mockLoadConversation,
+    addMessageToConversation: mockAddMessageToConversation,
   },
 }))
 
@@ -48,6 +50,7 @@ describe("acp-main-agent", () => {
     sessionUpdateHandler = undefined
 
     mockLoadConversation.mockResolvedValue(undefined)
+    mockAddMessageToConversation.mockResolvedValue(undefined)
     mockGetOrCreateSession.mockResolvedValue("acp-session-1")
     mockSendPrompt.mockResolvedValue({ success: true, response: "done" })
     mockOn.mockImplementation((eventName: string, handler: (event: any) => void) => {
@@ -444,6 +447,52 @@ describe("acp-main-agent", () => {
           toolCalls: [expect.objectContaining({ name: "respond_to_user" })],
         }),
       ]),
+    )
+  })
+
+  it("persists ACP tool-call and tool-result history back to the conversation", async () => {
+    const { processTranscriptWithACPAgent } = await import("./acp-main-agent")
+
+    mockLoadConversation.mockResolvedValue({
+      messages: [{ role: "user", content: "hello", timestamp: 1 }],
+    })
+
+    mockSendPrompt.mockImplementation(async () => {
+      sessionUpdateHandler?.({
+        sessionId: "acp-session-1",
+        toolCall: {
+          toolCallId: "tool-1",
+          title: "Tool: web_search",
+          status: "completed",
+          rawInput: { query: "persist this" },
+          rawOutput: { content: "Found persisted result" },
+        },
+        isComplete: false,
+      })
+
+      return { success: true, response: "done" }
+    })
+
+    await processTranscriptWithACPAgent("hello", {
+      agentName: "test-agent",
+      conversationId: "conversation-1",
+      sessionId: "ui-session-1",
+      runId: 1,
+    })
+
+    expect(mockAddMessageToConversation).toHaveBeenCalledWith(
+      "conversation-1",
+      "",
+      "assistant",
+      [expect.objectContaining({ name: "web_search" })],
+      undefined,
+    )
+    expect(mockAddMessageToConversation).toHaveBeenCalledWith(
+      "conversation-1",
+      '{\n  "content": "Found persisted result"\n}',
+      "tool",
+      undefined,
+      [expect.objectContaining({ success: true, content: '{\n  "content": "Found persisted result"\n}' })],
     )
   })
 })

--- a/apps/desktop/src/main/acp-main-agent.ts
+++ b/apps/desktop/src/main/acp-main-agent.ts
@@ -357,6 +357,27 @@ export async function processTranscriptWithACPAgent(
     logApp(`[ACP Main] Failed to load conversation history: ${err}`)
   }
 
+  let persistedConversationLength = conversationHistory.length
+
+  const persistConversationTail = async () => {
+    if (persistedConversationLength >= conversationHistory.length) {
+      return
+    }
+
+    const tail = conversationHistory.slice(persistedConversationLength)
+    for (const message of tail) {
+      await conversationService.addMessageToConversation(
+        conversationId,
+        message.content,
+        message.role,
+        message.toolCalls,
+        message.toolResults,
+      )
+    }
+
+    persistedConversationLength = conversationHistory.length
+  }
+
   const appendAssistantText = (text: string, timestamp: number) => {
     if (!text) return
     sawAssistantTextBlock = true
@@ -753,6 +774,12 @@ export async function processTranscriptWithACPAgent(
         isStreaming: false,
       })
 
+      try {
+        await persistConversationTail()
+      } catch (persistError) {
+        logApp(`[ACP Main] Failed to persist conversation tail: ${persistError}`)
+      }
+
       logApp(`[ACP Main] Completed - success: ${result.success}, response length: ${finalResponse?.length || 0}`)
 
       return {
@@ -782,6 +809,12 @@ export async function processTranscriptWithACPAgent(
       text: accumulatedText,
       isStreaming: false,
     })
+
+    try {
+      await persistConversationTail()
+    } catch (persistError) {
+      logApp(`[ACP Main] Failed to persist conversation tail after error: ${persistError}`)
+    }
 
     return {
       success: false,

--- a/apps/desktop/src/main/acp/acp-background-notifier.ts
+++ b/apps/desktop/src/main/acp/acp-background-notifier.ts
@@ -2,9 +2,11 @@ import { Notification } from 'electron'
 import { acpClientService } from './acp-client-service'
 import { emitAgentProgress } from '../emit-agent-progress'
 import { agentSessionStateManager } from '../state'
+import { agentSessionTracker } from '../agent-session-tracker'
 import type { ACPDelegationProgress } from '../../shared/types'
 import { logApp } from '../debug'
 import type { ACPSubAgentState } from './types'
+import { INTERNAL_COMPLETION_NUDGE_TEXT } from '../../shared/builtin-tool-names'
 
 /**
  * Background polling and notification system for ACP delegations.
@@ -157,6 +159,7 @@ export class ACPBackgroundNotifier {
       error: state.status === 'failed' ? state.result?.error : undefined,
       acpSessionId: state.acpSessionId,
       subSessionId: state.subSessionId,
+      conversationId: state.conversationId,
       acpRunId: state.acpRunId,
     }
 
@@ -189,6 +192,55 @@ export class ACPBackgroundNotifier {
 
     // Show native OS notification
     this.showSystemNotification(state, resultSummary)
+
+    await this.resumeParentSessionIfNeeded(state)
+  }
+
+  async resumeParentSessionIfNeeded(state: ACPSubAgentState): Promise<void> {
+    if (!state.isAsync || !state.parentSessionId || state.parentResumeQueued) {
+      return
+    }
+
+    const activeParentSession = agentSessionTracker.getSession(state.parentSessionId)
+    if (activeParentSession?.status === 'active') {
+      logApp(
+        `[ACPBackgroundNotifier] Skipping parent resume for ${state.runId}; parent session ${state.parentSessionId} is already active`
+      )
+      return
+    }
+
+    const conversationId = agentSessionTracker.getConversationIdForSession(state.parentSessionId)
+    if (!conversationId) {
+      logApp(
+        `[ACPBackgroundNotifier] Cannot resume parent for ${state.runId}; conversation not found for session ${state.parentSessionId}`
+      )
+      return
+    }
+
+    const revived = agentSessionTracker.reviveSession(state.parentSessionId, true)
+    if (!revived) {
+      logApp(
+        `[ACPBackgroundNotifier] Cannot resume parent for ${state.runId}; failed to revive session ${state.parentSessionId}`
+      )
+      return
+    }
+
+    state.parentResumeQueued = true
+
+    try {
+      const { runAgentLoopSession } = await import('../tipc')
+      await runAgentLoopSession(
+        INTERNAL_COMPLETION_NUDGE_TEXT,
+        conversationId,
+        state.parentSessionId,
+      )
+      logApp(
+        `[ACPBackgroundNotifier] Resumed parent session ${state.parentSessionId} after delegated run ${state.runId}`
+      )
+    } catch (error) {
+      state.parentResumeQueued = false
+      logApp('[ACPBackgroundNotifier] Failed to resume parent session:', error)
+    }
   }
 
   /**

--- a/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
+++ b/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
@@ -59,8 +59,8 @@ export const acpRouterToolDefinitions = [
         },
         waitForResult: {
           type: 'boolean',
-          description: 'Whether to wait for the agent to complete (default: true)',
-          default: true,
+          description: 'Whether to wait for the agent to complete before continuing (default: false/background)',
+          default: false,
         },
       },
       required: ['agentName'],
@@ -174,8 +174,8 @@ export const acpRouterToolDefinitions = [
         },
         waitForResult: {
           type: 'boolean',
-          description: 'Whether to wait for the agent to complete (default: true)',
-          default: true,
+          description: 'Whether to wait for the agent to complete before continuing (default: false/background)',
+          default: false,
         },
       },
       required: ['agentName'],

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -86,6 +86,7 @@ interface CreateSubAgentStateArgs {
   workingDirectory?: string;
   isInternal?: boolean;
   connectionType?: 'internal' | 'acp' | 'stdio' | 'remote';
+  isAsync?: boolean;
 }
 
 /**
@@ -111,6 +112,7 @@ function createSubAgentState(args: CreateSubAgentStateArgs): DelegatedRun {
     status: 'pending',
     startTime: now,
     isInternal: args.isInternal,
+    isAsync: args.isAsync,
     conversation: [userMessage],
     lastEmitTime: 0,
   };
@@ -475,6 +477,7 @@ acpService.on('sessionUpdate', (event: {
     progressMessage: stopReason ? `Stop reason: ${stopReason}` : undefined,
     acpSessionId: subAgentState.acpSessionId,
     subSessionId: subAgentState.subSessionId,
+    conversationId: subAgentState.conversationId,
     acpRunId: subAgentState.acpRunId,
     conversation: prepareConversationForUI(subAgentState.conversation),
   };
@@ -508,6 +511,7 @@ acpService.on('sessionUpdate', (event: {
   // Once the agent reports completion for this session, the mappings are no longer needed.
   // Clean them up to prevent leaks / stale fallbacks affecting future runs.
   if (isComplete) {
+    void acpBackgroundNotifier.resumeParentSessionIfNeeded(subAgentState);
     cleanupDelegationMappings(runId, subAgentState.agentName);
   }
 });
@@ -688,7 +692,7 @@ export async function handleDelegateToAgent(
     prepareOnly,
   };
 
-  const waitForResult = args.waitForResult !== false; // Default to true
+  const waitForResult = args.waitForResult === true; // Default to async/background
 
   // Try unified agent profile lookup first
   const profile = agentProfileService.getByName(normalizedArgs.agentName);
@@ -823,6 +827,7 @@ async function executeInternalAgent(
     workingDirectory: args.workingDirectory,
     isInternal: true,
     connectionType: 'internal',
+    isAsync: !waitForResult,
   });
   subAgentState.status = 'running';
 
@@ -831,8 +836,67 @@ async function executeInternalAgent(
   const preGeneratedSubSessionId = generateSubSessionId();
   subAgentState.subSessionId = preGeneratedSubSessionId;
 
-  // Internal agent always executes synchronously
-  // waitForResult is ignored for internal agent (always waits)
+  if (!waitForResult) {
+    void Promise.resolve()
+      .then(() => runInternalSubSession({
+        task: args.task,
+        context: args.context,
+        parentSessionId,
+        subSessionId: preGeneratedSubSessionId,
+        personaName: args.personaName,
+      }))
+      .then((result) => {
+        subAgentState.conversationId = result.conversationId;
+        subAgentState.conversation = result.conversationHistory.map(msg => ({
+          role: msg.role,
+          content: msg.content,
+          timestamp: msg.timestamp,
+        }));
+
+        if (result.success) {
+          subAgentState.status = 'completed';
+          subAgentState.result = {
+            runId: subAgentState.runId,
+            agentName,
+            status: 'completed',
+            startTime: subAgentState.startTime,
+            endTime: Date.now(),
+            metadata: { duration: result.duration },
+            output: [{ role: 'assistant', parts: [{ content: result.result || '' }] }],
+          };
+        } else {
+          subAgentState.status = result.error === 'Sub-session was cancelled' ? 'cancelled' : 'failed';
+          subAgentState.result = {
+            runId: subAgentState.runId,
+            agentName,
+            status: subAgentState.status,
+            startTime: subAgentState.startTime,
+            endTime: Date.now(),
+            metadata: { duration: result.duration },
+            error: result.error || 'Unknown error',
+          };
+        }
+
+        void acpBackgroundNotifier.resumeParentSessionIfNeeded(subAgentState);
+      })
+      .catch((error) => {
+        const endTime = Date.now();
+        subAgentState.status = 'failed';
+        subAgentState.result = {
+          runId: subAgentState.runId,
+          agentName,
+          status: 'failed',
+          startTime: subAgentState.startTime,
+          endTime,
+          metadata: { duration: endTime - subAgentState.startTime },
+          error: error instanceof Error ? error.message : String(error),
+        };
+        void acpBackgroundNotifier.resumeParentSessionIfNeeded(subAgentState);
+      });
+
+    return createRunningResult(subAgentState);
+  }
+
   try {
     const result = await runInternalSubSession({
       task: args.task,
@@ -841,6 +905,8 @@ async function executeInternalAgent(
       subSessionId: preGeneratedSubSessionId,
       personaName: args.personaName,
     });
+
+    subAgentState.conversationId = result.conversationId;
 
     // Update conversation history in consolidated state
     subAgentState.conversation = result.conversationHistory.map(msg => ({
@@ -991,6 +1057,7 @@ async function executeACPAgent(
       parentSessionId: parentSessionId || `orphaned-${Date.now()}`,
       workingDirectory: args.workingDirectory,
       connectionType: resolvedAgent.connectionType,
+      isAsync: !waitForResult,
     });
     subAgentState.status = 'running';
     registerAgentRunMapping(args.agentName, subAgentState.runId);
@@ -1163,6 +1230,7 @@ function executeStdioAgentAsync(
           error: result.error || 'Unknown error',
         };
       }
+      void acpBackgroundNotifier.resumeParentSessionIfNeeded(subAgentState);
       // Note: Don't cleanup delegation mappings here - the sessionUpdate handler
       // will clean up when isComplete arrives. Early cleanup can cause late
       // session/update notifications to be dropped/misrouted.
@@ -1192,6 +1260,7 @@ function finalizeAsyncRunWithError(
     metadata: { duration: endTime - subAgentState.startTime },
     error: error instanceof Error ? error.message : String(error),
   };
+  void acpBackgroundNotifier.resumeParentSessionIfNeeded(subAgentState);
   // Note: Don't cleanup delegation mappings here - the sessionUpdate handler
   // will clean up when isComplete arrives. Early cleanup can cause late
   // session/update notifications to be dropped/misrouted.
@@ -1512,6 +1581,7 @@ export function getDelegatedRunDetails(runId: string): ACPDelegationProgress | n
     error: state.result?.error,
     acpSessionId: state.acpSessionId,
     subSessionId: state.subSessionId,
+    conversationId: state.conversationId,
     acpRunId: state.acpRunId,
     conversation: [...state.conversation],
   };

--- a/apps/desktop/src/main/acp/internal-agent.ts
+++ b/apps/desktop/src/main/acp/internal-agent.ts
@@ -70,6 +70,8 @@ export interface InternalSubSession {
   error?: string;
   /** Display name for the agent executing this sub-session */
   agentDisplayName?: string;
+  /** DotAgents conversation ID used for stateful agent context */
+  conversationId?: string;
   /** Conversation history for this sub-session */
   conversationHistory: Array<{
     role: 'user' | 'assistant' | 'tool';
@@ -224,6 +226,7 @@ function emitSubSessionDelegationProgress(
     resultSummary: subSession.result?.substring(0, 200),
     error: subSession.error,
     subSessionId: subSession.id,
+    conversationId: subSession.conversationId,
     conversation,
   };
 
@@ -294,6 +297,7 @@ export interface RunSubSessionOptions {
 export interface SubSessionResult {
   success: boolean;
   subSessionId: string;
+  conversationId?: string;
   result?: string;
   error?: string;
   conversationHistory: InternalSubSession['conversationHistory'];
@@ -604,6 +608,8 @@ export async function runInternalSubSession(
     const effectiveSubSessionMaxIterations = maxIterations
       ?? (cfg.mcpUnlimitedIterations ? Infinity : (cfg.mcpMaxIterations ?? DEFAULT_SUB_SESSION_MAX_ITERATIONS));
 
+    subSession.conversationId = conversationId;
+
     const result = await processTranscriptWithAgentMode(
       fullPrompt,
       availableTools,
@@ -666,6 +672,7 @@ export async function runInternalSubSession(
       return {
         success: false,
         subSessionId,
+        conversationId: subSession.conversationId,
         error: 'Sub-session was cancelled',
         conversationHistory: subSession.conversationHistory,
         duration: Date.now() - subSession.startTime,
@@ -677,6 +684,7 @@ export async function runInternalSubSession(
     return {
       success: true,
       subSessionId,
+      conversationId: subSession.conversationId,
       result: getPreferredDelegationOutput(result.content, subSession.conversationHistory),
       conversationHistory: subSession.conversationHistory,
       duration: Date.now() - subSession.startTime,
@@ -695,6 +703,7 @@ export async function runInternalSubSession(
     return {
       success: false,
       subSessionId,
+      conversationId: subSession.conversationId,
       error: subSession.error,
       conversationHistory: subSession.conversationHistory,
       duration: Date.now() - subSession.startTime,

--- a/apps/desktop/src/main/acp/types.ts
+++ b/apps/desktop/src/main/acp/types.ts
@@ -164,12 +164,18 @@ export interface ACPSubAgentState {
   acpRunId?: string;
   /** Local ACP session ID for stdio/acp-backed delegated sessions */
   acpSessionId?: string;
+  /** DotAgents conversation ID for internal/stateful delegated sessions */
+  conversationId?: string;
   /** Base URL for the agent (needed for status checks) */
   baseUrl?: string;
   /** Whether this is an internal sub-agent (not external ACP) */
   isInternal?: boolean;
   /** The internal sub-session ID (for internal agents, used for cancellation) */
   subSessionId?: string;
+  /** Whether this delegation was launched asynchronously */
+  isAsync?: boolean;
+  /** Guards against resuming the parent session more than once */
+  parentResumeQueued?: boolean;
 }
 
 // NOTE: ACPAgentConfig is defined in shared/types.ts and should be imported from there.

--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -290,6 +290,19 @@ class AgentSessionTracker {
   }
 
   /**
+   * Get the conversation ID for a session, including completed sessions.
+   */
+  getConversationIdForSession(sessionId: string): string | undefined {
+    const activeSession = this.sessions.get(sessionId)
+    if (activeSession) {
+      return activeSession.conversationId
+    }
+
+    const completedSession = this.completedSessions.find(session => session.id === sessionId)
+    return completedSession?.conversationId
+  }
+
+  /**
    * Find a session by conversationId (active or completed)
    * Returns the session ID if found, undefined otherwise
    */

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -943,7 +943,8 @@ export async function processTranscriptWithAgentMode(
   const userMessageAlreadyExists = previousConversationHistory?.some(
     msg => msg.role === "user" && msg.content === transcript
   ) ?? false
-  if (!userMessageAlreadyExists) {
+  const shouldPersistInitialUserMessage = transcript !== INTERNAL_COMPLETION_NUDGE_TEXT
+  if (!userMessageAlreadyExists && shouldPersistInitialUserMessage) {
     saveMessageIncremental("user", transcript).catch(err => {
       logLLM("[processTranscriptWithAgentMode] Failed to save initial user message:", err)
     })

--- a/apps/desktop/src/renderer/src/stores/agent-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AgentProgressUpdate } from '@shared/types'
+import { useAgentStore } from './agent-store'
+
+const createBaseUpdate = (): AgentProgressUpdate => ({
+  sessionId: 'session-1',
+  runId: 1,
+  conversationId: 'parent-conversation',
+  currentIteration: 1,
+  maxIterations: 1,
+  isComplete: false,
+  steps: [],
+  conversationHistory: [],
+})
+
+describe('agent-store delegation merge', () => {
+  beforeEach(() => {
+    useAgentStore.setState({
+      agentProgressById: new Map(),
+      focusedSessionId: null,
+      scrollToSessionId: null,
+      messageQueuesByConversation: new Map(),
+      pausedQueueConversations: new Set(),
+      viewMode: 'grid',
+      filter: 'all',
+      sortBy: 'recent',
+      pinnedSessionIds: new Set(),
+    })
+  })
+
+  it('preserves delegation conversationId when later updates omit it', () => {
+    useAgentStore.getState().updateSessionProgress({
+      ...createBaseUpdate(),
+      steps: [
+        {
+          id: 'delegation-1',
+          type: 'completion',
+          title: 'Delegation',
+          status: 'in_progress',
+          timestamp: 1,
+          delegation: {
+            runId: 'delegated-run-1',
+            agentName: 'internal',
+            task: 'Do work',
+            status: 'running',
+            startTime: 1,
+            conversationId: 'delegated-conversation-1',
+          },
+        },
+      ],
+    })
+
+    useAgentStore.getState().updateSessionProgress({
+      ...createBaseUpdate(),
+      steps: [
+        {
+          id: 'delegation-1',
+          type: 'completion',
+          title: 'Delegation finished',
+          status: 'completed',
+          timestamp: 2,
+          delegation: {
+            runId: 'delegated-run-1',
+            agentName: 'internal',
+            task: 'Do work',
+            status: 'completed',
+            startTime: 1,
+            endTime: 2,
+          },
+        },
+      ],
+    })
+
+    const stored = useAgentStore.getState().agentProgressById.get('session-1')
+    const delegation = stored?.steps?.[0]?.delegation
+
+    expect(delegation?.status).toBe('completed')
+    expect(delegation?.conversationId).toBe('delegated-conversation-1')
+  })
+})
+

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -146,7 +146,19 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             // Merge delegation steps: new ones override existing ones with same runId
             const mergedDelegationSteps = new Map(existingDelegationSteps)
             for (const [runId, step] of newDelegationSteps) {
-              mergedDelegationSteps.set(runId, step)
+              const existingStep = mergedDelegationSteps.get(runId)
+              if (existingStep?.delegation || step.delegation) {
+                mergedDelegationSteps.set(runId, {
+                  ...existingStep,
+                  ...step,
+                  delegation: {
+                    ...existingStep?.delegation,
+                    ...step.delegation,
+                  },
+                })
+              } else {
+                mergedDelegationSteps.set(runId, step)
+              }
             }
 
             // Use new non-delegation steps if available, otherwise keep existing

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -158,6 +158,8 @@ export interface ACPDelegationProgress {
   acpSessionId?: string
   /** Internal DotAgents sub-session ID for internal delegations */
   subSessionId?: string
+  /** DotAgents conversation ID for internal/stateful delegated sessions */
+  conversationId?: string
   /** Remote ACP run ID for externally-managed async delegations */
   acpRunId?: string
   /** Full conversation history from the sub-agent */


### PR DESCRIPTION
## Summary
- default ACP delegation to background/async execution, including internal agent delegations
- resume the parent desktop session after async delegated runs complete and avoid persisting the internal completion nudge as a user message
- persist ACP tool-call/tool-result history and preserve delegated conversation metadata in the renderer store

## Testing
- `pnpm --filter @dotagents/desktop exec vitest run src/main/acp-main-agent.test.ts src/renderer/src/stores/agent-store.test.ts`
- `pnpm --filter @dotagents/desktop typecheck`

## Notes
- PR branch was created from `main` in an isolated worktree so unrelated local workspace edits were not included.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author