### PR TITLE
Desktop: improve chat home connection flow

### DIFF
--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -6,7 +6,7 @@ import { NavLink, Outlet, useNavigate, useLocation } from "react-router-dom"
 import { LoadingSpinner } from "@renderer/components/ui/loading-spinner"
 import { SettingsDragBar } from "@renderer/components/settings-drag-bar"
 import { ActiveAgentsSidebar } from "@renderer/components/active-agents-sidebar"
-import { AgentCapabilitiesSidebar } from "@renderer/components/agent-capabilities-sidebar"
+import { HomeSettingsDialog } from "@renderer/components/home-settings-dialog"
 
 import { PastSessionsDialog } from "@renderer/components/past-sessions-dialog"
 import { useSidebar, SIDEBAR_DIMENSIONS } from "@renderer/hooks/use-sidebar"
@@ -24,14 +24,8 @@ import {
   VolumeX,
   OctagonX,
   Loader2,
-  Plug2,
+  Settings2,
 } from "lucide-react"
-
-type NavLinkItem = {
-  text: string
-  href: string
-  icon: string | React.ComponentType<{ className?: string }>
-}
 
 interface AgentSession {
   id: string
@@ -47,8 +41,8 @@ interface AgentSessionsResponse {
 export const Component = () => {
   const navigate = useNavigate()
   const location = useLocation()
-  const [settingsExpanded, setSettingsExpanded] = useState(true)
   const [pastSessionsDialogOpen, setPastSessionsDialogOpen] = useState(false)
+  const [settingsDialogOpen, setSettingsDialogOpen] = useState(false)
   const [isEmergencyStopping, setIsEmergencyStopping] = useState(false)
   const { isCollapsed, width, isResizing, toggleCollapse, handleResizeStart } =
     useSidebar()
@@ -78,7 +72,6 @@ export const Component = () => {
     return unlisten
   }, [isCollapsed, refetchSessionData])
 
-  const whatsappEnabled = configQuery.data?.whatsappEnabled ?? false
   const isGlobalTTSEnabled = configQuery.data?.ttsEnabled ?? true
   const collapsedActiveSessions = sessionData?.activeSessions ?? []
   const collapsedPreviewSessions = useMemo(
@@ -152,113 +145,11 @@ export const Component = () => {
     [navigate, setFocusedSessionId, setScrollToSessionId],
   )
 
-  const settingsNavLinks: NavLinkItem[] = [
-    {
-      text: "General",
-      href: "/settings",
-      icon: "i-mingcute-settings-3-line",
-    },
-    {
-      text: "Models",
-      href: "/settings/models",
-      icon: "i-mingcute-brain-line",
-    },
-    {
-      text: "Providers",
-      href: "/settings/providers",
-      icon: Plug2,
-    },
-    {
-      text: "Memories",
-      href: "/memories",
-      icon: "i-mingcute-book-2-line",
-    },
-
-    {
-      text: "Capabilities",
-      href: "/settings/capabilities",
-      icon: "i-mingcute-tool-line",
-    },
-    // Only show WhatsApp settings when enabled
-    ...(whatsappEnabled
-      ? [
-          {
-            text: "WhatsApp",
-            href: "/settings/whatsapp",
-            icon: "i-mingcute-message-4-line",
-          },
-        ]
-      : []),
-    {
-      text: "Repeat Tasks",
-      href: "/settings/repeat-tasks",
-      icon: "i-mingcute-refresh-3-line",
-    },
-  ]
-
-  // Route aliases that should highlight the same nav item
-  // Maps route paths to their primary nav link href
-  const routeAliases: Record<string, string> = {
-    "/settings/general": "/settings",
-    "/settings/mcp-tools": "/settings/capabilities",
-    "/settings/skills": "/settings/capabilities",
-    "/settings/remote-server": "/settings",
-    "/settings/loops": "/settings/repeat-tasks",
-    "/settings/agents": "/settings/agents",
-  }
-
-  const isAgentsActive =
-    location.pathname === "/settings/agents" ||
-    location.pathname.startsWith("/settings/agents")
-
-  // Check if current path matches the nav link (including aliases)
-  const isNavLinkActive = (linkHref: string): boolean => {
-    const currentPath = location.pathname
-    // Exact match
-    if (currentPath === linkHref) return true
-    // Check if current path is an alias that maps to this link
-    const aliasTarget = routeAliases[currentPath]
-    return aliasTarget === linkHref
-  }
-
   useEffect(() => {
     return rendererHandlers.navigate.listen((url) => {
       navigate(url)
     })
-  }, [])
-
-  const renderNavLink = (link: NavLinkItem) => {
-    const isActive = isNavLinkActive(link.href)
-    const icon = typeof link.icon === "string"
-      ? <span className={cn(link.icon, "h-4 w-4 shrink-0")}></span>
-      : <link.icon className="h-4 w-4 shrink-0" />
-
-    return (
-      <NavLink
-        key={link.text}
-        to={link.href}
-        role="button"
-        draggable={false}
-        title={isCollapsed ? link.text : undefined}
-        aria-label={isCollapsed ? link.text : undefined}
-        aria-current={isActive ? "page" : undefined}
-        className={() => {
-          return cn(
-            "flex h-7 items-center rounded-md px-2 font-medium transition-all duration-200",
-            isCollapsed ? "justify-center" : "gap-2",
-            isActive
-              ? "bg-accent text-accent-foreground"
-              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          )
-        }}
-      >
-        {icon}
-        {!isCollapsed && (
-          <span className="truncate font-medium">{link.text}</span>
-        )}
-      </NavLink>
-    )
-  }
+  }, [navigate])
 
   const sidebarWidth = isCollapsed ? SIDEBAR_DIMENSIONS.width.collapsed : width
 
@@ -272,6 +163,10 @@ export const Component = () => {
 
   return (
     <>
+      <HomeSettingsDialog
+        open={settingsDialogOpen}
+        onOpenChange={setSettingsDialogOpen}
+      />
       <PastSessionsDialog
         open={pastSessionsDialogOpen}
         onOpenChange={setPastSessionsDialogOpen}
@@ -328,6 +223,18 @@ export const Component = () => {
 
                 <button
                   type="button"
+                  onClick={() => setSettingsDialogOpen(true)}
+                  className={cn(
+                    "text-muted-foreground hover:bg-accent/50 hover:text-foreground shrink-0 rounded p-1 transition-colors",
+                  )}
+                  title="Open settings"
+                  aria-label="Open settings"
+                >
+                  <Settings2 className="h-3.5 w-3.5" />
+                </button>
+
+                <button
+                  type="button"
                   onClick={handleEmergencyStopAll}
                   disabled={isEmergencyStopping}
                   className="text-destructive hover:bg-destructive/10 shrink-0 rounded p-1 transition-colors disabled:opacity-50"
@@ -360,7 +267,7 @@ export const Component = () => {
             </button>
           </header>
 
-          {/* Scrollable area: Settings + Sessions scroll together */}
+          {/* Scrollable area: sessions remain primary while settings stay behind the cog modal */}
           {isCollapsed ? (
             /* Collapsed: Sessions quick actions first, then settings shortcuts */
             <div className="mt-2 px-1">
@@ -413,6 +320,22 @@ export const Component = () => {
 
                 <button
                   type="button"
+                  onClick={() => setSettingsDialogOpen(true)}
+                  className={cn(
+                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                    settingsDialogOpen
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                  )}
+                  title="Open settings"
+                  aria-label="Open settings"
+                  aria-pressed={settingsDialogOpen || undefined}
+                >
+                  <Settings2 className="h-4 w-4" />
+                </button>
+
+                <button
+                  type="button"
                   onClick={() => setPastSessionsDialogOpen(true)}
                   className={cn(
                     "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
@@ -450,21 +373,6 @@ export const Component = () => {
                       </span>
                     )}
                   </div>
-                </NavLink>
-
-                <NavLink
-                  to="/settings/agents?view=list"
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    isAgentsActive
-                      ? "bg-accent text-accent-foreground"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Agents"
-                  aria-label="Agents"
-                  aria-current={isAgentsActive ? "page" : undefined}
-                >
-                  <span className="i-mingcute-group-line h-4 w-4"></span>
                 </NavLink>
 
                 {collapsedPreviewSessions.map((session) => {
@@ -527,73 +435,14 @@ export const Component = () => {
                   </button>
                 )}
               </div>
-
-              {/* Settings Section - collapsed quick navigation */}
-              <div className="mt-2 grid gap-1">
-                {settingsNavLinks.map((link) => {
-                  const isActive = isNavLinkActive(link.href)
-                  const icon = typeof link.icon === "string"
-                    ? <span className={cn(link.icon, "h-4 w-4")}></span>
-                    : <link.icon className="h-4 w-4" />
-
-                  return (
-                    <NavLink
-                      key={link.text}
-                      to={link.href}
-                      className={cn(
-                        "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                        isActive
-                          ? "bg-accent text-accent-foreground"
-                          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                      )}
-                      title={link.text}
-                      aria-label={link.text}
-                      aria-current={isActive ? "page" : undefined}
-                    >
-                      {icon}
-                    </NavLink>
-                  )
-                })}
-              </div>
             </div>
           ) : (
-            /* Expanded: Settings and Sessions share one scrollable container */
+            /* Expanded: keep the sidebar focused on live sessions; settings move behind the cog modal */
             <div className="scrollbar-none mt-2 min-h-0 flex-1 overflow-y-auto">
               {/* Sessions Section - shows sessions list */}
               <ActiveAgentsSidebar
                 onOpenPastSessionsDialog={() => setPastSessionsDialogOpen(true)}
               />
-
-              {/* Agents Section - capability management */}
-              <AgentCapabilitiesSidebar />
-
-              {/* Settings Section - Collapsible, collapsed by default */}
-              <div className="px-2">
-                <button
-                  onClick={() => setSettingsExpanded(!settingsExpanded)}
-                  className={cn(
-                    "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium transition-all duration-200",
-                    "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "transition-transform duration-200",
-                      settingsExpanded
-                        ? "i-mingcute-down-line"
-                        : "i-mingcute-right-line",
-                    )}
-                  ></span>
-                  <span className="i-mingcute-settings-3-line"></span>
-                  <span className="truncate">Settings</span>
-                </button>
-
-                {settingsExpanded && (
-                  <div className="mt-1 grid gap-0.5 text-sm">
-                    {settingsNavLinks.map(renderNavLink)}
-                  </div>
-                )}
-              </div>
 
               {/* Logo/version pushed down by menu content, scrolls naturally */}
               <div className="flex flex-col items-center pb-4 pt-2 space-y-2">
@@ -640,6 +489,7 @@ export const Component = () => {
             <Outlet
               context={{
                 onOpenPastSessionsDialog: () => setPastSessionsDialogOpen(true),
+                    onOpenSettingsDialog: () => setSettingsDialogOpen(true),
                 sidebarWidth,
               }}
             />

--- a/apps/desktop/src/renderer/src/components/connection-pairing-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/connection-pairing-dialog.tsx
@@ -1,0 +1,32 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@renderer/components/ui/dialog"
+import { RemoteServerSettingsGroups } from "@renderer/pages/settings-remote-server"
+
+type ConnectionPairingDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ConnectionPairingDialog({ open, onOpenChange }: ConnectionPairingDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Scan QR Code</DialogTitle>
+          <DialogDescription>
+            Pair DotAgents Mobile or another client from the main app window without leaving chat home.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[70vh] overflow-y-auto pr-1">
+          <RemoteServerSettingsGroups />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/home-settings-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/home-settings-dialog.tsx
@@ -1,0 +1,68 @@
+import { Button } from "@renderer/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@renderer/components/ui/dialog"
+import { useConfigQuery } from "@renderer/lib/query-client"
+import { Brain, BookOpen, Cog, MessageSquare, Plug2, QrCode, RefreshCw, Sparkles, Users } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+
+type HomeSettingsDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function HomeSettingsDialog({ open, onOpenChange }: HomeSettingsDialogProps) {
+  const navigate = useNavigate()
+  const configQuery = useConfigQuery()
+
+  const settingsLinks = [
+    { label: "General", href: "/settings", icon: Cog },
+    { label: "Connection", href: "/settings/remote-server", icon: QrCode },
+    { label: "Models", href: "/settings/models", icon: Brain },
+    { label: "Providers", href: "/settings/providers", icon: Plug2 },
+    { label: "Capabilities", href: "/settings/capabilities", icon: Sparkles },
+    { label: "Agents", href: "/settings/agents", icon: Users },
+    { label: "Repeat Tasks", href: "/settings/repeat-tasks", icon: RefreshCw },
+    { label: "Memories", href: "/memories", icon: BookOpen },
+    ...(configQuery.data?.whatsappEnabled
+      ? [{ label: "WhatsApp", href: "/settings/whatsapp", icon: MessageSquare }]
+      : []),
+  ] as const
+
+  const handleNavigate = (href: string) => {
+    onOpenChange(false)
+    navigate(href)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription>
+            Keep the main screen focused on chats and pairing, then jump into deeper settings only when you need them.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {settingsLinks.map(({ label, href, icon: Icon }) => (
+            <Button
+              key={href}
+              type="button"
+              variant="outline"
+              className="h-auto justify-start gap-2 px-3 py-3 text-left"
+              onClick={() => handleNavigate(href)}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="truncate">{label}</span>
+            </Button>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -167,11 +167,11 @@ export function useStoreSync() {
   }, [setPinnedSessionIds])
 
   useEffect(() => {
-    if (!pinnedSessionIdsHydratedRef.current) return
+    if (!pinnedSessionIdsHydratedRef.current) return undefined
 
     const nextPinnedSessionIds = Array.from(pinnedSessionIds)
     if (areStringArraysEqual(nextPinnedSessionIds, lastPersistedPinnedSessionIdsRef.current)) {
-      return
+      return undefined
     }
 
     let cancelled = false

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -6,7 +6,7 @@ import { useAgentStore, useAgentSessionProgress } from "@renderer/stores"
 import { SessionGrid, SessionTileWrapper, type TileLayoutMode } from "@renderer/components/session-grid"
 import { clearPersistedSize } from "@renderer/hooks/use-resizable"
 import { AgentProgress } from "@renderer/components/agent-progress"
-import { MessageCircle, Mic, Plus, CheckCircle2, LayoutGrid, Maximize2, Grid2x2, Keyboard, Clock, Loader2, Pin } from "lucide-react"
+import { MessageCircle, Mic, Plus, CheckCircle2, LayoutGrid, Maximize2, Grid2x2, Keyboard, Clock, Loader2, Pin, QrCode, Settings2, Link2, CircleDot } from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
 import type { AgentProfile, AgentProgressUpdate } from "@shared/types"
 import { toast } from "sonner"
@@ -20,9 +20,11 @@ import { useConfigQuery } from "@renderer/lib/query-client"
 import { useConversationHistoryQuery } from "@renderer/lib/queries"
 import { getMcpToolsShortcutDisplay, getTextInputShortcutDisplay, getDictationShortcutDisplay } from "@shared/key-utils"
 import dayjs from "dayjs"
+import { ConnectionPairingDialog } from "@renderer/components/connection-pairing-dialog"
 
 interface LayoutContext {
   onOpenPastSessionsDialog: () => void
+  onOpenSettingsDialog: () => void
   sidebarWidth: number
 }
 
@@ -142,17 +144,22 @@ const SessionAgentTile = React.memo(function SessionAgentTile({
   )
 })
 
-function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionClick, onOpenPastSessionsDialog, textInputShortcut, voiceInputShortcut, dictationShortcut, selectedAgentId, onSelectAgent }: {
+function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionClick, onOpenPastSessionsDialog, onOpenPairingDialog, onOpenSettingsDialog, textInputShortcut, voiceInputShortcut, dictationShortcut, selectedAgentId, onSelectAgent, isConnected, isConnectionEnabled, isConnectionRunning }: {
   onTextClick: () => void
   onVoiceClick: () => void
   onSelectPrompt: (content: string) => void
   onPastSessionClick: (conversationId: string) => void
   onOpenPastSessionsDialog: () => void
+  onOpenPairingDialog: () => void
+  onOpenSettingsDialog: () => void
   textInputShortcut: string
   voiceInputShortcut: string
   dictationShortcut: string
   selectedAgentId: string | null
   onSelectAgent: (id: string | null) => void
+  isConnected: boolean
+  isConnectionEnabled: boolean
+  isConnectionRunning: boolean
 }) {
   const conversationHistoryQuery = useConversationHistoryQuery()
   const pinnedSessionIds = useAgentStore((state) => state.pinnedSessionIds)
@@ -178,6 +185,11 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
 
   return (
     <div className="flex w-full flex-col items-center px-5 py-6 text-center sm:px-6">
+      <div className="mb-4 flex w-full max-w-md justify-end">
+        <Button variant="ghost" size="icon" onClick={onOpenSettingsDialog} aria-label="Open settings">
+          <Settings2 className="h-4 w-4" />
+        </Button>
+      </div>
       <div className="mb-3 rounded-full bg-muted/70 p-2.5">
         <MessageCircle className="h-5 w-5 text-muted-foreground" />
       </div>
@@ -199,6 +211,10 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
           <Button variant="secondary" onClick={onVoiceClick} className="gap-2">
             <Mic className="h-4 w-4" />
             Start with Voice
+          </Button>
+          <Button variant="outline" onClick={onOpenPairingDialog} className="gap-2">
+            <QrCode className="h-4 w-4" />
+            Scan QR Code
           </Button>
           <PredefinedPromptsMenu onSelectPrompt={onSelectPrompt} buttonSize="sm" />
         </div>
@@ -226,13 +242,13 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
         </div>
       </div>
 
-      {/* Recent past sessions */}
-      {recentSessions.length > 0 && (
+      {/* Connected users should return to history quickly; disconnected users should see pairing guidance instead. */}
+      {isConnected ? (
         <div className="mt-6 w-full max-w-md text-left">
           <div className="flex items-center justify-between mb-2 px-1">
             <h4 className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
               <Clock className="h-3.5 w-3.5" />
-              Recent Sessions
+              Conversation History
             </h4>
             {totalCount > RECENT_SESSIONS_LIMIT && (
               <button
@@ -243,45 +259,84 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
               </button>
             )}
           </div>
-          <div className="space-y-0.5">
-            {recentSessions.map((session) => {
-              const isPinned = pinnedSessionIds.has(session.id)
+          {recentSessions.length > 0 ? (
+            <div className="space-y-0.5">
+              {recentSessions.map((session) => {
+                const isPinned = pinnedSessionIds.has(session.id)
 
-              return (
-                <div
-                  key={session.id}
-                  role="button"
-                  tabIndex={0}
-                  onClick={() => onPastSessionClick(session.id)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault()
-                      onPastSessionClick(session.id)
-                    }
-                  }}
-                  className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left transition-colors hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                >
-                  <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                  <span className="truncate flex-1">{session.title}</span>
-                  <div className="ml-auto flex shrink-0 items-center gap-1">
-                    <button
-                      type="button"
-                      onClick={(e) => handleTogglePinnedSession(session.id, e)}
-                      onKeyDown={stopSessionRowKeyPropagation}
-                      className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
-                      title={isPinned ? "Unpin session" : "Pin session"}
-                      aria-label={`${isPinned ? "Unpin" : "Pin"} ${session.title}`}
-                      aria-pressed={isPinned}
-                    >
-                      <Pin className={isPinned ? "h-3.5 w-3.5 fill-current text-foreground" : "h-3.5 w-3.5"} />
-                    </button>
-                    <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
-                      {formatTimestamp(session.updatedAt)}
-                    </span>
+                return (
+                  <div
+                    key={session.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => onPastSessionClick(session.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        onPastSessionClick(session.id)
+                      }
+                    }}
+                    className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-left transition-colors hover:bg-accent/50 focus-visible:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
+                    <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <span className="truncate flex-1">{session.title}</span>
+                    <div className="ml-auto flex shrink-0 items-center gap-1">
+                      <button
+                        type="button"
+                        onClick={(e) => handleTogglePinnedSession(session.id, e)}
+                        onKeyDown={stopSessionRowKeyPropagation}
+                        className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
+                        title={isPinned ? "Unpin session" : "Pin session"}
+                        aria-label={`${isPinned ? "Unpin" : "Pin"} ${session.title}`}
+                        aria-pressed={isPinned}
+                      >
+                        <Pin className={isPinned ? "h-3.5 w-3.5 fill-current text-foreground" : "h-3.5 w-3.5"} />
+                      </button>
+                      <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+                        {formatTimestamp(session.updatedAt)}
+                      </span>
+                    </div>
                   </div>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
+              You’re connected. Start a chat and your conversation history will show up here for quick re-entry.
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="mt-6 w-full max-w-md text-left">
+          <div className="rounded-xl border border-dashed border-border/70 bg-muted/20 p-4">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-full bg-background/80 p-2">
+                <Link2 className="h-4 w-4 text-muted-foreground" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <h4 className="text-sm font-medium">Connection Info</h4>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-border/70 bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                    <CircleDot className="h-3 w-3" />
+                    {isConnectionRunning ? "Pairing not finished" : isConnectionEnabled ? "Starting up" : "Disconnected"}
+                  </span>
                 </div>
-              )
-            })}
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {isConnectionEnabled
+                    ? "Open the QR flow to finish pairing and bring your existing conversations back to the home screen."
+                    : "Enable the remote server, generate a QR code, and pair a client before the home screen switches over to conversation history."}
+                </p>
+                <div className="mt-3 flex flex-wrap items-center gap-2">
+                  <Button variant="outline" onClick={onOpenPairingDialog} className="gap-2">
+                    <QrCode className="h-4 w-4" />
+                    Scan QR Code
+                  </Button>
+                  <span className="text-xs text-muted-foreground">
+                    Use the cog for deeper settings.
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       )}
@@ -291,7 +346,7 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onPastSessionCl
 
 export function Component() {
   const { id: routeHistoryItemId } = useParams<{ id: string }>()
-  const { onOpenPastSessionsDialog, sidebarWidth } = (useOutletContext<LayoutContext>() ?? {}) as Partial<LayoutContext>
+  const { onOpenPastSessionsDialog, onOpenSettingsDialog, sidebarWidth } = (useOutletContext<LayoutContext>() ?? {}) as Partial<LayoutContext>
   const agentProgressById = useAgentStore((s) => s.agentProgressById)
   const focusedSessionId = useAgentStore((s) => s.focusedSessionId)
   const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
@@ -303,6 +358,14 @@ export function Component() {
   const textInputShortcut = getTextInputShortcutDisplay(configQuery.data?.textInputShortcut, configQuery.data?.customTextInputShortcut)
   const voiceInputShortcut = getMcpToolsShortcutDisplay(configQuery.data?.mcpToolsShortcut, configQuery.data?.customMcpToolsShortcut)
   const dictationShortcut = getDictationShortcutDisplay(configQuery.data?.shortcut, configQuery.data?.customShortcut)
+  const [pairingDialogOpen, setPairingDialogOpen] = useState(false)
+
+  const remoteServerStatusQuery = useQuery({
+    queryKey: ["remote-server-status"],
+    queryFn: () => tipcClient.getRemoteServerStatus(),
+    refetchInterval: 2000,
+    enabled: configQuery.data?.remoteServerEnabled ?? false,
+  })
 
   const [sessionOrder, setSessionOrder] = useState<string[]>([])
   const [draggedSessionId, setDraggedSessionId] = useState<string | null>(null)
@@ -769,6 +832,10 @@ export function Component() {
     return allProgressEntries.filter(([_, progress]) => progress?.isComplete).length
   }, [allProgressEntries])
 
+  const isConnectionEnabled = configQuery.data?.remoteServerEnabled ?? false
+  const isConnectionRunning = isConnectionEnabled && (remoteServerStatusQuery.data?.running ?? false)
+  const isConnected = isConnectionRunning && !!configQuery.data?.remoteServerApiKey
+
   const showPendingLoadingTile =
     !!pendingConversationId &&
     !pendingProgress &&
@@ -781,6 +848,11 @@ export function Component() {
 
   return (
     <div className="group/tile flex h-full flex-col">
+      <ConnectionPairingDialog
+        open={pairingDialogOpen}
+        onOpenChange={setPairingDialogOpen}
+      />
+
       {/* Header with start buttons - outside the scroll area so its height is excluded
           when SessionGrid measures the parent to size tiles. */}
       {hasSessions && (
@@ -817,6 +889,26 @@ export function Component() {
                 <span className="hidden md:inline">Past Sessions</span>
               </Button>
             )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setPairingDialogOpen(true)}
+              className="gap-1.5 text-muted-foreground hover:text-foreground"
+              title="Scan QR Code"
+            >
+              <QrCode className="h-4 w-4 shrink-0" />
+              <span className="hidden md:inline">Scan QR Code</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onOpenSettingsDialog ?? (() => {})}
+              className="h-7 px-2 text-muted-foreground hover:text-foreground"
+              title="Open settings"
+              aria-label="Open settings"
+            >
+              <Settings2 className="h-4 w-4" />
+            </Button>
             {/* Cycle tile layout mode button */}
             <Button
               variant="ghost"
@@ -860,11 +952,16 @@ export function Component() {
             onSelectPrompt={handleSelectPrompt}
             onPastSessionClick={handleContinueConversation}
             onOpenPastSessionsDialog={onOpenPastSessionsDialog ?? (() => {})}
+            onOpenPairingDialog={() => setPairingDialogOpen(true)}
+            onOpenSettingsDialog={onOpenSettingsDialog ?? (() => {})}
             textInputShortcut={textInputShortcut}
             voiceInputShortcut={voiceInputShortcut}
             dictationShortcut={dictationShortcut}
             selectedAgentId={selectedAgentId}
             onSelectAgent={setSelectedAgentId}
+            isConnected={isConnected}
+            isConnectionEnabled={isConnectionEnabled}
+            isConnectionRunning={isConnectionRunning}
           />
         ) : (
           /* Active sessions - grid view */

--- a/apps/desktop/tests/app-layout-settings-modal.test.mjs
+++ b/apps/desktop/tests/app-layout-settings-modal.test.mjs
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const appLayoutSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/renderer/src/components/app-layout.tsx'),
+  'utf8',
+)
+
+test('desktop app layout hides the old always-visible settings panel behind a cog modal', () => {
+  assert.match(appLayoutSource, /<HomeSettingsDialog[\s\S]*?open=\{settingsDialogOpen\}/)
+  assert.match(appLayoutSource, /<Settings2 className="h-3\.5 w-3\.5" \/>/)
+  assert.doesNotMatch(appLayoutSource, /<AgentCapabilitiesSidebar/)
+  assert.doesNotMatch(appLayoutSource, /Settings Section - Collapsible/)
+})

--- a/apps/desktop/tests/sessions-empty-state-density.test.mjs
+++ b/apps/desktop/tests/sessions-empty-state-density.test.mjs
@@ -19,6 +19,7 @@ test('desktop sessions empty state trims decorative chrome and keeps the selecto
 
 test('desktop sessions empty state keeps secondary controls and recent sessions tighter', () => {
   assert.match(sessionsSource, /<PredefinedPromptsMenu onSelectPrompt=\{onSelectPrompt\} buttonSize="sm" \/>/)
+  assert.match(sessionsSource, /Scan QR Code/)
   assert.match(sessionsSource, /flex flex-wrap items-center justify-center gap-2\.5 text-xs text-muted-foreground/)
   assert.match(sessionsSource, /mt-6 w-full max-w-md text-left/)
 })
@@ -28,4 +29,11 @@ test('desktop sessions empty state recent list supports pinning and pinned-first
   assert.match(sessionsSource, /sortedRecentSessions\.slice\(0, RECENT_SESSIONS_LIMIT\)/)
   assert.match(sessionsSource, /aria-label=\{`\$\{isPinned \? "Unpin" : "Pin"\} \$\{session\.title\}`\}/)
   assert.match(sessionsSource, /onKeyDown=\{stopSessionRowKeyPropagation\}/)
+})
+
+test('desktop sessions home switches between conversation history and connection guidance', () => {
+  assert.match(sessionsSource, /Conversation History/)
+  assert.match(sessionsSource, /Connection Info/)
+  assert.match(sessionsSource, /Use the cog for deeper settings\./)
+  assert.match(sessionsSource, /<ConnectionPairingDialog/)
 })


### PR DESCRIPTION
## Summary
- add a visible **Scan QR Code** entry to desktop chat home and the active sessions toolbar
- switch the desktop home empty state between **conversation history** and **connection guidance** based on remote-server readiness
- move desktop main-screen settings access behind a **cog-triggered modal** and remove the always-visible settings panel
- include focused source tests for the new home-screen/settings behavior and a tiny `use-store-sync` return-path fix required to restore renderer typecheck

## Validation
- `node --test apps/desktop/tests/sessions-empty-state-density.test.mjs apps/desktop/tests/app-layout-settings-modal.test.mjs`
- `pnpm --filter @dotagents/desktop typecheck:web`

Fixes #124

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author