### PR TITLE
Keep recognizer active during processing and pause queued-message drain when hands-free is paused

### DIFF
--- a/apps/mobile/src/lib/voice/useHandsFreeController.test.ts
+++ b/apps/mobile/src/lib/voice/useHandsFreeController.test.ts
@@ -231,4 +231,27 @@ describe('resolveHandsFreeUtterance', () => {
     expect(controller.state).toEqual(createInitialHandsFreeState());
     expect(controller.shouldKeepRecognizerActive).toBe(false);
   });
+
+  it('keeps the recognizer active while processing so overlapping utterances can be queued', async () => {
+    const runtime = createHookRuntime();
+    const { useHandsFreeController: useHook } = await loadUseHandsFreeController(runtime);
+    const options = {
+      runtimeActive: true,
+      wakePhrase: 'hey dot agents',
+      sleepPhrase: 'go to sleep',
+    };
+
+    let controller = runtime.render(useHook, { ...options, enabled: true });
+    runtime.commitEffects();
+    controller = runtime.render(useHook, { ...options, enabled: true });
+
+    expect(controller.handleFinalTranscript('hey dot agents what is the weather')).toEqual({
+      type: 'send',
+      text: 'what is the weather',
+    });
+
+    controller = runtime.render(useHook, { ...options, enabled: true });
+    expect(controller.state.phase).toBe('processing');
+    expect(controller.shouldKeepRecognizerActive).toBe(true);
+  });
 });

--- a/apps/mobile/src/lib/voice/useHandsFreeController.ts
+++ b/apps/mobile/src/lib/voice/useHandsFreeController.ts
@@ -507,7 +507,10 @@ export function useHandsFreeController(options: HandsFreeControllerOptions) {
     () => enabled
       && runtimeActive
       && state.pauseReason !== 'user'
-      && (state.phase === 'sleeping' || state.phase === 'waking' || state.phase === 'listening'),
+      && (state.phase === 'sleeping'
+        || state.phase === 'waking'
+        || state.phase === 'listening'
+        || state.phase === 'processing'),
     [enabled, runtimeActive, state.phase, state.pauseReason],
   );
 

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -57,6 +57,7 @@ import {
   groupToolActivity,
   type AgentConversationState,
   type AgentUserResponseEvent,
+  type HandsFreePhase,
   type PredefinedPromptSummary,
   type ToolActivityGroup,
 } from '@dotagents/shared';
@@ -512,6 +513,7 @@ export default function ChatScreen({ route, navigation }: any) {
   const messageQueueEnabled = config.messageQueueEnabled !== false; // default true
   const handsFreeRef = useRef<boolean>(handsFree);
   useEffect(() => { handsFreeRef.current = !!config.handsFree; }, [config.handsFree]);
+  const handsFreePhaseRef = useRef<HandsFreePhase>('sleeping');
   const [appState, setAppState] = useState<AppStateStatus>(AppState.currentState);
   const isAppActive = appState === 'active';
   const handsFreeRuntimeActive = handsFree && isFocused && isAppActive;
@@ -917,6 +919,9 @@ export default function ChatScreen({ route, navigation }: any) {
 		sleepPhrase: handsFreeSleepPhrase,
 		log: voiceLog,
 	  });
+  useEffect(() => {
+    handsFreePhaseRef.current = handsFreeController.state.phase;
+  }, [handsFreeController.state.phase]);
 
 	  const {
 		listening,
@@ -2372,13 +2377,16 @@ export default function ChatScreen({ route, navigation }: any) {
         }, 5000);
 
         // Process next queued message if any
