### PR TITLE
Improve desktop session titles and response history playback

### DIFF
--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -12,6 +12,7 @@ import {
 import { summarizeContent } from "./context-budget"
 import { assertSafeConversationId, validateAndSanitizeConversationId } from "./conversation-id"
 import { sanitizeMessageContentForDisplay } from "@dotagents/shared"
+import { makeTextCompletionWithFetch } from "./llm-fetch"
 
 // Threshold for compacting conversations on load
 // When a conversation exceeds this many messages, older ones are summarized
@@ -27,6 +28,8 @@ const CONVERSATION_REPAIR_MAX_PARSE_ATTEMPTS = 50
 // Skip repair entirely for files larger than this (bytes). Large corrupted files would
 // cause too many JSON.parse calls scanning for '}' characters (including inside strings).
 const CONVERSATION_REPAIR_MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
+const MAX_SESSION_TITLE_CHARS = 80
+const MAX_AGENT_SESSION_TITLE_WORDS = 10
 
 export class ConversationService {
   private static instance: ConversationService | null = null
@@ -96,6 +99,75 @@ export class ConversationService {
     // Generate a title from the first message (first 50 characters)
     const title = source.slice(0, 50)
     return title.length < source.length ? `${title}...` : title
+  }
+
+  private normalizeConversationTitle(title: string, maxWords?: number): string {
+    const cleaned = sanitizeMessageContentForDisplay(title)
+      .replace(/\s+/g, " ")
+      .replace(/^["'“”‘’\s]+|["'“”‘’\s]+$/g, "")
+      .trim()
+
+    if (!cleaned) {
+      return ""
+    }
+
+    const wordLimited = maxWords
+      ? cleaned.split(" ").filter(Boolean).slice(0, maxWords).join(" ")
+      : cleaned
+
+    const normalized = wordLimited.slice(0, MAX_SESSION_TITLE_CHARS).trim()
+    return normalized
+  }
+
+  private getAutoTitleSeed(conversation: Conversation): {
+    fallbackTitle: string
+    firstUserMessage: string
+    firstAssistantMessage: string
+  } | null {
+    const messages = this.getStoredRawMessages(conversation)
+    const firstUserMessage = messages.find((message) => message.role === "user" && message.content?.trim())?.content?.trim()
+    const firstAssistantMessage = messages.find((message) => message.role === "assistant" && message.content?.trim())?.content?.trim()
+
+    if (!firstUserMessage || !firstAssistantMessage) {
+      return null
+    }
+
+    const fallbackTitle = this.generateConversationTitle(firstUserMessage)
+    const currentTitle = this.normalizeConversationTitle(conversation.title)
+    if (currentTitle !== this.normalizeConversationTitle(fallbackTitle)) {
+      return null
+    }
+
+    return {
+      fallbackTitle,
+      firstUserMessage,
+      firstAssistantMessage,
+    }
+  }
+
+  private async generateAgentSessionTitle(
+    firstUserMessage: string,
+    firstAssistantMessage: string,
+    sessionId?: string,
+  ): Promise<string | null> {
+    const prompt = [
+      "Generate a short session title for this conversation.",
+      `Requirements: maximum ${MAX_AGENT_SESSION_TITLE_WORDS} words, no quotes, no markdown, plain text only.`,
+      "Prefer a specific topic label over a generic sentence fragment.",
+      "",
+      `User: ${firstUserMessage.slice(0, 400)}`,
+      `Assistant: ${firstAssistantMessage.slice(0, 600)}`,
+      "",
+      "Return only the title.",
+    ].join("\n")
+
+    try {
+      const completion = await makeTextCompletionWithFetch(prompt, undefined, sessionId)
+      return this.normalizeConversationTitle(completion, MAX_AGENT_SESSION_TITLE_WORDS) || null
+    } catch (error) {
+      logApp("[ConversationService] Failed to auto-generate session title:", error)
+      return null
+    }
   }
 
   /**
@@ -715,6 +787,66 @@ export class ConversationService {
       } catch (error) {
         return null
       }
+    })
+  }
+
+  async renameConversationTitle(conversationId: string, title: string): Promise<Conversation | null> {
+    const normalizedTitle = this.normalizeConversationTitle(title)
+    if (!normalizedTitle) {
+      return null
+    }
+
+    return this.enqueueConversationMutation(conversationId, async () => {
+      const conversation = await this.loadConversationFromDisk(conversationId)
+      if (!conversation) {
+        return null
+      }
+
+      if (this.normalizeConversationTitle(conversation.title) === normalizedTitle) {
+        return conversation
+      }
+
+      conversation.title = normalizedTitle
+      await this.saveConversationUnlocked(conversation)
+      return conversation
+    })
+  }
+
+  async maybeAutoGenerateConversationTitle(conversationId: string, sessionId?: string): Promise<Conversation | null> {
+    const conversation = await this.loadConversation(conversationId)
+    if (!conversation) {
+      return null
+    }
+
+    const seed = this.getAutoTitleSeed(conversation)
+    if (!seed) {
+      return null
+    }
+
+    const generatedTitle = await this.generateAgentSessionTitle(
+      seed.firstUserMessage,
+      seed.firstAssistantMessage,
+      sessionId,
+    )
+
+    if (!generatedTitle || generatedTitle === this.normalizeConversationTitle(seed.fallbackTitle)) {
+      return null
+    }
+
+    return this.enqueueConversationMutation(conversationId, async () => {
+      const latestConversation = await this.loadConversationFromDisk(conversationId)
+      if (!latestConversation) {
+        return null
+      }
+
+      const latestSeed = this.getAutoTitleSeed(latestConversation)
+      if (!latestSeed || latestSeed.fallbackTitle !== seed.fallbackTitle) {
+        return latestConversation
+      }
+
+      latestConversation.title = generatedTitle
+      await this.saveConversationUnlocked(latestConversation)
+      return latestConversation
     })
   }
 

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -705,13 +705,39 @@ export async function processTranscriptWithAgentMode(
           : undefined
       }))
 
-      await conversationService.addMessageToConversation(
+      const updatedConversation = await conversationService.addMessageToConversation(
         currentConversationId,
         content,
         role,
         toolCalls,
         convertedToolResults
       )
+
+      if (role === "assistant" && currentConversationId && sessionId) {
+        void conversationService.maybeAutoGenerateConversationTitle(currentConversationId, sessionId)
+          .then((retitledConversation) => {
+            if (!retitledConversation?.title) {
+              return
+            }
+
+            const trackedSession = agentSessionTracker.getSession(sessionId)
+            if (trackedSession?.conversationTitle !== retitledConversation.title) {
+              agentSessionTracker.updateSession(sessionId, {
+                conversationTitle: retitledConversation.title,
+              })
+            }
+          })
+          .catch((error) => {
+            logLLM("[saveMessageIncremental] Failed to auto-generate session title:", error)
+          })
+      } else if (updatedConversation?.title && sessionId) {
+        const trackedSession = agentSessionTracker.getSession(sessionId)
+        if (trackedSession?.conversationTitle !== updatedConversation.title) {
+          agentSessionTracker.updateSession(sessionId, {
+            conversationTitle: updatedConversation.title,
+          })
+        }
+      }
 
       if (isDebugLLM()) {
         logLLM("💾 Saved message incrementally", {

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -113,6 +113,21 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
     },
   },
   {
+    name: "set_session_title",
+    description:
+      "Set or update the current session title. Use this after the first substantive reply to replace a raw first-prompt title, or later if the conversation topic shifts. Keep the title short, specific, and ideally under 10 words.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: {
+          type: "string",
+          description: "Short session title, ideally under 10 words and without quotes.",
+        },
+      },
+      required: ["title"],
+    },
+  },
+  {
     name: "mark_work_complete",
     description: "Signal explicit completion for the current task. Call this only when all requested work is actually finished and ready for final delivery.",
     inputSchema: {

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -15,6 +15,7 @@ import { emergencyStopAll } from "./emergency-stop"
 import { executeACPRouterTool, isACPRouterTool } from "./acp/acp-router-tools"
 import { messageQueueService } from "./message-queue-service"
 import { appendSessionUserResponse } from "./session-user-response-store"
+import { conversationService } from "./conversation-service"
 import { promises as fs } from "fs"
 import { exec } from "child_process"
 import { promisify } from "util"
@@ -494,6 +495,51 @@ const toolHandlers: Record<string, ToolHandler> = {
           }, null, 2),
         },
       ],
+      isError: false,
+    }
+  },
+
+  set_session_title: async (args: Record<string, unknown>, context: BuiltinToolContext): Promise<MCPToolResult> => {
+    if (!context.sessionId) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "set_session_title requires an active agent session" }) }],
+        isError: true,
+      }
+    }
+
+    if (typeof args.title !== "string" || args.title.trim() === "") {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "title must be a non-empty string" }) }],
+        isError: true,
+      }
+    }
+
+    const session = agentSessionTracker.getSession(context.sessionId)
+    if (!session?.conversationId) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Current session is not linked to a conversation" }) }],
+        isError: true,
+      }
+    }
+
+    const updatedConversation = await conversationService.renameConversationTitle(
+      session.conversationId,
+      args.title,
+    )
+
+    if (!updatedConversation) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Failed to update session title" }) }],
+        isError: true,
+      }
+    }
+
+    agentSessionTracker.updateSession(context.sessionId, {
+      conversationTitle: updatedConversation.title,
+    })
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: true, title: updatedConversation.title }, null, 2) }],
       isError: false,
     }
   },

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3313,6 +3313,29 @@ export const router = {
       )
     }),
 
+  renameConversationTitle: t.procedure
+    .input<{ conversationId: string; title: string }>()
+    .action(async ({ input }) => {
+      const conversation = await conversationService.renameConversationTitle(
+        input.conversationId,
+        input.title,
+      )
+
+      if (conversation) {
+        const activeSession = agentSessionTracker
+          .getActiveSessions()
+          .find((session) => session.conversationId === input.conversationId)
+
+        if (activeSession) {
+          agentSessionTracker.updateSession(activeSession.id, {
+            conversationTitle: conversation.title,
+          })
+        }
+      }
+
+      return conversation
+    }),
+
   deleteConversation: t.procedure
     .input<{ conversationId: string }>()
     .action(async ({ input }) => {

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useMemo, useCallback } from "react"
-import { useQuery } from "@tanstack/react-query"
+import React, { useState, useEffect, useMemo, useCallback, useRef } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { tipcClient, rendererHandlers } from "@renderer/lib/tipc-client"
 import {
   Archive,
@@ -86,7 +86,11 @@ export function ActiveAgentsSidebar({
   const archivedSessionIds = useAgentStore((s) => s.archivedSessionIds)
   const toggleArchiveSession = useAgentStore((s) => s.toggleArchiveSession)
   const [visiblePastSessionCount, setVisiblePastSessionCount] = useState(0)
+  const [editingConversationId, setEditingConversationId] = useState<string | null>(null)
+  const [editingTitle, setEditingTitle] = useState("")
+  const skipTitleSaveOnBlurRef = useRef(false)
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
 
   const { data, refetch } = useQuery<AgentSessionsResponse>({
     queryKey: ["agentSessions"],
@@ -359,6 +363,102 @@ export function ActiveAgentsSidebar({
     setIsExpanded(newState)
   }
 
+  const clearTitleEditing = useCallback(() => {
+    setEditingConversationId(null)
+    setEditingTitle("")
+  }, [])
+
+  const startTitleEditing = useCallback((conversationId?: string, title?: string) => {
+    if (!conversationId) return
+    setEditingConversationId(conversationId)
+    setEditingTitle(title || "Untitled session")
+  }, [])
+
+  const saveTitleEdit = useCallback(async (conversationId?: string, currentTitle?: string) => {
+    if (!conversationId) {
+      clearTitleEditing()
+      return
+    }
+
+    const nextTitle = editingTitle.trim()
+    const previousTitle = (currentTitle || "Untitled session").trim()
+
+    if (!nextTitle || nextTitle === previousTitle) {
+      clearTitleEditing()
+      return
+    }
+
+    try {
+      await tipcClient.renameConversationTitle({ conversationId, title: nextTitle })
+      clearTitleEditing()
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["agentSessions"] }),
+        queryClient.invalidateQueries({ queryKey: ["conversation-history"] }),
+        queryClient.invalidateQueries({ queryKey: ["conversation", conversationId] }),
+      ])
+    } catch (error) {
+      console.error("Failed to rename session title:", error)
+    }
+  }, [clearTitleEditing, editingTitle, queryClient])
+
+  const renderEditableTitle = useCallback(
+    (session: AgentSession, className: string, prefix?: string) => {
+      const conversationId = session.conversationId
+      const title = session.conversationTitle || "Untitled session"
+
+      if (conversationId && editingConversationId === conversationId) {
+        return (
+          <input
+            value={editingTitle}
+            onChange={(event) => setEditingTitle(event.target.value)}
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) => {
+              event.stopPropagation()
+              if (event.key === "Enter") {
+                event.preventDefault()
+                void saveTitleEdit(conversationId, title)
+              } else if (event.key === "Escape") {
+                event.preventDefault()
+                skipTitleSaveOnBlurRef.current = true
+                clearTitleEditing()
+              }
+            }}
+            onBlur={() => {
+              if (skipTitleSaveOnBlurRef.current) {
+                skipTitleSaveOnBlurRef.current = false
+                return
+              }
+              void saveTitleEdit(conversationId, title)
+            }}
+            autoFocus
+            className={cn(
+              "h-6 w-full rounded border border-input bg-background px-1.5 text-xs text-foreground shadow-sm outline-none ring-0 focus-visible:border-ring",
+              className,
+            )}
+            aria-label="Rename session title"
+          />
+        )
+      }
+
+      return (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            startTitleEditing(conversationId, title)
+          }}
+          className={cn("min-w-0 truncate text-left", className)}
+          title={conversationId ? "Rename session title" : title}
+          disabled={!conversationId}
+        >
+          {prefix ? `${prefix}${title}` : title}
+        </button>
+      )
+    },
+    [clearTitleEditing, editingConversationId, editingTitle, saveTitleEdit, startTitleEditing],
+  )
+
   const handleHeaderClick = () => {
     // Navigate to sessions view
     logUI("[ActiveAgentsSidebar] Header clicked, navigating to sessions")
@@ -495,9 +595,7 @@ export function ActiveAgentsSidebar({
                     "h-1.5 w-1.5 shrink-0 rounded-full",
                     session.status === "error" ? "bg-red-500" : "bg-green-500",
                   )} />
-                  <p className="flex-1 truncate">
-                    {session.conversationTitle || "Untitled session"}
-                  </p>
+                  {renderEditableTitle(session, "flex-1")}
                   {session.conversationId && (
                     <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex group-focus-within:flex">
                       <button
@@ -573,20 +671,17 @@ export function ActiveAgentsSidebar({
                   )}
                 />
                 <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-                  <p
-                    className={cn(
-                      "truncate",
+                  {renderEditableTitle(
+                    session,
+                    cn(
                       hasPendingApproval
                         ? "text-amber-700 dark:text-amber-300"
                         : isSnoozed
                           ? "text-muted-foreground"
                           : "text-foreground",
-                    )}
-                  >
-                    {hasPendingApproval
-                      ? `⚠ ${session.conversationTitle}`
-                      : session.conversationTitle}
-                  </p>
+                    ),
+                    hasPendingApproval ? "⚠ " : undefined,
+                  )}
                   {/* Agent name indicator */}
                   {agentName && (
                     <span

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -12,6 +12,7 @@ function createHookRuntime() {
   const states: any[] = []
   const refs: Array<{ current: any }> = []
   const effects: EffectRecord[] = []
+  const audioRefs: any[] = []
   let stateIndex = 0
   let refIndex = 0
   let effectIndex = 0
@@ -42,9 +43,31 @@ function createHookRuntime() {
     if (typeof ref === "function") ref(value)
     else if (ref && typeof ref === "object") ref.current = value
   }
-  const createRefValue = (type: any) => type === "audio"
-    ? { addEventListener: vi.fn(), removeEventListener: vi.fn(), pause: vi.fn(), currentTime: 0, src: "" }
-    : { scrollTop: 0, scrollHeight: 100, clientHeight: 100 }
+  const createRefValue = (type: any) => {
+    if (type === "audio") {
+      const listeners = new Map<string, Set<(...args: any[]) => void>>()
+      const audioRef = {
+        addEventListener: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          const set = listeners.get(event) ?? new Set<(...args: any[]) => void>()
+          set.add(handler)
+          listeners.set(event, set)
+        }),
+        removeEventListener: vi.fn((event: string, handler: (...args: any[]) => void) => {
+          listeners.get(event)?.delete(handler)
+        }),
+        dispatchEvent(event: string) {
+          listeners.get(event)?.forEach((handler) => handler())
+        },
+        pause: vi.fn(),
+        currentTime: 0,
+        src: "",
+      }
+      audioRefs.push(audioRef)
+      return audioRef
+    }
+
+    return { scrollTop: 0, scrollHeight: 100, clientHeight: 100, scrollIntoView: vi.fn() }
+  }
   const invoke = (type: any, props: any) => {
     if (type === Fragment) return props?.children ?? null
     if (typeof type === "function") return type(props ?? {})
@@ -88,6 +111,7 @@ function createHookRuntime() {
         record.hasRun = true
       }
     },
+    audioRefs,
     reactMock,
     jsxRuntimeMock: { __esModule: true, Fragment, jsx: invoke, jsxs: invoke, jsxDEV: invoke },
   }
@@ -151,7 +175,10 @@ function findElementByTitle(tree: any, title: string) {
   return match
 }
 
-async function loadAgentProgress(runtime: ReturnType<typeof createHookRuntime>) {
+async function loadAgentProgress(
+  runtime: ReturnType<typeof createHookRuntime>,
+  options?: { ttsEnabled?: boolean },
+) {
   vi.resetModules()
   const captured = { tileFollowUpInputProps: null as any }
 
@@ -159,12 +186,33 @@ async function loadAgentProgress(runtime: ReturnType<typeof createHookRuntime>) 
     configurable: true,
     value: { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn(), clear: vi.fn() },
   })
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    },
+  })
+  Object.defineProperty(globalThis, "cancelAnimationFrame", {
+    configurable: true,
+    value: vi.fn(),
+  })
 
   const Null = () => null
   const icon = (name: string) => (props: any) => ({ type: name, props })
   const tipcMock = { tipcClient: new Proxy({ generateSpeech: vi.fn(), setPanelFocusable: vi.fn() }, { get: (target, key) => (target as any)[key] ?? vi.fn() }) }
