### PR TITLE
fix: prefer final ACP prompt output over streamed progress

### DIFF
--- a/apps/desktop/src/main/acp-service.test.ts
+++ b/apps/desktop/src/main/acp-service.test.ts
@@ -459,6 +459,70 @@ describe("ACP Service", () => {
     })
   })
 
+  describe("sendPrompt", () => {
+    it("prefers direct prompt response content over streamed session/update text", async () => {
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      vi.spyOn(acpService as any, "sendRequest").mockImplementation(async () => {
+        acpService.emit("notification", {
+          agentName: "test-agent",
+          method: "session/update",
+          params: {
+            sessionId: "session-final-answer",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              text: "Working through the task with detailed internal progress",
+            },
+          },
+        })
+
+        return {
+          content: [{ type: "text", text: "Concise final answer" }],
+        }
+      })
+
+      const result = await acpService.sendPrompt("test-agent", "session-final-answer", "Do the thing")
+
+      expect(result).toEqual({
+        success: true,
+        response: "Concise final answer",
+        stopReason: undefined,
+      })
+    })
+
+    it("falls back to streamed session/update text when the prompt response has no text", async () => {
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      vi.spyOn(acpService as any, "sendRequest").mockImplementation(async () => {
+        acpService.emit("notification", {
+          agentName: "test-agent",
+          method: "session/update",
+          params: {
+            sessionId: "session-stream-only",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              text: "Streamed final answer",
+            },
+          },
+        })
+
+        return {
+          stopReason: "end_turn",
+        }
+      })
+
+      const result = await acpService.sendPrompt("test-agent", "session-stream-only", "Do the thing")
+
+      expect(result).toEqual({
+        success: true,
+        response: "Streamed final answer",
+        stopReason: "end_turn",
+      })
+    })
+  })
+
   describe("getAgentStatus", () => {
     it("should return stopped for unspawned agent", async () => {
       const { acpService } = await import("./acp-service")

--- a/apps/desktop/src/main/acp-service.ts
+++ b/apps/desktop/src/main/acp-service.ts
@@ -2113,12 +2113,17 @@ class ACPService extends EventEmitter {
         }
       }
 
-      // Also check session output collected from notifications
-      const sessionOutput = this.getSessionOutput(sessionId)
-      if (sessionOutput) {
-        for (const block of sessionOutput.contentBlocks) {
-          if (block.type === "text" && block.text && !responseText.includes(block.text)) {
-            responseText += block.text + "\n"
+      // Only fall back to streamed session output when the direct prompt response is empty.
+      // Some ACP agents stream verbose progress text during execution but return a concise
+      // final answer in the session/prompt response. Appending all streamed text here can leak
+      // internal reasoning/progress into delegated results returned to the parent agent.
+      if (!responseText.trim()) {
+        const sessionOutput = this.getSessionOutput(sessionId)
+        if (sessionOutput) {
+          for (const block of sessionOutput.contentBlocks) {
+            if (block.type === "text" && block.text) {
+              responseText += block.text + "\n"
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- prefer direct ACP session/prompt response text over streamed session/update progress when both exist
- only fall back to streamed text when the prompt response has no text
- add regression coverage for concise final answer vs streamed progress behavior

## Testing
- pnpm vitest run apps/desktop/src/main/acp-service.test.ts apps/desktop/src/main/acp/acp-router-tools.test.ts apps/desktop/src/main/acp-main-agent.test.ts