### PR TITLE
fix: prefer delegated respond_to_user content in ACP results

### DIFF
--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+let sessionUpdateHandler: ((event: any) => void) | undefined
+
+const mockAcpService = {
+  on: vi.fn((eventName: string, handler: (event: any) => void) => {
+    if (eventName === "sessionUpdate") {
+      sessionUpdateHandler = handler
+    }
+  }),
+  spawnAgent: vi.fn(async () => ({ reusedExistingProcess: true })),
+  getOrCreateSession: vi.fn(async () => "acp-session-1"),
+  getAgentSessionId: vi.fn(() => "acp-session-1"),
+  sendPrompt: vi.fn(async () => {
+    sessionUpdateHandler?.({
+      agentName: "test-agent",
+      sessionId: "acp-session-1",
+      toolCall: {
+        toolCallId: "tool-r1",
+        title: "Tool: Respond to User",
+        status: "completed",
+        rawInput: { text: "Final user-facing answer" },
+        rawOutput: { success: true },
+      },
+      isComplete: false,
+      totalBlocks: 0,
+    })
+
+    return {
+      success: true,
+      response: "Internal trailing completion text",
+    }
+  }),
+}
+
+vi.mock("../acp-service", () => ({
+  acpService: mockAcpService,
+}))
+
+vi.mock("./acp-background-notifier", () => ({
+  acpBackgroundNotifier: {
+    setDelegatedRunsMap: vi.fn(),
+    resumeParentSessionIfNeeded: vi.fn(() => Promise.resolve()),
+  },
+}))
+
+vi.mock("../config", () => ({
+  configStore: {
+    get: vi.fn(() => ({
+      acpAgents: [{
+        name: "test-agent",
+        enabled: true,
+        connection: { type: "stdio" },
+      }],
+    })),
+  },
+}))
+
+vi.mock("../emit-agent-progress", () => ({
+  emitAgentProgress: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock("../state", () => ({
+  agentSessionStateManager: {
+    getSessionRunId: vi.fn(() => 7),
+  },
+}))
+
+vi.mock("../agent-profile-service", () => ({
+  agentProfileService: {
+    getByName: vi.fn(() => undefined),
+    getAll: vi.fn(() => []),
+  },
+}))
+
+vi.mock("./internal-agent", () => ({
+  runInternalSubSession: vi.fn(),
+  cancelSubSession: vi.fn(),
+  getInternalAgentInfo: vi.fn(() => ({
+    name: "internal",
+    displayName: "Internal",
+    description: "Internal agent",
+    maxRecursionDepth: 3,
+    maxConcurrent: 5,
+  })),
+  getSessionDepth: vi.fn(() => 0),
+  generateSubSessionId: vi.fn(() => "subsession-test"),
+}))
+
+describe("handleDelegateToAgent", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    sessionUpdateHandler = undefined
+  })
+
+  it("prefers ACP respond_to_user tool-call content over trailing plain text", async () => {
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "test-agent",
+      task: "Say hello",
+      waitForResult: true,
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({
+      success: true,
+      status: "completed",
+      output: "Final user-facing answer",
+    }))
+
+    expect(result.conversation).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        role: "tool",
+        toolName: "respond_to_user",
+        content: "Final user-facing answer",
+      }),
+    ]))
+  })
+})

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -11,11 +11,13 @@ import type {
 } from './types';
 import { acpBackgroundNotifier } from './acp-background-notifier';
 import { configStore } from '../config';
-import { acpService, ACPContentBlock } from '../acp-service';
+import { acpService, ACPContentBlock, ACPToolCallUpdate } from '../acp-service';
 import { buildProfileContext, getPreferredDelegationOutput } from '../agent-run-utils';
 import { emitAgentProgress } from '../emit-agent-progress';
 import { agentSessionStateManager } from '../state';
 import type { ACPDelegationProgress, ACPSubAgentMessage } from '../../shared/types';
+import { RESPOND_TO_USER_TOOL } from '../../shared/runtime-tool-names';
+import { extractRespondToUserContentFromArgs } from '../respond-to-user-utils';
 import {
   runInternalSubSession,
   cancelSubSession,
@@ -190,6 +192,55 @@ function createRunningResult(subAgentState: DelegatedRun): DelegationResult {
   };
 }
 
