### PR TITLE
Fix docs homepage hero messaging

### DIFF
--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -1,8 +1,13 @@
 .heroBanner {
-  padding: 5rem 0 4rem;
+  padding: 6rem 0 4.5rem;
   text-align: center;
   position: relative;
   overflow: hidden;
+  background:
+    radial-gradient(circle at top center, rgba(156, 220, 254, 0.16), transparent 32%),
+    radial-gradient(circle at 18% 20%, rgba(78, 201, 176, 0.12), transparent 24%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
 }
 
 @media screen and (max-width: 996px) {
@@ -11,12 +16,98 @@
   }
 }
 
+.eyebrowRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(156, 220, 254, 0.25);
+  background: rgba(156, 220, 254, 0.08);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.eyebrowDetail {
+  color: var(--da-fg-muted);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 0.85rem;
+}
+
+.heroTitle {
+  max-width: 13ch;
+  margin: 0 auto;
+  font-size: clamp(3rem, 8vw, 5.75rem);
+  line-height: 0.94;
+  letter-spacing: -0.06em;
+}
+
+.heroSubtitle {
+  max-width: 42rem;
+  margin: 1.5rem auto 0;
+  color: #f5f5f5;
+  font-size: clamp(1.15rem, 2vw, 1.45rem);
+}
+
+.heroBody {
+  max-width: 42rem;
+  margin: 1rem auto 0;
+  color: var(--da-fg-muted);
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
 .buttons {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 1rem;
   margin-top: 1.5rem;
+}
+
+.signalGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 2.5rem;
+}
+
+.signalCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem 1.1rem;
+  text-align: left;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+}
+
+.signalCard strong {
+  color: #fff;
+  font-size: 0.95rem;
+}
+
+.signalCard span {
+  color: var(--da-fg-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.signalCard code {
+  font-size: 0.85em;
 }
 
 /* Quick Links Section */
@@ -41,11 +132,19 @@
   .quickLinksGrid {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  .signalGrid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media screen and (max-width: 480px) {
   .quickLinksGrid {
     grid-template-columns: 1fr;
+  }
+
+  .buttons {
+    flex-direction: column;
   }
 }
 

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -112,11 +112,19 @@ function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <Heading as="h1" className="hero__title">
-          {siteConfig.title}
+        <div className={styles.eyebrowRow}>
+          <span className={styles.eyebrow}>{siteConfig.title}</span>
+          <span className={styles.eyebrowDetail}>Desktop and mobile agent runtime</span>
+        </div>
+        <Heading as="h1" className={clsx('hero__title', styles.heroTitle)}>
+          Agents that do real work in the background.
         </Heading>
-        <p className="hero__subtitle">
-          {siteConfig.tagline} Your assistant. Your machine. Your rules.
+        <p className={clsx('hero__subtitle', styles.heroSubtitle)}>
+          Free, transparent, and works with any agent provider.
+        </p>
+        <p className={styles.heroBody}>
+          Talk to agents naturally, give them tools and context, and let them keep
+          going without babysitting every step.
         </p>
         <div className={styles.buttons}>
           <Link
@@ -130,6 +138,20 @@ function HomepageHeader() {
             to="/getting-started/installation">
             Install
           </Link>
+        </div>
+        <div className={styles.signalGrid}>
+          <div className={styles.signalCard}>
+            <strong>Free to use</strong>
+            <span>Bring your own providers, tools, and local workflows.</span>
+          </div>
+          <div className={styles.signalCard}>
+            <strong>Transparent by default</strong>
+            <span>See agent progress, tool calls, artifacts, and handoffs as they happen.</span>
+          </div>
+          <div className={styles.signalCard}>
+            <strong>Provider-agnostic</strong>
+            <span>Open standards like <code>.agents</code>, MCP, and ACP keep you out of lock-in.</span>
+          </div>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- replace the generic docs homepage hero with the sharper background-work thesis from #157
- foreground the three proof points the issue called out: free to use, transparent by default, and provider-agnostic
- keep the rest of the landing page structure intact while giving the hero a stronger visual treatment

## Validation
- `pnpm typecheck` in `docs-site`
- `pnpm build` in `docs-site`

## Issue
Closes #157

## Local artifacts
- Before recording: `~/Movies/agent-videos/raw/2026-03-21-dotagents-homepage-before-v01.webm`
- After recording: `~/Movies/agent-videos/raw/2026-03-21-dotagents-homepage-after-v01.webm`
