### PR TITLE
Add pinned sessions for quick access

### DIFF
--- a/apps/desktop/src/main/config.ts
+++ b/apps/desktop/src/main/config.ts
@@ -178,6 +178,7 @@ const getConfig = (): LoadedConfig => {
     conversationsEnabled: true,
     maxConversationsToKeep: 100,
     autoSaveConversations: true,
+    pinnedSessionIds: [],
     // Settings hotkey defaults
     settingsHotkeyEnabled: true,
     settingsHotkey: "ctrl-shift-s",

--- a/apps/desktop/src/renderer/src/components/past-sessions-dialog.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/past-sessions-dialog.layout.test.ts
@@ -31,7 +31,7 @@ describe("past sessions dialog layout", () => {
     )
   })
 
-  it("keeps per-session delete affordances keyboard-accessible", () => {
+  it("keeps per-session row actions keyboard-accessible", () => {
     expect(pastSessionsDialogSource).toContain(
       'focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
     )
@@ -42,8 +42,18 @@ describe("past sessions dialog layout", () => {
       'group-hover:opacity-0 group-focus-within:opacity-0',
     )
     expect(pastSessionsDialogSource).toContain(
-      'focus-visible:opacity-100 focus-visible:pointer-events-auto group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto',
+      'group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto',
+    )
+    expect(pastSessionsDialogSource).toContain(
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
     )
     expect(pastSessionsDialogSource).toContain('aria-label={`Delete ${session.title}`}')
+  })
+
+  it("includes a keyboard-accessible pin action and pinned-first sort for past sessions", () => {
+    expect(pastSessionsDialogSource).toContain("orderConversationHistoryByPinnedFirst")
+    expect(pastSessionsDialogSource).toContain("return orderConversationHistoryByPinnedFirst(filteredSessions, pinnedSessionIds)")
+    expect(pastSessionsDialogSource).toContain('aria-label={`${isPinned ? "Unpin" : "Pin"} ${session.title}`}')
+    expect(pastSessionsDialogSource).toContain('onKeyDown={stopSessionRowKeyPropagation}')
   })
 })

--- a/apps/desktop/src/renderer/src/components/past-sessions-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/past-sessions-dialog.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
 import dayjs from "dayjs"
-import { AlertTriangle, CheckCircle2, Clock, Loader2, Search, Trash2 } from "lucide-react"
+import { AlertTriangle, CheckCircle2, Clock, Loader2, Pin, Search, Trash2 } from "lucide-react"
 
 import { cn } from "@renderer/lib/utils"
+import { orderConversationHistoryByPinnedFirst } from "@renderer/lib/pinned-session-history"
 import { useConversationHistoryQuery, useDeleteConversationMutation, useDeleteAllConversationsMutation } from "@renderer/lib/queries"
 import { Input } from "@renderer/components/ui/input"
 import { Button } from "@renderer/components/ui/button"
@@ -11,11 +12,11 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@renderer/components/ui/dialog"
 import { toast } from "sonner"
+import { useAgentStore } from "@renderer/stores"
 
 const INITIAL_PAST_SESSIONS = 20
 
@@ -48,6 +49,8 @@ export function PastSessionsDialog({
   const conversationHistoryQuery = useConversationHistoryQuery(open)
   const deleteConversationMutation = useDeleteConversationMutation()
   const deleteAllConversationsMutation = useDeleteAllConversationsMutation()
+  const pinnedSessionIds = useAgentStore((state) => state.pinnedSessionIds)
+  const togglePinSession = useAgentStore((state) => state.togglePinSession)
 
   const [searchQuery, setSearchQuery] = useState("")
   const [pastSessionsCount, setPastSessionsCount] = useState(
@@ -70,13 +73,16 @@ export function PastSessionsDialog({
   const filteredPastSessions = useMemo(() => {
     const all = conversationHistoryQuery.data ?? []
     const q = searchQuery.trim().toLowerCase()
-    if (!q) return all
-    return all.filter(
-      (session) =>
-        session.title.toLowerCase().includes(q) ||
-        session.preview.toLowerCase().includes(q),
-    )
-  }, [conversationHistoryQuery.data, searchQuery])
+    const filteredSessions = !q
+      ? all
+      : all.filter(
+        (session) =>
+          session.title.toLowerCase().includes(q) ||
+          session.preview.toLowerCase().includes(q),
+      )
+
+    return orderConversationHistoryByPinnedFirst(filteredSessions, pinnedSessionIds)
+  }, [conversationHistoryQuery.data, searchQuery, pinnedSessionIds])
 
   const visiblePastSessions = useMemo(
     () => filteredPastSessions.slice(0, pastSessionsCount),
@@ -98,6 +104,15 @@ export function PastSessionsDialog({
       console.error("Failed to delete session:", error)
       toast.error("Failed to delete session")
     }
+  }
+
+  const handleTogglePinnedSession = (conversationId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    togglePinSession(conversationId)
+  }
+
+  const stopSessionRowKeyPropagation = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
   }
 
   const handleDeleteAll = async () => {
@@ -194,55 +209,73 @@ export function PastSessionsDialog({
               </p>
             ) : (
               <>
-                {visiblePastSessions.map((session) => (
-                  <div
-                    key={session.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => handleOpenPastSession(session.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault()
-                        handleOpenPastSession(session.id)
-                      }
-                    }}
-                    className={cn(
-                      "group flex w-full cursor-pointer items-start gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",
-                      "hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                    )}
-                    title={`${session.preview}\n${dayjs(session.updatedAt).format("MMM D, h:mm A")}`}
-                  >
-                    <CheckCircle2 className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
-                    <div className="min-w-0 flex-1 overflow-hidden">
-                      <div className="flex flex-wrap items-start gap-2">
-                        <span className="min-w-0 flex-1 truncate font-medium">
-                          {session.title}
-                        </span>
-                        <div className="ml-auto grid shrink-0 place-items-center self-start">
-                          {/* Timestamp shown by default, replaced by delete button on hover or keyboard focus */}
-                          <span className="text-muted-foreground col-start-1 row-start-1 text-[10px] tabular-nums transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
-                            {formatTimestamp(session.updatedAt)}
-                          </span>
-                          <button
-                            type="button"
-                            onClick={(e) => handleDeleteSession(session.id, e)}
-                            disabled={deleteConversationMutation.isPending}
-                            className="col-start-1 row-start-1 rounded p-0.5 opacity-0 pointer-events-none transition-all hover:bg-destructive/20 hover:text-destructive focus-visible:opacity-100 focus-visible:pointer-events-auto group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
-                            title="Delete session"
-                            aria-label={`Delete ${session.title}`}
-                          >
-                            <Trash2 className="h-3.5 w-3.5" />
-                          </button>
-                        </div>
-                      </div>
-                      {session.preview && (
-                        <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed break-words [overflow-wrap:anywhere]">
-                          {session.preview}
-                        </p>
+                {visiblePastSessions.map((session) => {
+                  const isPinned = pinnedSessionIds.has(session.id)
+
+                  return (
+                    <div
+                      key={session.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => handleOpenPastSession(session.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault()
+                          handleOpenPastSession(session.id)
+                        }
+                      }}
+                      className={cn(
+                        "group flex w-full cursor-pointer items-start gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors",
+                        "hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                       )}
+                      title={`${session.preview}\n${dayjs(session.updatedAt).format("MMM D, h:mm A")}`}
+                    >
+                      <CheckCircle2 className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                      <div className="min-w-0 flex-1 overflow-hidden">
+                        <div className="flex flex-wrap items-start gap-2">
+                          <span className="min-w-0 flex-1 truncate font-medium">
+                            {session.title}
+                          </span>
+                          <div className="ml-auto grid shrink-0 place-items-center self-start">
+                            {/* Timestamp shown by default, replaced by row actions on hover or keyboard focus */}
+                            <span className="text-muted-foreground col-start-1 row-start-1 text-[10px] tabular-nums transition-opacity group-hover:opacity-0 group-focus-within:opacity-0">
+                              {formatTimestamp(session.updatedAt)}
+                            </span>
+                            <div className="col-start-1 row-start-1 flex items-center gap-0.5 opacity-0 pointer-events-none transition-all group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto">
+                              <button
+                                type="button"
+                                onClick={(e) => handleTogglePinnedSession(session.id, e)}
+                                onKeyDown={stopSessionRowKeyPropagation}
+                                className="rounded p-0.5 hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                                title={isPinned ? "Unpin session" : "Pin session"}
+                                aria-label={`${isPinned ? "Unpin" : "Pin"} ${session.title}`}
+                                aria-pressed={isPinned}
+                              >
+                                <Pin className={cn("h-3.5 w-3.5", isPinned && "fill-current text-foreground")} />
+                              </button>
+                              <button
+                                type="button"
+                                onClick={(e) => handleDeleteSession(session.id, e)}
+                                onKeyDown={stopSessionRowKeyPropagation}
+                                disabled={deleteConversationMutation.isPending}
+                                className="rounded p-0.5 hover:bg-destructive/20 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                                title="Delete session"
+                                aria-label={`Delete ${session.title}`}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                        {session.preview && (
+                          <p className="text-muted-foreground mt-0.5 line-clamp-2 text-xs leading-relaxed break-words [overflow-wrap:anywhere]">
+                            {session.preview}
+                          </p>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  )
+                })}
 
                 {hasMorePastSessions && (
                   <button

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type EffectRecord = {
+  deps?: any[]
+  nextDeps?: any[]
+  callback?: () => void | (() => void)
+  cleanup?: void | (() => void)
+  hasRun: boolean
+}
+
+function createHookRuntime() {
+  const refs: Array<{ current: any }> = []
+  const effects: EffectRecord[] = []
+  let refIndex = 0
+  let effectIndex = 0
+
+  const useRef = <T,>(initial: T) => {
+    const idx = refIndex++
+    if (!refs[idx]) refs[idx] = { current: initial }
+    return refs[idx] as { current: T }
+  }
+
+  const depsChanged = (prev: any[] | undefined, next: any[] | undefined) => {
+    if (prev === undefined || next === undefined) return true
+    if (prev.length !== next.length) return true
+    for (let i = 0; i < prev.length; i += 1) {
+      if (!Object.is(prev[i], next[i])) return true
+    }
+    return false
+  }
+
+  const useEffect = (callback: EffectRecord['callback'], deps?: any[]) => {
+    const idx = effectIndex++
+    const record = effects[idx] ?? { hasRun: false }
+    record.callback = callback
+    record.nextDeps = deps
+    effects[idx] = record
+  }
+
+  const render = (hook: () => void) => {
+    refIndex = 0
+    effectIndex = 0
+    hook()
+  }
+
+  const commitEffects = () => {
+    for (const record of effects) {
+      if (!record?.callback) continue
+      const shouldRun = !record.hasRun || depsChanged(record.deps, record.nextDeps)
+      if (!shouldRun) continue
+      if (typeof record.cleanup === 'function') record.cleanup()
+      record.cleanup = record.callback()
+      record.deps = record.nextDeps
+      record.hasRun = true
+    }
+  }
+
+  const cleanupAllEffects = () => {
+    for (const record of effects) {
+      if (typeof record?.cleanup === 'function') record.cleanup()
+    }
+  }
+
+  const reactMock = { __esModule: true, default: {} as any, useEffect, useRef }
+  reactMock.default = reactMock
+
+  return { render, commitEffects, cleanupAllEffects, reactMock }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+const flushPromises = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useStoreSync pinned session persistence', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('hydrates pinned session ids from config without immediately re-saving them', async () => {
+    const runtime = createHookRuntime()
+    const storeState = createAgentStoreState()
+    const loaded = await loadUseStoreSync(runtime, storeState, { pinnedSessionIds: ['session-1', 'session-2'] })
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+    await flushPromises()
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    expect(storeState.setPinnedSessionIds).toHaveBeenCalledWith(['session-1', 'session-2'])
+    expect(loaded.tipcClient.saveConfig).not.toHaveBeenCalled()
+
+    runtime.cleanupAllEffects()
+  })
+
+  it('persists pinned session id updates after hydration completes', async () => {
+    const runtime = createHookRuntime()
+    const storeState = createAgentStoreState()
+    const loaded = await loadUseStoreSync(runtime, storeState, { pinnedSessionIds: ['session-1'] })
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+    await flushPromises()
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    storeState.pinnedSessionIds = new Set(['session-1', 'session-2'])
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+    await flushPromises()
+
+    expect(loaded.tipcClient.saveConfig).toHaveBeenCalledWith({
+      config: { pinnedSessionIds: ['session-1', 'session-2'] },
+    })
+
+    const updateCachedConfig = loaded.queryClient.setQueryData.mock.calls[0]?.[1]
+    expect(updateCachedConfig({ themePreference: 'dark' })).toEqual({
+      themePreference: 'dark',
+      pinnedSessionIds: ['session-1', 'session-2'],
+    })
+
+    runtime.cleanupAllEffects()
+  })
+
+  it('does not let late hydration overwrite a local pin toggle', async () => {
+    const runtime = createHookRuntime()
+    const storeState = createAgentStoreState()
+    const deferredConfig = createDeferred<{ pinnedSessionIds: string[] }>()
+    const loaded = await loadUseStoreSync(runtime, storeState, deferredConfig.promise)
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    storeState.pinnedSessionIds = new Set(['local-session'])
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    deferredConfig.resolve({ pinnedSessionIds: ['persisted-session'] })
+    await flushPromises()
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+    await flushPromises()
+
+    expect(storeState.setPinnedSessionIds).toHaveBeenCalledWith(['local-session'])
+    expect(storeState.pinnedSessionIds).toEqual(new Set(['local-session']))
+    expect(loaded.tipcClient.saveConfig).toHaveBeenCalledWith({
+      config: { pinnedSessionIds: ['local-session'] },
+    })
+
+    runtime.cleanupAllEffects()
+  })
+
+  it('does not let late hydration restore stale pins after a pre-hydration toggle cycle', async () => {
+    const runtime = createHookRuntime()
+    const storeState = createAgentStoreState()
+    const deferredConfig = createDeferred<{ pinnedSessionIds: string[] }>()
+    const loaded = await loadUseStoreSync(runtime, storeState, deferredConfig.promise)
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    storeState.pinnedSessionIds = new Set(['temporary-session'])
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    storeState.pinnedSessionIds = new Set()
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    deferredConfig.resolve({ pinnedSessionIds: ['persisted-session'] })
+    await flushPromises()
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+    await flushPromises()
+
+    expect(storeState.setPinnedSessionIds).not.toHaveBeenCalledWith(['persisted-session'])
+    expect(storeState.setPinnedSessionIds).toHaveBeenCalledWith([])
+    expect(storeState.pinnedSessionIds).toEqual(new Set())
+    expect(loaded.tipcClient.saveConfig).toHaveBeenCalledWith({
+      config: { pinnedSessionIds: [] },
+    })
+
+    runtime.cleanupAllEffects()
+  })
+})
+
+function createAgentStoreState() {
+  const state = {
+    updateSessionProgress: vi.fn(),
+    clearAllProgress: vi.fn(),
+    clearSessionProgress: vi.fn(),
+    clearInactiveSessions: vi.fn(),
+    setFocusedSessionId: vi.fn(),
+    setScrollToSessionId: vi.fn(),
+    updateMessageQueue: vi.fn(),
+    pinnedSessionIds: new Set<string>(),
+    setPinnedSessionIds: vi.fn((sessionIds: Iterable<string>) => {
+      state.pinnedSessionIds = new Set(sessionIds)
+    }),
+  }
+
+  return state
+}
+
+async function loadUseStoreSync(
+  runtime: ReturnType<typeof createHookRuntime>,
+  storeState: ReturnType<typeof createAgentStoreState>,
+  config: Promise<{ pinnedSessionIds: string[] }> | { pinnedSessionIds: string[] },
+) {
+  const listen = vi.fn(() => vi.fn())
+  const tipcClient = {
+    getAllMessageQueues: vi.fn().mockResolvedValue([]),
+    getConfig: vi.fn().mockImplementation(() => Promise.resolve(config)),
+    saveConfig: vi.fn().mockResolvedValue(undefined),
+  }
+  const queryClient = {
+    fetchQuery: vi.fn(({ queryFn }: { queryFn: () => Promise<unknown> }) => queryFn()),
+    invalidateQueries: vi.fn(),
+    setQueryData: vi.fn(),
+  }
+  const conversationStore = {
+    markConversationCompleted: vi.fn(),
+  }
+  const reportConfigSaveError = vi.fn()
+
+  vi.doMock('react', () => runtime.reactMock)
+  vi.doMock('@renderer/lib/tipc-client', () => ({
+    __esModule: true,
+    tipcClient,
+    rendererHandlers: {
+      agentProgressUpdate: { listen },
+      clearAgentProgress: { listen },
+      clearAgentSessionProgress: { listen },
+      clearInactiveSessions: { listen },
+      stopAllTts: { listen },
+      focusAgentSession: { listen },
+      onMessageQueueUpdate: { listen },
+      conversationHistoryChanged: { listen },
+    },
+  }))
+  vi.doMock('@renderer/stores', () => ({
+    __esModule: true,
+    useAgentStore: Object.assign(
+      (selector: (state: typeof storeState) => unknown) => selector(storeState),
+      {
+        getState: () => storeState,
+      },
+    ),
+    useConversationStore: (selector: (state: typeof conversationStore) => unknown) => selector(conversationStore),
+  }))
+  vi.doMock('@renderer/lib/queries', () => ({ __esModule: true, queryClient }))
+  vi.doMock('@renderer/lib/tts-manager', () => ({
+    __esModule: true,
+    ttsManager: { getAudioCount: vi.fn(() => 0), stopAll: vi.fn() },
+  }))
+  vi.doMock('@renderer/lib/debug', () => ({ __esModule: true, logUI: vi.fn() }))
+  vi.doMock('@renderer/lib/config-save-error', () => ({ __esModule: true, reportConfigSaveError }))
+
+  const module = await import('./use-store-sync')
+  return { useStoreSync: module.useStoreSync, tipcClient, queryClient, reportConfigSaveError }
+}

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -1,10 +1,19 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
+import { reportConfigSaveError } from '@renderer/lib/config-save-error'
 import { rendererHandlers, tipcClient } from '@renderer/lib/tipc-client'
 import { useAgentStore, useConversationStore } from '@renderer/stores'
 import { AgentProgressUpdate, QueuedMessage } from '@shared/types'
 import { queryClient } from '@renderer/lib/queries'
 import { ttsManager } from '@renderer/lib/tts-manager'
 import { logUI } from '@renderer/lib/debug'
+
+const areStringArraysEqual = (left: string[], right: string[]): boolean => {
+  if (left.length !== right.length) return false
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) return false
+  }
+  return true
+}
 
 export function useStoreSync() {
   const updateSessionProgress = useAgentStore((s) => s.updateSessionProgress)
@@ -14,7 +23,13 @@ export function useStoreSync() {
   const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
   const setScrollToSessionId = useAgentStore((s) => s.setScrollToSessionId)
   const updateMessageQueue = useAgentStore((s) => s.updateMessageQueue)
+  const pinnedSessionIds = useAgentStore((s) => s.pinnedSessionIds)
+  const setPinnedSessionIds = useAgentStore((s) => s.setPinnedSessionIds)
   const markConversationCompleted = useConversationStore((s) => s.markConversationCompleted)
+  const initialPinnedSessionIdsRef = useRef(Array.from(pinnedSessionIds))
+  const pinnedSessionIdsHydratedRef = useRef(false)
+  const pinnedSessionIdsChangedBeforeHydrationRef = useRef(false)
+  const lastPersistedPinnedSessionIdsRef = useRef<string[]>([])
 
   useEffect(() => {
     const unlisten = rendererHandlers.agentProgressUpdate.listen(
@@ -104,6 +119,84 @@ export function useStoreSync() {
       // Silently ignore hydration failures
     })
   }, [])
+
+  useEffect(() => {
+    if (pinnedSessionIdsHydratedRef.current) return
+
+    const currentPinnedSessionIds = Array.from(pinnedSessionIds)
+    if (!areStringArraysEqual(currentPinnedSessionIds, initialPinnedSessionIdsRef.current)) {
+      pinnedSessionIdsChangedBeforeHydrationRef.current = true
+    }
+  }, [pinnedSessionIds])
+
+  useEffect(() => {
+    let cancelled = false
+
+    queryClient.fetchQuery<{ pinnedSessionIds?: string[] }>({
+      queryKey: ['config'],
+      queryFn: async () => tipcClient.getConfig(),
+    }).then((config) => {
+      if (cancelled) return
+
+      const nextPinnedSessionIds = Array.isArray(config?.pinnedSessionIds)
+        ? config.pinnedSessionIds.filter((sessionId): sessionId is string => typeof sessionId === 'string')
+        : []
+
+      lastPersistedPinnedSessionIdsRef.current = nextPinnedSessionIds
+      pinnedSessionIdsHydratedRef.current = true
+
+      if (pinnedSessionIdsChangedBeforeHydrationRef.current) {
+        setPinnedSessionIds(Array.from(useAgentStore.getState().pinnedSessionIds))
+        return
+      }
+
+      setPinnedSessionIds(nextPinnedSessionIds)
+    }).catch(() => {
+      if (cancelled) return
+
+      pinnedSessionIdsHydratedRef.current = true
+
+      if (pinnedSessionIdsChangedBeforeHydrationRef.current) {
+        setPinnedSessionIds(Array.from(useAgentStore.getState().pinnedSessionIds))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [setPinnedSessionIds])
+
+  useEffect(() => {
+    if (!pinnedSessionIdsHydratedRef.current) return
+
+    const nextPinnedSessionIds = Array.from(pinnedSessionIds)
+    if (areStringArraysEqual(nextPinnedSessionIds, lastPersistedPinnedSessionIdsRef.current)) {
+      return
+    }
+
+    let cancelled = false
+
+    tipcClient.saveConfig({
+      config: {
+        pinnedSessionIds: nextPinnedSessionIds,
+      },
+    }).then(() => {
+      if (cancelled) return
+
+      lastPersistedPinnedSessionIdsRef.current = nextPinnedSessionIds
+      queryClient.setQueryData(['config'], (previousConfig: Record<string, unknown> | undefined) => ({
+        ...(previousConfig ?? {}),
+        pinnedSessionIds: nextPinnedSessionIds,
+      }))
+    }).catch((error) => {
+      if (cancelled) return
+      reportConfigSaveError(error)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [pinnedSessionIds])
 
   // Listen for conversation history changes from remote server (mobile sync)
   // This ensures the sidebar refreshes when conversations are created/updated remotely

--- a/apps/desktop/src/renderer/src/lib/pinned-session-history.test.ts
+++ b/apps/desktop/src/renderer/src/lib/pinned-session-history.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import type { ConversationHistoryItem } from "@shared/types"
+
+import { orderConversationHistoryByPinnedFirst } from "./pinned-session-history"
+
+const createSession = (id: string, updatedAt: number): ConversationHistoryItem => ({
+  id,
+  title: id,
+  createdAt: updatedAt - 100,
+  updatedAt,
+  messageCount: 1,
+  lastMessage: "",
+  preview: "",
+})
+
+describe("orderConversationHistoryByPinnedFirst", () => {
+  it("moves pinned sessions ahead while preserving each group's existing order", () => {
+    const sessions = [
+      createSession("session-4", 40),
+      createSession("session-3", 30),
+      createSession("session-2", 20),
+      createSession("session-1", 10),
+    ]
+
+    const ordered = orderConversationHistoryByPinnedFirst(
+      sessions,
+      new Set(["session-3", "session-1"]),
+    )
+
+    expect(ordered.map((session) => session.id)).toEqual([
+      "session-3",
+      "session-1",
+      "session-4",
+      "session-2",
+    ])
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/pinned-session-history.ts
+++ b/apps/desktop/src/renderer/src/lib/pinned-session-history.ts
@@ -1,0 +1,23 @@
+import type { ConversationHistoryItem } from "@shared/types"
+
+export function orderConversationHistoryByPinnedFirst(
+  sessions: ConversationHistoryItem[],
+  pinnedSessionIds: ReadonlySet<string>,
+): ConversationHistoryItem[] {
+  if (sessions.length <= 1 || pinnedSessionIds.size === 0) {
+    return sessions
+  }
+
+  const pinnedSessions: ConversationHistoryItem[] = []
+  const unpinnedSessions: ConversationHistoryItem[] = []
+
+  for (const session of sessions) {
+    if (pinnedSessionIds.has(session.id)) {
+      pinnedSessions.push(session)
+    } else {
+      unpinnedSessions.push(session)
+    }
+  }
+
+  return [...pinnedSessions, ...unpinnedSessions]
+}

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -6,13 +6,14 @@ import { useAgentStore, useAgentSessionProgress } from "@renderer/stores"
 import { SessionGrid, SessionTileWrapper, type TileLayoutMode } from "@renderer/components/session-grid"
 import { clearPersistedSize } from "@renderer/hooks/use-resizable"
 import { AgentProgress } from "@renderer/components/agent-progress"
-import { MessageCircle, Mic, Plus, CheckCircle2, LayoutGrid, Maximize2, Grid2x2, Keyboard, Clock, Loader2 } from "lucide-react"
+import { MessageCircle, Mic, Plus, CheckCircle2, LayoutGrid, Maximize2, Grid2x2, Keyboard, Clock, Loader2, Pin } from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
 import type { AgentProfile, AgentProgressUpdate } from "@shared/types"
 import { toast } from "sonner"
 
 import { applySelectedAgentToNextSession as applySelectedAgentForNextSession } from "@renderer/lib/apply-selected-agent"
 import { logUI } from "@renderer/lib/debug"
+import { orderConversationHistoryByPinnedFirst } from "@renderer/lib/pinned-session-history"
 import { PredefinedPromptsMenu } from "@renderer/components/predefined-prompts-menu"
 import { AgentSelector, useSelectedAgentId } from "@renderer/components/agent-selector"
 import { useConfigQuery } from "@renderer/lib/query-client"
@@ -154,11 +155,26 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
   onSelectAgent: (id: string | null) => void
 }) {
   const conversationHistoryQuery = useConversationHistoryQuery()
+  const pinnedSessionIds = useAgentStore((state) => state.pinnedSessionIds)
+  const togglePinSession = useAgentStore((state) => state.togglePinSession)
+  const sortedRecentSessions = useMemo(
+    () => orderConversationHistoryByPinnedFirst(conversationHistoryQuery.data ?? [], pinnedSessionIds),
+    [conversationHistoryQuery.data, pinnedSessionIds],
+  )
   const recentSessions = useMemo(
-    () => (conversationHistoryQuery.data ?? []).slice(0, RECENT_SESSIONS_LIMIT),
-    [conversationHistoryQuery.data],
+    () => sortedRecentSessions.slice(0, RECENT_SESSIONS_LIMIT),
+    [sortedRecentSessions],
   )
   const totalCount = conversationHistoryQuery.data?.length ?? 0
+
+  const handleTogglePinnedSession = useCallback((conversationId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    togglePinSession(conversationId)
+  }, [togglePinSession])
+
+  const stopSessionRowKeyPropagation = useCallback((e: React.KeyboardEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+  }, [])
 
   return (
     <div className="flex w-full flex-col items-center px-5 py-6 text-center sm:px-6">
@@ -228,19 +244,44 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
             )}
           </div>
           <div className="space-y-0.5">
-            {recentSessions.map((session) => (
-              <button
-                key={session.id}
-                onClick={() => onPastSessionClick(session.id)}
-                className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left transition-colors hover:bg-accent/50"
-              >
-                <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate flex-1">{session.title}</span>
-                <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
-                  {formatTimestamp(session.updatedAt)}
-                </span>
-              </button>
-            ))}
+            {recentSessions.map((session) => {
+              const isPinned = pinnedSessionIds.has(session.id)
+
+              return (
+                <div
+                  key={session.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onPastSessionClick(session.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
+                      onPastSessionClick(session.id)
+                    }
+                  }}
+                  className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left transition-colors hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate flex-1">{session.title}</span>
+                  <div className="ml-auto flex shrink-0 items-center gap-1">
+                    <button
+                      type="button"
+                      onClick={(e) => handleTogglePinnedSession(session.id, e)}
+                      onKeyDown={stopSessionRowKeyPropagation}
+                      className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                      title={isPinned ? "Unpin session" : "Pin session"}
+                      aria-label={`${isPinned ? "Unpin" : "Pin"} ${session.title}`}
+                      aria-pressed={isPinned}
+                    >
+                      <Pin className={isPinned ? "h-3.5 w-3.5 fill-current text-foreground" : "h-3.5 w-3.5"} />
+                    </button>
+                    <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+                      {formatTimestamp(session.updatedAt)}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
           </div>
         </div>
       )}

--- a/apps/desktop/src/renderer/src/stores/agent-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.test.ts
@@ -77,5 +77,13 @@ describe('agent-store delegation merge', () => {
     expect(delegation?.status).toBe('completed')
     expect(delegation?.conversationId).toBe('delegated-conversation-1')
   })
+
+  it('replaces pinned session ids during hydration', () => {
+    useAgentStore.getState().togglePinSession('session-1')
+
+    useAgentStore.getState().setPinnedSessionIds(['session-2', 'session-2', 'session-3'])
+
+    expect(Array.from(useAgentStore.getState().pinnedSessionIds)).toEqual(['session-2', 'session-3'])
+  })
 })
 

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -54,6 +54,7 @@ interface AgentState {
   setViewMode: (mode: SessionViewMode) => void
   setFilter: (filter: SessionFilter) => void
   setSortBy: (sortBy: SessionSortBy) => void
+  setPinnedSessionIds: (sessionIds: Iterable<string>) => void
   togglePinSession: (sessionId: string) => void
   isPinned: (sessionId: string) => boolean
 }
@@ -431,6 +432,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   setSortBy: (sortBy: SessionSortBy) => {
     set({ sortBy })
+  },
+
+  setPinnedSessionIds: (sessionIds: Iterable<string>) => {
+    set({ pinnedSessionIds: new Set(sessionIds) })
   },
 
   togglePinSession: (sessionId: string) => {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1378,6 +1378,9 @@ export type Config = {
   maxConversationsToKeep?: number
   autoSaveConversations?: boolean
 
+  // Session History Configuration
+  pinnedSessionIds?: string[]
+
   // Provider Section Collapse Configuration
   providerSectionCollapsedOpenai?: boolean
   providerSectionCollapsedGroq?: boolean

--- a/apps/desktop/tests/sessions-empty-state-density.test.mjs
+++ b/apps/desktop/tests/sessions-empty-state-density.test.mjs
@@ -22,3 +22,10 @@ test('desktop sessions empty state keeps secondary controls and recent sessions 
   assert.match(sessionsSource, /flex flex-wrap items-center justify-center gap-2\.5 text-xs text-muted-foreground/)
   assert.match(sessionsSource, /mt-6 w-full max-w-md text-left/)
 })
+
+test('desktop sessions empty state recent list supports pinning and pinned-first ordering', () => {
+  assert.match(sessionsSource, /orderConversationHistoryByPinnedFirst/)
+  assert.match(sessionsSource, /sortedRecentSessions\.slice\(0, RECENT_SESSIONS_LIMIT\)/)
+  assert.match(sessionsSource, /aria-label=\{`\$\{isPinned \? "Unpin" : "Pin"\} \$\{session\.title\}`\}/)
+  assert.match(sessionsSource, /onKeyDown=\{stopSessionRowKeyPropagation\}/)
+})


### PR DESCRIPTION
## Summary
- add persistent pinned session IDs to desktop config/store sync
- add pin/unpin controls and pinned-first ordering to desktop past-session surfaces
- add targeted regression coverage for pinned session ordering and hydration behavior

## Testing
- `node --test apps/desktop/tests/sessions-empty-state-density.test.mjs`
- `git diff --check`
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/hooks/use-store-sync.test.ts src/renderer/src/components/past-sessions-dialog.layout.test.ts tests/sessions-empty-state-density.test.mjs` *(blocked locally: missing `node_modules` / `vitest`)*
- `pnpm --filter @dotagents/desktop typecheck` *(blocked locally: missing dependencies in workspace)*

Closes #70

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author