### PR TITLE
Fix mobile failed tool-call history rendering

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "pnpm run test:node && pnpm run test:vitest",
     "test:node": "node --test \"tests/*.js\"",
-    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
+    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/chat-history-tool-merge.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
   },
   "dependencies": {
     "@dotagents/shared": "workspace:^",

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -83,6 +83,7 @@ import { formatVoiceDebugEntry, useVoiceDebug } from '../lib/voice/voiceDebug';
 import { useSpeechRecognizer } from '../lib/voice/useSpeechRecognizer';
 import { useHandsFreeController } from '../lib/voice/useHandsFreeController';
 import { createDelegationProgressMessages } from '../lib/delegationProgress';
+import { mergeToolHistoryMessageIntoPreviousAssistant } from './chat-history-tool-merge';
 
 interface PendingImageAttachment {
   id: string;
@@ -1736,22 +1737,11 @@ export default function ChatScreen({ route, navigation }: any) {
           // Merge tool results into the preceding assistant message to avoid duplication
           // The server sends: assistant (with toolCalls) -> tool (with toolResults)
           // We want to display them as a single message with both toolCalls and toolResults
-          if (historyMsg.role === 'tool' && messages.length > 0) {
-            const lastMessage = messages[messages.length - 1];
-            if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-
-              if (hasToolResults) {
-                // Merge toolResults into the existing assistant message
-                lastMessage.toolResults = [
-                  ...(lastMessage.toolResults || []),
-                  ...(historyMsg.toolResults || []),
-                ];
-                // Skip adding this as a separate message only when we merged results
-                continue;
-              }
-              // If tool message has content but no toolResults, fall through to add it as a message
-            }
+          if (
+            historyMsg.role === 'tool' &&
+            mergeToolHistoryMessageIntoPreviousAssistant(messages, historyMsg, HIDDEN_META_TOOLS)
+          ) {
+            continue;
           }
 
           messages.push({
@@ -2148,22 +2138,11 @@ export default function ChatScreen({ route, navigation }: any) {
           // Merge tool results into the preceding assistant message to avoid duplication
           // The server sends: assistant (with toolCalls) -> tool (with toolResults)
           // We want to display them as a single message with both toolCalls and toolResults
-          if (historyMsg.role === 'tool' && newMessages.length > 0) {
-            const lastMessage = newMessages[newMessages.length - 1];
-            if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-
-              if (hasToolResults) {
-                // Merge toolResults into the existing assistant message
-                lastMessage.toolResults = [
-                  ...(lastMessage.toolResults || []),
-                  ...(historyMsg.toolResults || []),
-                ];
-                // Skip adding this as a separate message only when we merged results
-                continue;
-              }
-              // If tool message has content but no toolResults, fall through to add it as a message
-            }
+          if (
+            historyMsg.role === 'tool' &&
+            mergeToolHistoryMessageIntoPreviousAssistant(newMessages, historyMsg, HIDDEN_META_TOOLS)
+          ) {
+            continue;
           }
 
           newMessages.push({
@@ -3603,20 +3582,11 @@ export default function ChatScreen({ route, navigation }: any) {
                                 toolCalls: msg.toolCalls,
                                 toolResults: msg.toolResults,
                               });
-                            } else if (msg.role === 'tool' && recoveredMessages.length > 0) {
-                              // Merge tool message toolResults into the preceding assistant message
-                              const lastMessage = recoveredMessages[recoveredMessages.length - 1];
-                              if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-                                const hasToolResults = msg.toolResults && msg.toolResults.length > 0;
-
-                                if (hasToolResults) {
-                                  // Merge toolResults into the existing assistant message
-                                  lastMessage.toolResults = [
-                                    ...(lastMessage.toolResults || []),
-                                    ...(msg.toolResults || []),
-                                  ];
-                                }
-                              }
+                            } else if (
+                              msg.role === 'tool' &&
+                              mergeToolHistoryMessageIntoPreviousAssistant(recoveredMessages, msg, HIDDEN_META_TOOLS)
+                            ) {
+                              continue;
                             }
                           }
 

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -83,7 +83,10 @@ import { formatVoiceDebugEntry, useVoiceDebug } from '../lib/voice/voiceDebug';
 import { useSpeechRecognizer } from '../lib/voice/useSpeechRecognizer';
 import { useHandsFreeController } from '../lib/voice/useHandsFreeController';
 import { createDelegationProgressMessages } from '../lib/delegationProgress';
-import { mergeToolHistoryMessageIntoPreviousAssistant } from './chat-history-tool-merge';
+import {
+  alignStructuredToolResults,
+  mergeToolHistoryMessageIntoPreviousAssistant,
+} from './chat-history-tool-merge';
 
 interface PendingImageAttachment {
   id: string;
@@ -1687,8 +1690,8 @@ export default function ChatScreen({ route, navigation }: any) {
     console.log('[convertProgressToMessages] Processing update, steps:', update.steps?.length || 0, 'history:', update.conversationHistory?.length || 0, 'isComplete:', update.isComplete);
 
     if (update.steps && update.steps.length > 0) {
-      let currentToolCalls: any[] = [];
-      let currentToolResults: any[] = [];
+      let currentToolCalls: NonNullable<ChatMessage['toolCalls']> = [];
+      let currentToolResults: NonNullable<ChatMessage['toolResults']> = [];
       let thinkingContent = '';
 
       for (const step of update.steps) {
@@ -1700,10 +1703,24 @@ export default function ChatScreen({ route, navigation }: any) {
             currentToolCalls.push(step.toolCall);
           }
           if (step.toolResult) {
-            currentToolResults.push(step.toolResult);
+            if (step.toolCall) {
+              currentToolResults[currentToolCalls.length - 1] = step.toolResult;
+            } else {
+              currentToolResults = alignStructuredToolResults(
+                currentToolCalls,
+                currentToolResults,
+                [step.toolResult],
+                HIDDEN_META_TOOLS,
+              );
+            }
           }
         } else if (step.type === 'tool_result' && step.toolResult) {
-          currentToolResults.push(step.toolResult);
+          currentToolResults = alignStructuredToolResults(
+            currentToolCalls,
+            currentToolResults,
+            [step.toolResult],
+            HIDDEN_META_TOOLS,
+          );
         } else if (step.type === 'completion' && stepContent) {
           thinkingContent = stepContent;
         }

--- a/apps/mobile/src/screens/chat-history-tool-merge.test.ts
+++ b/apps/mobile/src/screens/chat-history-tool-merge.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChatMessage } from '../types/session';
+
+import { mergeToolHistoryMessageIntoPreviousAssistant } from './chat-history-tool-merge';
+
+describe('chat-history-tool-merge', () => {
+  it('merges structured tool results into the previous assistant tool call message', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '',
+        timestamp: 1,
+        toolCalls: [{ name: 'read_file', arguments: { path: 'README.md' } }],
+      },
+    ];
+
+    expect(mergeToolHistoryMessageIntoPreviousAssistant(messages, {
+      content: '',
+      toolResults: [{ success: true, content: 'hello world' }],
+    })).toBe(true);
+
+    expect(messages[0].toolResults).toEqual([{ success: true, content: 'hello world' }]);
+  });
+
+  it('synthesizes a failed tool result from a legacy content-only tool message', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        toolCalls: [{ name: 'execute_command', arguments: { command: 'false' } }],
+      },
+    ];
+
+    expect(mergeToolHistoryMessageIntoPreviousAssistant(messages, {
+      content: '[execute_command] ERROR: permission denied',
+    })).toBe(true);
+
+    expect(messages[0].toolResults).toEqual([
+      {
+        success: false,
+        content: 'permission denied',
+        error: 'permission denied',
+      },
+    ]);
+  });
+
+  it('keeps synthesized results aligned with the first unresolved visible tool call', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'assistant-3',
+        role: 'assistant',
+        content: '',
+        timestamp: 3,
+        toolCalls: [
+          { name: 'respond_to_user', arguments: { text: 'Working on it' } },
+          { name: 'execute_command', arguments: { command: 'false' } },
+        ],
+      },
+    ];
+
+    expect(mergeToolHistoryMessageIntoPreviousAssistant(
+      messages,
+      { content: 'Tool: execute_command\nResult: permission denied' },
+      new Set(['respond_to_user', 'mark_work_complete']),
+    )).toBe(true);
+
+    expect(messages[0].toolResults).toHaveLength(2);
+    expect(messages[0].toolResults?.[0]).toBeUndefined();
+    expect(messages[0].toolResults?.[1]).toEqual({
+      success: false,
+      content: 'permission denied',
+      error: 'permission denied',
+    });
+  });
+});

