### PR TITLE
Improve mobile stub chat recovery flow

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -53,9 +53,8 @@ import { MarkdownRenderer } from '../ui/MarkdownRenderer';
 import { AgentSelectorSheet } from '../ui/AgentSelectorSheet';
 import {
   StubSessionNotice,
-  activateStubSessionNotice,
+  createChatScreenStubSessionNoticeActionModel,
   createStubSessionCredentialsNotice,
-  getStubSessionNoticeViewModel,
   resolveStubSessionLazyLoad,
 } from './chat-stub-session-notice';
 import {
@@ -2791,8 +2790,12 @@ export default function ChatScreen({ route, navigation }: any) {
   const activeStubSessionNotice = stubSessionNotice && stubSessionNotice.sessionId === sessionStore.currentSessionId
     ? stubSessionNotice
     : null;
-  const activeStubSessionNoticeViewModel = activeStubSessionNotice
-    ? getStubSessionNoticeViewModel(activeStubSessionNotice)
+  const activeStubSessionNoticeAction = activeStubSessionNotice
+    ? createChatScreenStubSessionNoticeActionModel(activeStubSessionNotice, {
+        navigate: (screenName) => navigation.navigate(screenName),
+        setMessages,
+        loadStubSessionMessages,
+      })
     : null;
 
 
@@ -3194,7 +3197,7 @@ export default function ChatScreen({ route, navigation }: any) {
               <Text style={styles.connectionBannerIcon}>⚠️</Text>
               <View style={styles.connectionBannerTextContainer}>
                 <Text style={styles.connectionBannerText}>
-                  {activeStubSessionNoticeViewModel?.title}
+                  {activeStubSessionNoticeAction?.title}
                 </Text>
                 <Text style={styles.connectionBannerSubtext}>
                   {activeStubSessionNotice.message}
@@ -3202,22 +3205,14 @@ export default function ChatScreen({ route, navigation }: any) {
               </View>
               <TouchableOpacity
                 style={styles.retryButton}
-                onPress={() => {
-                  activateStubSessionNotice(activeStubSessionNotice, {
-                    openConnectionSettings: () => navigation.navigate('ConnectionSettings'),
-                    clearMessages: () => setMessages([]),
-                    retryLoad: (sessionId) => {
-                      void loadStubSessionMessages(sessionId);
-                    },
-                  });
-                }}
+                onPress={activeStubSessionNoticeAction?.onPress}
                 accessibilityRole="button"
-                accessibilityLabel={activeStubSessionNoticeViewModel?.accessibilityLabel}
-                accessibilityHint={activeStubSessionNoticeViewModel?.accessibilityHint}
+                accessibilityLabel={activeStubSessionNoticeAction?.accessibilityLabel}
+                accessibilityHint={activeStubSessionNoticeAction?.accessibilityHint}
                 activeOpacity={0.7}
               >
                 <Text style={styles.retryButtonText}>
-                  {activeStubSessionNoticeViewModel?.actionLabel}
+                  {activeStubSessionNoticeAction?.actionLabel}
                 </Text>
               </TouchableOpacity>
             </View>

--- a/apps/mobile/src/screens/chat-stub-session-notice.ts
+++ b/apps/mobile/src/screens/chat-stub-session-notice.ts
@@ -57,6 +57,30 @@ export const getStubSessionNoticeViewModel = (notice: StubSessionNotice) => {
   };
 };
 
+export const createChatScreenStubSessionNoticeActionModel = (
+  notice: StubSessionNotice,
+  handlers: {
+    navigate: (screenName: 'ConnectionSettings') => void;
+    setMessages: (messages: ChatMessage[]) => void;
+    loadStubSessionMessages: (sessionId: string) => Promise<void> | void;
+  },
+) => {
+  const viewModel = getStubSessionNoticeViewModel(notice);
+
+  return {
+    ...viewModel,
+    onPress: () => {
+      activateStubSessionNotice(notice, {
+        openConnectionSettings: () => handlers.navigate('ConnectionSettings'),
+        clearMessages: () => handlers.setMessages([]),
+        retryLoad: (sessionId) => {
+          void handlers.loadStubSessionMessages(sessionId);
+        },
+      });
+    },
+  };
+};
+
 export const activateStubSessionNotice = (
   notice: StubSessionNotice,
   handlers: {

--- a/apps/mobile/tests/chat-stub-session-state.test.js
+++ b/apps/mobile/tests/chat-stub-session-state.test.js
@@ -1,7 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
+
+const chatScreenSource = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'screens', 'ChatScreen.tsx'),
+  'utf8'
+);
 
 const helperModuleUrl = pathToFileURL(
   path.join(__dirname, '..', 'src', 'screens', 'chat-stub-session-notice.ts')
@@ -9,34 +15,38 @@ const helperModuleUrl = pathToFileURL(
 
 const loadStubSessionHelpers = () => import(helperModuleUrl);
 
-test('builds the connection-settings notice and routes its action to settings', async () => {
+test('builds the ChatScreen connection-settings notice action model and routes press to settings', async () => {
   const {
-    activateStubSessionNotice,
+    createChatScreenStubSessionNoticeActionModel,
     createStubSessionCredentialsNotice,
-    getStubSessionNoticeViewModel,
   } = await loadStubSessionHelpers();
 
   const notice = createStubSessionCredentialsNotice('stub-credentials');
-  const viewModel = getStubSessionNoticeViewModel(notice);
-  let openedSettings = 0;
+  const openedScreens = [];
+  const setMessagesCalls = [];
   const retriedSessionIds = [];
 
-  activateStubSessionNotice(notice, {
-    openConnectionSettings: () => {
-      openedSettings += 1;
+  const actionModel = createChatScreenStubSessionNoticeActionModel(notice, {
+    navigate: (screenName) => {
+      openedScreens.push(screenName);
     },
-    retryLoad: (sessionId) => {
+    setMessages: (messages) => {
+      setMessagesCalls.push(messages);
+    },
+    loadStubSessionMessages: (sessionId) => {
       retriedSessionIds.push(sessionId);
     },
   });
 
+  actionModel.onPress();
+
   assert.deepEqual(
     {
-      title: viewModel.title,
+      title: actionModel.title,
       message: notice.message,
-      actionLabel: viewModel.actionLabel,
-      accessibilityLabel: viewModel.accessibilityLabel,
-      accessibilityHint: viewModel.accessibilityHint,
+      actionLabel: actionModel.actionLabel,
+      accessibilityLabel: actionModel.accessibilityLabel,
+      accessibilityHint: actionModel.accessibilityHint,
     },
     {
       title: 'Synced chat needs connection settings',
@@ -46,41 +56,43 @@ test('builds the connection-settings notice and routes its action to settings', 
       accessibilityHint: 'Opens connection settings so this mobile app can load synced chat history.',
     }
   );
-  assert.equal(openedSettings, 1);
+  assert.deepEqual(openedScreens, ['ConnectionSettings']);
+  assert.deepEqual(setMessagesCalls, []);
   assert.deepEqual(retriedSessionIds, []);
 });
 
-test('builds the retry notice and routes its action back into stub-session loading', async () => {
+test('builds the ChatScreen retry notice action model and routes press to clear and reload', async () => {
   const {
-    activateStubSessionNotice,
+    createChatScreenStubSessionNoticeActionModel,
     createStubSessionLoadFailedNotice,
-    getStubSessionNoticeViewModel,
   } = await loadStubSessionHelpers();
 
   const notice = createStubSessionLoadFailedNotice('stub-retry');
-  const viewModel = getStubSessionNoticeViewModel(notice);
-  let clearedMessages = 0;
+  const openedScreens = [];
+  const setMessagesCalls = [];
   const retriedSessionIds = [];
 
-  activateStubSessionNotice(notice, {
-    openConnectionSettings: () => {
-      throw new Error('retry notice should not open settings');
+  const actionModel = createChatScreenStubSessionNoticeActionModel(notice, {
+    navigate: (screenName) => {
+      openedScreens.push(screenName);
     },
-    clearMessages: () => {
-      clearedMessages += 1;
+    setMessages: (messages) => {
+      setMessagesCalls.push(messages);
     },
-    retryLoad: (sessionId) => {
+    loadStubSessionMessages: (sessionId) => {
       retriedSessionIds.push(sessionId);
     },
   });
 
+  actionModel.onPress();
+
   assert.deepEqual(
     {
-      title: viewModel.title,
+      title: actionModel.title,
       message: notice.message,
-      actionLabel: viewModel.actionLabel,
-      accessibilityLabel: viewModel.accessibilityLabel,
-      accessibilityHint: viewModel.accessibilityHint,
+      actionLabel: actionModel.actionLabel,
+      accessibilityLabel: actionModel.accessibilityLabel,
+      accessibilityHint: actionModel.accessibilityHint,
     },
     {
       title: 'Couldn’t load synced chat history',
@@ -90,8 +102,20 @@ test('builds the retry notice and routes its action back into stub-session loadi
       accessibilityHint: 'Attempts to load the current synced chat history from desktop again.',
     }
   );
-  assert.equal(clearedMessages, 1);
+  assert.deepEqual(openedScreens, []);
+  assert.deepEqual(setMessagesCalls, [[]]);
   assert.deepEqual(retriedSessionIds, ['stub-retry']);
+});
+
+test('ChatScreen uses the ChatScreen stub-session action model for the rendered banner button', () => {
+  assert.match(
+    chatScreenSource,
+    /const activeStubSessionNoticeAction = activeStubSessionNotice[\s\S]*?createChatScreenStubSessionNoticeActionModel\(activeStubSessionNotice, \{[\s\S]*?navigate: \(screenName\) => navigation\.navigate\(screenName\),[\s\S]*?setMessages,[\s\S]*?loadStubSessionMessages,[\s\S]*?\}\)/
+  );
+  assert.match(chatScreenSource, /onPress=\{activeStubSessionNoticeAction\?\.onPress\}/);
+  assert.match(chatScreenSource, /accessibilityLabel=\{activeStubSessionNoticeAction\?\.accessibilityLabel\}/);
+  assert.match(chatScreenSource, /accessibilityHint=\{activeStubSessionNoticeAction\?\.accessibilityHint\}/);
+  assert.match(chatScreenSource, /\{activeStubSessionNoticeAction\?\.actionLabel\}/);
 });
 
 test('returns a retry notice when stub-session lazy loading resolves null for the active session', async () => {

--- a/mobile-app-improvement.md
+++ b/mobile-app-improvement.md
@@ -57,7 +57,7 @@
 
 ### Verified
 
-- [x] Source-backed regression coverage for navigation, connection validation, chat composer accessibility, session empty state, chat stub-session state, agent loop row actions, LoopEdit profile selection, AgentEdit connection types, MemoryEdit importance selection, and the Settings desktop warning state
+- [x] Source-backed regression coverage for navigation, connection validation, chat composer accessibility, session empty state, chat stub-session state and screen-owned banner action wiring, agent loop row actions, LoopEdit profile selection, AgentEdit connection types, MemoryEdit importance selection, and the Settings desktop warning state
 
 ### Blocked
 
@@ -69,6 +69,37 @@
 - [ ] Narrow-screen usability of the rest of `MemoryEdit` and the remaining `AgentEdit` / `LoopEdit` fields outside the newly checked sections
 
 ## Recent Iterations
+
+### 2026-03-09 — QA remediation 2 follow-up: pin stub-chat banner behavior to ChatScreen wiring
+
+- Status: completed with targeted behavior + source-backed verification; live Expo Web remained blocked by missing dependencies in this worktree
+- Area:
+  - `ChatScreen` stub-session notice button wiring in `apps/mobile/src/screens/ChatScreen.tsx`
+  - targeted regression coverage in `apps/mobile/tests/chat-stub-session-state.test.js`
+- Why this area:
+  - QA round 2 narrowed scope to one remaining gap only: the previous remediation still proved the generic stub-session helper behavior, but not the exact button action wiring consumed by `ChatScreen`
+  - the smallest practical fix in this dependency-light worktree was to make the screen-owned action model explicit and test that model directly, while pinning `ChatScreen` source to it
+- Findings:
+  - `apps/mobile/tests/chat-stub-session-state.test.js` imported `chat-stub-session-notice.ts` only, so it still did not cover the exact `ChatScreen` button path that calls `navigation.navigate('ConnectionSettings')`, `setMessages([])`, and `loadStubSessionMessages(sessionId)`
+  - importing full React Native screen code is still impractical in this worktree because mobile dependencies are absent, so this pass needed the smallest dependency-free fallback evidence that still closed the wiring gap
+- Change made:
+  - added `createChatScreenStubSessionNoticeActionModel(...)` in `apps/mobile/src/screens/chat-stub-session-notice.ts` to centralize the exact stub-banner button props and `onPress` behavior that `ChatScreen` uses
+  - rewired `ChatScreen.tsx` to render the stub-session banner button from that action model instead of inlining the notice press closure
+  - extended `apps/mobile/tests/chat-stub-session-state.test.js` so it now behavior-tests the `ChatScreen` action model for both `Open settings` and `Retry`, and source-asserts that `ChatScreen` renders the banner button from that same action model
+- Verification:
+  - `node --experimental-strip-types --test apps/mobile/tests/chat-stub-session-state.test.js`
+  - `git diff --check 88fcb982dbc316635071e2bdfd2fd11aede4c31f..HEAD`
+- Follow-up checks:
+  - once dependencies are available, verify in Expo Web that the same stub-session banner still renders and wraps correctly above the chat thread on narrow widths
+  - keep future work out of this stub-chat subsection unless a new QA finding appears
+
+Evidence
+- Scope: QA remediation for the remaining `ChatScreen` stub-session banner wiring evidence gap
+- Before evidence: QA round 2 reported that `apps/mobile/tests/chat-stub-session-state.test.js` still imported only `apps/mobile/src/screens/chat-stub-session-notice.ts`, so the pass did not cover the screen-owned `ChatScreen` button path for `navigation.navigate('ConnectionSettings')`, `setMessages([])`, and `loadStubSessionMessages(sessionId)`.
+- Change: Added `createChatScreenStubSessionNoticeActionModel(...)` to build the exact button copy/accessibility/onPress contract used by `ChatScreen`, updated `ChatScreen.tsx` to render the banner button from that action model, and extended `apps/mobile/tests/chat-stub-session-state.test.js` with both behavior checks for the action model and source assertions that `ChatScreen` uses it.
+- After evidence: `ChatScreen.tsx` now creates `activeStubSessionNoticeAction` via `createChatScreenStubSessionNoticeActionModel(activeStubSessionNotice, { navigate: (screenName) => navigation.navigate(screenName), setMessages, loadStubSessionMessages })`, and the banner button now reads its `onPress`, accessibility metadata, and label from that model. The updated test proves the credentials path navigates to `ConnectionSettings` without clearing messages, proves the retry path clears messages and retries the current stub-session ID, and pins the rendered `ChatScreen` banner button to that same action model in source.
+- Verification commands/run results: `node --experimental-strip-types --test apps/mobile/tests/chat-stub-session-state.test.js` ✅ (6/6 passing; Node emitted the existing non-blocking `MODULE_TYPELESS_PACKAGE_JSON` warning while importing the `.ts` helper); `git diff --check 88fcb982dbc316635071e2bdfd2fd11aede4c31f..HEAD` ✅.
+- Blockers/remaining uncertainty: Expo Web is still unavailable in this worktree because dependencies are missing, so this follow-up still lacks new live before/after screenshots. Remaining uncertainty is limited to runtime visual presentation of the already-shipped stub-session banner, not the targeted button wiring addressed here.
 
 ### 2026-03-09 — QA remediation 2: strengthen stub-chat behavior evidence and fix the committed-range whitespace regression
 


### PR DESCRIPTION
## Summary
- improve mobile stub-chat recovery and banner/session notice wiring
- add focused regression coverage for the stub session state flow
- preserve validation notes and evidence in `mobile-app-improvement.md`

## Validation
- loop-run validation and evidence were captured during the work in `mobile-app-improvement.md`
- manual worktree test reruns were not re-executed during PR prep; the branch was frozen and pushed from the worktree snapshot

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author