### PR TITLE
Fix mobile duplicate session creation race

### DIFF
--- a/apps/mobile/src/lib/syncService.pending-create.test.ts
+++ b/apps/mobile/src/lib/syncService.pending-create.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Session } from '../types/session';
+
+import { syncConversations } from './syncService';
+
+function createLocalSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: overrides.id ?? 'session-local-1',
+    title: overrides.title ?? 'New Chat',
+    createdAt: overrides.createdAt ?? 1,
+    updatedAt: overrides.updatedAt ?? 2,
+    messages: overrides.messages ?? [
+      { id: 'msg-1', role: 'user', content: 'hello', timestamp: 2 },
+    ],
+    serverConversationId: overrides.serverConversationId,
+    isPinned: overrides.isPinned,
+    isArchived: overrides.isArchived,
+    metadata: overrides.metadata,
+    serverMetadata: overrides.serverMetadata,
+  };
+}
+
+describe('syncConversations pending create guard', () => {
+  it('does not create or pull duplicate conversations while a new chat request is still linking its conversation id', async () => {
+    const client = {
+      getConversations: vi.fn().mockResolvedValue({
+        conversations: [
+          {
+            id: 'conv-chat-created',
+            title: 'New Chat',
+            createdAt: 10,
+            updatedAt: 11,
+            messageCount: 1,
+            lastMessage: 'hello',
+            preview: 'hello',
+          },
+        ],
+      }),
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      updateConversation: vi.fn(),
+    } as any;
+
+    const localSession = createLocalSession();
+
+    const { result, sessions } = await syncConversations(client, [localSession], {
+      pendingCreateSessionIds: new Set([localSession.id]),
+    });
+
+    expect(client.createConversation).not.toHaveBeenCalled();
+    expect(result.pushed).toBe(0);
+    expect(result.pulled).toBe(0);
+    expect(sessions).toEqual([localSession]);
+  });
+
+  it('still creates a server conversation for normal local-only sessions when no pending-create guard is active', async () => {
+    const client = {
+      getConversations: vi.fn().mockResolvedValue({ conversations: [] }),
+      createConversation: vi.fn().mockResolvedValue({
+        id: 'conv-created-by-sync',
+        title: 'New Chat',
+        createdAt: 1,
+        updatedAt: 3,
+        messages: [],
+      }),
+      getConversation: vi.fn(),
+      updateConversation: vi.fn(),
+    } as any;
+
+    const localSession = createLocalSession();
+
+    const { result, sessions } = await syncConversations(client, [localSession]);
+
+    expect(client.createConversation).toHaveBeenCalledTimes(1);
+    expect(result.pushed).toBe(1);
+    expect(sessions[0]?.serverConversationId).toBe('conv-created-by-sync');
+  });
+})

--- a/apps/mobile/src/lib/syncService.ts
+++ b/apps/mobile/src/lib/syncService.ts
@@ -22,6 +22,18 @@ export interface SyncableSession extends Session {
   // Session already has serverConversationId optional field
 }
 