--- a/apps/mobile/src/screens/chat-history-tool-merge.test.ts
+++ b/apps/mobile/src/screens/chat-history-tool-merge.test.ts
@@ -24,6 +24,37 @@ describe('chat-history-tool-merge', () => {
     expect(messages[0].toolResults).toEqual([{ success: true, content: 'hello world' }]);
   });
 
+  it('aligns structured tool results to the first unresolved visible tool call', () => {
+    const messages: ChatMessage[] = [
+      {
+        id: 'assistant-structured-hidden',
+        role: 'assistant',
+        content: '',
+        timestamp: 1,
+        toolCalls: [
+          { name: 'respond_to_user', arguments: { text: 'Working on it' } },
+          { name: 'read_file', arguments: { path: 'package.json' } },
+        ],
+      },
+    ];
+
+    expect(mergeToolHistoryMessageIntoPreviousAssistant(
+      messages,
+      {
+        content: '',
+        toolResults: [{ success: true, content: '{"name":"dotagents-mono"}' }],
+      },
+      new Set(['respond_to_user', 'mark_work_complete']),
+    )).toBe(true);
+
+    expect(messages[0].toolResults).toHaveLength(2);
+    expect(messages[0].toolResults?.[0]).toBeUndefined();
+    expect(messages[0].toolResults?.[1]).toEqual({
+      success: true,
+      content: '{"name":"dotagents-mono"}',
+    });
+  });
+
   it('synthesizes a failed tool result from a legacy content-only tool message', () => {
     const messages: ChatMessage[] = [
       {
@@ -74,6 +105,46 @@ describe('chat-history-tool-merge', () => {
       success: false,
       content: 'permission denied',
       error: 'permission denied',
+    });
+  });
+
+  it('keeps structured result batches aligned after an earlier visible result is already filled', () => {
+    const existingToolResults: NonNullable<ChatMessage['toolResults']> = [];
+    existingToolResults[1] = { success: true, content: '{"name":"dotagents-mono"}' };
+
+    const messages: ChatMessage[] = [
+      {
+        id: 'assistant-structured-batch',
+        role: 'assistant',
+        content: '',
+        timestamp: 4,
+        toolCalls: [
+          { name: 'respond_to_user', arguments: { text: 'Working on it' } },
+          { name: 'read_file', arguments: { path: 'package.json' } },
+          { name: 'execute_command', arguments: { command: 'pwd' } },
+        ],
+        toolResults: existingToolResults,
+      },
+    ];
+
+    expect(mergeToolHistoryMessageIntoPreviousAssistant(
+      messages,
+      {
+        content: '',
+        toolResults: [{ success: true, content: '/tmp/electron-ui-recording' }],
+      },
+      new Set(['respond_to_user', 'mark_work_complete']),
+    )).toBe(true);
+
+    expect(messages[0].toolResults).toHaveLength(3);
+    expect(messages[0].toolResults?.[0]).toBeUndefined();
+    expect(messages[0].toolResults?.[1]).toEqual({
+      success: true,
+      content: '{"name":"dotagents-mono"}',
+    });
+    expect(messages[0].toolResults?.[2]).toEqual({
+      success: true,
+      content: '/tmp/electron-ui-recording',
     });
   });
 });

