### PR TITLE
Clean up tray lifecycle on quit

### DIFF
--- a/apps/desktop/src/main/index.hub-install.test.ts
+++ b/apps/desktop/src/main/index.hub-install.test.ts
@@ -69,7 +69,7 @@ async function loadIndexForHubInstall(
   vi.doMock("./tipc", () => ({ router: {} }))
   vi.doMock("./serve", () => ({ registerServeProtocol: vi.fn(), registerServeSchema: vi.fn() }))
   vi.doMock("./menu", () => ({ createAppMenu: vi.fn(() => null) }))
-  vi.doMock("./tray", () => ({ initTray: vi.fn() }))
+  vi.doMock("./tray", () => ({ initTray: vi.fn(), destroyTray: vi.fn() }))
   vi.doMock("./utils", () => ({ isAccessibilityGranted: vi.fn(() => true) }))
   vi.doMock("./mcp-service", () => ({ mcpService: { initialize: vi.fn(() => Promise.resolve()), cleanup: vi.fn(() => Promise.resolve()) } }))
   vi.doMock("./debug", () => ({ initDebugFlags: vi.fn(), logApp: vi.fn() }))

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -14,7 +14,7 @@ import { registerIpcMain } from "@egoist/tipc/main"
 import { router } from "./tipc"
 import { registerServeProtocol, registerServeSchema } from "./serve"
 import { createAppMenu } from "./menu"
-import { initTray } from "./tray"
+import { destroyTray, initTray } from "./tray"
 import { isAccessibilityGranted } from "./utils"
 import { mcpService } from "./mcp-service"
 import { initDebugFlags, logApp } from "./debug"
@@ -584,13 +584,9 @@ app.whenReady().then(async () => {
 
   app.on("before-quit", async (event) => {
     setAppQuitting()
+    destroyTray()
     makePanelWindowClosable()
     loopService.stopAllLoops()
-
-    // Shutdown ACP agents gracefully
-    acpService.shutdown().catch((error) => {
-      console.error('[App] Error shutting down ACP service:', error)
-    })
 
     // Prevent re-entry during cleanup
     if (isCleaningUp) {
@@ -601,33 +597,48 @@ app.whenReady().then(async () => {
     event.preventDefault()
     isCleaningUp = true
 
-    // Clean up MCP server processes to prevent orphaned node processes
-    // This terminates all child processes spawned by StdioClientTransport
-    let timeoutId: ReturnType<typeof setTimeout> | undefined
-    try {
-      await Promise.race([
-        mcpService.cleanup(),
-        new Promise<void>((_, reject) => {
-          const id = setTimeout(
-            () => reject(new Error("MCP cleanup timeout")),
-            CLEANUP_TIMEOUT_MS
-          )
-          timeoutId = id
-          // unref() ensures this timer won't keep the event loop alive
-          // if cleanup finishes quickly (only available in Node.js)
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          if (id && typeof (id as any).unref === "function") {
-            (id as any).unref()
-          }
-        }),
-      ])
-    } catch (error) {
-      logApp("Error during MCP service cleanup on quit:", error)
-    } finally {
-      // Clear the timeout to avoid any lingering references
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId)
+    const withCleanupTimeout = async (
+      label: string,
+      cleanup: () => Promise<void>,
+    ): Promise<void> => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined
+      try {
+        await Promise.race([
+          cleanup(),
+          new Promise<void>((_, reject) => {
+            const id = setTimeout(
+              () => reject(new Error(`${label} cleanup timeout`)),
+              CLEANUP_TIMEOUT_MS,
+            )
+            timeoutId = id
+            // unref() ensures this timer won't keep the event loop alive
+            // if cleanup finishes quickly (only available in Node.js)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            if (id && typeof (id as any).unref === "function") {
+              ;(id as any).unref()
+            }
+          }),
+        ])
+      } finally {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId)
+        }
       }
+    }
+
+    try {
+      const cleanupResults = await Promise.allSettled([
+        withCleanupTimeout("ACP", () => acpService.shutdown()),
+        withCleanupTimeout("MCP", () => mcpService.cleanup()),
+      ])
+
+      for (const result of cleanupResults) {
+        if (result.status === "rejected") {
+          logApp("Error during service cleanup on quit:", result.reason)
+        }
+      }
+    } catch (error) {
+      logApp("Unexpected error during service cleanup on quit:", error)
     }
 
     // Now actually quit the app
@@ -654,6 +665,7 @@ app.on("window-all-closed", () => {
 for (const signal of ["SIGTERM", "SIGINT"] as const) {
   process.on(signal, () => {
     logApp(`Received ${signal}, forcing exit`)
+    destroyTray()
     app.quit()
     // Force exit after a short grace period in case before-quit cleanup hangs
     setTimeout(() => process.exit(0), 3000).unref()

--- a/apps/desktop/src/main/tray.test.ts
+++ b/apps/desktop/src/main/tray.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { EventEmitter } from "events"
+
+const buildFromTemplate = vi.fn((template) => template)
+const trayInstances: MockTray[] = []
+
+class MockTray extends EventEmitter {
+  setImage = vi.fn()
+  setContextMenu = vi.fn()
+  popUpContextMenu = vi.fn()
+  destroy = vi.fn()
+
+  constructor(_icon: string) {
+    super()
+    trayInstances.push(this)
+  }
+}
+
+vi.mock("electron", () => ({
+  Menu: { buildFromTemplate },
+  Tray: MockTray,
+}))
+
+vi.mock("./window", () => ({
+  getWindowRendererHandlers: vi.fn(() => ({ finishRecording: { send: vi.fn() } })),
+  hideFloatingPanelWindow: vi.fn(),
+  resetFloatingPanelPositionAndSize: vi.fn(),
+  resizePanelToNormal: vi.fn(),
+  showMainWindow: vi.fn(),
+  showPanelWindow: vi.fn(),
+  showPanelWindowAndStartRecording: vi.fn(),
+  stopRecordingAndHidePanelWindow: vi.fn(),
+}))
+
+vi.mock("./config", () => ({
+  configStore: { get: vi.fn(() => ({ floatingPanelAutoShow: true })), save: vi.fn() },
+}))
+
+vi.mock("./state", () => ({ state: { isRecording: false } }))
+
+describe("tray lifecycle", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    trayInstances.length = 0
+    const { destroyTray } = await import("./tray")
+    destroyTray()
+  })
+
+  it("destroys the previous tray before creating a new one", async () => {
+    const { initTray } = await import("./tray")
+
+    initTray()
+    const firstTray = trayInstances[0]
+
+    initTray()
+
+    expect(firstTray.destroy).toHaveBeenCalledTimes(1)
+    expect(trayInstances).toHaveLength(2)
+  })
+
+  it("destroyTray removes the active tray and clears future updates", async () => {
+    const { initTray, destroyTray, updateTrayIcon } = await import("./tray")
+
+    initTray()
+    const activeTray = trayInstances[0]
+
+    destroyTray()
+    updateTrayIcon()
+
+    expect(activeTray.setContextMenu).toHaveBeenCalledWith(null)
+    expect(activeTray.destroy).toHaveBeenCalledTimes(1)
+    expect(activeTray.setImage).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/tray.ts
+++ b/apps/desktop/src/main/tray.ts
@@ -134,6 +134,18 @@ const buildMenu = (tray: Tray) =>
 
 let _tray: Tray | undefined
 
+export const destroyTray = () => {
+  const tray = _tray
+  _tray = undefined
+  if (!tray) return
+
+  try {
+    tray.removeAllListeners()
+    tray.setContextMenu(null)
+    tray.destroy()
+  } catch {}
+}
+
 export const updateTrayIcon = () => {
   if (!_tray) return
 
@@ -150,6 +162,8 @@ const updateTrayMenu = (tray: Tray) => {
 }
 
 export const initTray = () => {
+  destroyTray()
+
   const tray = (_tray = new Tray(defaultIcon))
 
   // On Linux/Wayland (SNI tray), click events don't work reliably.


### PR DESCRIPTION
## Summary
- add explicit `destroyTray()` handling and make tray initialization idempotent
- destroy the tray at the start of app quit / signal shutdown so stale menu bar items do not linger
- await both ACP and MCP cleanup during quit and add tray lifecycle tests

## Validation
- `pnpm --filter @dotagents/desktop typecheck`
- `pnpm --filter @dotagents/desktop exec vitest run src/main/tray.test.ts src/main/index.hub-install.test.ts src/main/app-switcher.test.ts src/main/window.main-hide-recovery.test.ts`

## Notes
- left unrelated local mobile changes out of this PR

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author