### PR TITLE
fix(mobile): show unified agents in mobile selector

### DIFF
--- a/apps/mobile/src/store/profile.ts
+++ b/apps/mobile/src/store/profile.ts
@@ -6,7 +6,7 @@
  */
 
 import { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
-import { SettingsApiClient, Profile } from '../lib/settingsApi';
+import { ExtendedSettingsApiClient, Profile } from '../lib/settingsApi';
 import { getAcpMainAgentOptions, toMainAgentProfile } from '../lib/mainAgentOptions';
 
 export interface ProfileContextValue {
@@ -63,11 +63,12 @@ export function useProfileProvider(baseUrl: string, apiKey: string): ProfileCont
     setError(null);
     
     try {
-      const client = new SettingsApiClient(baseUrl, apiKey);
+      const client = new ExtendedSettingsApiClient(baseUrl, apiKey);
       const settings = await client.getSettings();
 
       if (settings.mainAgentMode === 'acp' && settings.mainAgentName) {
-        const options = getAcpMainAgentOptions(settings);
+        const agentProfilesResponse = await client.getAgentProfiles().catch(() => ({ profiles: [] }));
+        const options = getAcpMainAgentOptions(settings, agentProfilesResponse.profiles || []);
         const selectedOption = options.find((option) => option.name === settings.mainAgentName)
           || { name: settings.mainAgentName, displayName: settings.mainAgentName };
         setCurrentProfile(toMainAgentProfile(selectedOption));

--- a/apps/mobile/src/ui/AgentSelectorSheet.tsx
+++ b/apps/mobile/src/ui/AgentSelectorSheet.tsx
@@ -18,14 +18,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from './ThemeProvider';
 import { spacing, radius, Theme } from './theme';
 import { useConfigContext } from '../store/config';
-import { ExtendedSettingsApiClient, SettingsApiClient, Profile } from '../lib/settingsApi';
+import { ExtendedSettingsApiClient, SettingsApiClient } from '../lib/settingsApi';
 import { useProfile } from '../store/profile';
-import { getAcpMainAgentOptions, toMainAgentProfile } from '../lib/mainAgentOptions';
-
-interface SelectableProfile extends Profile {
-  selectorMode?: 'profile' | 'acp';
-  selectionValue?: string;
-}
+import { SelectableProfile, buildSelectorProfiles } from './agentSelectorOptions';
 
 interface AgentSelectorSheetProps {
   visible: boolean;
@@ -36,7 +31,7 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
   const { config } = useConfigContext();
-  const { currentProfile, setCurrentProfile, refresh } = useProfile();
+  const { currentProfile, setCurrentProfile } = useProfile();
   const styles = React.useMemo(() => createStyles(theme), [theme]);
   const hasApiConfig = Boolean(config.baseUrl && config.apiKey);
   const missingConfigError = 'Configure server URL and API key to switch agents';
@@ -60,26 +55,13 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
 
     try {
       const client = new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
-      const settings = await client.getSettings();
-
-      if (settings.mainAgentMode === 'acp') {
-        setSelectorMode('acp');
-        const agentProfilesResponse = await client.getAgentProfiles().catch(() => ({ profiles: [] }));
-        const mainAgentOptions = getAcpMainAgentOptions(settings, agentProfilesResponse.profiles || []);
-        setProfiles(mainAgentOptions.map((option) => ({
-          ...toMainAgentProfile(option),
-          selectorMode: 'acp',
-          selectionValue: option.name,
-        })));
-      } else {
-        setSelectorMode('profile');
-        const res = await client.getProfiles();
-        setProfiles((res.profiles || []).map((profile) => ({
-          ...profile,
-          selectorMode: 'profile',
-          selectionValue: profile.id,
-        })));
-      }
+      const [settings, agentProfilesResponse] = await Promise.all([
+        client.getSettings(),
+        client.getAgentProfiles().catch(() => ({ profiles: [] })),
+      ]);
+      const nextState = buildSelectorProfiles(settings, agentProfilesResponse.profiles || []);
+      setSelectorMode(nextState.selectorMode);
+      setProfiles(nextState.profiles);
     } catch (err: any) {
       console.warn('[AgentSelectorSheet] Failed to fetch profiles:', err);
       setError(err?.message || 'Failed to load agents');
@@ -110,7 +92,7 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
       const client = new SettingsApiClient(config.baseUrl, config.apiKey);
       if (profile.selectorMode === 'acp' && profile.selectionValue) {
         await client.updateSettings({ mainAgentName: profile.selectionValue });
-        setCurrentProfile(toMainAgentProfile({ name: profile.selectionValue, displayName: profile.name }));
+        setCurrentProfile(profile);
       } else {
         await client.setCurrentProfile(profile.id);
         setCurrentProfile(profile);
@@ -139,9 +121,9 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
           <Text style={[styles.profileName, isSelected && styles.profileNameSelected]}>
             {item.name}
           </Text>
-          {item.guidelines && (
+          {(item.description || item.guidelines) && (
             <Text style={styles.profileDescription} numberOfLines={1}>
-              {item.guidelines}
+              {item.description || item.guidelines}
             </Text>
           )}
         </View>

--- a/apps/mobile/src/ui/agentSelectorOptions.test.ts
+++ b/apps/mobile/src/ui/agentSelectorOptions.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { buildSelectorProfiles } from './agentSelectorOptions';
+
+describe('buildSelectorProfiles', () => {
+  it('uses enabled agent profiles for the mobile selector in API mode', () => {
+    const result = buildSelectorProfiles(
+      { mainAgentMode: 'api' } as any,
+      [
+        { id: 'main', name: 'main-agent', displayName: 'Main Agent', enabled: true, connectionType: 'internal', role: 'user-profile' },
+        { id: 'sub', name: 'augustus', displayName: 'Augustus', description: 'Delegated helper', enabled: true, connectionType: 'internal', role: 'delegation-target' },
+        { id: 'off', name: 'disabled', displayName: 'Disabled', enabled: false, connectionType: 'internal', role: 'delegation-target' },
+      ] as any
+    );
+
+    expect(result.selectorMode).toBe('profile');
+    expect(result.profiles.map((profile) => profile.id)).toEqual(['main', 'sub']);
+    expect(result.profiles.map((profile) => profile.name)).toEqual(['Main Agent', 'Augustus']);
+  });
+
+  it('uses ACP-capable agent profiles when ACP mode is enabled', () => {
+    const result = buildSelectorProfiles(
+      {
+        mainAgentMode: 'acp',
+        acpAgents: [{ name: 'legacy-agent', displayName: 'Legacy Agent' }],
+      } as any,
+      [
+        { id: 'stdio-1', name: 'augustus', displayName: 'Augustus', enabled: true, connectionType: 'stdio' },
+        { id: 'internal-1', name: 'helper', displayName: 'Helper', enabled: true, connectionType: 'internal' },
+      ] as any
+    );
+
+    expect(result.selectorMode).toBe('acp');
+    expect(result.profiles.map((profile) => profile.selectionValue)).toEqual(['augustus', 'legacy-agent']);
+    expect(result.profiles.map((profile) => profile.name)).toEqual(['Augustus', 'Legacy Agent']);
+  });
+});

--- a/apps/mobile/src/ui/agentSelectorOptions.ts
+++ b/apps/mobile/src/ui/agentSelectorOptions.ts
@@ -1,0 +1,44 @@
+import type { AgentProfile, Profile, Settings } from '../lib/settingsApi';
+import { getAcpMainAgentOptions, toMainAgentProfile } from '../lib/mainAgentOptions';
+
+export interface SelectableProfile extends Profile {
+  description?: string;
+  selectorMode: 'profile' | 'acp';
+  selectionValue: string;
+}
+
+export function toSelectableAgentProfile(profile: AgentProfile): SelectableProfile {
+  const summary = profile.description || profile.guidelines || '';
+
+  return {
+    id: profile.id,
+    name: profile.displayName || profile.name,
+    guidelines: summary,
+    description: summary,
+    selectorMode: 'profile',
+    selectionValue: profile.id,
+  };
+}
+
+export function buildSelectorProfiles(
+  settings?: Settings | null,
+  agentProfiles: AgentProfile[] = []
+): { selectorMode: 'profile' | 'acp'; profiles: SelectableProfile[] } {
+  const enabledAgentProfiles = agentProfiles.filter((profile) => profile.enabled !== false);
+
+  if (settings?.mainAgentMode === 'acp') {
+    return {
+      selectorMode: 'acp',
+      profiles: getAcpMainAgentOptions(settings, enabledAgentProfiles).map((option) => ({
+        ...toMainAgentProfile(option),
+        selectorMode: 'acp',
+        selectionValue: option.name,
+      })),
+    };
+  }
+
+  return {
+    selectorMode: 'profile',
+    profiles: enabledAgentProfiles.map(toSelectableAgentProfile),
+  };
+}

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -292,10 +292,13 @@ export interface ApiAgentProfile {
   name: string;
   displayName: string;
   description?: string;
+  guidelines?: string;
+  systemPrompt?: string;
   enabled: boolean;
   isBuiltIn?: boolean;
   isUserProfile?: boolean;
   isAgentTarget?: boolean;
+  isDefault?: boolean;
   role?: 'user-profile' | 'delegation-target' | 'external-agent';
   connectionType: 'internal' | 'acp' | 'stdio' | 'remote';
   autoSpawn?: boolean;
@@ -305,11 +308,8 @@ export interface ApiAgentProfile {
 
 // Full agent profile detail (from GET /v1/agent-profiles/:id)
 export interface ApiAgentProfileFull extends ApiAgentProfile {
-  systemPrompt?: string;
-  guidelines?: string;
   properties?: Record<string, string>;
   avatarDataUrl?: string;
-  isDefault?: boolean;
   isStateful?: boolean;
   conversationId?: string;
   connection?: {


### PR DESCRIPTION
## Summary
- use unified agent profiles for the mobile agent selector instead of the legacy user-profile list
- surface enabled sub-agents/delegation targets in the mobile selector just like desktop
- resolve ACP main-agent labels from the same agent profile data so the mobile header stays accurate
- align shared API types with the `/v1/agent-profiles` response shape already returned by the server

## Fixes
- Closes #113
- Closes #116
- Closes #117

## Notes
- #116 and #117 appear to be duplicate reports of the same mobile sub-agent visibility problem, so they are handled together here.

## Verification
- `node --test tests/agent-selector-sheet-density.test.js tests/chat-screen-density.test.js` (cwd: `apps/mobile`)
- `pnpm --filter @dotagents/mobile exec vitest run src/ui/agentSelectorOptions.test.ts`
- `pnpm build:shared`
- `pnpm --filter @dotagents/mobile exec tsc --noEmit`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author