+function normalizeDelegatedToolName(toolName?: string): string | undefined {
+  if (typeof toolName !== 'string') return undefined;
+
+  const normalized = toolName
+    .trim()
+    .toLowerCase()
+    .replace(/^tool:\s*/i, '')
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function formatDelegatedToolCallName(toolCall: ACPToolCallUpdate): string {
+  const title = toolCall.title?.trim();
+  return normalizeDelegatedToolName(title) || title || 'tool_call';
+}
+
+function maybeTrackRespondToUserToolCall(
+  conversation: ACPSubAgentMessage[],
+  toolCall: ACPToolCallUpdate,
+  timestamp: number,
+): void {
+  if (toolCall.status === 'failed') return;
+
+  const toolName = formatDelegatedToolCallName(toolCall);
+  if (toolName !== RESPOND_TO_USER_TOOL) return;
+
+  const content = extractRespondToUserContentFromArgs(toolCall.rawInput);
+  if (!content) return;
+
+  const lastMessage = conversation[conversation.length - 1];
+  if (
+    lastMessage?.role === 'tool'
+    && lastMessage.toolName === toolName
+    && lastMessage.content === content
+  ) {
+    return;
+  }
+
+  conversation.push({
+    role: 'tool',
+    toolName,
+    toolInput: toolCall.rawInput,
+    content,
+    timestamp,
+  });
+}
+
 /**
  * Register agent name to run ID mapping for session update fallback.
  */
@@ -362,11 +413,12 @@ acpService.on('sessionUpdate', (event: {
   agentName: string;
   sessionId: string;
   content?: ACPContentBlock[];
+  toolCall?: ACPToolCallUpdate;
   isComplete?: boolean;
   stopReason?: string;
   totalBlocks: number;
 }) => {
-  const { agentName, sessionId, content, isComplete, stopReason } = event;
+  const { agentName, sessionId, content, toolCall, isComplete, stopReason } = event;
 
   // Find the run ID for this session
   const mappedRunId = sessionToRunId.get(sessionId);
@@ -451,6 +503,10 @@ acpService.on('sessionUpdate', (event: {
         conversation.push(message);
       }
     }
+  }
+
+  if (toolCall) {
+    maybeTrackRespondToUserToolCall(conversation, toolCall, Date.now());
   }
 
   // Enforce conversation size limit (keep most recent messages)

--- a/apps/desktop/src/main/agent-run-utils.test.ts
+++ b/apps/desktop/src/main/agent-run-utils.test.ts
@@ -80,6 +80,17 @@ describe("getPreferredDelegationOutput", () => {
     ])).toBe("Final delegated answer")
   })
 
+  it("prefers ACP-style respond_to_user tool messages over trailing fallback text", () => {
+    expect(getPreferredDelegationOutput("Internal trailing completion text", [
+      {
+        role: "tool",
+        content: "Final delegated answer",
+        toolName: "Tool: Respond to User",
+        toolInput: { text: "Final delegated answer" },
+      },
+    ])).toBe("Final delegated answer")
+  })
+
   it("falls back to the latest assistant message when no explicit user response exists", () => {
     expect(getPreferredDelegationOutput("raw tool output", [
       { role: "assistant", content: "Assistant summary" },

--- a/apps/desktop/src/main/agent-run-utils.ts
+++ b/apps/desktop/src/main/agent-run-utils.ts
@@ -1,5 +1,9 @@
 import type { SessionProfileSnapshot } from "../shared/types"
-import { resolveLatestUserFacingResponse } from "./respond-to-user-utils"
+import { RESPOND_TO_USER_TOOL } from "../shared/runtime-tool-names"
+import {
+  extractRespondToUserContentFromArgs,
+  resolveLatestUserFacingResponse,
+} from "./respond-to-user-utils"
 
 export const DEFAULT_UNLIMITED_GUARDRAIL_ITERATION_BUDGET = 60
 export const AGENT_STOP_NOTE =
@@ -13,10 +17,43 @@ export interface AgentIterationLimits {
 interface ConversationMessageLike {
   role: string
   content?: string | null
+  toolName?: string
+  toolInput?: unknown
   toolCalls?: Array<{
     name?: string
     arguments?: unknown
   }>
+}
+
+function normalizeDelegationToolName(toolName?: string): string | undefined {
+  if (typeof toolName !== "string") return undefined
+
+  const normalized = toolName
+    .trim()
+    .toLowerCase()
+    .replace(/^tool:\s*/i, "")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function getLatestAcpRespondToUserContent(
+  conversation?: ConversationMessageLike[],
+): string | undefined {
+  if (!Array.isArray(conversation)) return undefined
+
+  for (let index = conversation.length - 1; index >= 0; index--) {
+    const message = conversation[index]
+    if (normalizeDelegationToolName(message?.toolName) !== RESPOND_TO_USER_TOOL) continue
+
+    const content = extractRespondToUserContentFromArgs(message?.toolInput)
+    if (content) {
+      return content
+    }
+  }
+
+  return undefined
 }
 
 type ProfileContextSource = {
@@ -117,9 +154,11 @@ export function getPreferredDelegationOutput(
   const explicitUserResponse = resolveLatestUserFacingResponse({
     conversationHistory: conversation,
   })
+  const explicitAcpUserResponse = getLatestAcpRespondToUserContent(conversation)
 
   return (
     explicitUserResponse ??
+    explicitAcpUserResponse ??
     getLatestAssistantMessageContent(conversation) ??
     (typeof output === "string" ? output : "")
   )


### PR DESCRIPTION
## Summary
- fix synchronous ACP delegated runs so explicit `respond_to_user` content is preserved when it arrives via ACP `toolCall` updates
- prefer the explicit delegated user-facing response over weaker trailing internal completion text
- add focused regression coverage for ACP delegated result selection

## Verification
- `NODE_PATH="$HOME/Development/dotagents-mono/node_modules" "$HOME/Development/dotagents-mono/node_modules/.bin/vitest" run apps/desktop/src/main/agent-run-utils.test.ts apps/desktop/src/main/acp/acp-router-tools.test.ts`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author