### PR TITLE
fix: initialize ACP agent profiles during startup

### DIFF
--- a/apps/desktop/src/main/acp-service.test.ts
+++ b/apps/desktop/src/main/acp-service.test.ts
@@ -294,6 +294,30 @@ describe("ACP Service", () => {
       expect(acpService.getAgentStatus("augustus")?.status).toBe("ready")
     })
 
+    it("initializes ACP agent profiles during startup before marking them ready", async () => {
+      mockGetByName.mockReturnValue({
+        name: "augustus",
+        displayName: "augustus",
+        description: "Augment Code's AI coding assistant with native ACP support",
+        enabled: true,
+        autoSpawn: false,
+        isBuiltIn: false,
+        connection: {
+          type: "acp",
+          command: "auggie",
+          args: ["--acp"],
+        },
+      })
+
+      const { acpService } = await import("./acp-service")
+      const initializeSpy = vi.spyOn(acpService as any, "initializeAgent").mockResolvedValue(undefined)
+
+      await acpService.spawnAgent("augustus")
+
+      expect(initializeSpy).toHaveBeenCalledWith("augustus")
+      expect(acpService.getAgentStatus("augustus")?.status).toBe("ready")
+    })
+
     it("should resolve relative configured cwd from DOTAGENTS_WORKSPACE_DIR", async () => {
       const workspaceDir = mkdtempSync(join(tmpdir(), "acp-workspace-"))
       const agentCwd = "repo/subdir"

--- a/apps/desktop/src/main/acp-service.ts
+++ b/apps/desktop/src/main/acp-service.ts
@@ -740,7 +740,7 @@ class ACPService extends EventEmitter {
         autoSpawn: profile.autoSpawn,
         isInternal: profile.isBuiltIn,
         connection: {
-          type: "stdio",
+          type: profile.connection.type,
           command: profile.connection.command,
           args: profile.connection.args,
           env: profile.connection.env,
@@ -800,7 +800,7 @@ class ACPService extends EventEmitter {
       }
     }
 
-    if (agentConfig.connection.type !== "stdio") {
+    if (agentConfig.connection.type !== "stdio" && agentConfig.connection.type !== "acp") {
       throw new Error(`Connection type ${agentConfig.connection.type} not yet supported`)
     }
 
@@ -895,8 +895,20 @@ class ACPService extends EventEmitter {
         this.emit("agentStatusChanged", { agentName, status: "error", error: error.message })
       })
 
-      // Wait a moment for the process to start, then mark as ready
-      await new Promise(resolve => setTimeout(resolve, 500))
+      // ACP agents like auggie may exit immediately unless initialize is sent promptly.
+      // Perform the handshake during startup before reporting the agent as ready.
+      if (agentConfig.connection.type === "acp") {
+        await this.initializeAgent(agentName)
+      } else {
+        await new Promise(resolve => setTimeout(resolve, 500))
+      }
+
+      if (instance.status === "error") {
+        throw new Error(instance.error || `Agent ${agentName} failed to start`)
+      }
+      if (instance.status === "stopped") {
+        throw new Error(`Agent ${agentName} stopped unexpectedly during startup`)
+      }
 
       if (instance.status === "starting") {
         instance.status = "ready"
@@ -1028,7 +1040,7 @@ class ACPService extends EventEmitter {
    */
   private async sendRequest(agentName: string, method: string, params?: unknown): Promise<unknown> {
     const instance = this.agents.get(agentName)
-    if (!instance || !instance.process || instance.status !== "ready") {
+    if (!instance || !instance.process || (instance.status !== "ready" && instance.status !== "starting")) {
       throw new Error(`Agent ${agentName} is not ready`)
     }
 


### PR DESCRIPTION
## Summary
- preserve ACP agent profile connection types instead of coercing them to stdio during spawn
- initialize ACP agents during startup before marking them ready so agents like auggie do not exit before the handshake
- add regression coverage for ACP profile startup initialization

## Testing
- pnpm vitest run apps/desktop/src/main/acp-service.test.ts apps/desktop/src/main/main-agent-selection.test.ts