### PR TITLE
feat: add mobile split view and continue-response fallbacks

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -36,6 +36,7 @@ import {
   getSessionUserResponse,
   getSessionUserResponseHistory,
 } from "./session-user-response-store"
+import { resolveLatestUserFacingResponse } from "./respond-to-user-utils"
 import {
   MARK_WORK_COMPLETE_TOOL,
   RESPOND_TO_USER_TOOL,
@@ -541,10 +542,10 @@ export async function processTranscriptWithAgentMode(
     const conversationTitle = session?.conversationTitle
     const profileName = session?.profileSnapshot?.profileName
     const storedUserResponse = getSessionUserResponse(currentSessionId)
-    const normalizedStoredUserResponse =
-      typeof storedUserResponse === "string" && storedUserResponse.trim().length > 0
-        ? storedUserResponse
-        : undefined
+    const normalizedStoredUserResponse = resolveLatestUserFacingResponse({
+      storedResponse: storedUserResponse,
+      conversationHistory: update.conversationHistory as any,
+    })
     const isKillSwitchCompletion =
       update.isComplete &&
       typeof update.finalContent === "string" &&
@@ -2063,7 +2064,10 @@ Return ONLY JSON per schema.`,
         }
 
         // Skip post-verify summary if respond_to_user already provided a response (#1084)
-        const existingUserResponse1 = getSessionUserResponse(currentSessionId)
+        const existingUserResponse1 = resolveLatestUserFacingResponse({
+          storedResponse: getSessionUserResponse(currentSessionId),
+          conversationHistory: conversationHistory as any,
+        })
         if (existingUserResponse1?.trim().length) {
           finalContent = existingUserResponse1
           if (finalContent.trim().length > 0) {
@@ -2214,7 +2218,11 @@ Return ONLY JSON per schema.`,
         // spin until maxIterations. The noOpCount threshold (2) matches the one
         // used in the !hasToolCalls path so both branches converge consistently.
         if (noOpCount >= 2) {
-          const storedResponse = getSessionUserResponse(currentSessionId)
+          const storedResponse = resolveLatestUserFacingResponse({
+            storedResponse: getSessionUserResponse(currentSessionId),
+            plannedToolCalls: toolCallsArray,
+            conversationHistory: conversationHistory as any,
+          })
           if (storedResponse?.trim().length) {
             // Already have a user-facing response — skip tool execution and break
             finalContent = storedResponse
@@ -2658,7 +2666,10 @@ Return ONLY JSON per schema.`,
       const hasMinimalContent = lastAssistantContent.trim().length < 50
 
       // Skip summary generation if respond_to_user already provided a response (#1084)
-      const existingUserResponse = getSessionUserResponse(currentSessionId)
+      const existingUserResponse = resolveLatestUserFacingResponse({
+        storedResponse: getSessionUserResponse(currentSessionId),
+        conversationHistory: conversationHistory as any,
+      })
       let respondToUserAlreadyInHistory = false
       if (existingUserResponse?.trim().length) {
         finalContent = existingUserResponse
@@ -2834,7 +2845,10 @@ Return ONLY JSON per schema.`,
         // Skip when forced incomplete - the fallback message below will be the only assistant message
         // Skip summary generation if respond_to_user already provided a response (#1084)
         // Also skip if respond_to_user response was already added to history above
-        const existingUserResponse2 = getSessionUserResponse(currentSessionId)
+        const existingUserResponse2 = resolveLatestUserFacingResponse({
+          storedResponse: getSessionUserResponse(currentSessionId),
+          conversationHistory: conversationHistory as any,
+        })
         if (existingUserResponse2?.trim().length && !respondToUserAlreadyInHistory) {
           finalContent = existingUserResponse2
           if (finalContent.trim().length > 0) {

--- a/apps/desktop/src/main/respond-to-user-utils.test.ts
+++ b/apps/desktop/src/main/respond-to-user-utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  extractRespondToUserContentFromArgs,
+  getLatestRespondToUserContentFromConversationHistory,
+  getLatestRespondToUserContentFromToolCalls,
+  resolveLatestUserFacingResponse,
+} from "./respond-to-user-utils"
+
+describe("respond-to-user-utils", () => {
+  it("extracts text and image markdown from respond_to_user args", () => {
+    expect(extractRespondToUserContentFromArgs({
+      text: "Done",
+      images: [{ alt: "Preview", path: "/tmp/result.png" }],
+    })).toBe("Done\n\n![Preview](/tmp/result.png)")
+  })
+
+  it("returns the latest respond_to_user content from tool calls", () => {
+    expect(getLatestRespondToUserContentFromToolCalls([
+      { name: "web_search", arguments: { query: "ignore" } },
+      { name: "respond_to_user", arguments: { text: "First update" } },
+      { name: "respond_to_user", arguments: { text: "Final answer" } },
+    ])).toBe("Final answer")
+  })
+
+  it("falls back to the latest respond_to_user entry in conversation history", () => {
+    expect(getLatestRespondToUserContentFromConversationHistory([
+      { role: "assistant", toolCalls: [{ name: "respond_to_user", arguments: { text: "Earlier" } }] },
+      { role: "tool", toolCalls: [{ name: "respond_to_user", arguments: { text: "Ignored" } }] },
+      { role: "assistant", toolCalls: [{ name: "respond_to_user", arguments: { text: "Latest" } }] },
+    ])).toBe("Latest")
+  })
+
+  it("prefers the current iteration's planned respond_to_user over a stale stored response", () => {
+    expect(resolveLatestUserFacingResponse({
+      storedResponse: "Stale answer",
+      plannedToolCalls: [{ name: "respond_to_user", arguments: { text: "Fresh answer" } }],
+      conversationHistory: [{ role: "assistant", toolCalls: [{ name: "respond_to_user", arguments: { text: "Older history" } }] }],
+    })).toBe("Fresh answer")
+  })
+
+  it("uses the stored response before falling back to history", () => {
+    expect(resolveLatestUserFacingResponse({
+      storedResponse: "Stored answer",
+      conversationHistory: [{ role: "assistant", toolCalls: [{ name: "respond_to_user", arguments: { text: "History answer" } }] }],
+    })).toBe("Stored answer")
+  })
+})

--- a/apps/desktop/src/main/respond-to-user-utils.ts
+++ b/apps/desktop/src/main/respond-to-user-utils.ts
@@ -1,0 +1,89 @@
+import { RESPOND_TO_USER_TOOL } from "../shared/builtin-tool-names"
+
+type ToolCallLike = {
+  name?: string
+  arguments?: unknown
+}
+
+type ConversationHistoryLike = Array<{
+  role?: string
+  toolCalls?: ToolCallLike[]
+}>
+
+export function extractRespondToUserContentFromArgs(args: unknown): string | undefined {
+  if (!args || typeof args !== "object") return undefined
+
+  const parsedArgs = args as Record<string, unknown>
+  const text = typeof parsedArgs.text === "string" ? parsedArgs.text.trim() : ""
+  const images = Array.isArray(parsedArgs.images) ? parsedArgs.images : []
+
+  const imageMarkdown = images
+    .map((image, index) => {
+      if (!image || typeof image !== "object") return ""
+      const parsedImage = image as Record<string, unknown>
+      const alt = typeof parsedImage.alt === "string" && parsedImage.alt.trim().length > 0
+        ? parsedImage.alt.trim()
+        : `Image ${index + 1}`
+      const path = typeof parsedImage.path === "string" ? parsedImage.path.trim() : ""
+      const dataUrl = typeof parsedImage.dataUrl === "string" ? parsedImage.dataUrl.trim() : ""
+      const uri = dataUrl || path
+      if (!uri) return ""
+      return `![${alt}](${uri})`
+    })
+    .filter(Boolean)
+    .join("\n\n")
+
+  const combined = [text, imageMarkdown].filter(Boolean).join("\n\n").trim()
+  return combined.length > 0 ? combined : undefined
+}
+
+export function getLatestRespondToUserContentFromToolCalls(toolCalls?: ToolCallLike[]): string | undefined {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return undefined
+
+  let latestResponse: string | undefined
+  for (const toolCall of toolCalls) {
+    if (toolCall?.name !== RESPOND_TO_USER_TOOL) continue
+    const content = extractRespondToUserContentFromArgs(toolCall.arguments)
+    if (content) {
+      latestResponse = content
+    }
+  }
+
+  return latestResponse
+}
+
+export function getLatestRespondToUserContentFromConversationHistory(
+  conversationHistory: ConversationHistoryLike,
+): string | undefined {
+  if (!Array.isArray(conversationHistory) || conversationHistory.length === 0) return undefined
+
+  let latestResponse: string | undefined
+  for (const message of conversationHistory) {
+    if (message?.role !== "assistant") continue
+    const content = getLatestRespondToUserContentFromToolCalls(message.toolCalls)
+    if (content) {
+      latestResponse = content
+    }
+  }
+
+  return latestResponse
+}
+
+export function resolveLatestUserFacingResponse({
+  storedResponse,
+  plannedToolCalls,
+  conversationHistory,
+}: {
+  storedResponse?: string
+  plannedToolCalls?: ToolCallLike[]
+  conversationHistory?: ConversationHistoryLike
+}): string | undefined {
+  const normalizedStoredResponse =
+    typeof storedResponse === "string" && storedResponse.trim().length > 0
+      ? storedResponse
+      : undefined
+
+  return getLatestRespondToUserContentFromToolCalls(plannedToolCalls)
+    ?? normalizedStoredResponse
+    ?? getLatestRespondToUserContentFromConversationHistory(conversationHistory ?? [])
+}

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SettingsScreen from './src/screens/SettingsScreen';
 import ChatScreen from './src/screens/ChatScreen';
 import SessionListScreen from './src/screens/SessionListScreen';
+import SplitChatScreen from './src/screens/SplitChatScreen';
 import ConnectionSettingsScreen from './src/screens/ConnectionSettingsScreen';
 import AgentEditScreen from './src/screens/AgentEditScreen';
 import MemoryEditScreen from './src/screens/MemoryEditScreen';
@@ -405,6 +406,11 @@ function Navigation() {
                       name="Sessions"
                       component={SessionListScreen}
                       options={{ title: 'Chats' }}
+                    />
+                    <Stack.Screen
+                      name="SplitChat"
+                      component={SplitChatScreen}
+                      options={{ title: 'Split View' }}
                     />
                     <Stack.Screen name="Chat" component={ChatScreen} />
                     <Stack.Screen

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "pnpm run test:node && pnpm run test:vitest",
     "test:node": "node --test \"tests/*.js\"",
-    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts"
+    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
   },
   "dependencies": {
     "@dotagents/shared": "workspace:^",

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -597,6 +597,10 @@ export default function SessionListScreen({ navigation }: Props) {
     navigation.navigate('Settings');
   }, [navigation]);
 
+  const handleOpenSplitView = useCallback(() => {
+    navigation.navigate('SplitChat');
+  }, [navigation]);
+
   const handleOpenConnectionSettings = useCallback((openScanner = false) => {
     if (openScanner) {
       navigation.navigate('ConnectionSettings', { openScanner: true });
@@ -644,6 +648,15 @@ export default function SessionListScreen({ navigation }: Props) {
             compact
           />
           <TouchableOpacity
+            onPress={handleOpenSplitView}
+            style={styles.headerSettingsButton}
+            accessibilityRole="button"
+            accessibilityLabel={createButtonAccessibilityLabel('Open split view')}
+            accessibilityHint="Opens two chats at once for comparison"
+          >
+            <Text style={{ fontSize: 17, color: theme.colors.foreground }}>◫</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
             onPress={handleOpenSettings}
             style={styles.headerSettingsButton}
             accessibilityRole="button"
@@ -655,7 +668,7 @@ export default function SessionListScreen({ navigation }: Props) {
         </View>
       ),
     });
-  }, [navigation, styles, theme, connectionInfo.state, connectionInfo.retryCount, currentProfile, setAgentSelectorVisible, handleOpenSettings]);
+  }, [navigation, styles, theme, connectionInfo.state, connectionInfo.retryCount, currentProfile, setAgentSelectorVisible, handleOpenSettings, handleOpenSplitView]);
   const insets = useSafeAreaInsets();
   const sessionStore = useSessionContext();
   sessionStoreRef.current = sessionStore;
@@ -760,7 +773,7 @@ export default function SessionListScreen({ navigation }: Props) {
     const date = new Date(timestamp);
     const now = new Date();
     const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
-    
+
     if (diffDays === 0) {
       return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     } else if (diffDays === 1) {

--- a/apps/mobile/src/screens/SplitChatScreen.tsx
+++ b/apps/mobile/src/screens/SplitChatScreen.tsx
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  FlatList,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { ChatMessage } from '../lib/openaiClient';
+import { createButtonAccessibilityLabel } from '../lib/accessibility';
+import { ConfigContext, useConfigContext } from '../store/config';
+import { SessionContext, useSessionContext } from '../store/sessions';
+import type { SessionStore } from '../store/sessions';
+import type { SessionListItem } from '../types/session';
+import { useTheme } from '../ui/ThemeProvider';
+import { radius, spacing } from '../ui/theme';
+import type { Theme } from '../ui/theme';
+import ChatScreen from './ChatScreen';
+import {
+  reconcileSplitPaneSelection,
+  replaceSplitPaneSelection,
+  resolveSplitOrientation,
+} from './split-chat-utils';
+import type { SplitOrientationPreference, SplitPane } from './split-chat-utils';
+
+interface Props {
+  navigation: any;
+}
+
+function createSplitPaneSessionStore(
+  baseStore: SessionStore,
+  sessionId: string | null,
+  onPaneSessionChange: (nextSessionId: string | null) => void,
+): SessionStore {
+  const getPaneSession = () => sessionId ? baseStore.sessions.find((entry) => entry.id === sessionId) ?? null : null;
+
+  return {
+    ...baseStore,
+    currentSessionId: sessionId,
+    createNewSession: () => {
+      const createdSession = baseStore.createNewSession();
+      onPaneSessionChange(createdSession.id);
+      return createdSession;
+    },
+    setCurrentSession: (id) => {
+      onPaneSessionChange(id);
+      baseStore.setCurrentSession(id);
+    },
+    deleteSession: async (id) => {
+      const fallbackSessionId = sessionId === id
+        ? baseStore.getSessionList().find((entry) => entry.id !== id)?.id ?? null
+        : sessionId;
+      await baseStore.deleteSession(id);
+      if (sessionId === id) {
+        onPaneSessionChange(fallbackSessionId);
+      }
+    },
+    clearAllSessions: async () => {
+      await baseStore.clearAllSessions();
+      onPaneSessionChange(null);
+    },
+    addMessage: async (role, content, toolCalls, toolResults) => {
+      const paneSession = getPaneSession();
+      if (!paneSession) return;
+      const nextMessages: ChatMessage[] = [
+        ...paneSession.messages,
+        { role, content, toolCalls, toolResults, timestamp: Date.now() } as ChatMessage,
+      ];
+      await baseStore.setMessagesForSession(paneSession.id, nextMessages);
+    },
+    getCurrentSession: () => getPaneSession(),
+    setMessages: async (messages) => {
+      if (!sessionId) return;
+      await baseStore.setMessagesForSession(sessionId, messages);
+    },
+    setServerConversationId: async (serverConversationId) => {
+      if (!sessionId) return;
+      await baseStore.setServerConversationIdForSession(sessionId, serverConversationId);
+    },
+    getServerConversationId: () => getPaneSession()?.serverConversationId,
+  };
+}
+
+export default function SplitChatScreen({ navigation }: Props) {
+  const { theme } = useTheme();
+  const { width, height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const configStore = useConfigContext();
+  const sessionStore = useSessionContext();
+  const sessionList = useMemo(() => sessionStore.getSessionList(), [sessionStore.sessions]);
+  const sessionIdsKey = useMemo(() => sessionList.map((entry) => entry.id).join('|'), [sessionList]);
+  const [layoutPreference, setLayoutPreference] = useState<SplitOrientationPreference>('auto');
+  const [pickerPane, setPickerPane] = useState<SplitPane | null>(null);
+  const [selection, setSelection] = useState({ primary: null as string | null, secondary: null as string | null });
+
+  useEffect(() => {
+    if (!sessionStore.ready) return;
+    setSelection((current) => reconcileSplitPaneSelection(current, sessionList.map((entry) => entry.id), sessionStore.currentSessionId));
+  }, [sessionStore.ready, sessionStore.currentSessionId, sessionIdsKey]);
+
+  const setPrimarySessionId = useCallback((nextSessionId: string | null) => {
+    setSelection((current) => replaceSplitPaneSelection(current, 'primary', nextSessionId));
+  }, []);
+
+  const setSecondarySessionId = useCallback((nextSessionId: string | null) => {
+    setSelection((current) => replaceSplitPaneSelection(current, 'secondary', nextSessionId));
+  }, []);
+
+  const primaryStore = useMemo(
+    () => createSplitPaneSessionStore(sessionStore, selection.primary, setPrimarySessionId),
+    [selection.primary, sessionStore, setPrimarySessionId],
+  );
+  const secondaryStore = useMemo(
+    () => createSplitPaneSessionStore(sessionStore, selection.secondary, setSecondarySessionId),
+    [selection.secondary, sessionStore, setSecondarySessionId],
+  );
+
+  const effectiveOrientation = resolveSplitOrientation(layoutPreference, width, height);
+  const splitConfigValue = useMemo(() => ({
+    ...configStore,
+    config: {
+      ...configStore.config,
+      handsFree: false,
+      handsFreeDebug: false,
+    },
+  }), [configStore]);
+
+  const createSessionForPane = useCallback((pane: SplitPane) => {
+    const createdSession = sessionStore.createNewSession();
+    if (pane === 'primary') {
+      setPrimarySessionId(createdSession.id);
+      return;
+    }
+    setSecondarySessionId(createdSession.id);
+  }, [sessionStore, setPrimarySessionId, setSecondarySessionId]);
+
+  const openFullScreenChat = useCallback((sessionId: string | null) => {
+    if (!sessionId) return;
+    sessionStore.setCurrentSession(sessionId);
+    navigation.navigate('Chat');
+  }, [navigation, sessionStore]);
+
+  const renderPane = useCallback((pane: SplitPane, sessionId: string | null, store: SessionStore) => {
+    const session = sessionList.find((entry) => entry.id === sessionId) ?? null;
+    return (
+      <View style={[styles.pane, effectiveOrientation === 'vertical' ? styles.paneVertical : styles.paneHorizontal]}>
+        <View style={styles.paneToolbar}>
+          <View style={styles.paneToolbarTextWrap}>
+            <Text style={styles.paneLabel}>{pane === 'primary' ? 'Primary chat' : 'Secondary chat'}</Text>
+            <Text style={styles.paneTitle} numberOfLines={1}>{session?.title || 'No chat selected'}</Text>
+          </View>
+          <View style={styles.paneToolbarActions}>
+            <TouchableOpacity
+              onPress={() => setPickerPane(pane)}
+              style={styles.toolbarButton}
+              accessibilityRole="button"
+              accessibilityLabel={createButtonAccessibilityLabel(`Choose ${pane} split chat`)}
+            >
+              <Text style={styles.toolbarButtonText}>Choose</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => openFullScreenChat(sessionId)}
+              disabled={!sessionId}
+              style={[styles.toolbarButton, !sessionId && styles.toolbarButtonDisabled]}
+              accessibilityRole="button"
+              accessibilityLabel={createButtonAccessibilityLabel(`Open ${pane} split chat full screen`)}
+            >
+              <Text style={styles.toolbarButtonText}>Open</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+        <View style={styles.paneBody}>
+          {sessionId ? (
+            <SessionContext.Provider value={store}>
+              <ChatScreen route={{ params: { splitView: true, pane } }} navigation={undefined} />
+            </SessionContext.Provider>
+          ) : (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyStateTitle}>Pick a chat for this pane</Text>
+              <Text style={styles.emptyStateCopy}>
+                Compare two active conversations side by side, or create a fresh chat for this split pane.
+              </Text>
+              <View style={styles.emptyStateActions}>
+                <TouchableOpacity style={styles.primaryButton} onPress={() => setPickerPane(pane)}>
+                  <Text style={styles.primaryButtonText}>Choose chat</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.secondaryButton} onPress={() => createSessionForPane(pane)}>
+                  <Text style={styles.secondaryButtonText}>New chat</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          )}
+        </View>
+      </View>
+    );
+  }, [createSessionForPane, effectiveOrientation, openFullScreenChat, sessionList, styles]);
+
+  return (
+    <ConfigContext.Provider value={splitConfigValue}>
+      <View style={[styles.screen, { paddingBottom: insets.bottom }]}>
+        <View style={styles.controlBar}>
+          <Text style={styles.controlBarTitle}>Split view</Text>
+          <Text style={styles.controlBarCopy}>Run and compare two sessions at once. Hands-free mode is paused while split view is open.</Text>
+          <View style={styles.segmentedRow}>
+            {(['auto', 'horizontal', 'vertical'] as SplitOrientationPreference[]).map((option) => (
+              <Pressable
+                key={option}
+                onPress={() => setLayoutPreference(option)}
+                style={[styles.segmentButton, layoutPreference === option && styles.segmentButtonActive]}
+              >
+                <Text style={[styles.segmentButtonText, layoutPreference === option && styles.segmentButtonTextActive]}>
+                  {option === 'auto' ? 'Auto' : option === 'horizontal' ? 'Horizontal' : 'Vertical'}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+
+        <View style={[styles.splitContainer, effectiveOrientation === 'vertical' ? styles.splitVertical : styles.splitHorizontal]}>
+          {renderPane('primary', selection.primary, primaryStore)}
+          {renderPane('secondary', selection.secondary, secondaryStore)}
+        </View>
+
+        <Modal transparent visible={pickerPane !== null} animationType="fade" onRequestClose={() => setPickerPane(null)}>
+          <Pressable style={styles.modalOverlay} onPress={() => setPickerPane(null)}>
+            <Pressable style={styles.modalCard} onPress={(event) => event.stopPropagation()}>
+              <Text style={styles.modalTitle}>Choose {pickerPane === 'primary' ? 'primary' : 'secondary'} chat</Text>
+              <FlatList<SessionListItem>
+                data={sessionList}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => {
+                  const isSelected = (pickerPane === 'primary' ? selection.primary : selection.secondary) === item.id;
+                  return (
+                    <TouchableOpacity
+                      style={[styles.sessionOption, isSelected && styles.sessionOptionActive]}
+                      onPress={() => {
+                        if (pickerPane === 'primary') setPrimarySessionId(item.id);
+                        if (pickerPane === 'secondary') setSecondarySessionId(item.id);
+                        setPickerPane(null);
+                      }}
+                    >
+                      <Text style={styles.sessionOptionTitle} numberOfLines={1}>{item.title}</Text>
+                      <Text style={styles.sessionOptionPreview} numberOfLines={2}>{item.preview || 'No messages yet'}</Text>
+                    </TouchableOpacity>
+                  );
+                }}
+                ListFooterComponent={(
+                  <TouchableOpacity
+                    style={styles.newChatOption}
+                    onPress={() => {
+                      if (pickerPane) createSessionForPane(pickerPane);
+                      setPickerPane(null);
+                    }}
+                  >
+                    <Text style={styles.newChatOptionText}>Create a new chat for this pane</Text>
+                  </TouchableOpacity>
+                )}
+              />
+            </Pressable>
+          </Pressable>
+        </Modal>
+      </View>
+    </ConfigContext.Provider>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    screen: { flex: 1, backgroundColor: theme.colors.background, padding: spacing.sm, gap: spacing.sm },
+    controlBar: { backgroundColor: theme.colors.card, borderRadius: radius.xl, padding: spacing.md, borderWidth: 1, borderColor: theme.colors.border, gap: spacing.xs },
+    controlBarTitle: { ...theme.typography.h2, color: theme.colors.foreground },
+    controlBarCopy: { ...theme.typography.body, color: theme.colors.mutedForeground },
+    segmentedRow: { flexDirection: 'row', gap: spacing.xs, flexWrap: 'wrap' },
+    segmentButton: { borderRadius: radius.lg, borderWidth: 1, borderColor: theme.colors.border, paddingHorizontal: spacing.md, paddingVertical: spacing.xs, backgroundColor: theme.colors.background },
+    segmentButtonActive: { borderColor: theme.colors.primary, backgroundColor: theme.colors.primary + '18' },
+    segmentButtonText: { ...theme.typography.caption, color: theme.colors.foreground, fontWeight: '600' },
+    segmentButtonTextActive: { color: theme.colors.primary },
+    splitContainer: { flex: 1, gap: spacing.sm },
+    splitHorizontal: { flexDirection: 'column' },
+    splitVertical: { flexDirection: 'row' },
+    pane: { flex: 1, minHeight: 0, backgroundColor: theme.colors.card, borderRadius: radius.xl, borderWidth: 1, borderColor: theme.colors.border, overflow: 'hidden' },
+    paneHorizontal: { minHeight: 260 },
+    paneVertical: { minWidth: 0 },
+    paneToolbar: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: spacing.sm, paddingHorizontal: spacing.md, paddingVertical: spacing.sm, borderBottomWidth: 1, borderBottomColor: theme.colors.border, backgroundColor: theme.colors.background },
+    paneToolbarTextWrap: { flex: 1, minWidth: 0 },
+    paneLabel: { ...theme.typography.caption, color: theme.colors.primary, textTransform: 'uppercase', letterSpacing: 0.6 },
+    paneTitle: { ...theme.typography.body, color: theme.colors.foreground, fontWeight: '600' },
+    paneToolbarActions: { flexDirection: 'row', gap: spacing.xs },
+    toolbarButton: { borderRadius: radius.md, paddingHorizontal: spacing.sm, paddingVertical: spacing.xs, backgroundColor: theme.colors.card, borderWidth: 1, borderColor: theme.colors.border },
+    toolbarButtonDisabled: { opacity: 0.45 },
+    toolbarButtonText: { ...theme.typography.caption, color: theme.colors.foreground, fontWeight: '600' },
+    paneBody: { flex: 1, minHeight: 0 },
+    emptyState: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: spacing.lg, gap: spacing.sm },
+    emptyStateTitle: { ...theme.typography.h2, color: theme.colors.foreground, textAlign: 'center' },
+    emptyStateCopy: { ...theme.typography.body, color: theme.colors.mutedForeground, textAlign: 'center', maxWidth: 360 },
+    emptyStateActions: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: spacing.sm },
+    primaryButton: { borderRadius: radius.lg, backgroundColor: theme.colors.primary, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
+    primaryButtonText: { ...theme.typography.body, color: theme.colors.background, fontWeight: '700' },
+    secondaryButton: { borderRadius: radius.lg, borderWidth: 1, borderColor: theme.colors.border, paddingHorizontal: spacing.md, paddingVertical: spacing.sm, backgroundColor: theme.colors.card },
+    secondaryButtonText: { ...theme.typography.body, color: theme.colors.foreground, fontWeight: '600' },
+    modalOverlay: { flex: 1, backgroundColor: '#00000066', justifyContent: 'center', padding: spacing.lg },
+    modalCard: { maxHeight: '75%', borderRadius: radius.xl, backgroundColor: theme.colors.card, borderWidth: 1, borderColor: theme.colors.border, padding: spacing.md, gap: spacing.sm },
+    modalTitle: { ...theme.typography.h2, color: theme.colors.foreground },
+    sessionOption: { borderRadius: radius.lg, borderWidth: 1, borderColor: theme.colors.border, padding: spacing.md, marginBottom: spacing.sm, backgroundColor: theme.colors.background },
+    sessionOptionActive: { borderColor: theme.colors.primary, backgroundColor: theme.colors.primary + '12' },
+    sessionOptionTitle: { ...theme.typography.body, color: theme.colors.foreground, fontWeight: '600', marginBottom: 4 },
+    sessionOptionPreview: { ...theme.typography.caption, color: theme.colors.mutedForeground },
+    newChatOption: { alignItems: 'center', justifyContent: 'center', paddingVertical: spacing.sm },
+    newChatOptionText: { ...theme.typography.body, color: theme.colors.primary, fontWeight: '700' },
+  });
+}

--- a/apps/mobile/src/screens/split-chat-utils.test.ts
+++ b/apps/mobile/src/screens/split-chat-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getInitialSplitSessionIds,
+  reconcileSplitPaneSelection,
+  replaceSplitPaneSelection,
+  resolveSplitOrientation,
+} from './split-chat-utils';
+
+describe('split-chat-utils', () => {
+  it('prefers the current session when choosing initial panes', () => {
+    expect(getInitialSplitSessionIds(['s1', 's2', 's3'], 's2')).toEqual({
+      primary: 's2',
+      secondary: 's1',
+    });
+  });
+
+  it('swaps panes instead of duplicating the same session in both panes', () => {
+    expect(replaceSplitPaneSelection({ primary: 's1', secondary: 's2' }, 'primary', 's2')).toEqual({
+      primary: 's2',
+      secondary: 's1',
+    });
+  });
+
+  it('reconciles missing selections against the available sessions', () => {
+    expect(reconcileSplitPaneSelection({ primary: 'missing', secondary: null }, ['s1', 's2'], 's2')).toEqual({
+      primary: 's2',
+      secondary: 's1',
+    });
+  });
+
+  it('chooses a side-by-side layout automatically on wide screens', () => {
+    expect(resolveSplitOrientation('auto', 1200, 800)).toBe('vertical');
+  });
+
+  it('chooses a stacked layout automatically on narrow screens', () => {
+    expect(resolveSplitOrientation('auto', 430, 932)).toBe('horizontal');
+  });
+})

--- a/apps/mobile/src/screens/split-chat-utils.ts
+++ b/apps/mobile/src/screens/split-chat-utils.ts
@@ -1,0 +1,74 @@
+export type SplitOrientationPreference = 'auto' | 'horizontal' | 'vertical';
+export type SplitPane = 'primary' | 'secondary';
+
+export type SplitPaneSelection = {
+  primary: string | null;
+  secondary: string | null;
+};
+
+function uniqueSessionIds(sessionIds: string[]): string[] {
+  return Array.from(new Set(sessionIds.filter(Boolean)));
+}
+
+export function getInitialSplitSessionIds(sessionIds: string[], preferredId?: string | null): SplitPaneSelection {
+  const uniqueIds = uniqueSessionIds(sessionIds);
+  const primary = preferredId && uniqueIds.includes(preferredId)
+    ? preferredId
+    : uniqueIds[0] ?? null;
+  const secondary = uniqueIds.find((id) => id !== primary) ?? null;
+
+  return { primary, secondary };
+}
+
+export function replaceSplitPaneSelection(
+  selection: SplitPaneSelection,
+  pane: SplitPane,
+  nextSessionId: string | null,
+): SplitPaneSelection {
+  if (pane === 'primary') {
+    if (!nextSessionId) return { ...selection, primary: null };
+    return nextSessionId === selection.secondary
+      ? { primary: nextSessionId, secondary: selection.primary }
+      : { ...selection, primary: nextSessionId };
+  }
+
+  if (!nextSessionId) return { ...selection, secondary: null };
+  return nextSessionId === selection.primary
+    ? { primary: selection.secondary, secondary: nextSessionId }
+    : { ...selection, secondary: nextSessionId };
+}
+
+export function reconcileSplitPaneSelection(
+  selection: SplitPaneSelection,
+  sessionIds: string[],
+  preferredId?: string | null,
+): SplitPaneSelection {
+  const uniqueIds = uniqueSessionIds(sessionIds);
+  let primary = selection.primary && uniqueIds.includes(selection.primary) ? selection.primary : null;
+  let secondary = selection.secondary && uniqueIds.includes(selection.secondary) ? selection.secondary : null;
+
+  if (!primary) {
+    primary = preferredId && uniqueIds.includes(preferredId)
+      ? preferredId
+      : uniqueIds[0] ?? null;
+  }
+
+  if (secondary === primary) {
+    secondary = null;
+  }
+
+  if (!secondary) {
+    secondary = uniqueIds.find((id) => id !== primary) ?? null;
+  }
+
+  return { primary, secondary };
+}
+
+export function resolveSplitOrientation(
+  preference: SplitOrientationPreference,
+  width: number,
+  height: number,
+): 'horizontal' | 'vertical' {
+  if (preference !== 'auto') return preference;
+  return width >= 960 || width > height ? 'vertical' : 'horizontal';
+}


### PR DESCRIPTION
## Summary
- add a mobile split-view screen so two chats can run side by side or stacked with selectable sessions per pane
- add split-view selection/orientation helpers plus regression tests for the new mobile behavior
- improve desktop `respond_to_user` completion fallbacks so communication-only loops surface the latest planned user-facing response instead of requiring another `continue`
- add focused desktop tests for extracting and resolving the latest user-facing response from tool calls/history

## Issues
- Closes #125
- Addresses #123

## Validation
- `git diff --check`
- Attempted to run desktop and mobile Vitest targets, but this workspace is missing local dependencies / `node_modules`, so `vitest` / `tsup` were unavailable


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author