### PR TITLE
Preserve ACP sessions across desktop restarts

### DIFF
--- a/apps/desktop/src/main/acp-main-agent.test.ts
+++ b/apps/desktop/src/main/acp-main-agent.test.ts
@@ -587,4 +587,33 @@ describe("acp-main-agent", () => {
       [expect.objectContaining({ success: true, content: '{\n  "content": "Found persisted result"\n}' })],
     )
   })
+
+  it("passes the persisted ACP session id back into getOrCreateSession for restart-safe reuse", async () => {
+    const acpSessionState = await import("./acp-session-state")
+    vi.mocked(acpSessionState.getSessionForConversation).mockReturnValue({
+      sessionId: "persisted-acp-session",
+      agentName: "test-agent",
+      createdAt: 1,
+      lastUsedAt: 1,
+    })
+
+    mockGetOrCreateSession.mockResolvedValue("persisted-acp-session")
+
+    const { processTranscriptWithACPAgent } = await import("./acp-main-agent")
+
+    await processTranscriptWithACPAgent("hello", {
+      agentName: "test-agent",
+      conversationId: "conversation-1",
+      sessionId: "ui-session-1",
+      runId: 1,
+    })
+
+    expect(mockGetOrCreateSession).toHaveBeenCalledWith(
+      "test-agent",
+      false,
+      undefined,
+      { appSessionId: "ui-session-1" },
+      "persisted-acp-session",
+    )
+  })
 })