-  const queriesMock = { useConfigQuery: () => ({ data: { ttsEnabled: false, ttsAutoPlay: false, dualModelEnabled: false } }) }
+  const queriesMock = { useConfigQuery: () => ({ data: { ttsEnabled: options?.ttsEnabled ?? false, ttsAutoPlay: false, dualModelEnabled: false } }) }
   const themeContextMock = { useTheme: () => ({ isDark: false }) }
+  const ttsManagerMock = {
+    ttsManager: {
+      stopAll: vi.fn(),
+      registerAudio: () => () => {},
+      registerStopCallback: () => () => {},
+      playExclusive: vi.fn(async (audio: any) => {
+        audio.dispatchEvent?.("play")
+      }),
+    },
+  }
   const storesMock = {
     useAgentStore: (selector: any) => selector({ setFocusedSessionId: vi.fn(), setSessionSnoozed: vi.fn() }),
     useMessageQueue: () => [],
@@ -205,6 +253,8 @@ async function loadAgentProgress(runtime: ReturnType<typeof createHookRuntime>) 
     Brain: icon("Brain"),
     Volume2: icon("Volume2"),
     Wrench: icon("Wrench"),
+    Play: icon("Play"),
+    Pause: icon("Pause"),
   }))
   vi.doMock("@renderer/lib/utils", () => ({ cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(" ") }))
   vi.doMock("@renderer/components/markdown-renderer", () => ({ MarkdownRenderer: ({ content }: any) => ({ type: "MarkdownRenderer", props: { content, children: content } }) }))