+export interface SyncConversationOptions {
+  /**
+   * Session IDs that are in the middle of creating their first server-side
+   * conversation through /v1/chat/completions.
+   *
+   * While that request is still linking its returned conversationId back into
+   * local state, sync must not create another server conversation or pull an
+   * unmatched server conversation into a duplicate local stub.
+   */
+  pendingCreateSessionIds?: ReadonlySet<string>;
+}
+
 const VALID_ROLES = ['user', 'assistant', 'tool'] as const;
 
 /**
@@ -108,7 +120,8 @@ function serverConversationToStubSession(item: ServerConversation): Session {
  */
 export async function syncConversations(
   client: SettingsApiClient,
-  localSessions: Session[]
+  localSessions: Session[],
+  options: SyncConversationOptions = {}
 ): Promise<{ result: SyncResult; sessions: Session[] }> {
   const result: SyncResult = {
     pulled: 0,
@@ -118,6 +131,8 @@ export async function syncConversations(
   };
 
   const updatedSessions: Session[] = [...localSessions];
+  const pendingCreateSessionIds = options.pendingCreateSessionIds ?? new Set<string>();
+  const shouldDeferUnmatchedPulls = pendingCreateSessionIds.size > 0;
 
   try {
     // Step 1: Fetch server conversation list
@@ -179,6 +194,10 @@ export async function syncConversations(
         // We could handle this by either deleting locally or re-pushing
         // For now, we leave it as is
       } else if (session.messages.length > 0) {
+        if (pendingCreateSessionIds.has(session.id)) {
+          continue;
+        }
+
         // Local-only session with messages - push to server
         try {
           const created = await client.createConversation({
@@ -206,6 +225,10 @@ export async function syncConversations(
     const newSessions: Session[] = [];
     for (const serverItem of serverList) {
       if (!localByServerId.has(serverItem.id)) {
+        if (shouldDeferUnmatchedPulls) {
+          continue;
+        }
+
         // Server conversation not in local - create a lazy stub (no message fetch)
         const stubSession = serverConversationToStubSession(serverItem);
         newSessions.push(stubSession);

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -1762,11 +1762,11 @@ export default function ChatScreen({ route, navigation }: any) {
     activeRequestIdRef.current = thisRequestId;
 
     const currentSession = sessionStore.getCurrentSession();
-    const serverConversationId = currentSession?.serverConversationId;
+    const startingServerConversationId = currentSession?.serverConversationId;
 
     console.log('[ChatScreen] Session info:', {
       sessionId: currentSession?.id,
-      serverConversationId: serverConversationId || 'new',
+      serverConversationId: startingServerConversationId || 'new',
       requestId: thisRequestId
     });
 
@@ -1777,6 +1777,11 @@ export default function ChatScreen({ route, navigation }: any) {
 
     // Capture the session ID at request start to guard against session changes
     const requestSessionId = sessionStore.currentSessionId;
+    let resolvedConversationId: string | undefined;
+
+    if (requestSessionId && !startingServerConversationId) {
+      sessionStore.markPendingServerConversation(requestSessionId, true);
+    }
 
     // Mark this request as the latest for this session in the connection manager
     // and increment active request count
@@ -1919,6 +1924,7 @@ export default function ChatScreen({ route, navigation }: any) {
         } else {
           await sessionStore.setServerConversationId(response.conversationId);
         }
+        resolvedConversationId = response.conversationId;
       }
 
       if (response.conversationHistory && response.conversationHistory.length > 0) {
@@ -2130,6 +2136,10 @@ export default function ChatScreen({ route, navigation }: any) {
 	        handsFreeController.onRequestCompleted();
 	      }
     } finally {
+      if (requestSessionId && !startingServerConversationId && !resolvedConversationId) {
+        sessionStore.markPendingServerConversation(requestSessionId, false);
+      }
+
       console.log('[ChatScreen] Chat request finished, requestId:', thisRequestId);
 
       // Decrement active request count in the connection manager
@@ -2223,9 +2233,14 @@ export default function ChatScreen({ route, navigation }: any) {
     activeRequestIdRef.current = thisRequestId;
 
     const currentSession = sessionStore.getCurrentSession();
-    const serverConversationId = currentSession?.serverConversationId;
+    const startingServerConversationId = currentSession?.serverConversationId;
 
     const requestSessionId = sessionStore.currentSessionId;
+    let resolvedConversationId: string | undefined;
+
+    if (requestSessionId && !startingServerConversationId) {
+      sessionStore.markPendingServerConversation(requestSessionId, true);
+    }
 
     try {
       let streamingText = '';
@@ -2292,7 +2307,7 @@ export default function ChatScreen({ route, navigation }: any) {
       };
 
       const modelMessages = sanitizeMessagesForModel([...currentMessages, userMsg]);
-      const response = await client.chat(modelMessages, onToken, onProgress, serverConversationId);
+      const response = await client.chat(modelMessages, onToken, onProgress, startingServerConversationId);
       const finalText = response.content || streamingText;
       const finalDisplayText = lastUserResponse || finalText;
 
@@ -2311,6 +2326,7 @@ export default function ChatScreen({ route, navigation }: any) {
 
       if (response.conversationId) {
         await sessionStore.setServerConversationId(response.conversationId);
+        resolvedConversationId = response.conversationId;
       }
 
       if (response.conversationHistory && response.conversationHistory.length > 0) {
@@ -2375,6 +2391,10 @@ export default function ChatScreen({ route, navigation }: any) {
 	        handsFreeController.onRequestCompleted();
 	      }
     } finally {
+      if (requestSessionId && !startingServerConversationId && !resolvedConversationId) {
+        sessionStore.markPendingServerConversation(requestSessionId, false);
+      }
+
       if (activeRequestIdRef.current === thisRequestId) {
         setResponding(false);
         setConnectionState(null);

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -31,6 +31,8 @@ export interface SessionStore {
   setMessagesForSession: (sessionId: string, messages: ChatMessage[]) => Promise<void>;
 
   // Server conversation ID management (for continuing conversations with DotAgents server)
+  markPendingServerConversation: (sessionId: string, pending: boolean) => void;
+  hasPendingServerConversation: () => boolean;
   setServerConversationId: (serverConversationId: string) => Promise<void>;
   setServerConversationIdForSession: (sessionId: string, serverConversationId: string) => Promise<void>;
   getServerConversationId: () => string | undefined;
@@ -80,6 +82,7 @@ export function useSessions(): SessionStore {
   const [ready, setReady] = useState(false);
   // Track sessions being deleted to prevent race conditions (fixes #571)
   const [deletingSessionIds, setDeletingSessionIds] = useState<Set<string>>(new Set());
+  const pendingServerConversationSessionIdsRef = useRef<Set<string>>(new Set());
   // Use ref to ensure we always have the latest sessions for async operations
   // NOTE: We update these refs synchronously in our callbacks, not just in useEffect,
   // to ensure queued async saves always see the correct state (fixes PR review comment)
@@ -168,6 +171,8 @@ export function useSessions(): SessionStore {
   }, [queueSave]);
 
   const deleteSession = useCallback(async (id: string) => {
+    pendingServerConversationSessionIdsRef.current.delete(id);
+
     // Mark session as being deleted to prevent race conditions
     setDeletingSessionIds(prev => new Set(prev).add(id));
 
@@ -222,6 +227,8 @@ export function useSessions(): SessionStore {
   }, [queueSave]);
 
   const clearAllSessions = useCallback(async () => {
+    pendingServerConversationSessionIdsRef.current.clear();
+
     // Mark all sessions as being deleted
     const allIds = new Set(sessionsRef.current.map(s => s.id));
     setDeletingSessionIds(allIds);
@@ -249,6 +256,19 @@ export function useSessions(): SessionStore {
       setDeletingSessionIds(new Set());
     }
   }, [queueSave]);
+
+  const markPendingServerConversation = useCallback((sessionId: string, pending: boolean) => {
+    if (!sessionId) return;
+    if (pending) {
+      pendingServerConversationSessionIdsRef.current.add(sessionId);
+    } else {
+      pendingServerConversationSessionIdsRef.current.delete(sessionId);
+    }
+  }, []);
+
+  const hasPendingServerConversation = useCallback(() => {
+    return pendingServerConversationSessionIdsRef.current.size > 0;
+  }, []);
 
   const toggleSessionPinned = useCallback(async (id: string, client?: SettingsApiClient) => {
     const sessionsToSave = sessionsRef.current.map((session) => {
@@ -519,6 +539,8 @@ export function useSessions(): SessionStore {
     const targetSessionId = currentSessionId;
     const now = Date.now();
 
+    pendingServerConversationSessionIdsRef.current.delete(targetSessionId);
+
     const sessionsToSave = currentSessions.map(session => {
       if (session.id !== targetSessionId) return session;
       return {
@@ -548,6 +570,8 @@ export function useSessions(): SessionStore {
     // is exactly what we intend to set (same pattern as setServerConversationId)
     const currentSessions = sessionsRef.current;
     const now = Date.now();
+
+    pendingServerConversationSessionIdsRef.current.delete(sessionId);
 
     const sessionsToSave = currentSessions.map(session => {
       if (session.id !== sessionId) return session;
@@ -600,8 +624,9 @@ export function useSessions(): SessionStore {
     try {
       // Take snapshot before async operations
       const snapshotSessions = sessionsRef.current;
+      const pendingCreateSessionIds = new Set(pendingServerConversationSessionIdsRef.current);
       const [{ result, sessions: syncedSessions }, serverSettings] = await Promise.all([
-        syncConversations(client, snapshotSessions),
+        syncConversations(client, snapshotSessions, { pendingCreateSessionIds }),
         client.getSettings().catch(() => null),
       ]);
 
@@ -759,6 +784,8 @@ export function useSessions(): SessionStore {
     addMessage,
     getCurrentSession,
     getSessionList,
+    markPendingServerConversation,
+    hasPendingServerConversation,
     setMessages,
     setMessagesForSession,
     setServerConversationId,


### PR DESCRIPTION
## Summary

- prevent mobile sync from creating or pulling duplicate conversations while a brand-new chat request is still linking its server conversation id
- track pending first-time server conversation creation in the mobile session store
- add targeted regression coverage for the pending-create sync guard

## Problem

Sending a message from mobile in a brand-new local session could create two sessions/conversations:

1. the chat request starts with `conversationId = new`
2. the server creates the real conversation for that request
3. before the returned `conversationId` is attached locally, auto-sync runs
4. sync sees a local session with messages but no `serverConversationId`
5. sync may create another server conversation and/or pull the just-created conversation as a new stub

That can fan out into duplicate mobile sessions for a single user send.

## What changed

- added a `pendingCreateSessionIds` guard to `syncConversations(...)`
- while a new chat request is still waiting to attach its first `conversationId`, sync now:
  - skips `createConversation(...)` for that local session
  - skips pulling unmatched server conversations into new local stubs
- added transient mobile session-store tracking for pending first-time server conversation creation
- updated both mobile send paths in `ChatScreen` to:
  - mark pending creation before the first send on an unlinked session
  - clear the pending flag when the returned `conversationId` is saved or the request fails

## Validation

Passed:
- `pnpm --filter @dotagents/mobile exec vitest run src/lib/syncService.pending-create.test.ts`

Additional check:
- `pnpm --filter @dotagents/mobile exec tsc --noEmit`

The TypeScript check is currently blocked by pre-existing duplicate variable declarations in `apps/mobile/src/screens/ChatScreen.tsx` quick-start constants (`commandQuickStarts`, `savedPromptQuickStarts`, `starterPackQuickStarts`, etc.). Those errors are unrelated to this fix.

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author