### PR TITLE
fix: resolve sidebar pinning and mobile voice timing issues

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -16,6 +16,10 @@ import { cn } from "@renderer/lib/utils"
 import { useAgentStore } from "@renderer/stores"
 import { logUI, logStateChange, logExpand } from "@renderer/lib/debug"
 import { useConversationHistoryQuery } from "@renderer/lib/queries"
+import {
+  filterPastSessionsAgainstActiveSessions,
+  orderActiveSessionsByPinnedFirst,
+} from "@renderer/lib/sidebar-sessions"
 import { useNavigate } from "react-router-dom"
 
 interface AgentSession {
@@ -110,7 +114,7 @@ export function ActiveAgentsSidebar({
         .map((session) => session.conversationId)
         .filter((id): id is string => !!id),
     )
-    const seenFallbackIds = new Set<string>()
+    const seenFallbackIds = new Set<string>(activeSessions.map((session) => session.id))
 
     const addPastSession = (session: AgentSession, keyPrefix: string) => {
       const conversationId = session.conversationId
@@ -161,17 +165,25 @@ export function ActiveAgentsSidebar({
   )
 
   const { sidebarSessions, hasMorePastSessions } = useMemo(() => {
-    const activeItems: SidebarSession[] = activeSessions.map((session) => ({
+    const orderedActiveSessions = orderActiveSessionsByPinnedFirst(
+      activeSessions,
+      pinnedSessionIds,
+    )
+    const activeItems: SidebarSession[] = orderedActiveSessions.map((session) => ({
       session,
       isPast: false,
       key: `active:${session.id}`,
     }))
+    const dedupedPastSessions = filterPastSessionsAgainstActiveSessions<SidebarSession>(
+      allPastSessions,
+      orderedActiveSessions,
+    )
 
     // Ensure pinned past sessions always appear, even if beyond the visible count.
     // Split into pinned (always shown) and unpinned (paginated).
     const pinnedPast: SidebarSession[] = []
     const unpinnedPast: SidebarSession[] = []
-    for (const item of allPastSessions) {
+    for (const item of dedupedPastSessions) {
       const cid = item.session.conversationId
       if (cid && pinnedSessionIds.has(cid)) {
         pinnedPast.push(item)

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -167,11 +167,11 @@ export function useStoreSync() {
   }, [setPinnedSessionIds])
 
   useEffect(() => {
-    if (!pinnedSessionIdsHydratedRef.current) return
+    if (!pinnedSessionIdsHydratedRef.current) return undefined
 
     const nextPinnedSessionIds = Array.from(pinnedSessionIds)
     if (areStringArraysEqual(nextPinnedSessionIds, lastPersistedPinnedSessionIdsRef.current)) {
-      return
+      return undefined
     }
 
     let cancelled = false

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  filterPastSessionsAgainstActiveSessions,
+  orderActiveSessionsByPinnedFirst,
+} from "./sidebar-sessions"
+
+const activeSession = (id: string, conversationId?: string) => ({
+  id,
+  conversationId,
+})
+const pastSession = (id: string, conversationId?: string) => ({
+  session: { id, conversationId },
+})
+
+describe("orderActiveSessionsByPinnedFirst", () => {
+  it("moves pinned active sessions to the top while preserving each group's order", () => {
+    const ordered = orderActiveSessionsByPinnedFirst(
+      [
+        activeSession("session-1", "conversation-1"),
+        activeSession("session-2", "conversation-2"),
+        activeSession("session-3", "conversation-3"),
+      ],
+      new Set(["conversation-2"]),
+    )
+
+    expect(ordered.map((session) => session.id)).toEqual([
+      "session-2",
+      "session-1",
+      "session-3",
+    ])
+  })
+})
+
+describe("filterPastSessionsAgainstActiveSessions", () => {
+  it("removes past entries whose conversation is already active", () => {
+    const filtered = filterPastSessionsAgainstActiveSessions(
+      [
+        pastSession("history-1", "conversation-1"),
+        pastSession("history-2", "conversation-2"),
+      ],
+      [activeSession("session-1", "conversation-1")],
+    )
+
+    expect(filtered).toEqual([pastSession("history-2", "conversation-2")])
+  })
+
+  it("removes fallback past entries whose session id is already active", () => {
+    const filtered = filterPastSessionsAgainstActiveSessions(
+      [pastSession("session-1"), pastSession("session-2")],
+      [activeSession("session-1")],
+    )
+
+    expect(filtered).toEqual([pastSession("session-2")])
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
@@ -1,0 +1,53 @@
+type SessionLike = {
+  id: string
+  conversationId?: string
+}
+
+export function orderActiveSessionsByPinnedFirst<T extends SessionLike>(
+  sessions: T[],
+  pinnedSessionIds: ReadonlySet<string>,
+): T[] {
+  if (sessions.length <= 1 || pinnedSessionIds.size === 0) {
+    return sessions
+  }
+
+  const pinnedSessions: T[] = []
+  const unpinnedSessions: T[] = []
+
+  for (const session of sessions) {
+    if (
+      session.conversationId &&
+      pinnedSessionIds.has(session.conversationId)
+    ) {
+      pinnedSessions.push(session)
+    } else {
+      unpinnedSessions.push(session)
+    }
+  }
+
+  return [...pinnedSessions, ...unpinnedSessions]
+}
+
+export function filterPastSessionsAgainstActiveSessions<
+  T extends { session: SessionLike },
+>(pastSessions: T[], activeSessions: SessionLike[]): T[] {
+  if (pastSessions.length === 0 || activeSessions.length === 0) {
+    return pastSessions
+  }
+
+  const activeConversationIds = new Set(
+    activeSessions
+      .map((session) => session.conversationId)
+      .filter((conversationId): conversationId is string => !!conversationId),
+  )
+  const activeSessionIds = new Set(activeSessions.map((session) => session.id))
+
+  return pastSessions.filter((item) => {
+    if (activeSessionIds.has(item.session.id)) {
+      return false
+    }
+
+    const conversationId = item.session.conversationId
+    return !conversationId || !activeConversationIds.has(conversationId)
+  })
+}

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
@@ -1,16 +1,153 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import { mergeVoiceText } from './mergeVoiceText';
+
+type EffectRecord = {
+  callback?: () => void | (() => void);
+  deps?: any[];
+  nextDeps?: any[];
+  cleanup?: void | (() => void);
+  hasRun: boolean;
+};
+
+function createHookRuntime() {
+  const states: any[] = [];
+  const refs: Array<{ current: any }> = [];
+  const effects: EffectRecord[] = [];
+  let stateIndex = 0;
+  let refIndex = 0;
+  let effectIndex = 0;
+  const depsChanged = (prev?: any[], next?: any[]) => !prev || !next || prev.length !== next.length || prev.some((value, index) => !Object.is(value, next[index]));
+  const useState = <T,>(initial: T | (() => T)) => {
+    const idx = stateIndex++;
+    if (states[idx] === undefined) states[idx] = typeof initial === 'function' ? (initial as () => T)() : initial;
+    return [states[idx] as T, (update: T | ((prev: T) => T)) => {
+      states[idx] = typeof update === 'function' ? (update as (prev: T) => T)(states[idx]) : update;
+    }] as const;
+  };
+  const useRef = <T,>(initial: T) => {
+    const idx = refIndex++;
+    refs[idx] ??= { current: initial };
+    return refs[idx] as { current: T };
+  };
+  const useEffect = (callback: () => void | (() => void), deps?: any[]) => {
+    const idx = effectIndex++;
+    const record = effects[idx] ?? { hasRun: false };
+    record.callback = callback;
+    record.nextDeps = deps;
+    effects[idx] = record;
+  };
+  const reactMock: any = { __esModule: true, default: {} as any, useState, useRef, useEffect, useCallback: (fn: any) => fn };
+  reactMock.default = reactMock;
+  return {
+    render<P, Result>(hook: (props: P) => Result, props: P) {
+      stateIndex = 0;
+      refIndex = 0;
+      effectIndex = 0;
+      return hook(props);
+    },
+    commitEffects() {
+      for (const record of effects) {
+        if (!record?.callback) continue;
+        const shouldRun = !record.hasRun || depsChanged(record.deps, record.nextDeps);
+        if (!shouldRun) continue;
+        if (typeof record.cleanup === 'function') record.cleanup();
+        record.cleanup = record.callback();
+        record.deps = record.nextDeps;
+        record.hasRun = true;
+      }
+    },
+    reactMock,
+  };
+}
+
+class FakeSpeechRecognition {
+  static instances: FakeSpeechRecognition[] = [];
+  continuous = false;
+  interimResults = false;
+  lang = 'en-US';
+  onstart?: () => void;
+  onresult?: (event: any) => void;
+  onend?: () => void;
+  startCalls = 0;
+  failNextStart = false;
+  constructor() {
+    FakeSpeechRecognition.instances.push(this);
+  }
+  start() {
+    this.startCalls += 1;
+    if (this.failNextStart) {
+      this.failNextStart = false;
+      throw new Error('restart failed');
+    }
+    this.onstart?.();
+  }
+  stop() {
+    this.onend?.();
+  }
+}
+
+async function loadUseSpeechRecognizer(runtime: ReturnType<typeof createHookRuntime>) {
+  vi.resetModules();
+  vi.doMock('react', async () => {
+    const actual = await vi.importActual<typeof import('react')>('react');
+    return {
+      ...actual,
+      ...runtime.reactMock,
+      default: {
+        ...(actual as any).default,
+        ...runtime.reactMock,
+      },
+    };
+  });
+  vi.doMock('react-native', () => ({ Alert: { alert: vi.fn() }, Platform: { OS: 'web' }, View: function MockView() { return null; } }));
+  vi.doMock('expo-modules-core', () => ({ EventEmitter: class MockEventEmitter {} }));
+  return import('./useSpeechRecognizer');
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.unmock('react');
+  vi.unmock('react-native');
+  vi.unmock('expo-modules-core');
+  FakeSpeechRecognition.instances = [];
+  delete (globalThis as any).window;
+});
 
 describe('mergeVoiceText', () => {
   it('keeps cumulative recognizer results from duplicating words', () => {
     expect(mergeVoiceText('hello', 'hello world')).toBe('hello world');
   });
-
   it('merges overlapping transcript chunks without repeating the overlap', () => {
     expect(mergeVoiceText('turn on', 'on the lights')).toBe('turn on the lights');
   });
-
   it('preserves non-overlapping chunks in order', () => {
     expect(mergeVoiceText('summarize my', 'latest emails')).toBe('summarize my latest emails');
+  });
+});
+
+describe('useSpeechRecognizer', () => {
+  it('waits for push-to-talk release before finalizing if the recognizer ends mid-hold', async () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    (globalThis as any).window = { SpeechRecognition: FakeSpeechRecognition };
+    const runtime = createHookRuntime();
+    const { useSpeechRecognizer } = await loadUseSpeechRecognizer(runtime);
+    const onVoiceFinalized = vi.fn();
+    const recognizer = runtime.render(useSpeechRecognizer, { handsFree: false, willCancel: false, onVoiceFinalized });
+    runtime.commitEffects();
+    recognizer.handlePushToTalkPressIn({} as any);
+    const speechRecognition = FakeSpeechRecognition.instances[0];
+    speechRecognition.onresult?.({ resultIndex: 0, results: [{ 0: { transcript: 'hello world' }, isFinal: true }] });
+    speechRecognition.failNextStart = true;
+    speechRecognition.onend?.();
+    expect(onVoiceFinalized).not.toHaveBeenCalled();
+    now = 1_300;
+    recognizer.handlePushToTalkPressOut();
+    expect(onVoiceFinalized).toHaveBeenCalledWith({ text: 'hello world', mode: 'send', source: 'web' });
+    expect(speechRecognition.startCalls).toBe(2);
   });
 });

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
@@ -18,6 +18,12 @@ type VoiceFinalizedPayload = {
   source: 'native' | 'web';
 };
 
+type DeferredPushToTalkFinal = {
+  gestureId: number;
+  text: string;
+  source: 'native' | 'web';
+};
+
 type UseSpeechRecognizerOptions = {
   handsFree: boolean;
   handsFreeDebounceMs?: number;
@@ -66,6 +72,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
   const srSubsRef = useRef<any[]>([]);
   const voiceGestureIdRef = useRef(0);
   const voiceGestureFinalizedIdRef = useRef(0);
+  const pendingPushToTalkFinalRef = useRef<DeferredPushToTalkFinal | null>(null);
   const suppressFinalizeRef = useRef(false);
 
   const setListeningValue = useCallback((value: boolean) => {
@@ -113,6 +120,33 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     });
   }, [handsFree, onVoiceFinalized, setSttPreviewWithExpiry, willCancel]);
 
+  const deferPushToTalkFinalization = useCallback((text: string, source: 'native' | 'web') => {
+    const finalText = normalizeVoiceText(text);
+    if (!finalText) {
+      return false;
+    }
+
+    pendingPushToTalkFinalRef.current = {
+      gestureId: voiceGestureIdRef.current,
+      text: finalText,
+      source,
+    };
+    setSttPreviewWithExpiry(finalText);
+    return true;
+  }, [setSttPreviewWithExpiry]);
+
+  const flushPendingPushToTalkFinalization = useCallback(() => {
+    const pendingFinal = pendingPushToTalkFinalRef.current;
+    if (!pendingFinal) {
+      return false;
+    }
+
+    pendingPushToTalkFinalRef.current = null;
+    voiceGestureFinalizedIdRef.current = pendingFinal.gestureId;
+    emitFinalized(pendingFinal.text, pendingFinal.source);
+    return true;
+  }, [emitFinalized]);
+
   const stopRecognitionOnly = useCallback(async () => {
     suppressFinalizeRef.current = true;
     userReleasedButtonRef.current = true;
@@ -135,6 +169,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
       setListeningValue(false);
       setLiveTranscriptValue('');
       pendingHandsFreeFinalRef.current = '';
+      pendingPushToTalkFinalRef.current = null;
       nativeFinalRef.current = '';
       webFinalRef.current = '';
       webPressInSeenRef.current = false;
@@ -218,10 +253,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
             const accumulatedText = mergeVoiceText(webFinalRef.current, liveTranscriptRef.current);
             setListeningValue(false);
             setLiveTranscriptValue('');
-            if (accumulatedText) {
-              setSttPreviewWithExpiry(accumulatedText);
-              voiceGestureFinalizedIdRef.current = voiceGestureIdRef.current;
-            }
+            deferPushToTalkFinalization(accumulatedText, 'web');
             webFinalRef.current = '';
             pendingHandsFreeFinalRef.current = '';
             return;
@@ -236,6 +268,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
         );
 
         pendingHandsFreeFinalRef.current = '';
+        pendingPushToTalkFinalRef.current = null;
         setListeningValue(false);
         setLiveTranscriptValue('');
         if (finalText && !alreadyFinalizedPushToTalk) {
@@ -252,6 +285,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     return true;
   }, [
     clearHandsFreeDebounce,
+    deferPushToTalkFinalization,
     emitFinalized,
     handsFree,
     handsFreeDebounceMs,
@@ -277,6 +311,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     nativeFinalRef.current = '';
     webFinalRef.current = '';
     pendingHandsFreeFinalRef.current = '';
+    pendingPushToTalkFinalRef.current = null;
     clearHandsFreeDebounce();
 
     if (event) {
@@ -358,6 +393,14 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
                     return;
                   }
                 } catch {}
+
+                const accumulatedText = mergeVoiceText(nativeFinalRef.current, liveTranscriptRef.current);
+                setListeningValue(false);
+                setLiveTranscriptValue('');
+                deferPushToTalkFinalization(accumulatedText, 'native');
+                pendingHandsFreeFinalRef.current = '';
+                nativeFinalRef.current = '';
+                return;
               }
 
               const gestureId = voiceGestureIdRef.current;
@@ -368,6 +411,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
                 liveTranscriptRef.current,
               );
               pendingHandsFreeFinalRef.current = '';
+              pendingPushToTalkFinalRef.current = null;
               setLiveTranscriptValue('');
               if (finalText && !alreadyFinalizedPushToTalk) {
                 if (!handsFree) {
@@ -441,6 +485,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
   }, [
     cleanupNativeSubs,
     clearHandsFreeDebounce,
+    deferPushToTalkFinalization,
     emitFinalized,
     ensureWebRecognizer,
     handsFree,
@@ -462,8 +507,8 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     userReleasedButtonRef.current = true;
 
     try {
-      const hasWebRecognizer = Platform.OS === 'web' && webRecognitionRef.current;
-      if (!listeningRef.current && !hasWebRecognizer) {
+      if (!listeningRef.current) {
+        flushPendingPushToTalkFinalization();
         return;
       }
 
@@ -486,7 +531,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
       stoppingRef.current = false;
       log?.('recognizer-stop', 'Speech recognizer stopped.');
     }
-  }, [log, setListeningValue]);
+  }, [flushPendingPushToTalkFinalization, log, setListeningValue]);
 
   stopRecordingAndHandleRef.current = stopRecordingAndHandle;
 
@@ -498,21 +543,26 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     }
   }, [startRecording]);
 
+  const stopOrFinalizePushToTalk = useCallback(() => {
+    if (listeningRef.current) {
+      void stopRecordingAndHandle();
+      return;
+    }
+
+    flushPendingPushToTalkFinalization();
+  }, [flushPendingPushToTalkFinalization, stopRecordingAndHandle]);
+
   const handlePushToTalkPressOut = useCallback(() => {
     webPressInSeenRef.current = false;
     const delay = Math.max(0, MIN_HOLD_MS - (Date.now() - lastGrantTimeRef.current));
     if (delay > 0) {
       setTimeout(() => {
-        if (listeningRef.current) {
-          void stopRecordingAndHandle();
-        }
+        stopOrFinalizePushToTalk();
       }, delay);
       return;
     }
-    if (listeningRef.current) {
-      void stopRecordingAndHandle();
-    }
-  }, [stopRecordingAndHandle]);
+    stopOrFinalizePushToTalk();
+  }, [stopOrFinalizePushToTalk]);
 
   useEffect(() => {
     if (Platform.OS !== 'web' || !micButtonRef.current) return;

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -4,8 +4,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   AppConfig,
   DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
-  MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
-  MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
   saveConfig,
   useConfigContext,
 } from '../store/config';
@@ -170,6 +168,9 @@ export default function SettingsScreen({ navigation }: any) {
   const { theme, themeMode, setThemeMode } = useTheme();
   const { config, setConfig, ready } = useConfigContext();
   const [draft, setDraft] = useState<AppConfig>(config);
+  const [handsFreeDebounceInput, setHandsFreeDebounceInput] = useState(
+    String(config.handsFreeMessageDebounceMs ?? DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS),
+  );
   const [hasPendingLocalSave, setHasPendingLocalSave] = useState(false);
   const [pendingRemoteSaveKeys, setPendingRemoteSaveKeys] = useState<string[]>([]);
   const [isSavingAllSettings, setIsSavingAllSettings] = useState(false);
@@ -262,6 +263,9 @@ export default function SettingsScreen({ navigation }: any) {
 
   useEffect(() => {
     setDraft(config);
+    setHandsFreeDebounceInput(
+      String(config.handsFreeMessageDebounceMs ?? DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS),
+    );
     setHasPendingLocalSave(false);
   }, [ready, config]);
 
@@ -298,6 +302,39 @@ export default function SettingsScreen({ navigation }: any) {
     setHasPendingLocalSave(false);
     setSaveStatusMessage('Saved');
   }, [draft, setConfig]);
+
+  const handleHandsFreeDebounceInputChange = useCallback((value: string) => {
+    const sanitized = value.replace(/[^0-9]/g, '');
+    setHandsFreeDebounceInput(sanitized);
+    updateDraftField({
+      handsFreeMessageDebounceMs: sanitized ? Number(sanitized) : undefined,
+    });
+  }, [updateDraftField]);
+
+  const commitHandsFreeDebounceInput = useCallback(() => {
+    const trimmed = handsFreeDebounceInput.trim();
+    const fallbackValue = draft.handsFreeMessageDebounceMs ?? DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS;
+
+    if (!trimmed) {
+      setHandsFreeDebounceInput(String(DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS));
+      updateLocalConfig({ handsFreeMessageDebounceMs: DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS });
+      return;
+    }
+
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      setHandsFreeDebounceInput(String(fallbackValue));
+      setDraft((current) => ({
+        ...current,
+        handsFreeMessageDebounceMs: fallbackValue,
+      }));
+      return;
+    }
+
+    const normalized = Math.round(parsed);
+    setHandsFreeDebounceInput(String(normalized));
+    updateLocalConfig({ handsFreeMessageDebounceMs: normalized });
+  }, [draft.handsFreeMessageDebounceMs, handsFreeDebounceInput, updateLocalConfig]);
 
   // Create settings API client when we have valid credentials
   const settingsClient = useMemo(() => {
@@ -1247,28 +1284,19 @@ export default function SettingsScreen({ navigation }: any) {
           autoCorrect={false}
         />
 
-        <View style={{ marginTop: spacing.md }}>
-          <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
-            <Text style={styles.label}>Send after silence</Text>
-            <Text style={[styles.helperText, { marginTop: 0 }]}>
-              {Math.round((draft.handsFreeMessageDebounceMs ?? DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS) / 10) / 100}s
-            </Text>
-          </View>
-          <Slider
-            style={{ width: '100%', height: 40 }}
-            minimumValue={MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS}
-            maximumValue={MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS}
-            step={100}
-            value={draft.handsFreeMessageDebounceMs ?? DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS}
-            onValueChange={(value) => setDraft((current) => ({ ...current, handsFreeMessageDebounceMs: value }))}
-            onSlidingComplete={(value) => updateLocalConfig({ handsFreeMessageDebounceMs: value })}
-            minimumTrackTintColor={theme.colors.primary}
-            maximumTrackTintColor={theme.colors.muted}
-            thumbTintColor={theme.colors.primary}
-          />
-        </View>
+        <Text style={[styles.label, { marginTop: spacing.md }]}>Send after silence</Text>
+        <TextInput
+          style={styles.input}
+          value={handsFreeDebounceInput}
+          onChangeText={handleHandsFreeDebounceInputChange}
+          onEndEditing={commitHandsFreeDebounceInput}
+          placeholder={`${DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS}`}
+          placeholderTextColor={theme.colors.mutedForeground}
+          keyboardType='number-pad'
+        />
         <Text style={styles.helperText}>
-          Wait this long without new speech before sending a hands-free message.
+          Wait this many milliseconds without new speech before sending a hands-free message. Any value ≥ 0 works.
+          Current: {Math.round((draft.handsFreeMessageDebounceMs ?? DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS) / 10) / 100}s.
         </Text>
 
         <View style={styles.row}>

--- a/apps/mobile/src/store/config.test.ts
+++ b/apps/mobile/src/store/config.test.ts
@@ -12,7 +12,6 @@ import {
   DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
   DEFAULT_HANDS_FREE_SLEEP_PHRASE,
   DEFAULT_HANDS_FREE_WAKE_PHRASE,
-  MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
   MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
   normalizeStoredConfig,
 } from './config';
@@ -45,17 +44,18 @@ describe('normalizeStoredConfig', () => {
     expect(normalized.handsFreeSleepPhrase).toBe('go quiet');
   });
 
-  it('clamps the handsfree send delay to a safe range', () => {
+  it('accepts arbitrary non-negative handsfree send delays while still rejecting negatives', () => {
     const tooLow = normalizeStoredConfig({
       ...DEFAULT_APP_CONFIG,
       handsFreeMessageDebounceMs: MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS - 200,
     });
-    const tooHigh = normalizeStoredConfig({
+    const customHighValue = 12345;
+    const arbitraryHigh = normalizeStoredConfig({
       ...DEFAULT_APP_CONFIG,
-      handsFreeMessageDebounceMs: MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS + 200,
+      handsFreeMessageDebounceMs: customHighValue,
     });
 
     expect(tooLow.handsFreeMessageDebounceMs).toBe(MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS);
-    expect(tooHigh.handsFreeMessageDebounceMs).toBe(MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS);
+    expect(arbitraryHigh.handsFreeMessageDebounceMs).toBe(customHighValue);
   });
 });

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -23,18 +23,14 @@ export type AppConfig = {
 export const DEFAULT_HANDS_FREE_WAKE_PHRASE = 'hey dot agents';
 export const DEFAULT_HANDS_FREE_SLEEP_PHRASE = 'go to sleep';
 export const DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS = 1500;
-export const MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS = 500;
-export const MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS = 5000;
+export const MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS = 0;
 
 function normalizeHandsFreeMessageDebounceMs(value?: number) {
   if (!Number.isFinite(value)) {
     return DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS;
   }
 
-  return Math.min(
-    MAX_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
-    Math.max(MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS, Math.round(value as number)),
-  );
+  return Math.max(MIN_HANDS_FREE_MESSAGE_DEBOUNCE_MS, Math.round(value as number));
 }
 
 export const DEFAULT_APP_CONFIG: AppConfig = {


### PR DESCRIPTION
## Summary
- keep pinned active desktop sessions at the top and prevent them from duplicating into past sessions
- allow arbitrary non-negative hands-free silence durations in mobile settings while preserving the runtime-config path
- defer push-to-talk finalization until release when recognition restarts fail mid-hold
- add focused regression coverage for the new sidebar ordering/deduping and voice-finalization behavior

## Validation
- `pnpm --filter @dotagents/mobile test:vitest`
- `pnpm --filter @dotagents/desktop test -- --run src/renderer/src/lib/sidebar-sessions.test.ts && pnpm --filter @dotagents/desktop typecheck`

Closes #93
Closes #106
Closes #114
Closes #115

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author