@@ -244,12 +294,12 @@ async function loadAgentProgress(runtime: ReturnType<typeof createHookRuntime>) 
   vi.doMock("./acp-session-badge", () => ({ ACPSessionBadge: Null }))
   vi.doMock("./agent-summary-view", () => ({ AgentSummaryView: Null }))
   vi.doMock("@renderer/lib/tts-tracking", () => ({ hasTTSPlayed: () => false, markTTSPlayed: vi.fn(), removeTTSKey: vi.fn() }))
-  vi.doMock("@renderer/lib/tts-manager", () => ({ ttsManager: { stopAll: vi.fn(), registerAudio: () => () => {}, registerStopCallback: () => () => {}, playExclusive: vi.fn() } }))
+  vi.doMock("@renderer/lib/tts-manager", () => ttsManagerMock)
   vi.doMock("@dotagents/shared/message-display-utils", () => ({ sanitizeMessageContentForSpeech: (text: string) => text }))
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
   const mod = await import("./agent-progress")
-  return { AgentProgress: mod.AgentProgress, captured }
+  return { AgentProgress: mod.AgentProgress, captured, tipcMock, ttsManagerMock, audioRefs: runtime.audioRefs }
 }
 
 afterEach(() => {
@@ -533,5 +583,40 @@ describe("agent progress response history", () => {
     })
 
     expect(onExpand).toHaveBeenCalledTimes(2)
+  })
+
+  it("plays response history newest-to-oldest from the header playback control", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress, tipcMock, audioRefs } = await loadAgentProgress(runtime, { ttsEnabled: true })
+    ;(tipcMock.tipcClient.generateSpeech as any)
+      .mockResolvedValueOnce({ audio: new Uint8Array([1, 2, 3]), mimeType: "audio/wav" })
+      .mockResolvedValueOnce({ audio: new Uint8Array([4, 5, 6]), mimeType: "audio/wav" })
+
+    const progress = {
+      sessionId: "session-8",
+      conversationId: "conversation-8",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [],
+      isComplete: false,
+      finalContent: "",
+      conversationHistory: [],
+      userResponse: "Newest answer",
+      userResponseHistory: ["Oldest draft", "Middle draft"],
+    }
+
+    let tree = runtime.render(AgentProgress, { progress })
+    runtime.commitEffects()
+
+    const playButton = findElementByTitle(tree, "Play newest to oldest")
+    await playButton.props.onClick({ stopPropagation: vi.fn() })
+
+    expect(tipcMock.tipcClient.generateSpeech).toHaveBeenNthCalledWith(1, { text: "Newest answer" })
+
+    tree = runtime.render(AgentProgress, { progress })
+    expect(findElementByTitle(tree, "Stop playback")).toBeTruthy()
+
+    audioRefs[0].dispatchEvent("ended")
+    expect(tipcMock.tipcClient.generateSpeech).toHaveBeenNthCalledWith(2, { text: "Middle draft" })
   })
 })

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { cn } from "@renderer/lib/utils"
 import { AgentProgressUpdate, ACPDelegationProgress, ACPSubAgentMessage } from "../../../shared/types"
 import { INTERNAL_COMPLETION_NUDGE_TEXT, RESPOND_TO_USER_TOOL, MARK_WORK_COMPLETE_TOOL } from "../../../shared/runtime-tool-names"