-        if (messageQueueEnabled) {
+        if (messageQueueEnabled && (!handsFree || handsFreePhaseRef.current !== 'paused')) {
           const nextMessage = messageQueue.peek(currentConversationId);
           if (nextMessage) {
             console.log('[ChatScreen] Processing next queued message:', nextMessage.id);
-            messageQueue.markProcessing(currentConversationId, nextMessage.id);
             // Use setTimeout to avoid recursive call stack issues
             setTimeout(() => {
+              if (handsFreeRef.current && handsFreePhaseRef.current === 'paused') {
+                return;
+              }
+              messageQueue.markProcessing(currentConversationId, nextMessage.id);
               processQueuedMessage(nextMessage);
             }, 100);
           }
@@ -2610,10 +2618,13 @@ export default function ChatScreen({ route, navigation }: any) {
 
         // Process next queued message if any
         const nextMessage = messageQueue.peek(currentConversationId);
-        if (nextMessage) {
+        if (nextMessage && (!handsFree || handsFreePhaseRef.current !== 'paused')) {
           console.log('[ChatScreen] Processing next queued message:', nextMessage.id);
-          messageQueue.markProcessing(currentConversationId, nextMessage.id);
           setTimeout(() => {
+            if (handsFreeRef.current && handsFreePhaseRef.current === 'paused') {
+              return;
+            }
+            messageQueue.markProcessing(currentConversationId, nextMessage.id);
             processQueuedMessage(nextMessage);
           }, 100);
         }
@@ -2627,12 +2638,17 @@ export default function ChatScreen({ route, navigation }: any) {
     const nextMessage = messageQueue.peek(currentConversationId);
     if (!nextMessage) return;
 
+    if (handsFree && handsFreeController.state.phase === 'paused') return;
+
     console.log('[ChatScreen] Processing queue while idle, next message:', nextMessage.id);
-    messageQueue.markProcessing(currentConversationId, nextMessage.id);
     setTimeout(() => {
+      if (handsFreeRef.current && handsFreePhaseRef.current === 'paused') {
+        return;
+      }
+      messageQueue.markProcessing(currentConversationId, nextMessage.id);
       processQueuedMessage(nextMessage);
     }, 100);
-  }, [currentConversationId, messageQueue, processQueuedMessage, responding]);
+  }, [currentConversationId, handsFree, handsFreeController.state.phase, messageQueue, processQueuedMessage, responding]);
 
 	// Keep sendRef in sync with the latest send() implementation for speech callbacks.
 	// IMPORTANT: This must live outside send() so voice callbacks can send even before any manual send() occurs.

--- a/apps/mobile/tests/chat-screen-handsfree-density.test.js
+++ b/apps/mobile/tests/chat-screen-handsfree-density.test.js
@@ -52,3 +52,10 @@ test('keeps wake/sleep controls inline and wires a dedicated pause/resume contro
   assert.match(screenSource, /<View style=\{styles\.handsFreeControlsRow\}>[\s\S]*?onPress=\{\(\) => \{[\s\S]*?handsFreeController\.state\.phase === 'paused'[\s\S]*?handsFreeController\.resumeByUser\(\)[\s\S]*?handsFreeController\.pauseByUser\(\)[\s\S]*?void stopRecognitionOnly\(\);[\s\S]*?<Text style=\{styles\.handsFreeControlButtonText\}>\s*\{handsFreeController\.state\.phase === 'paused' \? 'Resume' : 'Pause'\}\s*<\/Text>[\s\S]*?<\/View>/);
   assert.match(screenSource, /onPress=\{handsFree \? \(\) => \{[\s\S]*?handsFreeController\.state\.phase === 'paused'[\s\S]*?handsFreeController\.resumeByUser\(\)[\s\S]*?handsFreeController\.pauseByUser\(\)[\s\S]*?\} : undefined\}/);
 });
+
+test('pauses queued-message auto-processing while handsfree is paused', () => {
+  assert.match(screenSource, /const handsFreePhaseRef = useRef<HandsFreePhase>\('sleeping'\);/);
+  assert.match(screenSource, /handsFreePhaseRef\.current = handsFreeController\.state\.phase;/);
+  assert.match(screenSource, /if \(messageQueueEnabled && \(!handsFree \|\| handsFreePhaseRef\.current !== 'paused'\)\) \{/);
+  assert.match(screenSource, /if \(handsFreeRef\.current && handsFreePhaseRef\.current === 'paused'\) \{\s*return;\s*\}[\s\S]*?messageQueue\.markProcessing\(currentConversationId, nextMessage\.id\);/);
+});


### PR DESCRIPTION
### Motivation

- Fix two hands-free UX bugs: overlapping speech utterances getting dropped while the app is processing, and the bottom pause control not preventing queued-message auto-drain.

### Description

- Keep the recognizer active during the `processing` phase by including `processing` in `shouldKeepRecognizerActive` in `useHandsFreeController` so follow-up speech can be captured and queued. (`apps/mobile/src/lib/voice/useHandsFreeController.ts`)
- Track the latest hands-free phase via a ref and short-circuit queued-message auto-drain when the controller is in the user-`paused` phase, including re-checks inside delayed dequeue callbacks to avoid marking items as processing while paused. (`apps/mobile/src/screens/ChatScreen.tsx`)
- Add regression tests: a controller unit test asserting the recognizer stays active while processing, and a ChatScreen density test asserting the paused-phase queue guards are wired. (`apps/mobile/src/lib/voice/useHandsFreeController.test.ts`, `apps/mobile/tests/chat-screen-handsfree-density.test.js`)

### Testing

- Ran `node --test tests/chat-screen-handsfree-density.test.js` in `apps/mobile` and the hands-free density tests passed. ✅
- Ran `pnpm exec vitest run src/lib/voice/useHandsFreeController.test.ts` in `apps/mobile` and the `useHandsFreeController` suite passed. ✅
- Running the package-wide mobile test script `pnpm --filter @dotagents/mobile test -- useHandsFreeController.test.ts chat-screen-handsfree-density.test.js` failed due to an unrelated existing regex assertion in `tests/chat-screen-density.test.js` present in the broader node suite, not the changes in this PR. ⚠️
- Running the package `test:vitest` script in this environment triggers additional suites that fail due to workspace/module resolution assumptions (e.g. `@dotagents/shared` entry resolution) and are unrelated to the functional change in this PR. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef88979508330942784389f00f069)