--- a/apps/desktop/src/main/acp-main-agent.ts
+++ b/apps/desktop/src/main/acp-main-agent.ts
@@ -564,22 +564,24 @@ export async function processTranscriptWithACPAgent(
   try {
     // Get or create ACP session
     const existingSession = forceNewSession ? undefined : getSessionForConversation(conversationId)
-    let acpSessionId: string | undefined
+    const preferredSessionId = existingSession?.agentName === agentName
+      ? existingSession.sessionId
+      : undefined
+    const acpSessionId = await acpService.getOrCreateSession(
+      agentName,
+      !preferredSessionId,
+      undefined,
+      { appSessionId: sessionId },
+      preferredSessionId,
+    )
 
-    if (existingSession && existingSession.agentName === agentName) {
-      // Reuse existing session
-      acpSessionId = existingSession.sessionId
+    setSessionForConversation(conversationId, acpSessionId, agentName)
+    if (preferredSessionId && preferredSessionId === acpSessionId) {
       touchSession(conversationId)
-      logApp(`[ACP Main] Reusing existing session ${acpSessionId}`)
+      logApp(`[ACP Main] Reused existing session ${acpSessionId}`)
+    } else if (preferredSessionId) {
+      logApp(`[ACP Main] Replaced stale session ${preferredSessionId} with ${acpSessionId}`)
     } else {
-      // Create new session
-      acpSessionId = await acpService.getOrCreateSession(
-        agentName,
-        true,
-        undefined,
-        { appSessionId: sessionId },
-      )
-      setSessionForConversation(conversationId, acpSessionId, agentName)
       logApp(`[ACP Main] Created new session ${acpSessionId}`)
     }
 

--- a/apps/desktop/src/main/acp-service.test.ts
+++ b/apps/desktop/src/main/acp-service.test.ts
@@ -93,6 +93,7 @@ vi.mock("./config", () => ({
     get: () => mockConfig,
   },
   // AgentProfileService imports these from ./config
+  dataFolder: process.env.TMPDIR || process.env.TEMP || process.env.TMP || "/tmp",
   globalAgentsFolder: process.env.TMPDIR || process.env.TEMP || process.env.TMP || "/tmp",
   resolveWorkspaceAgentsFolder: () => null,
 }))
@@ -100,6 +101,7 @@ vi.mock("./config", () => ({
 // Mock debug
 vi.mock("./debug", () => ({
   logApp: vi.fn(),
+  logACP: vi.fn(),
 }))
 
 // Keep ACP service tests deterministic: use legacy acpAgents config path directly.
@@ -409,6 +411,89 @@ describe("ACP Service", () => {
       )
 
       rmSync(workspaceDir, { recursive: true, force: true })
+    })
+
+    it("passes a preferred persisted session id through to createSession", async () => {
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      const instance = acpService.getAgentInstance("test-agent")!
+      instance.status = "ready"
+      instance.initialized = true
+
+      const createSessionSpy = vi.spyOn(acpService as any, "createSession").mockResolvedValue("persisted-session-1")
+
+      const sessionId = await acpService.getOrCreateSession(
+        "test-agent",
+        false,
+        undefined,
+        undefined,
+        "persisted-session-1",
+      )
+
+      expect(sessionId).toBe("persisted-session-1")
+      expect(createSessionSpy).toHaveBeenCalledWith("test-agent", undefined, "persisted-session-1")
+    })
+
+    it("loads a preferred persisted session when createSession is asked to reuse one", async () => {
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      const instance = acpService.getAgentInstance("test-agent")!
+      instance.status = "ready"
+      instance.initialized = true
+      instance.agentCapabilities = { loadSession: true }
+
+      const sendRequestSpy = vi.spyOn(acpService as any, "sendRequest")
+      sendRequestSpy.mockResolvedValueOnce({ sessionId: "persisted-session-1" })
+
+      const sessionId = await (acpService as any).createSession(
+        "test-agent",
+        undefined,
+        "persisted-session-1",
+      )
+
+      expect(sessionId).toBe("persisted-session-1")
+      expect(sendRequestSpy).toHaveBeenCalledWith(
+        "test-agent",
+        "session/load",
+        expect.objectContaining({ sessionId: "persisted-session-1" }),
+      )
+    })
+
+    it("falls back to session/new when loading a persisted session fails", async () => {
+      const { acpService } = await import("./acp-service")
+      await acpService.spawnAgent("test-agent")
+
+      const instance = acpService.getAgentInstance("test-agent")!
+      instance.status = "ready"
+      instance.initialized = true
+      instance.agentCapabilities = { loadSession: true }
+
+      const sendRequestSpy = vi.spyOn(acpService as any, "sendRequest")
+      sendRequestSpy
+        .mockRejectedValueOnce(new Error("session missing"))
+        .mockResolvedValueOnce({ sessionId: "fresh-session-1" })
+
+      const sessionId = await (acpService as any).createSession(
+        "test-agent",
+        undefined,
+        "persisted-session-1",
+      )
+
+      expect(sessionId).toBe("fresh-session-1")
+      expect(sendRequestSpy).toHaveBeenNthCalledWith(
+        1,
+        "test-agent",
+        "session/load",
+        expect.objectContaining({ sessionId: "persisted-session-1" }),
+      )
+      expect(sendRequestSpy).toHaveBeenNthCalledWith(
+        2,
+        "test-agent",
+        "session/new",
+        expect.any(Object),
+      )
     })
   })
 

--- a/apps/desktop/src/main/acp-service.ts
+++ b/apps/desktop/src/main/acp-service.ts
@@ -1720,6 +1720,7 @@ class ACPService extends EventEmitter {
   private async createSession(
     agentName: string,
     pendingInjectedMcpContext?: { appSessionId: string },
+    preferredSessionId?: string,
   ): Promise<string | undefined> {
     const instance = this.agents.get(agentName)
     if (!instance) {
@@ -1729,8 +1730,13 @@ class ACPService extends EventEmitter {
     // Reuse existing session if available, but clear previous output to avoid
     // mixing content from different runTask() calls
     if (instance.sessionId) {
-      this.clearSessionOutput(instance.sessionId)
-      return instance.sessionId
+      if (preferredSessionId && instance.sessionId !== preferredSessionId) {
+        this.clearSessionOutput(instance.sessionId)
+        instance.sessionId = undefined
+      } else {
+        this.clearSessionOutput(instance.sessionId)
+        return instance.sessionId
+      }
     }
 
     try {
@@ -1768,8 +1774,95 @@ class ACPService extends EventEmitter {
         }
       }
 
-      // Use session/new per ACP spec (not session/create)
       const sessionCwd = instance.workingDirectory || this.resolveAgentWorkingDirectory(instance.config)
+      const storeSessionMetadata = (result: {
+        sessionId?: string
+        models?: {
+          availableModels: Array<{ modelId: string; name: string; description?: string }>
+          currentModelId: string
+        }
+        modes?: {
+          availableModes: Array<{ id: string; name: string; description?: string }>
+          currentModeId: string
+        }
+        configOptions?: ACPConfigOption[]
+        config_options?: ACPConfigOption[]
+      }, fallbackSessionId?: string) => {
+        const sessionId = result?.sessionId || fallbackSessionId
+        if (sessionId) {
+          instance.sessionId = sessionId
+          if (instance.clientSessionToken) {
+            setAcpClientSessionTokenMapping(instance.clientSessionToken, sessionId)
+          }
+        } else if (instance.clientSessionToken) {
+          clearAcpClientSessionTokenMapping(instance.clientSessionToken)
+          instance.clientSessionToken = undefined
+        }
+
+        // Store models from session/new or session/load response
+        if (result?.models) {
+          instance.sessionInfo = {
+            ...instance.sessionInfo,
+            models: result.models,
+          }
+        }
+
+        // Store modes from session/new or session/load response
+        if (result?.modes) {
+          instance.sessionInfo = {
+            ...instance.sessionInfo,
+            modes: result.modes,
+          }
+        }
+
+        const sessionConfigOptions = Array.isArray(result?.configOptions)
+          ? result.configOptions
+          : Array.isArray(result?.config_options)
+            ? result.config_options
+            : undefined
+
+        if (sessionConfigOptions) {
+          instance.sessionInfo = {
+            ...instance.sessionInfo,
+            configOptions: sessionConfigOptions,
+          }
+        }
+
+        return sessionId
+      }
+
+      if (preferredSessionId) {
+        try {
+          logACP("REQUEST", agentName, "session/load", `Loading existing session ${preferredSessionId}`)
+          const result = await this.sendRequest(agentName, "session/load", {
+            sessionId: preferredSessionId,
+            cwd: sessionCwd,
+            mcpServers,
+          }) as {
+            sessionId?: string
+            models?: {
+              availableModels: Array<{ modelId: string; name: string; description?: string }>
+              currentModelId: string
+            }
+            modes?: {
+              availableModes: Array<{ id: string; name: string; description?: string }>
+              currentModeId: string
+            }
+            configOptions?: ACPConfigOption[]
+            config_options?: ACPConfigOption[]
+          }
+
+          return storeSessionMetadata(result, preferredSessionId)
+        } catch (error) {
+          logApp(`[ACP Service] Failed to load existing ACP session ${preferredSessionId} for ${agentName}; falling back to session/new:`, error)
+          if (instance.clientSessionToken) {
+            clearAcpClientSessionTokenMapping(instance.clientSessionToken)
+            instance.clientSessionToken = undefined
+          }
+        }
+      }
+
+      // Use session/new per ACP spec (not session/create)
       const result = await this.sendRequest(agentName, "session/new", {
         cwd: sessionCwd,
         mcpServers,
@@ -1787,47 +1880,7 @@ class ACPService extends EventEmitter {
         config_options?: ACPConfigOption[]
       }
 
-      const sessionId = result?.sessionId
-      if (sessionId) {
-        instance.sessionId = sessionId
-        if (instance.clientSessionToken) {
-          setAcpClientSessionTokenMapping(instance.clientSessionToken, sessionId)
-        }
-      } else if (instance.clientSessionToken) {
-        clearAcpClientSessionTokenMapping(instance.clientSessionToken)
-        instance.clientSessionToken = undefined
-      }
-
-      // Store models from session/new response (Task 2.2)
-      if (result?.models) {
-        instance.sessionInfo = {
-          ...instance.sessionInfo,
-          models: result.models,
-        }
-      }
-
-      // Store modes from session/new response (Task 2.2)
-      if (result?.modes) {
-        instance.sessionInfo = {
-          ...instance.sessionInfo,
-          modes: result.modes,
-        }
-      }
-
-      const sessionConfigOptions = Array.isArray(result?.configOptions)
-        ? result.configOptions
-        : Array.isArray(result?.config_options)
-          ? result.config_options
-          : undefined
-
-      if (sessionConfigOptions) {
-        instance.sessionInfo = {
-          ...instance.sessionInfo,
-          configOptions: sessionConfigOptions,
-        }
-      }
-
-      return sessionId
+      return storeSessionMetadata(result)
     } catch {
       if (instance.clientSessionToken) {
         clearAcpClientSessionTokenMapping(instance.clientSessionToken)
@@ -2012,6 +2065,7 @@ class ACPService extends EventEmitter {
     forceNew?: boolean,
     workingDirectory?: string,
     pendingInjectedMcpContext?: { appSessionId: string },
+    preferredSessionId?: string,
   ): Promise<string> {
     // Ensure agent is spawned, ready, and reconciled with the latest working-directory config.
     let instance = this.agents.get(agentName)
@@ -2039,11 +2093,11 @@ class ACPService extends EventEmitter {
     }
 
     // Create or reuse session
-    const sessionId = await this.createSession(agentName, pendingInjectedMcpContext)
+    const sessionId = await this.createSession(agentName, pendingInjectedMcpContext, preferredSessionId)
     if (!sessionId) {
       throw new Error(
         `Failed to create ACP session for agent ${agentName}. ` +
-        "Verify the agent command is valid and supports ACP methods like session/new."
+        "Verify the agent command is valid and supports ACP methods like session/new/session/load."
       )
     }
     return sessionId

--- a/apps/desktop/src/main/acp-session-state.persistence.test.ts
+++ b/apps/desktop/src/main/acp-session-state.persistence.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+const loadAcpSessionState = async (dataFolder: string) => {
+  vi.resetModules()
+  vi.doMock("./config", () => ({ dataFolder }))
+  vi.doMock("./debug", () => ({ logApp: vi.fn() }))
+  return import("./acp-session-state")
+}
+
+describe("acp-session-state persistence", () => {
+  let dataFolder: string
+
+  beforeEach(() => {
+    dataFolder = mkdtempSync(join(tmpdir(), "acp-session-state-"))
+  })
+
+  it("restores persisted conversation to ACP session mappings after restart", async () => {
+    const firstLoad = await loadAcpSessionState(dataFolder)
+    firstLoad.setSessionForConversation("conversation-1", "acp-session-1", "test-agent")
+
+    const secondLoad = await loadAcpSessionState(dataFolder)
+
+    expect(secondLoad.getSessionForConversation("conversation-1")).toEqual(
+      expect.objectContaining({ sessionId: "acp-session-1", agentName: "test-agent" }),
+    )
+
+    rmSync(dataFolder, { recursive: true, force: true })
+  })
+})

--- a/apps/desktop/src/main/acp-session-state.ts
+++ b/apps/desktop/src/main/acp-session-state.ts
@@ -6,7 +6,10 @@
  * when using an ACP agent as the main agent.
  */
 
+import { join } from "path"
 import { logApp } from "./debug"
+import { dataFolder } from "./config"
+import { loadPersistedJson, savePersistedJson } from "./session-persistence"
 
 /**
  * Information about an active ACP session
@@ -24,6 +27,12 @@ export interface ACPSessionInfo {
 
 // In-memory storage for conversation-to-session mapping
 const conversationSessions: Map<string, ACPSessionInfo> = new Map()
+const ACP_SESSION_STATE_PATH = join(dataFolder, "acp-session-state.json")
+
+type PersistedAcpSessionState = {
+  version: 1
+  conversationSessions: Array<[string, ACPSessionInfo]>
+}
 
 // Mapping from ACP session ID → DotAgents session ID
 // This is needed for routing tool approval requests to the correct UI session
@@ -38,6 +47,32 @@ const acpToAppRunId: Map<string, number> = new Map()
 const acpClientTokenToSession: Map<string, string> = new Map()
 const acpSessionToClientToken: Map<string, string> = new Map()
 const pendingClientTokenToAppSession: Map<string, string> = new Map()
+
+function persistConversationSessions(): void {
+  savePersistedJson(
+    ACP_SESSION_STATE_PATH,
+    {
+      version: 1,
+      conversationSessions: Array.from(conversationSessions.entries()),
+    } satisfies PersistedAcpSessionState,
+    "ACP Session",
+  )
+}
+
+const persistedSessionState = loadPersistedJson<PersistedAcpSessionState>(
+  ACP_SESSION_STATE_PATH,
+  "ACP Session",
+)
+
+if (persistedSessionState?.conversationSessions) {
+  for (const [conversationId, sessionInfo] of persistedSessionState.conversationSessions) {
+    if (typeof conversationId !== "string" || typeof sessionInfo?.sessionId !== "string") {
+      continue
+    }
+
+    conversationSessions.set(conversationId, sessionInfo)
+  }
+}
 
 /**
  * Get the ACP session for a conversation (if any).
@@ -78,6 +113,8 @@ export function setSessionForConversation(
     })
     logApp(`[ACP Session] Created session mapping for conversation ${conversationId}: ${sessionId}`)
   }
+
+  persistConversationSessions()
 }
 
 /**
@@ -89,6 +126,7 @@ export function clearSessionForConversation(conversationId: string): void {
   if (conversationSessions.has(conversationId)) {
     conversationSessions.delete(conversationId)
     logApp(`[ACP Session] Cleared session for conversation ${conversationId}`)
+    persistConversationSessions()
   }
 }
 
@@ -100,6 +138,7 @@ export function clearAllSessions(): void {
   const count = conversationSessions.size
   conversationSessions.clear()
   logApp(`[ACP Session] Cleared all ${count} sessions`)
+  persistConversationSessions()
 }
 
 /**
@@ -119,6 +158,7 @@ export function touchSession(conversationId: string): void {
   const session = conversationSessions.get(conversationId)
   if (session) {
     session.lastUsedAt = Date.now()
+    persistConversationSessions()
   }
 }
 

--- a/apps/desktop/src/main/agent-session-tracker.persistence.test.ts
+++ b/apps/desktop/src/main/agent-session-tracker.persistence.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { mkdtempSync, rmSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+
+const loadTracker = async (dataFolder: string) => {
+  vi.resetModules()
+  vi.doMock("./config", () => ({ dataFolder }))
+  vi.doMock("./debug", () => ({ logApp: vi.fn() }))
+  vi.doMock("./window", () => ({ WINDOWS: new Map() }))
+  vi.doMock("@egoist/tipc/main", () => ({ getRendererHandlers: vi.fn(() => ({})) }))
+  vi.doMock("./session-user-response-store", () => ({ clearSessionUserResponse: vi.fn() }))
+  return import("./agent-session-tracker")
+}
+
+describe("agent-session-tracker persistence", () => {
+  let dataFolder: string
+
+  beforeEach(() => {
+    dataFolder = mkdtempSync(join(tmpdir(), "agent-session-tracker-"))
+  })
+
+  it("restores a completed session so it can be revived after restart", async () => {
+    const firstLoad = await loadTracker(dataFolder)
+    const sessionId = firstLoad.agentSessionTracker.startSession(
+      "conversation-1",
+      "Persist me",
+      true,
+      { profileName: "augustus" } as any,
+    )
+    firstLoad.agentSessionTracker.completeSession(sessionId, "done")
+
+    const secondLoad = await loadTracker(dataFolder)
+
+    expect(secondLoad.agentSessionTracker.findSessionByConversationId("conversation-1")).toBe(sessionId)
+    expect(secondLoad.agentSessionTracker.getSessionProfileSnapshot(sessionId)).toEqual(
+      expect.objectContaining({ profileName: "augustus" }),
+    )
+    expect(secondLoad.agentSessionTracker.reviveSession(sessionId, false)).toBe(true)
+    expect(secondLoad.agentSessionTracker.getSession(sessionId)).toEqual(
+      expect.objectContaining({ id: sessionId, status: "active" }),
+    )
+
+    rmSync(dataFolder, { recursive: true, force: true })
+  })
+
+  it("reclassifies active sessions as stopped after restart", async () => {
+    const firstLoad = await loadTracker(dataFolder)
+    const sessionId = firstLoad.agentSessionTracker.startSession("conversation-2", "Interrupted run", true)
+
+    const secondLoad = await loadTracker(dataFolder)
+
+    expect(secondLoad.agentSessionTracker.getActiveSessions()).toHaveLength(0)
+    expect(secondLoad.agentSessionTracker.findCompletedSession(sessionId)).toEqual(
+      expect.objectContaining({ id: sessionId, status: "stopped" }),
+    )
+
+    rmSync(dataFolder, { recursive: true, force: true })
+  })
+})

--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -4,11 +4,14 @@
  */
 
 import type { RendererHandlers } from "./renderer-handlers"
+import { join } from "path"
 import { logApp } from "./debug"
 import { WINDOWS } from "./window"
 import { getRendererHandlers } from "@egoist/tipc/main"
 import type { SessionProfileSnapshot } from "../shared/types"
 import { clearSessionUserResponse } from "./session-user-response-store"
+import { dataFolder } from "./config"
+import { loadPersistedJson, savePersistedJson } from "./session-persistence"
 
 export interface AgentSession {
   id: string
@@ -28,6 +31,15 @@ export interface AgentSession {
    */
   profileSnapshot?: SessionProfileSnapshot
 }
+
+type PersistedAgentSessionState = {
+  version: 1
+  activeSessions: AgentSession[]
+  completedSessions: AgentSession[]
+}
+
+const AGENT_SESSION_STATE_PATH = join(dataFolder, "agent-session-state.json")
+const MAX_COMPLETED_SESSIONS = 20
 
 /**
  * Emit session updates to all renderer windows
@@ -76,7 +88,62 @@ class AgentSessionTracker {
     return AgentSessionTracker.instance
   }
 
-  private constructor() {}
+  private constructor() {
+    this.restorePersistedState()
+  }
+
+  private normalizeCompletedSessions(sessions: AgentSession[]): AgentSession[] {
+    return sessions
+      .slice(0, MAX_COMPLETED_SESSIONS)
+      .sort((a, b) => (b.endTime || b.startTime || 0) - (a.endTime || a.startTime || 0))
+  }
+
+  private persistState(): void {
+    savePersistedJson(
+      AGENT_SESSION_STATE_PATH,
+      {
+        version: 1,
+        activeSessions: Array.from(this.sessions.values()),
+        completedSessions: this.completedSessions,
+      } satisfies PersistedAgentSessionState,
+      "AgentSessionTracker",
+    )
+  }
+
+  private restorePersistedState(): void {
+    const persisted = loadPersistedJson<PersistedAgentSessionState>(
+      AGENT_SESSION_STATE_PATH,
+      "AgentSessionTracker",
+    )
+    if (!persisted) {
+      return
+    }
+
+    const restoredCompleted = Array.isArray(persisted.completedSessions)
+      ? persisted.completedSessions.filter((session): session is AgentSession => typeof session?.id === "string")
+      : []
+
+    const restoredInterrupted = Array.isArray(persisted.activeSessions)
+      ? persisted.activeSessions
+        .filter((session): session is AgentSession => typeof session?.id === "string")
+        .map((session) => ({
+          ...session,
+          status: "stopped" as const,
+          endTime: session.endTime || Date.now(),
+          lastActivity: session.lastActivity || "Interrupted by app restart",
+        }))
+      : []
+
+    this.sessions.clear()
+    this.completedSessions = this.normalizeCompletedSessions([
+      ...restoredInterrupted,
+      ...restoredCompleted,
+    ])
+
+    if (restoredInterrupted.length > 0) {
+      this.persistState()
+    }
+  }
 
   /**
    * Start tracking a new agent session
@@ -109,6 +176,7 @@ class AgentSessionTracker {
 
     this.sessions.set(sessionId, session)
     logApp(`[AgentSessionTracker] Started session: ${sessionId}, snoozed: ${startSnoozed}, profile: ${profileSnapshot?.profileName || 'none'}, total sessions: ${this.sessions.size}`)
+    this.persistState()
 
     // Emit update to UI
     emitSessionUpdate()
@@ -126,6 +194,7 @@ class AgentSessionTracker {
     const session = this.sessions.get(sessionId)
     if (session) {
       Object.assign(session, updates)
+      this.persistState()
       // Emit update to UI so sidebar and other components reflect changes (e.g., title updates)
       emitSessionUpdate()
     }
@@ -147,14 +216,15 @@ class AgentSessionTracker {
     }
     // Move to recent list (newest first), cap length
     this.completedSessions.unshift({ ...session })
-    if (this.completedSessions.length > 20) {
-      const evictedSessions = this.completedSessions.splice(20)
+    if (this.completedSessions.length > MAX_COMPLETED_SESSIONS) {
+      const evictedSessions = this.completedSessions.splice(MAX_COMPLETED_SESSIONS)
       for (const evicted of evictedSessions) {
         clearSessionUserResponse(evicted.id)
       }
     }
     this.sessions.delete(sessionId)
     logApp(`[AgentSessionTracker] Completing session: ${sessionId}, remaining sessions: ${this.sessions.size}`)
+    this.persistState()
 
     // Emit update to UI
     emitSessionUpdate()
@@ -172,14 +242,15 @@ class AgentSessionTracker {
     session.status = "stopped"
     session.endTime = Date.now()
     this.completedSessions.unshift({ ...session })
-    if (this.completedSessions.length > 20) {
-      const evictedSessions = this.completedSessions.splice(20)
+    if (this.completedSessions.length > MAX_COMPLETED_SESSIONS) {
+      const evictedSessions = this.completedSessions.splice(MAX_COMPLETED_SESSIONS)
       for (const evicted of evictedSessions) {
         clearSessionUserResponse(evicted.id)
       }
     }
     this.sessions.delete(sessionId)
     logApp(`[AgentSessionTracker] Stopping session: ${sessionId}, remaining sessions: ${this.sessions.size}`)
+    this.persistState()
 
     // Emit update to UI
     emitSessionUpdate()
@@ -198,14 +269,15 @@ class AgentSessionTracker {
     session.errorMessage = errorMessage
     session.endTime = Date.now()
     this.completedSessions.unshift({ ...session })
-    if (this.completedSessions.length > 20) {
-      const evictedSessions = this.completedSessions.splice(20)
+    if (this.completedSessions.length > MAX_COMPLETED_SESSIONS) {
+      const evictedSessions = this.completedSessions.splice(MAX_COMPLETED_SESSIONS)
       for (const evicted of evictedSessions) {
         clearSessionUserResponse(evicted.id)
       }
     }
     this.sessions.delete(sessionId)
     logApp(`[AgentSessionTracker] Error in session: ${sessionId}, remaining sessions: ${this.sessions.size}`)
+    this.persistState()
 
     // Emit update to UI
     emitSessionUpdate()
@@ -239,6 +311,7 @@ class AgentSessionTracker {
       session.isSnoozed = true
       this.sessions.set(sessionId, session)
       logApp(`[AgentSessionTracker] Session ${sessionId} is now snoozed: ${session.isSnoozed}`)
+      this.persistState()
 
       // Emit update to UI
       emitSessionUpdate()
@@ -257,6 +330,7 @@ class AgentSessionTracker {
       session.isSnoozed = false
       this.sessions.set(sessionId, session)
       logApp(`[AgentSessionTracker] Session ${sessionId} is now snoozed: ${session.isSnoozed}`)
+      this.persistState()
 
       // Emit update to UI
       emitSessionUpdate()
@@ -286,7 +360,12 @@ class AgentSessionTracker {
    */
   getSessionProfileSnapshot(sessionId: string): SessionProfileSnapshot | undefined {
     const session = this.sessions.get(sessionId)
-    return session?.profileSnapshot
+    if (session?.profileSnapshot) {
+      return session.profileSnapshot
+    }
+
+    const completedSession = this.completedSessions.find((candidate) => candidate.id === sessionId)
+    return completedSession?.profileSnapshot
   }
 
   /**
@@ -361,6 +440,7 @@ class AgentSessionTracker {
     this.sessions.set(sessionId, session)
 
     logApp(`[AgentSessionTracker] Revived session: ${sessionId}, snoozed: ${startSnoozed}`)
+    this.persistState()
     emitSessionUpdate()
     return true
   }
@@ -376,6 +456,7 @@ class AgentSessionTracker {
     this.completedSessions.splice(index, 1)
     clearSessionUserResponse(sessionId)
     logApp(`[AgentSessionTracker] Removed completed session: ${sessionId}`)
+    this.persistState()
     emitSessionUpdate()
     return true
   }
@@ -385,6 +466,8 @@ class AgentSessionTracker {
    */
   clearAllSessions(): void {
     this.sessions.clear()
+    this.completedSessions = []
+    this.persistState()
   }
 
   /**
@@ -406,6 +489,7 @@ class AgentSessionTracker {
 
     logApp(`[AgentSessionTracker] Cleared ${this.completedSessions.length - retainedSessions.length} completed sessions`)
     this.completedSessions = retainedSessions
+    this.persistState()
     emitSessionUpdate()
   }
 }

--- a/apps/desktop/src/main/index.hub-install.test.ts
+++ b/apps/desktop/src/main/index.hub-install.test.ts
@@ -21,6 +21,7 @@ async function loadIndexForHubInstall(
   const createPanelWindow = vi.fn()
   const createSetupWindow = vi.fn()
   const showMainWindow = vi.fn()
+  const stopListeningToKeyboardEvents = vi.fn(() => Promise.resolve())
   const requestSingleInstanceLock = vi.fn(() => gotSingleInstanceLock)
   const releaseSingleInstanceLock = vi.fn()
   const quit = vi.fn()
@@ -80,7 +81,10 @@ async function loadIndexForHubInstall(
     showMainWindow,
     WINDOWS: new Map(),
   }))
-  vi.doMock("./keyboard", () => ({ listenToKeyboardEvents: vi.fn() }))
+  vi.doMock("./keyboard", () => ({
+    listenToKeyboardEvents: vi.fn(),
+    stopListeningToKeyboardEvents,
+  }))
   vi.doMock("./tipc", () => ({ router: {} }))
   vi.doMock("./serve", () => ({
     registerServeProtocol: vi.fn(),
@@ -163,6 +167,7 @@ async function loadIndexForHubInstall(
     downloadHubBundleToTempFile,
     requestSingleInstanceLock,
     releaseSingleInstanceLock,
+    stopListeningToKeyboardEvents,
     quit,
   }
 }
@@ -245,6 +250,22 @@ describe("Hub install handoff routing", () => {
     expect(requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(quit).toHaveBeenCalledTimes(1)
     expect(createMainWindow).not.toHaveBeenCalled()
+  })
+
+  it("stops the keyboard listener during before-quit cleanup", async () => {
+    const { handlers, quit, stopListeningToKeyboardEvents } =
+      await loadIndexForHubInstall(["electron"])
+
+    const beforeQuitHandler = handlers.get("before-quit")?.[0] as (
+      event: { preventDefault: () => void },
+    ) => Promise<void>
+    const event = { preventDefault: vi.fn() }
+
+    await beforeQuitHandler(event)
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(stopListeningToKeyboardEvents).toHaveBeenCalledTimes(1)
+    expect(quit).toHaveBeenCalled()
   })
 
   it("downloads Hub install deep links received via open-url and routes them into showMainWindow", async () => {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -9,7 +9,7 @@ import {
   setAppQuitting,
   WINDOWS,
 } from "./window"
-import { listenToKeyboardEvents } from "./keyboard"
+import { listenToKeyboardEvents, stopListeningToKeyboardEvents } from "./keyboard"
 import { registerIpcMain } from "@egoist/tipc/main"
 import { router } from "./tipc"
 import { registerServeProtocol, registerServeSchema } from "./serve"
@@ -91,6 +91,8 @@ const startupHubBundleInstallUrl = pendingHubBundleHandoffPath
   ? null
   : findHubBundleInstallBundleUrl(process.argv)
 const shouldEnforceSingleInstance = !isQRMode && !isHeadlessMode
+const CLEANUP_TIMEOUT_MS = 5000
+const GUI_SIGNAL_FORCE_EXIT_DELAY_MS = CLEANUP_TIMEOUT_MS + 2000
 
 function releaseAppSingleInstanceLock() {
   if (!shouldEnforceSingleInstance) return
@@ -692,8 +694,6 @@ if (!gotSingleInstanceLock) {
 
     // Track if we're already cleaning up to prevent re-entry
     let isCleaningUp = false
-    const CLEANUP_TIMEOUT_MS = 5000 // 5 second timeout for graceful cleanup
-
     app.on("before-quit", async (event) => {
       setAppQuitting()
       releaseAppSingleInstanceLock()
@@ -741,6 +741,7 @@ if (!gotSingleInstanceLock) {
 
       try {
         const cleanupResults = await Promise.allSettled([
+          withCleanupTimeout("keyboard", () => stopListeningToKeyboardEvents()),
           withCleanupTimeout("ACP", () => acpService.shutdown()),
           withCleanupTimeout("MCP", () => mcpService.cleanup()),
         ])
@@ -783,6 +784,6 @@ for (const signal of ["SIGTERM", "SIGINT"] as const) {
     destroyTray()
     app.quit()
     // Force exit after a short grace period in case before-quit cleanup hangs
-    setTimeout(() => process.exit(0), 3000).unref()
+    setTimeout(() => process.exit(0), GUI_SIGNAL_FORCE_EXIT_DELAY_MS).unref()
   })
 }

--- a/apps/desktop/src/main/keyboard.test.ts
+++ b/apps/desktop/src/main/keyboard.test.ts
@@ -1,0 +1,94 @@
+import { EventEmitter } from "events"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockSpawn = vi.fn()
+
+vi.mock("child_process", () => ({
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}))
+
+vi.mock("electron", () => ({ systemPreferences: {} }))
+vi.mock("./window", () => ({
+  WINDOWS: new Map(),
+  emergencyStopAgentMode: vi.fn(),
+  getWindowRendererHandlers: vi.fn(() => undefined),
+  showMainWindow: vi.fn(),
+  showPanelWindowAndShowTextInput: vi.fn(),
+  showPanelWindowAndStartMcpRecording: vi.fn(),
+  showPanelWindowAndStartRecording: vi.fn(),
+  stopRecordingAndHidePanelWindow: vi.fn(),
+  stopTextInputAndHidePanelWindow: vi.fn(),
+}))
+vi.mock("./floating-panel-session-state", () => ({
+  snoozeAgentSessionsAndHidePanelWindow: vi.fn(),
+}))
+vi.mock("./config", () => ({ configStore: { get: vi.fn(() => ({})) } }))
+vi.mock("./state", () => ({
+  state: {
+    isAgentModeActive: false,
+    isRecording: false,
+    isRecordingFromButtonClick: false,
+    isRecordingMcpMode: false,
+    isTextInputActive: false,
+    isToggleRecordingActive: false,
+  },
+  agentProcessManager: { registerProcess: vi.fn() },
+}))
+vi.mock("./conversation-service", () => ({
+  conversationService: { getMostRecentConversation: vi.fn() },
+}))
+vi.mock("../shared/key-utils", () => ({
+  getEffectiveShortcut: vi.fn(() => undefined),
+  matchesKeyCombo: vi.fn(() => false),
+}))
+vi.mock("./debug", () => ({ isDebugKeybinds: vi.fn(() => false), logKeybinds: vi.fn() }))
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new EventEmitter()
+  stderr = new EventEmitter()
+  exitCode: number | null = null
+  signalCode: NodeJS.Signals | null = null
+  killed = false
+  kill = vi.fn((signal?: NodeJS.Signals) => {
+    this.killed = true
+    queueMicrotask(() => {
+      this.signalCode = signal ?? null
+      this.emit("exit", null, signal ?? null)
+    })
+    return true
+  })
+}
+
+describe("keyboard listener lifecycle", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mockSpawn.mockReset()
+  })
+
+  it("does not spawn duplicate keyboard listeners while one is active", async () => {
+    const child = new FakeChildProcess()
+    mockSpawn.mockReturnValue(child)
+
+    const { listenToKeyboardEvents } = await import("./keyboard")
+
+    listenToKeyboardEvents()
+    listenToKeyboardEvents()
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1)
+  })
+
+  it("stops the active keyboard listener and allows a clean restart", async () => {
+    const firstChild = new FakeChildProcess()
+    const secondChild = new FakeChildProcess()
+    mockSpawn.mockReturnValueOnce(firstChild).mockReturnValueOnce(secondChild)
+
+    const { listenToKeyboardEvents, stopListeningToKeyboardEvents } = await import("./keyboard")
+
+    listenToKeyboardEvents()
+    await stopListeningToKeyboardEvents()
+    listenToKeyboardEvents()
+
+    expect(firstChild.kill).toHaveBeenCalledWith("SIGTERM")
+    expect(mockSpawn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/main/keyboard.ts
+++ b/apps/desktop/src/main/keyboard.ts
@@ -26,6 +26,10 @@ const rdevPath = path
   )
   .replace("app.asar", "app.asar.unpacked")
 
+const KEYBOARD_LISTENER_SHUTDOWN_TIMEOUT_MS = 1000
+
+let keyboardListenerChild: ChildProcess | null = null
+
 type RdevEvent = {
   event_type: "KeyPress" | "KeyRelease"
   data: {
@@ -290,6 +294,13 @@ const showTextInputWithLastConversation = async () => {
 }
 
 export function listenToKeyboardEvents() {
+  if (keyboardListenerChild && keyboardListenerChild.exitCode === null) {
+    if (isDebugKeybinds()) {
+      logKeybinds("Keyboard event listener already running")
+    }
+    return
+  }
+
   let isHoldingCtrlKey = false
   let startRecordingTimer: ReturnType<typeof setTimeout> | undefined
   let isPressedCtrlKey = false
@@ -1340,6 +1351,7 @@ export function listenToKeyboardEvents() {
   }
 
   const child = spawn(rdevPath, ["listen"], {})
+  keyboardListenerChild = child
 
   if (isDebugKeybinds()) {
     logKeybinds("Starting keyboard event listener with rdev path:", rdevPath)
@@ -1375,6 +1387,10 @@ export function listenToKeyboardEvents() {
   })
 
   child.on("exit", (code, signal) => {
+    if (keyboardListenerChild === child) {
+      keyboardListenerChild = null
+    }
+
     if (isDebugKeybinds()) {
       logKeybinds("Keyboard listener process exited:", { code, signal })
     }
@@ -1404,6 +1420,70 @@ export function listenToKeyboardEvents() {
           "Then log out and log back in."
         )
       }
+    }
+  })
+}
+
+export async function stopListeningToKeyboardEvents(): Promise<void> {
+  const child = keyboardListenerChild
+  if (!child) {
+    return
+  }
+
+  if (child.exitCode !== null) {
+    if (keyboardListenerChild === child) {
+      keyboardListenerChild = null
+    }
+    return
+  }
+
+  await new Promise<void>((resolve) => {
+    let done = false
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined
+
+    const finish = () => {
+      if (done) return
+      done = true
+      child.off("exit", onExit)
+      child.off("error", onError)
+      if (forceKillTimer !== undefined) {
+        clearTimeout(forceKillTimer)
+      }
+      if (keyboardListenerChild === child) {
+        keyboardListenerChild = null
+      }
+      resolve()
+    }
+
+    const onExit = () => {
+      finish()
+    }
+
+    const onError = () => {
+      finish()
+    }
+
+    child.once("exit", onExit)
+    child.once("error", onError)
+
+    forceKillTimer = setTimeout(() => {
+      if (child.exitCode === null) {
+        try {
+          child.kill("SIGKILL")
+        } catch {
+          finish()
+        }
+      }
+    }, KEYBOARD_LISTENER_SHUTDOWN_TIMEOUT_MS)
+
+    if (typeof forceKillTimer.unref === "function") {
+      forceKillTimer.unref()
+    }
+
+    try {
+      child.kill("SIGTERM")
+    } catch {
+      finish()
     }
   })
 }

--- a/apps/desktop/src/main/session-persistence.ts
+++ b/apps/desktop/src/main/session-persistence.ts
@@ -1,0 +1,25 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
+import { dirname } from "path"
+import { logApp } from "./debug"
+
+export function loadPersistedJson<T>(filePath: string, label: string): T | undefined {
+  try {
+    if (!existsSync(filePath)) {
+      return undefined
+    }
+
+    return JSON.parse(readFileSync(filePath, "utf8")) as T
+  } catch (error) {
+    logApp(`[${label}] Failed to load persisted state:`, error)
+    return undefined
+  }
+}
+
+export function savePersistedJson(filePath: string, value: unknown, label: string): void {
+  try {
+    mkdirSync(dirname(filePath), { recursive: true })
+    writeFileSync(filePath, JSON.stringify(value, null, 2), "utf8")
+  } catch (error) {
+    logApp(`[${label}] Failed to persist state:`, error)
+  }
+}


### PR DESCRIPTION
## Summary
- make the keyboard rust listener disposable and clean it up during desktop shutdown
- persist ACP conversation/session mappings and agent session tracker state across Electron restarts
- reuse or reload persisted ACP sessions on restart instead of creating fresh desktop sessions

## Testing
- `./node_modules/.bin/vitest run src/main/keyboard.test.ts src/main/index.hub-install.test.ts src/main/acp-service.test.ts src/main/acp-main-agent.test.ts src/main/agent-session-tracker.persistence.test.ts src/main/acp-session-state.persistence.test.ts`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.node.json --composite false`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author