-import { ChevronDown, ChevronUp, ChevronRight, X, AlertTriangle, Minimize2, Shield, Check, XCircle, Loader2, Clock, Copy, CheckCheck, GripHorizontal, Activity, Moon, Maximize2, LayoutGrid, Bot, OctagonX, MessageSquare, Brain, Volume2, Wrench } from "lucide-react"
+import { ChevronDown, ChevronUp, ChevronRight, X, AlertTriangle, Minimize2, Shield, Check, XCircle, Loader2, Clock, Copy, CheckCheck, GripHorizontal, Activity, Moon, Maximize2, LayoutGrid, Bot, OctagonX, MessageSquare, Brain, Volume2, Wrench, Play, Pause } from "lucide-react"
 import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
@@ -2203,7 +2203,8 @@ const PastResponseItem: React.FC<{
   response: string
   index: number
   sessionId?: string
-}> = ({ response, index, sessionId }) => {
+  isHighlighted?: boolean
+}> = ({ response, index, sessionId, isHighlighted = false }) => {
   const [audioData, setAudioData] = useState<ArrayBuffer | null>(null)
   const [audioMimeType, setAudioMimeType] = useState<string | null>(null)
   const [isExpanded, setIsExpanded] = useState(false)
@@ -2226,7 +2227,10 @@ const PastResponseItem: React.FC<{
   const preview = response.length > 80 ? response.slice(0, 80) + "…" : response
 
   return (
-    <div className="min-w-0 max-w-full overflow-hidden rounded-md border border-green-200/60 dark:border-green-800/40">
+    <div className={cn(
+      "min-w-0 max-w-full overflow-hidden rounded-md border border-green-200/60 dark:border-green-800/40",
+      isHighlighted && "bg-green-100/70 ring-1 ring-inset ring-green-300 dark:bg-green-900/30 dark:ring-green-700",
+    )}>
       <div
         className="flex min-w-0 items-start gap-2 cursor-pointer px-2.5 py-1.5 transition-colors hover:bg-green-50/50 dark:hover:bg-green-900/20"
         onClick={() => setIsExpanded(!isExpanded)}
@@ -2393,6 +2397,14 @@ const ResponseHistoryPanel: React.FC<{
   pastResponses?: string[]
 }> = ({ currentResponse, pastResponses }) => {
   const [displayState, setDisplayState] = useState<ResponsePanelState>("expanded")
+  const [sequentialPlaybackState, setSequentialPlaybackState] = useState<"idle" | "generating" | "playing">("idle")
+  const [activePlaybackKey, setActivePlaybackKey] = useState<string | null>(null)
+  const configQuery = useConfigQuery()
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const audioUrlRef = useRef<string | null>(null)
+  const playbackGenerationIdRef = useRef(0)
+  const playbackIndexRef = useRef(-1)
+  const entryRefs = useRef<Record<string, HTMLDivElement | null>>({})
 
   const responseEntries = useMemo(() => {
     const fingerprint = (response: string) => `${response.slice(0, 64).replace(/\W/g, "")}-${response.length}`
@@ -2420,6 +2432,13 @@ const ResponseHistoryPanel: React.FC<{
 
     return entries
   }, [currentResponse, pastResponses])
+  const responseEntriesRef = useRef(responseEntries)
+  responseEntriesRef.current = responseEntries
+  const responseEntriesSignature = useMemo(
+    () => responseEntries.map((entry) => entry.key).join("|"),
+    [responseEntries],
+  )
+  const previousResponseEntriesSignatureRef = useRef(responseEntriesSignature)
 
   const cycleState = useCallback(() => {
     setDisplayState(prev => {
@@ -2429,9 +2448,137 @@ const ResponseHistoryPanel: React.FC<{
     })
   }, [])
 
+  const stopSequentialPlayback = useCallback((resetAudio: boolean = true) => {
+    playbackGenerationIdRef.current += 1
+    playbackIndexRef.current = -1
+    setSequentialPlaybackState("idle")
+    setActivePlaybackKey(null)
+
+    if (resetAudio && audioRef.current) {
+      audioRef.current.pause()
+      audioRef.current.currentTime = 0
+    }
+  }, [])
+
+  const scrollToResponse = useCallback((key: string) => {
+    entryRefs.current[key]?.scrollIntoView?.({ block: "nearest", behavior: "smooth" })
+  }, [])
+
+  const playSequentialEntry = useCallback(async (entryIndex: number) => {
+    const audio = audioRef.current
+    const entry = responseEntriesRef.current[entryIndex]
+
+    if (!audio || !entry) {
+      stopSequentialPlayback(false)
+      return
+    }
+
+    const ttsSource = sanitizeMessageContentForSpeech(entry.text)
+    if (!ttsSource) {
+      stopSequentialPlayback(false)
+      return
+    }
+
+    playbackIndexRef.current = entryIndex
+    setActivePlaybackKey(entry.key)
+    scrollToResponse(entry.key)
+
+    const generationId = ++playbackGenerationIdRef.current
+    setSequentialPlaybackState("generating")
+
+    try {
+      const result = await tipcClient.generateSpeech({ text: ttsSource })
+      if (playbackGenerationIdRef.current !== generationId) {
+        return
+      }
+
+      if (audioUrlRef.current) {
+        URL.revokeObjectURL(audioUrlRef.current)
+      }
+
+      const blob = new Blob([result.audio], { type: result.mimeType || "audio/wav" })
+      audioUrlRef.current = URL.createObjectURL(blob)
+      audio.src = audioUrlRef.current
+      await ttsManager.playExclusive(audio, {
+        source: "response-history-sequence",
+        autoPlay: false,
+        textPreview: ttsSource.slice(0, 80),
+      })
+    } catch {
+      if (playbackGenerationIdRef.current === generationId) {
+        stopSequentialPlayback(false)
+      }
+    }
+  }, [scrollToResponse, stopSequentialPlayback])
+
+  useEffect(() => {
+    const audio = audioRef.current
+    if (!audio) return undefined
+
+    const unregisterAudio = ttsManager.registerAudio(audio)
+    const unregisterStop = ttsManager.registerStopCallback(() => {
+      playbackGenerationIdRef.current += 1
+      playbackIndexRef.current = -1
+      setSequentialPlaybackState("idle")
+      setActivePlaybackKey(null)
+    }, audio)
+    const onEnded = () => {
+      const nextIndex = playbackIndexRef.current + 1
+      if (nextIndex >= responseEntriesRef.current.length) {
+        stopSequentialPlayback(false)
+        return
+      }
+      void playSequentialEntry(nextIndex)
+    }
+    const onPlay = () => setSequentialPlaybackState("playing")
+    const onPause = () => {
+      setSequentialPlaybackState((state) => (state === "playing" ? "idle" : state))
+    }
+
+    audio.addEventListener("ended", onEnded)
+    audio.addEventListener("play", onPlay)
+    audio.addEventListener("pause", onPause)
+
+    return () => {
+      unregisterAudio()
+      unregisterStop()
+      audio.removeEventListener("ended", onEnded)
+      audio.removeEventListener("play", onPlay)
+      audio.removeEventListener("pause", onPause)
+    }
+  }, [playSequentialEntry, stopSequentialPlayback])
+
+  useEffect(() => () => {
+    playbackGenerationIdRef.current += 1
+    if (audioUrlRef.current) {
+      URL.revokeObjectURL(audioUrlRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (previousResponseEntriesSignatureRef.current !== responseEntriesSignature) {
+      previousResponseEntriesSignatureRef.current = responseEntriesSignature
+      if (sequentialPlaybackState !== "idle") {
+        stopSequentialPlayback(true)
+      }
+    }
+  }, [responseEntriesSignature, sequentialPlaybackState, stopSequentialPlayback])
+
   if (responseEntries.length === 0) return null
 
   const stateLabel = displayState === "collapsed" ? "Expand" : displayState === "expanded" ? "Full height" : "Collapse"
+  const canPlaySequentialResponses = !!configQuery.data?.ttsEnabled
+
+  const handleSequentialPlaybackClick = useCallback(async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+
+    if (sequentialPlaybackState === "playing" || sequentialPlaybackState === "generating") {
+      stopSequentialPlayback(true)
+      return
+    }
+
+    await playSequentialEntry(0)
+  }, [playSequentialEntry, sequentialPlaybackState, stopSequentialPlayback])
 
   return (
     <div className={cn(
@@ -2440,28 +2587,41 @@ const ResponseHistoryPanel: React.FC<{
         : "flex-shrink-0 border-t bg-green-50/50 dark:bg-green-950/30",
     )}>
       {/* Header */}
-      <button
-        type="button"
-        onClick={cycleState}
-        className="flex w-full items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-green-100/50 dark:hover:bg-green-900/30 flex-shrink-0"
-        title={stateLabel}
-      >
-        <MessageSquare className="h-3.5 w-3.5 shrink-0 text-green-600 dark:text-green-400" />
-        <span className="text-xs font-medium text-green-800 dark:text-green-200">
-          Agent Responses
-        </span>
-        <Badge variant="secondary" className="ml-0.5 h-4 shrink-0 px-1 py-0 text-[10px] bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200">
-          {responseEntries.length}
-        </Badge>
-        <div className="flex-1" />
-        {displayState === "collapsed" ? (
-          <ChevronUp className="h-3 w-3 text-green-600 dark:text-green-400" />
-        ) : displayState === "expanded" ? (
-          <Maximize2 className="h-3 w-3 text-green-600 dark:text-green-400" />
-        ) : (
-          <ChevronDown className="h-3 w-3 text-green-600 dark:text-green-400" />
+      <div className="flex items-center gap-1 pr-1.5">
+        <button
+          type="button"
+          onClick={cycleState}
+          className="flex min-w-0 flex-1 items-center gap-1.5 px-2.5 py-1.5 text-left transition-colors hover:bg-green-100/50 dark:hover:bg-green-900/30 flex-shrink-0"
+          title={stateLabel}
+        >
+          <MessageSquare className="h-3.5 w-3.5 shrink-0 text-green-600 dark:text-green-400" />
+          <span className="text-xs font-medium text-green-800 dark:text-green-200">
+            Agent Responses
+          </span>
+          <Badge variant="secondary" className="ml-0.5 h-4 shrink-0 px-1 py-0 text-[10px] bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-200">
+            {responseEntries.length}
+          </Badge>
+          <div className="flex-1" />
+          {displayState === "collapsed" ? (
+            <ChevronUp className="h-3 w-3 text-green-600 dark:text-green-400" />
+          ) : displayState === "expanded" ? (
+            <Maximize2 className="h-3 w-3 text-green-600 dark:text-green-400" />
+          ) : (
+            <ChevronDown className="h-3 w-3 text-green-600 dark:text-green-400" />
+          )}
+        </button>
+        {canPlaySequentialResponses && (
+          <button
+            type="button"
+            onClick={handleSequentialPlaybackClick}
+            disabled={sequentialPlaybackState === "generating"}
+            className="rounded p-1 text-green-700 transition-colors hover:bg-green-100/70 hover:text-green-900 disabled:cursor-wait disabled:opacity-70 dark:text-green-200 dark:hover:bg-green-900/40 dark:hover:text-green-50"
+            title={sequentialPlaybackState === "idle" ? "Play newest to oldest" : "Stop playback"}
+          >
+            {sequentialPlaybackState === "idle" ? <Play className="h-3.5 w-3.5" /> : <Pause className="h-3.5 w-3.5" />}
+          </button>
         )}
-      </button>
+      </div>
       {/* Response list */}
       {displayState !== "collapsed" && (
         <div className={cn(
@@ -2473,10 +2633,14 @@ const ResponseHistoryPanel: React.FC<{
             return (
             <div
               key={key}
+              ref={(node) => {
+                entryRefs.current[key] = node
+              }}
               className={cn(
                 "px-3 py-2 text-xs text-green-900 dark:text-green-100",
                 !isCurrent && "border-t border-green-200/40 dark:border-green-800/40",
                 isCurrent && "bg-green-100/30 dark:bg-green-900/20",
+                activePlaybackKey === key && "bg-green-100/80 ring-1 ring-inset ring-green-300 dark:bg-green-900/40 dark:ring-green-700",
               )}
             >
               <div className="flex items-start gap-1">
@@ -2496,6 +2660,7 @@ const ResponseHistoryPanel: React.FC<{
           )})}
         </div>
       )}
+      <audio ref={audioRef} className="hidden" />
     </div>
   )
 }
@@ -2531,9 +2696,15 @@ const MidTurnUserResponseBubble: React.FC<{
   const [ttsError, setTtsError] = useState<string | null>(null)
   const [isTTSPlaying, setIsTTSPlaying] = useState(false)
   const [isPastResponsesExpanded, setIsPastResponsesExpanded] = useState(false)
+  const [sequentialPlaybackState, setSequentialPlaybackState] = useState<"idle" | "generating" | "playing">("idle")
+  const [activeSequentialKey, setActiveSequentialKey] = useState<string | null>(null)
   const inFlightTtsKeyRef = useRef<string | null>(null)
   const inFlightCompletionTTSKeysRef = useRef<string[]>([])
   const maximizeTriggeredOnPointerDownRef = useRef(false)
+  const sequenceAudioRef = useRef<HTMLAudioElement | null>(null)
+  const sequenceAudioUrlRef = useRef<string | null>(null)
+  const sequenceGenerationIdRef = useRef(0)
+  const sequenceIndexRef = useRef(-1)
   const configQuery = useConfigQuery()
   const ttsGenerationIdRef = useRef(0)
   const ttsSource = sanitizeMessageContentForSpeech(userResponse)
@@ -2671,10 +2842,27 @@ const MidTurnUserResponseBubble: React.FC<{
   )
   const pastResponseCount = pastResponses?.length ?? 0
   const hasPastResponses = pastResponseCount > 0
+  const sequentialResponses = useMemo(
+    () => [
+      { key: `current-${currentResponse.id}`, text: userResponse },
+      ...[...(pastResponses ?? [])]
+        .reverse()
+        .map((response) => ({ key: `past-${response.id}`, text: response.text })),
+    ],
+    [currentResponse.id, pastResponses, userResponse],
+  )
+  const sequentialResponsesRef = useRef(sequentialResponses)
+  sequentialResponsesRef.current = sequentialResponses
+  const sequentialResponsesSignature = useMemo(
+    () => sequentialResponses.map((response) => response.key).join("|"),
+    [sequentialResponses],
+  )
+  const previousSequentialResponsesSignatureRef = useRef(sequentialResponsesSignature)
 
   const shouldKeepAudioPlayerMounted =
     shouldShowTTSButton &&
     (isExpanded || (variant === "overlay" && (configQuery.data?.ttsAutoPlay ?? true)))
+  const isCurrentSequentialResponseHighlighted = activeSequentialKey === `current-${currentResponse.id}`
 
   const handleHeaderClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLElement | null
@@ -2707,8 +2895,130 @@ const MidTurnUserResponseBubble: React.FC<{
     maximizeTriggeredOnPointerDownRef.current = false
   }, [])
 
+  const resetSequentialPlayback = useCallback((pauseAudio: boolean = true) => {
+    sequenceGenerationIdRef.current += 1
+    sequenceIndexRef.current = -1
+    setSequentialPlaybackState("idle")
+    setActiveSequentialKey(null)
+
+    if (pauseAudio && sequenceAudioRef.current) {
+      sequenceAudioRef.current.pause()
+      sequenceAudioRef.current.currentTime = 0
+    }
+  }, [])
+
+  const playSequentialResponse = useCallback(async (responseIndex: number) => {
+    const audio = sequenceAudioRef.current
+    const response = sequentialResponsesRef.current[responseIndex]
+    if (!audio || !response) {
+      resetSequentialPlayback(false)
+      return
+    }
+
+    const ttsText = sanitizeMessageContentForSpeech(response.text)
+    if (!ttsText) {
+      resetSequentialPlayback(false)
+      return
+    }
+
+    sequenceIndexRef.current = responseIndex
+    setActiveSequentialKey(response.key)
+    setSequentialPlaybackState("generating")
+    const generationId = ++sequenceGenerationIdRef.current
+
+    try {
+      const result = await tipcClient.generateSpeech({ text: ttsText })
+
+      if (!sequenceAudioRef.current || sequenceGenerationIdRef.current !== generationId) {
+        return
+      }
+
+      if (sequenceAudioUrlRef.current) {
+        URL.revokeObjectURL(sequenceAudioUrlRef.current)
+      }
+
+      const blob = new Blob([result.audio], { type: result.mimeType || "audio/wav" })
+      sequenceAudioUrlRef.current = URL.createObjectURL(blob)
+      audio.src = sequenceAudioUrlRef.current
+
+      await ttsManager.playExclusive(audio, {
+        source: "latest-response-sequence",
+        autoPlay: false,
+        textPreview: ttsText.slice(0, 80),
+      })
+
+      if (sequenceGenerationIdRef.current === generationId) {
+        setSequentialPlaybackState("playing")
+      }
+    } catch {
+      resetSequentialPlayback(false)
+    }
+  }, [resetSequentialPlayback])
+
+  const handleSequentialPlaybackClick = useCallback(async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+
+    if (sequentialPlaybackState !== "idle") {
+      ttsManager.stopAll("latest-response-sequence-stop")
+      return
+    }
+
+    if (hasPastResponses) {
+      setIsPastResponsesExpanded(true)
+    }
+
+    await playSequentialResponse(0)
+  }, [hasPastResponses, playSequentialResponse, sequentialPlaybackState])
+
+  useEffect(() => {
+    const audio = sequenceAudioRef.current
+    if (!audio) return undefined
+
+    const unregisterAudio = ttsManager.registerAudio(audio)
+    const unregisterStop = ttsManager.registerStopCallback(() => {
+      resetSequentialPlayback(false)
+    }, audio)
+    const onEnded = () => {
+      const nextIndex = sequenceIndexRef.current + 1
+      if (nextIndex >= sequentialResponsesRef.current.length) {
+        resetSequentialPlayback(false)
+        return
+      }
+      void playSequentialResponse(nextIndex)
+    }
+    const onPlay = () => setSequentialPlaybackState("playing")
+
+    audio.addEventListener("ended", onEnded)
+    audio.addEventListener("play", onPlay)
+
+    return () => {
+      unregisterAudio()
+      unregisterStop()
+      audio.removeEventListener("ended", onEnded)
+      audio.removeEventListener("play", onPlay)
+    }
+  }, [playSequentialResponse, resetSequentialPlayback])
+
+  useEffect(() => {
+    if (previousSequentialResponsesSignatureRef.current !== sequentialResponsesSignature) {
+      previousSequentialResponsesSignatureRef.current = sequentialResponsesSignature
+      if (sequentialPlaybackState !== "idle") {
+        resetSequentialPlayback(true)
+      }
+    }
+  }, [resetSequentialPlayback, sequentialPlaybackState, sequentialResponsesSignature])
+
+  useEffect(() => () => {
+    if (sequenceAudioUrlRef.current) {
+      URL.revokeObjectURL(sequenceAudioUrlRef.current)
+    }
+  }, [])
+
   return (
-    <div className="min-w-0 max-w-full overflow-hidden rounded-lg border-2 border-green-400 bg-green-50/50 dark:bg-green-950/30">
+    <div className={cn(
+      "min-w-0 max-w-full overflow-hidden rounded-lg border-2 border-green-400 bg-green-50/50 dark:bg-green-950/30",
+      isCurrentSequentialResponseHighlighted && "ring-2 ring-green-300 dark:ring-green-700",
+    )}>
       {/* Header */}
       <div
         className={cn(
@@ -2750,6 +3060,24 @@ const MidTurnUserResponseBubble: React.FC<{
                 <Loader2 className="h-3 w-3 animate-spin text-green-600 dark:text-green-400" />
               ) : (
                 <Volume2 className="h-3 w-3 text-green-600 dark:text-green-400" />
+              )}
+            </button>
+          )}
+          {shouldShowTTSButton && (
+            <button
+              onClick={handleSequentialPlaybackClick}
+              className={cn(
+                "shrink-0 rounded p-1 transition-colors hover:bg-green-200/50 dark:hover:bg-green-800/50",
+                sequentialPlaybackState !== "idle" && "animate-pulse",
+              )}
+              title={sequentialPlaybackState === "idle" ? "Play newest to oldest" : "Stop playback"}
+            >
+              {sequentialPlaybackState === "idle" ? (
+                <Play className="h-3 w-3 text-green-600 dark:text-green-400" />
+              ) : sequentialPlaybackState === "generating" ? (
+                <Loader2 className="h-3 w-3 animate-spin text-green-600 dark:text-green-400" />
+              ) : (
+                <Pause className="h-3 w-3 text-green-600 dark:text-green-400" />
               )}
             </button>
           )}
@@ -2831,6 +3159,7 @@ const MidTurnUserResponseBubble: React.FC<{
                       response={response.text}
                       index={idx}
                       sessionId={sessionId}
+                      isHighlighted={activeSequentialKey === `past-${response.id}`}
                     />
                   ))}
                 </div>
@@ -2839,6 +3168,7 @@ const MidTurnUserResponseBubble: React.FC<{
           )}
         </>
       )}
+      <audio ref={sequenceAudioRef} className="hidden" />
     </div>
   )
 }

--- a/apps/desktop/tests/session-title-density.test.mjs
+++ b/apps/desktop/tests/session-title-density.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = path.resolve(process.cwd())
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('conversation service exposes rename + auto-title helpers', () => {
+  const source = read('apps/desktop/src/main/conversation-service.ts')
+
+  assert.match(source, /async renameConversationTitle\(/)
+  assert.match(source, /async maybeAutoGenerateConversationTitle\(/)
+  assert.match(source, /Generate a short session title for this conversation\./)
+  assert.match(source, /MAX_AGENT_SESSION_TITLE_WORDS = 10/)
+})
+
+test('runtime tool surface exposes set_session_title', () => {
+  const definitions = read('apps/desktop/src/main/runtime-tool-definitions.ts')
+  const handlers = read('apps/desktop/src/main/runtime-tools.ts')
+
+  assert.match(definitions, /name: "set_session_title"/)
+  assert.match(handlers, /set_session_title: async/)
+  assert.match(handlers, /conversationService\.renameConversationTitle\(/)
+})
+
+test('sidebar supports inline session title editing and persistence', () => {
+  const source = read('apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx')
+
+  assert.match(source, /aria-label="Rename session title"/)
+  assert.match(source, /tipcClient\.renameConversationTitle\(/)
+  assert.match(source, /event\.key === "Enter"/)
+  assert.match(source, /event\.key === "Escape"/)
+})


### PR DESCRIPTION
## Summary

- add inline session-title editing in the desktop sidebar with persisted conversation title updates
- add automatic short session title generation after the first assistant reply plus a built-in `set_session_title` runtime tool
- add newest-to-oldest response playback controls for the latest response bubble and keep coverage focused on the desktop response history/session title flows

## Validation

- `pnpm exec vitest run apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts`
- `node --test apps/desktop/tests/session-title-density.test.mjs`
- `pnpm exec tsc -p apps/desktop/tsconfig.json --noEmit`

Closes #159
Closes #160

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author