### PR TITLE
Fix mobile chat history rendering for tool failure summaries

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "pnpm run test:node && pnpm run test:vitest",
     "test:node": "node --test \"tests/*.js\"",
-    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
+    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/chat-history-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
   },
   "dependencies": {
     "@dotagents/shared": "workspace:^",

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -83,6 +83,7 @@ import { formatVoiceDebugEntry, useVoiceDebug } from '../lib/voice/voiceDebug';
 import { useSpeechRecognizer } from '../lib/voice/useSpeechRecognizer';
 import { useHandsFreeController } from '../lib/voice/useHandsFreeController';
 import { createDelegationProgressMessages } from '../lib/delegationProgress';
+import { buildChatMessagesFromHistory, isSyntheticToolFailureSummary } from './chat-history-utils';
 
 interface PendingImageAttachment {
   id: string;
@@ -304,6 +305,17 @@ const getCollapsedMessagePreview = (content: string) =>
     .trim();
 
 const TOOL_PAYLOAD_PREFIX_REGEX = /^(?:using tool:|tool result:)/i;
+
+const shouldHideSyntheticToolFailureSummaryMessage = (
+  message: ChatMessage,
+  previousMessage?: ChatMessage,
+): boolean => (
+  message.role === 'assistant' &&
+  isSyntheticToolFailureSummary(message.content) &&
+  previousMessage?.role === 'assistant' &&
+  (previousMessage.toolCalls?.length ?? 0) > 0 &&
+  (previousMessage.toolResults?.some((result) => result?.success === false) ?? false)
+);
 
 const getRespondToUserContentFromMessage = (message: ChatMessage): string | null => {
   if (message.role !== 'assistant' || !message.toolCalls?.length) {
@@ -1729,38 +1741,7 @@ export default function ChatScreen({ route, navigation }: any) {
       const hasAssistantMessages = currentTurnStartIndex + 1 < update.conversationHistory.length;
       if (hasAssistantMessages) {
         messages.length = 0;
-
-        for (let i = currentTurnStartIndex + 1; i < update.conversationHistory.length; i++) {
-          const historyMsg = update.conversationHistory[i];
-
-          // Merge tool results into the preceding assistant message to avoid duplication
-          // The server sends: assistant (with toolCalls) -> tool (with toolResults)
-          // We want to display them as a single message with both toolCalls and toolResults
-          if (historyMsg.role === 'tool' && messages.length > 0) {
-            const lastMessage = messages[messages.length - 1];
-            if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-
-              if (hasToolResults) {
-                // Merge toolResults into the existing assistant message
-                lastMessage.toolResults = [
-                  ...(lastMessage.toolResults || []),
-                  ...(historyMsg.toolResults || []),
-                ];
-                // Skip adding this as a separate message only when we merged results
-                continue;
-              }
-              // If tool message has content but no toolResults, fall through to add it as a message
-            }
-          }
-
-          messages.push({
-            role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-            content: historyMsg.content || '',
-            toolCalls: historyMsg.toolCalls,
-            toolResults: historyMsg.toolResults,
-          });
-        }
+        messages.push(...buildChatMessagesFromHistory(update.conversationHistory, { startFromLastUser: true }));
       }
     }
 
@@ -2140,40 +2121,8 @@ export default function ChatScreen({ route, navigation }: any) {
         }
         console.log('[ChatScreen] currentTurnStartIndex:', currentTurnStartIndex);
 
-        const newMessages: ChatMessage[] = [];
-        for (let i = currentTurnStartIndex; i < response.conversationHistory.length; i++) {
-          const historyMsg = response.conversationHistory[i];
-          if (historyMsg.role === 'user') continue;
-
-          // Merge tool results into the preceding assistant message to avoid duplication
-          // The server sends: assistant (with toolCalls) -> tool (with toolResults)
-          // We want to display them as a single message with both toolCalls and toolResults
-          if (historyMsg.role === 'tool' && newMessages.length > 0) {
-            const lastMessage = newMessages[newMessages.length - 1];
-            if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-
-              if (hasToolResults) {
-                // Merge toolResults into the existing assistant message
-                lastMessage.toolResults = [
-                  ...(lastMessage.toolResults || []),
-                  ...(historyMsg.toolResults || []),
-                ];
-                // Skip adding this as a separate message only when we merged results
-                continue;
-              }
-              // If tool message has content but no toolResults, fall through to add it as a message
-            }
-          }
-
-          newMessages.push({
-            role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-            content: historyMsg.content || '',
-            toolCalls: historyMsg.toolCalls,
-            toolResults: historyMsg.toolResults,
-          });
-        }
-		        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
+        const newMessages = buildChatMessagesFromHistory(response.conversationHistory, { startFromLastUser: true });
+	        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
 	        console.log('[ChatScreen] newMessages count:', finalTurnMessages.length);
 	        console.log('[ChatScreen] newMessages roles:', finalTurnMessages.map(m => `${m.role}(toolCalls:${m.toolCalls?.length || 0},toolResults:${m.toolResults?.length || 0})`).join(', '));
         console.log('[ChatScreen] messageCountBeforeTurn:', messageCountBeforeTurn);
@@ -2547,17 +2496,7 @@ export default function ChatScreen({ route, navigation }: any) {
           }
         }
 
-        const newMessages: ChatMessage[] = [];
-        for (let i = currentTurnStartIndex; i < response.conversationHistory.length; i++) {
-          const historyMsg = response.conversationHistory[i];
-          if (historyMsg.role === 'user') continue;
-          newMessages.push({
-            role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-            content: historyMsg.content || '',
-            toolCalls: historyMsg.toolCalls,
-            toolResults: historyMsg.toolResults,
-          });
-        }
+        const newMessages = buildChatMessagesFromHistory(response.conversationHistory, { startFromLastUser: true });
 	        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
 
         setMessages((m) => {
@@ -3061,6 +3000,11 @@ export default function ChatScreen({ route, navigation }: any) {
               visibleMessageContent.trim().length > 0 &&
               config.ttsEnabled !== false &&
               (shouldShowExpandedContent || shouldShowCollapsedTextPreview);
+
+            const previousMessage = i > 0 ? messages[i - 1] : undefined;
+            if (shouldHideSyntheticToolFailureSummaryMessage(m, previousMessage)) {
+              return null;
+            }
 
             const toolCalls = m.toolCalls ?? [];
             const toolResults = m.toolResults ?? [];
@@ -3590,35 +3534,10 @@ export default function ChatScreen({ route, navigation }: any) {
                           // Update the server conversation ID
                           await sessionStore.setServerConversationId(recoveryConversationId);
 
-                          // Convert server messages to ChatMessage format, filtering out tool messages
-                          // and merging their toolResults into the preceding assistant message
-                          const recoveredMessages: ChatMessage[] = [];
-                          for (const msg of serverMessages) {
-                            // Only include 'user' and 'assistant' roles
-                            if (msg.role === 'user' || msg.role === 'assistant') {
-                              recoveredMessages.push({
-                                id: msg.id,
-                                role: msg.role,
-                                content: msg.content,
-                                toolCalls: msg.toolCalls,
-                                toolResults: msg.toolResults,
-                              });
-                            } else if (msg.role === 'tool' && recoveredMessages.length > 0) {
-                              // Merge tool message toolResults into the preceding assistant message
-                              const lastMessage = recoveredMessages[recoveredMessages.length - 1];
-                              if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-                                const hasToolResults = msg.toolResults && msg.toolResults.length > 0;
-
-                                if (hasToolResults) {
-                                  // Merge toolResults into the existing assistant message
-                                  lastMessage.toolResults = [
-                                    ...(lastMessage.toolResults || []),
-                                    ...(msg.toolResults || []),
-                                  ];
-                                }
-                              }
-                            }
-                          }
+                          const recoveredMessages = buildChatMessagesFromHistory(serverMessages, {
+                            includeUserMessages: true,
+                            startFromLastUser: false,
+                          });
 
                           // Replace local messages with server state
                           setMessages(recoveredMessages);

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -15,6 +15,7 @@ import { ChatMessage, AgentProgressUpdate } from '../lib/openaiClient';
 import { SettingsApiClient } from '../lib/settingsApi';
 import { SessionListItem, isStubSession } from '../types/session';
 import { createButtonAccessibilityLabel, createMinimumTouchTargetStyle, createTextInputAccessibilityLabel } from '../lib/accessibility';
+import { buildChatMessagesFromHistory, isSyntheticToolFailureSummary } from './chat-history-utils';
 import { filterSessionSearchResults, type SessionSearchResult } from './session-list-search';
 
 const darkSpinner = require('../../assets/loading-spinner.gif');
@@ -93,44 +94,7 @@ export default function SessionListScreen({ navigation }: Props) {
   }, [normalizeVoiceText]);
 
   const rfBuildMessagesFromHistory = useCallback((history: any[]): ChatMessage[] => {
-    if (!history || history.length === 0) return [];
-
-    let currentTurnStartIndex = 0;
-    for (let i = 0; i < history.length; i++) {
-      if (history[i]?.role === 'user') {
-        currentTurnStartIndex = i;
-      }
-    }
-
-    const messages: ChatMessage[] = [];
-    for (let i = currentTurnStartIndex + 1; i < history.length; i++) {
-      const historyMsg = history[i];
-      if (!historyMsg) continue;
-
-      // Merge tool results into the preceding assistant message, matching ChatScreen behavior.
-      if (historyMsg.role === 'tool' && messages.length > 0) {
-        const lastMessage = messages[messages.length - 1];
-        if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-          const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-          if (hasToolResults) {
-            lastMessage.toolResults = [
-              ...(lastMessage.toolResults || []),
-              ...(historyMsg.toolResults || []),
-            ];
-            continue;
-          }
-        }
-      }
-
-      messages.push({
-        role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-        content: historyMsg.content || '',
-        toolCalls: historyMsg.toolCalls,
-        toolResults: historyMsg.toolResults,
-      });
-    }
-
-    return messages;
+    return buildChatMessagesFromHistory(history, { startFromLastUser: true });
   }, []);
 
   const rfRunBackgroundSend = useCallback(async (sessionId: string, userText: string) => {
@@ -846,7 +810,9 @@ export default function SessionListScreen({ navigation }: Props) {
     const isActive = item.id === sessionStore.currentSessionId;
     const isStub = stubSessionIds.has(item.id);
     const rawPreview = (item.searchPreview ?? item.preview) || 'No messages yet';
-    const sessionPreviewText = rawPreview.startsWith('tool: [') || rawPreview.includes('{"success":')
+    const sessionPreviewText = isSyntheticToolFailureSummary(rawPreview)
+      ? 'Tool failed'
+      : rawPreview.startsWith('tool: [') || rawPreview.includes('{"success":')
       ? 'Used a tool'
       : rawPreview.includes('{"')
         ? rawPreview.replace(/\{.*\}/g, '{...}').trim()

--- a/apps/mobile/src/screens/chat-history-utils.test.ts
+++ b/apps/mobile/src/screens/chat-history-utils.test.ts
@@ -43,6 +43,34 @@ describe('chat-history-utils', () => {
     });
   });
 
+  it('keeps synthetic tool failure summaries when they are the only failure signal', () => {
+    const messages = buildChatMessagesFromHistory([
+      { role: 'user', content: 'Open the missing file', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        toolCalls: [{ name: 'read_file', arguments: { path: 'package.json.missing' } }],
+      },
+      {
+        role: 'tool',
+        content: 'TOOL FAILED: read_file (attempt 1/3)\nError: ENOENT: package.json.missing',
+        timestamp: 3,
+      },
+    ]);
+
+    expect(messages).toEqual([
+      expect.objectContaining({
+        role: 'assistant',
+        toolCalls: [{ name: 'read_file', arguments: { path: 'package.json.missing' } }],
+      }),
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'TOOL FAILED: read_file (attempt 1/3)\nError: ENOENT: package.json.missing',
+      }),
+    ]);
+  });
+
   it('keeps user messages when requested', () => {
     const messages = buildChatMessagesFromHistory(
       [

--- a/apps/mobile/src/screens/chat-history-utils.test.ts
+++ b/apps/mobile/src/screens/chat-history-utils.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { buildChatMessagesFromHistory, isSyntheticToolFailureSummary } from './chat-history-utils';
+
+describe('chat-history-utils', () => {
+  it('drops synthetic tool failure summaries when structured tool results already exist', () => {
+    const messages = buildChatMessagesFromHistory([
+      { role: 'user', content: 'Search for the latest status', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        toolCalls: [{ name: 'search_query', arguments: { q: 'latest status' } }],
+      },
+      {
+        role: 'tool',
+        content: '[search_query] ERROR: Request timed out while fetching search results.',
+        timestamp: 3,
+        toolResults: [
+          {
+            success: false,
+            content: 'Request timed out while fetching search results.',
+            error: 'Request timed out while fetching search results.',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: 'TOOL FAILED: search_query (attempt 1/3)\nError: Request timed out while fetching search results.',
+        timestamp: 4,
+      },
+    ]);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      role: 'assistant',
+      toolCalls: [{ name: 'search_query' }],
+      toolResults: [
+        expect.objectContaining({
+          success: false,
+          error: 'Request timed out while fetching search results.',
+        }),
+      ],
+    });
+  });
+
+  it('keeps user messages when requested', () => {
+    const messages = buildChatMessagesFromHistory(
+      [
+        { role: 'user', content: 'Hello', timestamp: 1 },
+        { role: 'assistant', content: 'Hi', timestamp: 2 },
+      ],
+      { includeUserMessages: true, startFromLastUser: false },
+    );
+
+    expect(messages).toEqual([
+      expect.objectContaining({ role: 'user', content: 'Hello' }),
+      expect.objectContaining({ role: 'assistant', content: 'Hi' }),
+    ]);
+  });
+
+  it('detects the synthetic failure marker', () => {
+    expect(isSyntheticToolFailureSummary('TOOL FAILED: search_query')).toBe(true);
+    expect(isSyntheticToolFailureSummary('Tool failed softly')).toBe(false);
+  });
+});

--- a/apps/mobile/src/screens/chat-history-utils.ts
+++ b/apps/mobile/src/screens/chat-history-utils.ts
@@ -1,0 +1,76 @@
+import type { ChatMessage } from '../lib/openaiClient';
+
+type HistoryMessageLike = {
+  id?: string;
+  role: 'user' | 'assistant' | 'tool';
+  content?: string;
+  timestamp?: number;
+  toolCalls?: ChatMessage['toolCalls'];
+  toolResults?: ChatMessage['toolResults'];
+};
+
+type BuildChatMessagesOptions = {
+  includeUserMessages?: boolean;
+  startFromLastUser?: boolean;
+};
+
+const SYNTHETIC_TOOL_FAILURE_SUMMARY_REGEX = /^TOOL FAILED:/i;
+
+export function isSyntheticToolFailureSummary(content?: string): boolean {
+  return SYNTHETIC_TOOL_FAILURE_SUMMARY_REGEX.test(content?.trim() ?? '');
+}
+
+export function buildChatMessagesFromHistory(
+  history: Array<HistoryMessageLike | null | undefined>,
+  options: BuildChatMessagesOptions = {},
+): ChatMessage[] {
+  const { includeUserMessages = false, startFromLastUser = true } = options;
+
+  if (!history.length) {
+    return [];
+  }
+
+  let startIndex = 0;
+  if (startFromLastUser) {
+    for (let i = 0; i < history.length; i += 1) {
+      if (history[i]?.role === 'user') {
+        startIndex = i;
+      }
+    }
+  }
+
+  const messages: ChatMessage[] = [];
+  for (let i = startIndex; i < history.length; i += 1) {
+    const historyMsg = history[i];
+    if (!historyMsg) continue;
+    if (!includeUserMessages && historyMsg.role === 'user') continue;
+
+    if (historyMsg.role === 'tool' && messages.length > 0) {
+      const lastMessage = messages[messages.length - 1];
+      if (lastMessage.role === 'assistant' && (lastMessage.toolCalls?.length ?? 0) > 0) {
+        if ((historyMsg.toolResults?.length ?? 0) > 0) {
+          lastMessage.toolResults = [
+            ...(lastMessage.toolResults || []),
+            ...historyMsg.toolResults!,
+          ];
+          continue;
+        }
+
+        if (isSyntheticToolFailureSummary(historyMsg.content)) {
+          continue;
+        }
+      }
+    }
+
+    messages.push({
+      id: historyMsg.id,
+      role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
+      content: historyMsg.content || '',
+      timestamp: historyMsg.timestamp,
+      toolCalls: historyMsg.toolCalls,
+      toolResults: historyMsg.toolResults,
+    });
+  }
+
+  return messages;
+}

--- a/apps/mobile/src/screens/chat-history-utils.ts
+++ b/apps/mobile/src/screens/chat-history-utils.ts
@@ -56,7 +56,10 @@ export function buildChatMessagesFromHistory(
           continue;
         }
 
-        if (isSyntheticToolFailureSummary(historyMsg.content)) {
+        if (
+          isSyntheticToolFailureSummary(historyMsg.content)
+          && (lastMessage.toolResults?.length ?? 0) > 0
+        ) {
           continue;
         }
       }


### PR DESCRIPTION
## Summary
- centralize mobile chat history message building into a shared utility
- merge tool results into the preceding assistant message consistently across chat and session flows
- hide synthetic `TOOL FAILED:` summary messages when structured tool failure results already exist
- update session previews to show `Tool failed` for synthetic failure summaries
- add coverage for chat history utility behavior and include the new test file in the mobile Vitest script

## Testing
- Not run (not requested)