--- a/apps/mobile/src/screens/chat-history-tool-merge.test.ts
+++ b/apps/mobile/src/screens/chat-history-tool-merge.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { ChatMessage } from '../types/session';
 
-import { mergeToolHistoryMessageIntoPreviousAssistant } from './chat-history-tool-merge';
+import {
+  alignStructuredToolResults,
+  mergeToolHistoryMessageIntoPreviousAssistant,
+} from './chat-history-tool-merge';
 
 describe('chat-history-tool-merge', () => {
   it('merges structured tool results into the previous assistant tool call message', () => {
@@ -50,6 +53,27 @@ describe('chat-history-tool-merge', () => {
     expect(messages[0].toolResults).toHaveLength(2);
     expect(messages[0].toolResults?.[0]).toBeUndefined();
     expect(messages[0].toolResults?.[1]).toEqual({
+      success: true,
+      content: '{"name":"dotagents-mono"}',
+    });
+  });
+
+  it('aligns standalone progress tool results to the first unresolved visible tool call', () => {
+    const toolCalls: NonNullable<ChatMessage['toolCalls']> = [
+      { name: 'respond_to_user', arguments: { content: 'Working on it' } },
+      { name: 'read_file', arguments: { path: 'package.json' } },
+    ];
+
+    const nextResults = alignStructuredToolResults(
+      toolCalls,
+      [],
+      [{ success: true, content: '{"name":"dotagents-mono"}' }],
+      new Set(['respond_to_user', 'mark_work_complete']),
+    );
+
+    expect(nextResults).toHaveLength(2);
+    expect(nextResults[0]).toBeUndefined();
+    expect(nextResults[1]).toEqual({
       success: true,
       content: '{"name":"dotagents-mono"}',
     });

--- a/apps/mobile/src/screens/chat-history-tool-merge.ts
+++ b/apps/mobile/src/screens/chat-history-tool-merge.ts
@@ -38,9 +38,18 @@ function findLegacyToolResultTargetIndex(
   message: ChatMessage,
   hiddenToolNames: ReadonlySet<string>,
 ): number {
-  const toolCalls = message.toolCalls ?? [];
-  const toolResults = message.toolResults ?? [];
+  return findNextToolResultTargetIndex(
+    message.toolCalls ?? [],
+    message.toolResults ?? [],
+    hiddenToolNames,
+  );
+}
 
+function findNextToolResultTargetIndex(
+  toolCalls: NonNullable<ChatMessage['toolCalls']>,
+  toolResults: NonNullable<ChatMessage['toolResults']>,
+  hiddenToolNames: ReadonlySet<string>,
+): number {
   for (let i = 0; i < toolCalls.length; i += 1) {
     if (hiddenToolNames.has(toolCalls[i].name)) continue;
     if (toolResults[i] !== undefined) continue;
@@ -69,10 +78,25 @@ export function mergeToolHistoryMessageIntoPreviousAssistant(
 
   const structuredResults = toolMessage.toolResults;
   if (structuredResults && structuredResults.length > 0) {
-    lastMessage.toolResults = [
-      ...(lastMessage.toolResults || []),
-      ...structuredResults,
-    ];
+    const nextResults = [...(lastMessage.toolResults || [])];
+    const toolCalls = lastMessage.toolCalls ?? [];
+
+    for (const structuredResult of structuredResults) {
+      const targetIndex = findNextToolResultTargetIndex(
+        toolCalls,
+        nextResults,
+        hiddenToolNames,
+      );
+
+      if (targetIndex < 0) {
+        nextResults.push(structuredResult);
+        continue;
+      }
+
+      nextResults[targetIndex] = structuredResult;
+    }
+
+    lastMessage.toolResults = nextResults as typeof lastMessage.toolResults;
     return true;
   }
 

--- a/apps/mobile/src/screens/chat-history-tool-merge.ts
+++ b/apps/mobile/src/screens/chat-history-tool-merge.ts
@@ -1,0 +1,100 @@
+import type { ConversationHistoryMessage } from '@dotagents/shared';
+
+import type { ChatMessage } from '../lib/openaiClient';
+
+const BRACKETED_TOOL_RESULT_REGEX = /^\[([^\]]+)\]\s*(ERROR:\s*)?([\s\S]*)$/i;
+const LEGACY_TOOL_RESULT_REGEX = /^Tool:\s*(.+?)\s*\r?\nResult:\s*([\s\S]*)$/i;
+const TOOL_FAILURE_HINT_REGEX = /\b(error|failed|failure|denied|timeout|timed out|exception|invalid|unauthorized|forbidden|unavailable|not found|stopped)\b/i;
+
+function normalizeLegacyToolResultContent(rawContent: string, expectedToolName?: string): string {
+  const trimmed = rawContent.trim();
+  if (!trimmed) return '';
+
+  const bracketedMatch = trimmed.match(BRACKETED_TOOL_RESULT_REGEX);
+  if (bracketedMatch) {
+    const [, toolName, , resultContent] = bracketedMatch;
+    if (!expectedToolName || toolName === expectedToolName) {
+      return resultContent.trim();
+    }
+  }
+
+  const legacyMatch = trimmed.match(LEGACY_TOOL_RESULT_REGEX);
+  if (legacyMatch) {
+    const [, toolName, resultContent] = legacyMatch;
+    if (!expectedToolName || toolName === expectedToolName) {
+      return resultContent.trim();
+    }
+  }
+
+  return trimmed;
+}
+
+function inferLegacyToolResultSuccess(rawContent: string, normalizedContent: string): boolean {
+  const combined = `${rawContent}\n${normalizedContent}`;
+  return !TOOL_FAILURE_HINT_REGEX.test(combined);
+}
+
+function findLegacyToolResultTargetIndex(
+  message: ChatMessage,
+  hiddenToolNames: ReadonlySet<string>,
+): number {
+  const toolCalls = message.toolCalls ?? [];
+  const toolResults = message.toolResults ?? [];
+
+  for (let i = 0; i < toolCalls.length; i += 1) {
+    if (hiddenToolNames.has(toolCalls[i].name)) continue;
+    if (toolResults[i] !== undefined) continue;
+    return i;
+  }
+
+  for (let i = 0; i < toolCalls.length; i += 1) {
+    if (toolResults[i] !== undefined) continue;
+    return i;
+  }
+
+  return -1;
+}
+
+export function mergeToolHistoryMessageIntoPreviousAssistant(
+  messages: ChatMessage[],
+  toolMessage: Pick<ConversationHistoryMessage, 'content' | 'toolResults'>,
+  hiddenToolNames: ReadonlySet<string> = new Set(),
+): boolean {
+  if (messages.length === 0) return false;
+
+  const lastMessage = messages[messages.length - 1];
+  if (lastMessage.role !== 'assistant' || !lastMessage.toolCalls?.length) {
+    return false;
+  }
+
+  const structuredResults = toolMessage.toolResults;
+  if (structuredResults && structuredResults.length > 0) {
+    lastMessage.toolResults = [
+      ...(lastMessage.toolResults || []),
+      ...structuredResults,
+    ];
+    return true;
+  }
+
+  const trimmedContent = toolMessage.content?.trim();
+  if (!trimmedContent) {
+    return false;
+  }
+
+  const targetIndex = findLegacyToolResultTargetIndex(lastMessage, hiddenToolNames);
+  if (targetIndex < 0) {
+    return false;
+  }
+
+  const expectedToolName = lastMessage.toolCalls[targetIndex]?.name;
+  const normalizedContent = normalizeLegacyToolResultContent(trimmedContent, expectedToolName);
+  const success = inferLegacyToolResultSuccess(trimmedContent, normalizedContent);
+  const nextResults = [...(lastMessage.toolResults || [])];
+  nextResults[targetIndex] = {
+    success,
+    content: normalizedContent || trimmedContent,
+    error: success ? undefined : (normalizedContent || trimmedContent),
+  };
+  lastMessage.toolResults = nextResults as typeof lastMessage.toolResults;
+  return true;
+}

--- a/apps/mobile/src/screens/chat-history-tool-merge.ts
+++ b/apps/mobile/src/screens/chat-history-tool-merge.ts
@@ -64,6 +64,32 @@ function findNextToolResultTargetIndex(
   return -1;
 }
 
+export function alignStructuredToolResults(
+  toolCalls: NonNullable<ChatMessage['toolCalls']>,
+  existingToolResults: NonNullable<ChatMessage['toolResults']>,
+  structuredResults: ReadonlyArray<NonNullable<ConversationHistoryMessage['toolResults']>[number]>,
+  hiddenToolNames: ReadonlySet<string> = new Set(),
+): NonNullable<ChatMessage['toolResults']> {
+  const nextResults = [...existingToolResults];
+
+  for (const structuredResult of structuredResults) {
+    const targetIndex = findNextToolResultTargetIndex(
+      toolCalls,
+      nextResults,
+      hiddenToolNames,
+    );
+
+    if (targetIndex < 0) {
+      nextResults.push(structuredResult);
+      continue;
+    }
+
+    nextResults[targetIndex] = structuredResult;
+  }
+
+  return nextResults as NonNullable<ChatMessage['toolResults']>;
+}
+
 export function mergeToolHistoryMessageIntoPreviousAssistant(
   messages: ChatMessage[],
   toolMessage: Pick<ConversationHistoryMessage, 'content' | 'toolResults'>,
@@ -78,24 +104,12 @@ export function mergeToolHistoryMessageIntoPreviousAssistant(
 
   const structuredResults = toolMessage.toolResults;
   if (structuredResults && structuredResults.length > 0) {
-    const nextResults = [...(lastMessage.toolResults || [])];
-    const toolCalls = lastMessage.toolCalls ?? [];
-
-    for (const structuredResult of structuredResults) {
-      const targetIndex = findNextToolResultTargetIndex(
-        toolCalls,
-        nextResults,
-        hiddenToolNames,
-      );
-
-      if (targetIndex < 0) {
-        nextResults.push(structuredResult);
-        continue;
-      }
-
-      nextResults[targetIndex] = structuredResult;
-    }
-
+    const nextResults = alignStructuredToolResults(
+      lastMessage.toolCalls ?? [],
+      lastMessage.toolResults ?? [],
+      structuredResults,
+      hiddenToolNames,
+    );
     lastMessage.toolResults = nextResults as typeof lastMessage.toolResults;
     return true;
   }


### PR DESCRIPTION
## Summary
- add a shared mobile helper to merge tool history entries into the preceding assistant tool-call message
- synthesize structured failed tool results from legacy content-only tool messages instead of falling back to raw plain text
- reuse the helper across live history updates, final response handling, and recovery sync paths in mobile chat
- add focused tests for structured merges, legacy error parsing, and result alignment

## Testing
- `pnpm --filter @dotagents/mobile exec tsc --noEmit`
- `pnpm --filter @dotagents/mobile test:vitest`