### PR TITLE
Fix hands-free wake-word gating after toggle off

### DIFF
--- a/apps/mobile/src/lib/voice/useHandsFreeController.test.ts
+++ b/apps/mobile/src/lib/voice/useHandsFreeController.test.ts
@@ -1,5 +1,92 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createInitialHandsFreeState, resolveHandsFreeUtterance } from './useHandsFreeController';
+
+type EffectRecord = {
+  callback?: () => void | (() => void);
+  deps?: any[];
+  nextDeps?: any[];
+  cleanup?: void | (() => void);
+  hasRun: boolean;
+};
+
+function createHookRuntime() {
+  const states: any[] = [];
+  const refs: Array<{ current: any }> = [];
+  const effects: EffectRecord[] = [];
+  let stateIndex = 0;
+  let refIndex = 0;
+  let effectIndex = 0;
+
+  const depsChanged = (prev?: any[], next?: any[]) => !prev
+    || !next
+    || prev.length !== next.length
+    || prev.some((value, index) => !Object.is(value, next[index]));
+
+  const useState = <T,>(initial: T | (() => T)) => {
+    const idx = stateIndex++;
+    if (states[idx] === undefined) states[idx] = typeof initial === 'function' ? (initial as () => T)() : initial;
+    return [states[idx] as T, (update: T | ((prev: T) => T)) => {
+      states[idx] = typeof update === 'function' ? (update as (prev: T) => T)(states[idx]) : update;
+    }] as const;
+  };
+
+  const useRef = <T,>(initial: T) => {
+    const idx = refIndex++;
+    refs[idx] ??= { current: initial };
+    return refs[idx] as { current: T };
+  };
+
+  const useEffect = (callback: () => void | (() => void), deps?: any[]) => {
+    const idx = effectIndex++;
+    const record = effects[idx] ?? { hasRun: false };
+    record.callback = callback;
+    record.nextDeps = deps;
+    effects[idx] = record;
+  };
+
+  const reactMock: any = {
+    __esModule: true,
+    default: {} as any,
+    useState,
+    useRef,
+    useEffect,
+    useCallback: (fn: any) => fn,
+    useMemo: (factory: () => any) => factory(),
+  };
+  reactMock.default = reactMock;
+
+  return {
+    render<P, Result>(hook: (props: P) => Result, props: P) {
+      stateIndex = 0;
+      refIndex = 0;
+      effectIndex = 0;
+      return hook(props);
+    },
+    commitEffects() {
+      for (const record of effects) {
+        if (!record?.callback) continue;
+        const shouldRun = !record.hasRun || depsChanged(record.deps, record.nextDeps);
+        if (!shouldRun) continue;
+        if (typeof record.cleanup === 'function') record.cleanup();
+        record.cleanup = record.callback();
+        record.deps = record.nextDeps;
+        record.hasRun = true;
+      }
+    },
+    reactMock,
+  };
+}
+
+async function loadUseHandsFreeController(runtime: ReturnType<typeof createHookRuntime>) {
+  vi.resetModules();
+  vi.doMock('react', () => runtime.reactMock);
+  return import('./useHandsFreeController');
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.unmock('react');
+});
 
 describe('resolveHandsFreeUtterance', () => {
   it('keeps sleeping when no wake phrase is present', () => {
@@ -69,5 +156,37 @@ describe('resolveHandsFreeUtterance', () => {
 
     expect(result.action).toEqual({ type: 'send', text: 'summarize my unread email' });
     expect(result.nextState.phase).toBe('processing');
+  });
+
+  it('resets controller state when hands-free is disabled after waking up', async () => {
+    const runtime = createHookRuntime();
+    const { useHandsFreeController: useHook } = await loadUseHandsFreeController(runtime);
+    const options = {
+      runtimeActive: true,
+      wakePhrase: 'hey dot agents',
+      sleepPhrase: 'go to sleep',
+    };
+
+    let controller = runtime.render(useHook, { ...options, enabled: true });
+    runtime.commitEffects();
+    controller = runtime.render(useHook, { ...options, enabled: true });
+
+    expect(controller.shouldKeepRecognizerActive).toBe(true);
+
+    expect(controller.handleFinalTranscript('hey dot agents what is the weather')).toEqual({
+      type: 'send',
+      text: 'what is the weather',
+    });
+
+    controller = runtime.render(useHook, { ...options, enabled: true });
+    expect(controller.state.phase).toBe('processing');
+    expect(controller.state.resumePhase).toBe('listening');
+
+    controller = runtime.render(useHook, { ...options, enabled: false, runtimeActive: false });
+    runtime.commitEffects();
+    controller = runtime.render(useHook, { ...options, enabled: false, runtimeActive: false });
+
+    expect(controller.state).toEqual(createInitialHandsFreeState());
+    expect(controller.shouldKeepRecognizerActive).toBe(false);
   });
 });

--- a/apps/mobile/src/lib/voice/useHandsFreeController.ts
+++ b/apps/mobile/src/lib/voice/useHandsFreeController.ts
@@ -423,6 +423,10 @@ export function useHandsFreeController(options: HandsFreeControllerOptions) {
     log?.('recognizer-error', 'Speech recognizer error.', { message });
   }, [log, repeatedErrorThreshold, updateState]);
 
+  const reset = useCallback(() => {
+    updateState(() => createInitialHandsFreeState());
+  }, [updateState]);
+
   const resetError = useCallback(() => {
     updateState((prev) => ({
       ...prev,
@@ -454,6 +458,7 @@ export function useHandsFreeController(options: HandsFreeControllerOptions) {
     onRecognizerError,
     pauseByUser,
     resumeByUser,
+    reset,
     resetError,
   } as const;
 }

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -316,10 +316,12 @@ export default function ChatScreen({ route, navigation }: any) {
 
   const toggleHandsFree = async () => {
     const next = !handsFreeRef.current;
+	    handsFreeRef.current = next;
     const nextCfg = { ...config, handsFree: next } as any;
     setConfig(nextCfg);
     try { await saveConfig(nextCfg); } catch {}
     if (!next) {
+	      handsFreeController.reset();
       void stopRecognitionOnly?.();
       Speech.stop();
       setDebugInfo('Handsfree mode turned off.');
@@ -669,13 +671,15 @@ export default function ChatScreen({ route, navigation }: any) {
 				return;
 			}
 
-			if (mode === 'handsfree') {
-				const action = handsFreeController.handleFinalTranscript(finalText);
-				if (action.type === 'send') {
-					void sendRef.current(action.text);
+				if (mode === 'handsfree') {
+					if (handsFreeRef.current) {
+						const action = handsFreeController.handleFinalTranscript(finalText);
+						if (action.type === 'send') {
+							void sendRef.current(action.text);
+						}
+						return;
+					}
 				}
-				return;
-			}
 
 			void sendRef.current(finalText);
 		},

--- a/apps/mobile/tests/chat-screen-handsfree-density.test.js
+++ b/apps/mobile/tests/chat-screen-handsfree-density.test.js
@@ -22,6 +22,15 @@ test('wires ChatScreen through the extracted handsfree controller and recognizer
   assert.match(screenSource, /handlePushToTalkPressOut/);
 });
 
+test('resets the handsfree controller before shutting down recognizer state when toggled off', () => {
+  assert.match(screenSource, /const next = !handsFreeRef\.current;\s*handsFreeRef\.current = next;/);
+  assert.match(screenSource, /if \(!next\) \{[\s\S]*?handsFreeController\.reset\(\);[\s\S]*?void stopRecognitionOnly\?\.\(\);[\s\S]*?Speech\.stop\(\);[\s\S]*?Handsfree mode turned off\./);
+});
+
+test('falls back to normal direct-send handling for stale handsfree finalizations after toggle-off', () => {
+  assert.match(screenSource, /if \(mode === 'handsfree'\) \{\s*if \(handsFreeRef\.current\) \{[\s\S]*?handsFreeController\.handleFinalTranscript\(finalText\);[\s\S]*?return;\s*\}\s*\}\s*void sendRef\.current\(finalText\);/);
+});
+
 test('surfaces recent voice debug events in chat when internal diagnostics are enabled', () => {
   assert.match(screenSource, /handsFreeDebugEnabled && voiceEvents\.length > 0/);
   assert.match(screenSource, /formatVoiceDebugEntry\(entry\)/);


### PR DESCRIPTION
## Summary
- fix the mobile Chat hands-free toggle-off path so stale hands-free finalizations do not remain wake-word gated
- reset the hands-free controller when the toggle is turned off and keep normal non-hands-free dictation behavior intact
- add focused regression coverage for the controller disable path and chat-screen wiring

## Testing
- `pnpm --filter @dotagents/mobile exec node --test tests/chat-screen-handsfree-density.test.js` ✅
- `pnpm --filter @dotagents/mobile exec vitest run src/lib/voice/useHandsFreeController.test.ts` ⚠️ blocked in this workspace because mobile dependencies/node_modules are unavailable
- static review + verifier review found no remaining acceptance-criteria blockers

Closes #81

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author