### PR TITLE
Mobile: lazy-load chat messages; fix dark-mode titles; correct session status icons

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -569,7 +569,7 @@ export function ActiveAgentsSidebar({
             // Use store's isSnoozed for active sessions (matches main view), backend for past
             const isSnoozed = isPast
               ? false
-              : (sessionProgress?.isSnoozed ?? session.isSnoozed ?? false)
+              : (sessionProgress?.isSnoozed ?? false)
 
             if (isPast) {
               const isPinned = session.conversationId ? pinnedSessionIds.has(session.conversationId) : false

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -31,6 +31,7 @@ import {
 import { ToolExecutionStats } from "./tool-execution-stats"
 import { ACPSessionBadge } from "./acp-session-badge"
 import { AgentSummaryView } from "./agent-summary-view"
+import { LoadingSpinner } from "./ui/loading-spinner"
 import { buildContentTTSKey, buildResponseEventTTSKey, hasTTSPlayed, markTTSPlayed, removeTTSKey } from "@renderer/lib/tts-tracking"
 import { ttsManager } from "@renderer/lib/tts-manager"
 import { sanitizeMessageContentForSpeech } from "@dotagents/shared/message-display-utils"
@@ -4337,7 +4338,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       return <Shield className="h-4 w-4 text-amber-500 animate-pulse" />
     }
     if (conversationState === "running") {
-      return <Activity className="h-4 w-4 text-blue-500 animate-pulse" />
+      return <LoadingSpinner size="sm" className="[&>div]:gap-0 [&_img]:h-4 [&_img]:w-4" />
     }
     if (isSnoozed) {
       return <Moon className="h-4 w-4 text-muted-foreground" />

--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -474,7 +474,7 @@ export const Component = () => {
                   const hasPendingApproval =
                     !!sessionProgress?.pendingToolApproval
                   const isSnoozed =
-                    sessionProgress?.isSnoozed ?? session.isSnoozed ?? false
+                    sessionProgress?.isSnoozed ?? false
                   const statusDotColor = hasPendingApproval
                     ? "bg-amber-500"
                     : isSnoozed

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -92,6 +92,8 @@ interface PendingImageAttachment {
 const MAX_PENDING_IMAGES = 4;
 const MAX_PENDING_IMAGE_FILE_SIZE_BYTES = 4 * 1024 * 1024;
 const MAX_TOTAL_PENDING_IMAGE_EMBEDDED_BYTES = 900 * 1024;
+const INITIAL_VISIBLE_CHAT_MESSAGES = 80;
+const VISIBLE_CHAT_MESSAGES_INCREMENT = 60;
 const CHAT_COMPOSER_HINT_NATIVE_ID = 'chat-composer-hint';
 const CHAT_VOICE_STATUS_LIVE_REGION_NATIVE_ID = 'chat-voice-status-live-region';
 
@@ -870,6 +872,7 @@ export default function ChatScreen({ route, navigation }: any) {
 
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [visibleMessageCount, setVisibleMessageCount] = useState(INITIAL_VISIBLE_CHAT_MESSAGES);
   // Keep a ref to messages to avoid stale closures in setTimeout callbacks (PR review fix)
   const messagesRef = useRef<ChatMessage[]>(messages);
   // Track progress messages so we can merge them with final conversationHistory
@@ -1268,6 +1271,7 @@ export default function ChatScreen({ route, navigation }: any) {
     const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
     // Consider "at bottom" if within 50 pixels of the bottom
     const isAtBottom = layoutMeasurement.height + contentOffset.y >= contentSize.height - 50;
+    const isNearTop = contentOffset.y <= 120;
 
     if (isAtBottom && !shouldAutoScroll) {
       // User scrolled back to bottom, resume auto-scroll
@@ -1276,7 +1280,22 @@ export default function ChatScreen({ route, navigation }: any) {
       // Only pause auto-scroll when user is actively dragging (not programmatic scroll)
       setShouldAutoScroll(false);
     }
-  }, [shouldAutoScroll]);
+    if (isNearTop && visibleMessageCount < messages.length) {
+      setVisibleMessageCount((current) => Math.min(messages.length, current + VISIBLE_CHAT_MESSAGES_INCREMENT));
+    }
+  }, [messages.length, shouldAutoScroll, visibleMessageCount]);
+
+  useEffect(() => {
+    setVisibleMessageCount(INITIAL_VISIBLE_CHAT_MESSAGES);
+  }, [sessionStore.currentSessionId]);
+
+  useEffect(() => {
+    setVisibleMessageCount((current) => {
+      if (messages.length === 0) return INITIAL_VISIBLE_CHAT_MESSAGES;
+      const next = Math.max(INITIAL_VISIBLE_CHAT_MESSAGES, current);
+      return Math.min(messages.length, next);
+    });
+  }, [messages.length]);
 
   // Scroll to bottom when messages change and auto-scroll is enabled
   // Uses debouncing to handle rapid streaming updates efficiently
@@ -2862,6 +2881,9 @@ export default function ChatScreen({ route, navigation }: any) {
 		? (handsFreeController.state.phase === 'paused' ? 'Resume' : 'Pause')
 		: (listening ? '...' : 'Hold');
 
+  const firstVisibleMessageIndex = Math.max(0, messages.length - visibleMessageCount);
+  const visibleMessages = messages.slice(firstVisibleMessageIndex);
+  const canLoadOlderMessages = firstVisibleMessageIndex > 0;
 
 
 
@@ -2934,7 +2956,15 @@ export default function ChatScreen({ route, navigation }: any) {
               ))}
             </View>
           )}
-          {messages.map((m, i) => {
+          {canLoadOlderMessages && (
+            <View style={styles.loadOlderContainer}>
+              <Text style={styles.loadOlderText}>
+                Showing latest {visibleMessages.length} of {messages.length} messages. Scroll up to load older messages.
+              </Text>
+            </View>
+          )}
+          {visibleMessages.map((m, visibleIndex) => {
+            const i = firstVisibleMessageIndex + visibleIndex;
             // --- Tool-activity group handling ---
             const group = toolActivityGroups.groupByIndex.get(i);
             if (group) {
@@ -2985,22 +3015,21 @@ export default function ChatScreen({ route, navigation }: any) {
             // Messages whose visible content comes from respond_to_user should
             // never be collapsed — they ARE the assistant's response to the user
             const hasRespondToUserContent = !!getRespondToUserContentFromMessage(m);
-            const shouldCollapse = hasRespondToUserContent
-              ? false
-              : m.role === 'assistant'
-                ? shouldCollapseMessage(visibleMessageContent)
-                : shouldCollapseMessage(m.content, m.toolCalls, m.toolResults);
+            const shouldCollapse = m.role === 'assistant'
+              ? shouldCollapseMessage(visibleMessageContent)
+              : shouldCollapseMessage(m.content, m.toolCalls, m.toolResults);
+            const effectiveShouldCollapse = hasRespondToUserContent ? false : shouldCollapse;
             // expandedMessages is auto-updated via useEffect to expand the last assistant message
             // and persist the expansion state so it doesn't collapse when new messages arrive
             const isExpanded = expandedMessages[i] ?? false;
             const hasToolMetadata =
               (m.toolCalls?.length ?? 0) > 0 ||
               (m.toolResults?.length ?? 0) > 0;
-            const shouldShowExpandedContent = visibleMessageContent.length > 0 && (isExpanded || !shouldCollapse);
+            const shouldShowExpandedContent = visibleMessageContent.length > 0 && (isExpanded || !effectiveShouldCollapse);
             const shouldShowCollapsedTextPreview =
               visibleMessageContent.length > 0 &&
               !isExpanded &&
-              shouldCollapse;
+              effectiveShouldCollapse;
             const canSpeakVisibleContent =
               m.role === 'assistant' &&
               visibleMessageContent.trim().length > 0 &&
@@ -3909,6 +3938,15 @@ function createStyles(theme: Theme, screenHeight: number) {
     },
     headerPinButtonTextActive: {
       color: theme.colors.primary,
+    },
+    loadOlderContainer: {
+      alignItems: 'center',
+      paddingVertical: spacing.xs,
+    },
+    loadOlderText: {
+      ...theme.typography.caption,
+      color: theme.colors.mutedForeground,
+      textAlign: 'center',
     },
     // Compact desktop-style messages: left-border accent, full width, no bubbles
     msg: {

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -846,12 +846,11 @@ export default function SessionListScreen({ navigation }: Props) {
     const isActive = item.id === sessionStore.currentSessionId;
     const isStub = stubSessionIds.has(item.id);
     const rawPreview = (item.searchPreview ?? item.preview) || 'No messages yet';
-    let sessionPreviewText = rawPreview;
-    if (rawPreview.startsWith('tool: [') || rawPreview.includes('{"success":')) {
-      sessionPreviewText = 'Used a tool';
-    } else if (rawPreview.includes('{"')) {
-      sessionPreviewText = rawPreview.replace(/\{.*\}/g, '{...}').trim();
-    }
+    const sessionPreviewText = rawPreview.startsWith('tool: [') || rawPreview.includes('{"success":')
+      ? 'Used a tool'
+      : rawPreview.includes('{"')
+        ? rawPreview.replace(/\{.*\}/g, '{...}').trim()
+        : rawPreview;
     const sessionMetaLabel = `${item.messageCount} message${item.messageCount !== 1 ? 's' : ''}${isStub ? ' · from desktop' : ''}`;
 
     return (
@@ -1279,6 +1278,7 @@ function createStyles(theme: Theme, screenHeight: number) {
       fontSize: 15,
       lineHeight: 20,
       fontWeight: '600',
+      color: theme.colors.foreground,
       flex: 1,
       minWidth: 0,
     },

--- a/apps/mobile/tests/chat-screen-density.test.js
+++ b/apps/mobile/tests/chat-screen-density.test.js
@@ -62,9 +62,11 @@ test('derives visible assistant content from respond_to_user output and suppress
 });
 
 test('bases assistant collapse decisions on visible content instead of raw tool payload metadata', () => {
-  assert.match(screenSource, /const visibleMessageContent = getVisibleMessageContent\(m\);\s+const shouldCollapse = m\.role === 'assistant'\s+\? shouldCollapseMessage\(visibleMessageContent\)\s+: shouldCollapseMessage\(m\.content, m\.toolCalls, m\.toolResults\);/);
+  assert.match(screenSource, /const visibleMessageContent = getVisibleMessageContent\(m\);/);
+  assert.match(screenSource, /const shouldCollapse = m\.role === 'assistant'\s+\? shouldCollapseMessage\(visibleMessageContent\)\s+: shouldCollapseMessage\(m\.content, m\.toolCalls, m\.toolResults\);/);
+  assert.match(screenSource, /const effectiveShouldCollapse = hasRespondToUserContent \? false : shouldCollapse;/);
   assert.doesNotMatch(screenSource, /const shouldCollapse = shouldCollapseMessage\(m\.content, m\.toolCalls, m\.toolResults\);/);
-  assert.match(screenSource, /const shouldShowCollapsedTextPreview =\s+visibleMessageContent\.length > 0 &&\s+!isExpanded &&\s+shouldCollapse;/);
+  assert.match(screenSource, /const shouldShowCollapsedTextPreview =\s+visibleMessageContent\.length > 0 &&\s+!isExpanded &&\s+effectiveShouldCollapse;/);
 });
 
 test('derives tool execution card status from displayed non-meta tool entries', () => {

--- a/apps/mobile/tests/session-list-search.test.js
+++ b/apps/mobile/tests/session-list-search.test.js
@@ -16,5 +16,6 @@ test('adds a mobile chat search field with a search-specific empty state', () =>
 });
 
 test('shows matched message snippets in search results when available', () => {
-  assert.match(screenSource, /const sessionPreviewText = \(item\.searchPreview \?\? item\.preview\) \|\| 'No messages yet';/);
+  assert.match(screenSource, /const rawPreview = \(item\.searchPreview \?\? item\.preview\) \|\| 'No messages yet';/);
+  assert.match(screenSource, /const sessionPreviewText = rawPreview\.startsWith\('tool: \['\) \|\| rawPreview\.includes\('\{"success":'\)/);
 });


### PR DESCRIPTION
### Motivation

- Reduce UI lag on mobile web for large open threads by avoiding rendering the entire message history at once.
- Fix unreadable old-chat titles in mobile dark mode by using the theme foreground color.
- Ensure session status icons reflect live session state and use the spinner logo for running sessions for clearer active-state feedback.

### Description

- Added incremental message windowing to `ChatScreen.tsx` with `INITIAL_VISIBLE_CHAT_MESSAGES` and `VISIBLE_CHAT_MESSAGES_INCREMENT`, `visibleMessageCount` state, and scroll-top triggered batch loading that slices `messages` into `visibleMessages` while preserving absolute indexes for grouping/collapse logic and added a small "Showing latest…" hint and styles (`loadOlderContainer`, `loadOlderText`).
- Made collapse logic in `ChatScreen.tsx` use visible content while respecting `respond_to_user` content by introducing `effectiveShouldCollapse` to avoid collapsing visible assistant responses.
- Updated `SessionListScreen.tsx` to explicitly set `sessionTitle` color to `theme.colors.foreground` to fix dark-mode readability and simplified `sessionPreviewText` computation to avoid deep conditionals.
- Fixed sidebar/session status behavior by ensuring snooze state uses live progress only (`sessionProgress?.isSnoozed ?? false`) in `active-agents-sidebar.tsx` and `app-layout.tsx` to avoid grey/snoozed fallbacks from stale backend values.
- Replaced the running-session status icon with the branded spinner in `agent-progress.tsx` by importing and using `LoadingSpinner` for the running state.
- Updated related mobile source-check tests to match the refined collapse/session-preview implementation in `apps/mobile/tests/chat-screen-density.test.js` and `apps/mobile/tests/session-list-search.test.js`.

### Testing

- Ran `cd apps/mobile && node --test tests/session-list-search.test.js` which passed. ✅
- Ran desktop renderer unit tests with `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/lib/sidebar-sessions.test.ts` which passed. ✅
- Ran combined mobile checks `cd apps/mobile && node --test tests/chat-screen-density.test.js tests/session-list-search.test.js` and observed one existing/related expectation mismatch in the quick-start eyebrow text (test harness flagged a failing expectation). ⚠️
- Ran workspace `pnpm typecheck` which showed unrelated pre-existing typecheck failures in `packages/core` (missing `@dotagents/shared` resolution) that are not introduced by these changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69becc0efb888330b90e836beb97a227)