### PR TITLE
Fix tile continuation backgrounding and TTS autoplay

### DIFF
--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  sendSpy: vi.fn(),
+  showPanelWindow: vi.fn(),
+  resizePanelForAgentMode: vi.fn(),
+  isSessionSnoozed: vi.fn(),
+  shouldStopSession: vi.fn(() => false),
+  getSessionRunId: vi.fn(() => undefined),
+  mainWindow: { isVisible: vi.fn(() => true), isFocused: vi.fn(() => false), webContents: { id: "main" } },
+  panelWindow: { isVisible: vi.fn(() => false), webContents: { id: "panel" } },
+}))
+
+vi.mock("@egoist/tipc/main", () => ({
+  getRendererHandlers: vi.fn(() => ({ agentProgressUpdate: { send: mocks.sendSpy } })),
+}))
+
+vi.mock("./window", () => ({
+  WINDOWS: { get: (id: string) => (id === "main" ? mocks.mainWindow : id === "panel" ? mocks.panelWindow : null) },
+  showPanelWindow: mocks.showPanelWindow,
+  resizePanelForAgentMode: mocks.resizePanelForAgentMode,
+}))
+
+vi.mock("./state", () => ({
+  isPanelAutoShowSuppressed: vi.fn(() => false),
+  agentSessionStateManager: { shouldStopSession: mocks.shouldStopSession, getSessionRunId: mocks.getSessionRunId },
+}))
+
+vi.mock("./agent-session-tracker", () => ({
+  agentSessionTracker: { isSessionSnoozed: mocks.isSessionSnoozed },
+}))
+
+vi.mock("./config", () => ({
+  configStore: { get: () => ({ floatingPanelAutoShow: true, hidePanelWhenMainFocused: true }) },
+}))
+
+vi.mock("@dotagents/shared", () => ({
+  sanitizeAgentProgressUpdateForDisplay: (update: unknown) => update,
+}))
+
+import { emitAgentProgress } from "./emit-agent-progress"
+
+describe("emitAgentProgress snoozed propagation", () => {
+  beforeEach(() => {
+    mocks.sendSpy.mockClear()
+    mocks.showPanelWindow.mockClear()
+    mocks.resizePanelForAgentMode.mockClear()
+    mocks.isSessionSnoozed.mockReset()
+    mocks.shouldStopSession.mockClear()
+    mocks.getSessionRunId.mockClear()
+  })
+
+  it("backfills isSnoozed from the session tracker when callers omit it", async () => {
+    mocks.isSessionSnoozed.mockReturnValue(true)
+
+    await emitAgentProgress({ sessionId: "session-snoozed-1", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
+
+    expect(mocks.sendSpy).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "session-snoozed-1", isSnoozed: true }))
+    expect(mocks.showPanelWindow).not.toHaveBeenCalled()
+    expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
+  })
+
+  it("preserves an explicit isSnoozed value from the caller", async () => {
+    mocks.isSessionSnoozed.mockReturnValue(true)
+
+    await emitAgentProgress({ sessionId: "session-snoozed-2", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false, isSnoozed: false })
+
+    expect(mocks.sendSpy).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "session-snoozed-2", isSnoozed: false }))
+    expect(mocks.showPanelWindow).not.toHaveBeenCalled()
+    expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -78,6 +78,14 @@ function isCriticalUpdate(update: AgentProgressUpdate): boolean {
 export async function emitAgentProgress(update: AgentProgressUpdate): Promise<void> {
   const displayUpdate = sanitizeAgentProgressUpdateForDisplay(update)
 
+  // Backfill snoozed state from the session tracker when callers omit it.
+  // Tile follow-ups intentionally start snoozed so the panel stays quiet; if
+  // early progress updates lose that flag, the renderer can briefly switch the
+  // hidden panel into overlay/agent mode and trigger unintended focus/TTS side effects.
+  if (displayUpdate.sessionId && typeof displayUpdate.isSnoozed === "undefined") {
+    displayUpdate.isSnoozed = agentSessionTracker.isSessionSnoozed(displayUpdate.sessionId)
+  }
+
   // Skip updates for stopped sessions, except final completion updates
   if (displayUpdate.sessionId && !displayUpdate.isComplete) {
     const shouldStop = agentSessionStateManager.shouldStopSession(displayUpdate.sessionId)

--- a/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const agentProgressSource = readFileSync(new URL("./agent-progress.tsx", import.meta.url), "utf8")
+
+describe("agent progress snoozed TTS guardrails", () => {
+  it("disables overlay auto-play generation when the session is snoozed", () => {
+    expect(agentProgressSource).toContain('const shouldAutoPlay = variant === "overlay" && !isSnoozed')
+  })
+
+  it("threads snoozed state through overlay and tile TTS players", () => {
+    expect(agentProgressSource).toContain('isSnoozed={progress.isSnoozed}')
+    expect(agentProgressSource).toContain('autoPlay={!isSnoozed && (configQuery.data?.ttsAutoPlay ?? true)}')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -235,10 +235,12 @@ type CompactMessageProps = {
   variant?: "default" | "overlay" | "tile"
   /** Session ID for tracking TTS playback across remounts */
   sessionId?: string
+  /** Snoozed/background sessions must never auto-play overlay TTS */
+  isSnoozed?: boolean
 }
 
 // Compact message component for space efficiency
-const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default", sessionId }) => {
+const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default", sessionId, isSnoozed = false }) => {
   const [audioData, setAudioData] = useState<ArrayBuffer | null>(null)
   const [audioMimeType, setAudioMimeType] = useState<string | null>(null)
   const [isGeneratingAudio, setIsGeneratingAudio] = useState(false)
@@ -405,7 +407,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   //   single-session and multi-session views in the panel)
   useEffect(() => {
     // Only auto-generate and play TTS in overlay variant to prevent double playback
-    const shouldAutoPlay = variant === "overlay"
+    const shouldAutoPlay = variant === "overlay" && !isSnoozed
     if (!shouldAutoPlay || !shouldAutoPlayTTS || !configQuery.data?.ttsAutoPlay || audioData || isGeneratingAudio || ttsError || wasStopped) {
       return
     }
@@ -455,7 +457,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
         }
         // Error is already handled in generateAudio function
       })
-  }, [shouldAutoPlayTTS, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, ttsError, wasStopped, variant, sessionId, ttsSource])
+  }, [shouldAutoPlayTTS, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isSnoozed, ttsError, wasStopped, variant, sessionId, ttsSource])
 
   const getRoleStyle = () => {
     switch (message.role) {
@@ -606,7 +608,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
                 isGenerating={isGeneratingAudio}
                 error={ttsError}
                 compact={true}
-                autoPlay={isLast ? (configQuery.data?.ttsAutoPlay ?? true) : false}
+                autoPlay={isLast ? ((configQuery.data?.ttsAutoPlay ?? true) && !isSnoozed) : false}
                 onPlayStateChange={setIsTTSPlaying}
                 audioOutputDeviceId={configQuery.data?.audioOutputDeviceId}
               />
@@ -702,7 +704,8 @@ const CompactMessage = React.memo(CompactMessageBase, (prev, next) => (
   prev.wasStopped === next.wasStopped &&
   prev.isExpanded === next.isExpanded &&
   prev.variant === next.variant &&
-  prev.sessionId === next.sessionId
+  prev.sessionId === next.sessionId &&
+  prev.isSnoozed === next.isSnoozed
 ))
 
 // Helper to extract execute_command display info
@@ -2549,6 +2552,7 @@ const MidTurnUserResponseBubble: React.FC<{
   sessionId?: string
   agentLabel?: string
   variant?: "default" | "overlay" | "tile"
+  isSnoozed?: boolean
   isComplete: boolean
   isExpanded: boolean
   onToggleExpand: () => void
@@ -2559,6 +2563,7 @@ const MidTurnUserResponseBubble: React.FC<{
   sessionId,
   agentLabel = "Agent",
   variant = "default",
+  isSnoozed = false,
   isComplete,
   isExpanded,
   onToggleExpand,
@@ -2641,7 +2646,7 @@ const MidTurnUserResponseBubble: React.FC<{
 
   // Auto-play TTS for mid-turn userResponse (only in overlay variant to prevent double-play)
   useEffect(() => {
-    const shouldAutoPlay = variant === "overlay"
+    const shouldAutoPlay = variant === "overlay" && !isSnoozed
     if (!shouldAutoPlay || !ttsSource || !configQuery.data?.ttsEnabled || !configQuery.data?.ttsAutoPlay || audioData || isGeneratingAudio || ttsError || isComplete) {
       return
     }
@@ -2674,7 +2679,7 @@ const MidTurnUserResponseBubble: React.FC<{
           inFlightTtsKeyRef.current = null
         }
       })
-  }, [ttsSource, configQuery.data?.ttsEnabled, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, ttsError, variant, sessionId, isComplete])
+  }, [ttsSource, configQuery.data?.ttsEnabled, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isSnoozed, ttsError, variant, sessionId, isComplete])
 
   // Cleanup in-flight TTS key on unmount
   useEffect(() => {
@@ -2785,7 +2790,7 @@ const MidTurnUserResponseBubble: React.FC<{
             isGenerating={isGeneratingAudio}
             error={ttsError}
             compact={true}
-            autoPlay={configQuery.data?.ttsAutoPlay ?? true}
+            autoPlay={!isSnoozed && (configQuery.data?.ttsAutoPlay ?? true)}
             onPlayStateChange={setIsTTSPlaying}
           />
           {isExpanded && ttsError && (
@@ -3920,6 +3925,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                             onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
                             variant="tile"
                             sessionId={progress.sessionId}
+                            isSnoozed={progress.isSnoozed}
                           />
                         )
                       } else if (item.kind === "assistant_with_tools") {
@@ -3954,6 +3960,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                             sessionId={progress.sessionId}
                             agentLabel={primaryAgentLabel}
                             variant="tile"
+                            isSnoozed={progress.isSnoozed}
                             isComplete={isComplete}
                             isExpanded={expandedItems[itemKey] ?? false}
                             onToggleExpand={() => toggleItemExpansion(itemKey, expandedItems[itemKey] ?? false)}
@@ -4298,6 +4305,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                       onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
                       variant={variant}
                       sessionId={progress.sessionId}
+                      isSnoozed={progress.isSnoozed}
                     />
                   )
                 } else if (item.kind === "assistant_with_tools") {
@@ -4342,6 +4350,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                       sessionId={progress.sessionId}
                       agentLabel={primaryAgentLabel}
                       variant="overlay"
+                      isSnoozed={progress.isSnoozed}
                       isComplete={isComplete}
                       isExpanded={expandedItems[itemKey] ?? false}
                       onToggleExpand={() => toggleItemExpansion(itemKey, expandedItems[itemKey] ?? false)}


### PR DESCRIPTION
## Summary

- preserve snoozed/background session state on early desktop agent progress updates
- prevent overlay TTS auto-play for snoozed tile continuation sessions
- add targeted regression tests for snoozed progress propagation and TTS guardrails

## Problem

Submitting a continuation/follow-up message from a session tile could briefly lose the session's `isSnoozed` state during early progress emission. That allowed the hidden panel to treat the run like an active overlay session, which could:

- send the app into the background / trigger panel mode changes unexpectedly
- start TTS playback even though the continuation was supposed to remain backgrounded

## What changed

- backfilled `isSnoozed` in `emitAgentProgress(...)` when callers omit it, using `agentSessionTracker`
- threaded `progress.isSnoozed` into the relevant `AgentProgress` message components
- blocked overlay auto-play and `AudioPlayer` auto-play when a session is snoozed
- added regression tests covering:
  - snoozed-state propagation in main-process progress emission
  - snoozed-session TTS auto-play guardrails in the renderer

## Validation

- `pnpm --filter @dotagents/desktop exec vitest run src/main/emit-agent-progress.snoozed.test.ts src/renderer/src/components/agent-progress.snoozed-tts.test.ts`

## Notes

- the targeted desktop tests pass
- Vitest still prints an unrelated existing `docs-site/tsconfig.json` warning about `@docusaurus/tsconfig`, but it does not block the desktop test run

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author