### PR TITLE
Add Community Hub browsing and legacy bundle compatibility

### DIFF
--- a/apps/desktop/src/main/bundle-service.test.ts
+++ b/apps/desktop/src/main/bundle-service.test.ts
@@ -524,6 +524,80 @@ describe("bundle-service", () => {
       expect(result?.manifest.components.knowledgeNotes).toBe(0)
     })
 
+    it("accepts legacy Hub bundles that still declare memories", async () => {
+      const legacyHubBundle = {
+        manifest: {
+          version: 1,
+          name: "Legacy Hub Bundle",
+          createdAt: new Date().toISOString(),
+          exportedFrom: "dotagents-hub",
+          components: {
+            agentProfiles: 0,
+            mcpServers: 0,
+            skills: 0,
+            repeatTasks: 0,
+            memories: 0,
+          },
+        },
+        agentProfiles: [],
+        mcpServers: [],
+        skills: [],
+        repeatTasks: [],
+        memories: [],
+      }
+
+      const bundlePath = path.join(tempDir, "legacy-hub.dotagents")
+      fs.writeFileSync(bundlePath, JSON.stringify(legacyHubBundle))
+
+      const result = previewBundle(bundlePath)
+      expect(result).not.toBeNull()
+      expect(result?.knowledgeNotes).toEqual([])
+      expect(result?.manifest.components.knowledgeNotes).toBe(0)
+    })
+
+    it('accepts public Hub bundles with legacy "assistant" profile roles', async () => {
+      const legacyHubBundle = {
+        manifest: {
+          version: 1,
+          name: "Public Hub Bundle",
+          createdAt: new Date().toISOString(),
+          exportedFrom: "dotagents-hub",
+          components: {
+            agentProfiles: 1,
+            mcpServers: 0,
+            skills: 0,
+            repeatTasks: 0,
+            memories: 0,
+          },
+        },
+        agentProfiles: [
+          {
+            id: "personal-assistant",
+            name: "personal-assistant",
+            displayName: "Personal Assistant",
+            enabled: true,
+            role: "assistant",
+            connection: {
+              type: "internal",
+            },
+          },
+        ],
+        mcpServers: [],
+        skills: [],
+        repeatTasks: [],
+        memories: [],
+      }
+
+      const bundlePath = path.join(tempDir, "public-hub.dotagents")
+      fs.writeFileSync(bundlePath, JSON.stringify(legacyHubBundle))
+
+      const result = previewBundle(bundlePath)
+      expect(result).not.toBeNull()
+      expect(result?.agentProfiles[0].role).toBeUndefined()
+      expect(result?.manifest.components.agentProfiles).toBe(1)
+      expect(result?.manifest.components.knowledgeNotes).toBe(0)
+    })
+
     it("handles legacy bundles with metadata-only skills", async () => {
       const oldBundle = {
         manifest: {
@@ -1258,6 +1332,42 @@ describe("bundle-service", () => {
         baseUrl: "https://agents.example.com",
       })
       expect(imported?.connection.env).toBeUndefined()
+    })
+
+    it('imports public Hub bundles that still use the legacy "assistant" profile role', async () => {
+      const bundlePath = path.join(tempDir, "import-public-hub.dotagents")
+      fs.writeFileSync(bundlePath, JSON.stringify({
+        manifest: {
+          version: 1,
+          name: "Public Hub Import",
+          createdAt: new Date().toISOString(),
+          exportedFrom: "dotagents-hub",
+          components: { agentProfiles: 1, mcpServers: 0, skills: 0, repeatTasks: 0, memories: 0 },
+        },
+        agentProfiles: [
+          {
+            id: "personal-assistant",
+            name: "personal-assistant",
+            displayName: "Personal Assistant",
+            enabled: true,
+            role: "assistant",
+            connection: { type: "internal" },
+          },
+        ],
+        mcpServers: [],
+        skills: [],
+        repeatTasks: [],
+        memories: [],
+      }))
+
+      const result = await importBundle(bundlePath, targetDir, { conflictStrategy: "skip" })
+      const layer = getAgentsLayerPaths(targetDir)
+      const imported = loadAgentProfilesLayer(layer).profiles.find((profile) => profile.id === "personal-assistant")
+
+      expect(result.success).toBe(true)
+      expect(imported).toBeTruthy()
+      expect(imported?.role).toBeUndefined()
+      expect(imported?.connection.type).toBe("internal")
     })
 
     it("respects component selection", async () => {

--- a/apps/desktop/src/main/bundle-service.ts
+++ b/apps/desktop/src/main/bundle-service.ts
@@ -71,7 +71,7 @@ export interface BundleAgentProfile {
   displayName?: string
   description?: string
   enabled: boolean
-  role?: AgentProfileRole
+  role?: AgentProfileRole | "assistant"
   systemPrompt?: string
   guidelines?: string
   connection: {
@@ -318,6 +318,7 @@ const MCP_SERVER_CONFIG_KEYS = [
 ] as const
 const AGENT_PROFILE_CONNECTION_TYPES = ["internal", "acp", "stdio", "remote"] as const
 const AGENT_PROFILE_ROLES = ["user-profile", "delegation-target", "external-agent"] as const
+const LEGACY_PUBLIC_AGENT_PROFILE_ROLES = ["assistant"] as const
 
 function isReservedTopLevelMcpKey(key: string): boolean {
   if (key === "mcpConfig" || key === "mcpServers") return true
@@ -1037,6 +1038,7 @@ export function findHubBundleHandoffFilePath(candidates: readonly string[]): str
 type BundleManifestInputComponents = Omit<BundleManifest["components"], "repeatTasks" | "knowledgeNotes"> & {
   repeatTasks?: number
   knowledgeNotes?: number
+  memories?: number
 }
 
 type ParsedDotAgentsBundle = Omit<DotAgentsBundle, "manifest" | "repeatTasks" | "knowledgeNotes"> & {
@@ -1045,6 +1047,7 @@ type ParsedDotAgentsBundle = Omit<DotAgentsBundle, "manifest" | "repeatTasks" | 
   }
   repeatTasks?: BundleRepeatTask[]
   knowledgeNotes?: BundleKnowledgeNote[]
+  memories?: unknown[]
 }
 
 function isNonEmptyString(value: unknown): value is string {
@@ -1092,6 +1095,15 @@ function isAgentProfileRole(value: unknown): value is AgentProfileRole {
   return typeof value === "string" && (AGENT_PROFILE_ROLES as readonly string[]).includes(value)
 }
 
+function isBundleAgentProfileRole(value: unknown): value is BundleAgentProfile["role"] {
+  return typeof value === "string" &&
+    [...AGENT_PROFILE_ROLES, ...LEGACY_PUBLIC_AGENT_PROFILE_ROLES].includes(value as any)
+}
+
+function normalizeBundleAgentProfileRole(role: BundleAgentProfile["role"]): AgentProfileRole | undefined {
+  return role === "assistant" ? undefined : role
+}
+
 function isBundleAgentProfile(value: unknown): value is BundleAgentProfile {
   if (!isRecordObject(value)) return false
   if (!isNonEmptyString(value.id)) return false
@@ -1099,7 +1111,7 @@ function isBundleAgentProfile(value: unknown): value is BundleAgentProfile {
   if (typeof value.enabled !== "boolean") return false
   if (!isOptionalString(value.displayName)) return false
   if (!isOptionalString(value.description)) return false
-  if (value.role !== undefined && !isAgentProfileRole(value.role)) return false
+  if (value.role !== undefined && !isBundleAgentProfileRole(value.role)) return false
   if (!isOptionalString(value.systemPrompt)) return false
   if (!isOptionalString(value.guidelines)) return false
   if (!isRecordObject(value.connection)) return false
@@ -1162,6 +1174,7 @@ function hasValidManifestComponents(value: unknown): value is BundleManifestInpu
   if (!isNonNegativeFiniteNumber(value.skills)) return false
   if (value.repeatTasks !== undefined && !isNonNegativeFiniteNumber(value.repeatTasks)) return false
   if (value.knowledgeNotes !== undefined && !isNonNegativeFiniteNumber(value.knowledgeNotes)) return false
+  if (value.memories !== undefined && !isNonNegativeFiniteNumber(value.memories)) return false
   return true
 }
 
@@ -1186,20 +1199,27 @@ function validateBundle(bundle: unknown): bundle is ParsedDotAgentsBundle {
   if ("knowledgeNotes" in b && b.knowledgeNotes !== undefined) {
     if (!Array.isArray(b.knowledgeNotes) || !b.knowledgeNotes.every(isBundleKnowledgeNote)) return false
   }
+  if ("memories" in b && b.memories !== undefined && !Array.isArray(b.memories)) return false
   return true
 }
 
 function normalizeBundle(bundle: ParsedDotAgentsBundle): DotAgentsBundle {
   const repeatTasks = Array.isArray(bundle.repeatTasks) ? bundle.repeatTasks : []
   const knowledgeNotes = Array.isArray(bundle.knowledgeNotes) ? bundle.knowledgeNotes : []
+  const legacyMemories = Array.isArray(bundle.memories) ? bundle.memories : []
   const rawComponents = isRecordObject(bundle.manifest.components)
     ? (bundle.manifest.components as Record<string, unknown>)
     : {}
   const countOrFallback = (value: unknown, fallback: number): number =>
     typeof value === "number" && Number.isFinite(value) ? value : fallback
+  const knowledgeNotesCountFallback = knowledgeNotes.length > 0 ? knowledgeNotes.length : legacyMemories.length
 
   return {
     ...bundle,
+    agentProfiles: bundle.agentProfiles.map((profile) => ({
+      ...profile,
+      role: normalizeBundleAgentProfileRole(profile.role),
+    })),
     manifest: {
       ...bundle.manifest,
       components: {
@@ -1207,7 +1227,10 @@ function normalizeBundle(bundle: ParsedDotAgentsBundle): DotAgentsBundle {
         mcpServers: countOrFallback(rawComponents.mcpServers, bundle.mcpServers.length),
         skills: countOrFallback(rawComponents.skills, bundle.skills.length),
         repeatTasks: countOrFallback(rawComponents.repeatTasks, repeatTasks.length),
-        knowledgeNotes: countOrFallback(rawComponents.knowledgeNotes, knowledgeNotes.length),
+        knowledgeNotes: countOrFallback(
+          rawComponents.knowledgeNotes ?? rawComponents.memories,
+          knowledgeNotesCountFallback,
+        ),
       },
     },
     repeatTasks,
@@ -1440,7 +1463,7 @@ export async function importBundle(
           systemPrompt: bundleProfile.systemPrompt,
           guidelines: bundleProfile.guidelines,
           connection,
-          role: bundleProfile.role,
+          role: normalizeBundleAgentProfileRole(bundleProfile.role),
           enabled: bundleProfile.enabled,
           createdAt: now,
           updatedAt: now,

--- a/apps/desktop/src/main/hub-catalog.test.ts
+++ b/apps/desktop/src/main/hub-catalog.test.ts
@@ -1,0 +1,77 @@
+import {
+  buildHubBundleDownloadUrls,
+  buildHubCatalogRawBundleUrl,
+  normalizeHubCatalogResponse,
+} from "./hub-catalog"
+
+describe("hub-catalog", () => {
+  it("normalizes legacy memories counts into knowledge notes", () => {
+    const result = normalizeHubCatalogResponse({
+      version: 1,
+      updatedAt: "2026-03-07T00:00:00.000Z",
+      items: [
+        {
+          id: "content-creator",
+          name: "Content Creator",
+          summary: "Writing and social bundle",
+          author: { displayName: "TechFriend AJ" },
+          tags: ["content", "starter", ""],
+          bundleVersion: 1,
+          componentCounts: {
+            agentProfiles: 2,
+            mcpServers: 1,
+            skills: 1,
+            repeatTasks: 2,
+            memories: 3,
+          },
+          artifact: {
+            url: "https://hub.dotagentsprotocol.com/bundles/content-creator.dotagents",
+            fileName: "content-creator.dotagents",
+            sizeBytes: 5931,
+          },
+          publishedAt: "2026-03-07T00:00:00.000Z",
+          updatedAt: "2026-03-07T00:00:00.000Z",
+        },
+        {
+          id: "",
+          name: "Broken",
+          summary: "Should be ignored",
+        },
+      ],
+    })
+
+    expect(result.updatedAt).toBe("2026-03-07T00:00:00.000Z")
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].componentCounts).toEqual({
+      agentProfiles: 2,
+      mcpServers: 1,
+      skills: 1,
+      repeatTasks: 2,
+      knowledgeNotes: 3,
+    })
+    expect(result.items[0].tags).toEqual(["content", "starter"])
+  })
+
+  it("prefers the raw GitHub artifact when the catalog points at the Hub website", () => {
+    const fileName = "personal-assistant.dotagents"
+
+    expect(buildHubBundleDownloadUrls({
+      artifactUrl: "https://hub.dotagentsprotocol.com/bundles/personal-assistant.dotagents",
+      fileName,
+      catalogId: "personal-assistant",
+    })).toEqual([
+      buildHubCatalogRawBundleUrl(fileName),
+      "https://hub.dotagentsprotocol.com/bundles/personal-assistant.dotagents",
+    ])
+  })
+
+  it("falls back to the raw artifact only once when the artifact already points to GitHub", () => {
+    const rawUrl = buildHubCatalogRawBundleUrl("research-analyst.dotagents")
+
+    expect(buildHubBundleDownloadUrls({
+      artifactUrl: rawUrl,
+      fileName: "research-analyst.dotagents",
+      catalogId: "research-analyst",
+    })).toEqual([rawUrl])
+  })
+})

--- a/apps/desktop/src/main/hub-catalog.ts
+++ b/apps/desktop/src/main/hub-catalog.ts
@@ -1,0 +1,199 @@
+import type { HubCatalogComponentCounts, HubCatalogItem } from "@dotagents/shared"
+import { downloadHubBundleToTempFile } from "./hub-install"
+
+export const HUB_CATALOG_URL = "https://raw.githubusercontent.com/aj47/dotagents-hub/main/catalog.json"
+
+const HUB_RAW_BUNDLES_BASE_URL = "https://raw.githubusercontent.com/aj47/dotagents-hub/main/bundles/"
+
+interface RawHubCatalogComponentCounts extends Partial<HubCatalogComponentCounts> {
+  memories?: unknown
+}
+
+interface RawHubCatalogItem extends Omit<HubCatalogItem, "componentCounts"> {
+  componentCounts?: RawHubCatalogComponentCounts
+}
+
+interface RawHubCatalogResponse {
+  version?: unknown
+  updatedAt?: unknown
+  items?: unknown[]
+}
+
+export interface HubCatalogResponse {
+  version: 1
+  updatedAt: string
+  items: HubCatalogItem[]
+}
+
+export interface DownloadHubCatalogBundleOptions {
+  artifactUrl: string
+  fileName?: string
+  catalogId?: string
+}
+
+export interface DownloadHubCatalogBundleResult {
+  filePath: string
+  downloadedFrom: string
+}
+
+function toNonNegativeInt(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return 0
+  }
+
+  return Math.trunc(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0
+}
+
+function normalizeTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) {
+    return []
+  }
+
+  return tags
+    .filter((tag): tag is string => isNonEmptyString(tag))
+    .map((tag) => tag.trim())
+}
+
+function normalizeComponentCounts(
+  componentCounts: RawHubCatalogComponentCounts | undefined,
+): HubCatalogComponentCounts {
+  return {
+    agentProfiles: toNonNegativeInt(componentCounts?.agentProfiles),
+    mcpServers: toNonNegativeInt(componentCounts?.mcpServers),
+    skills: toNonNegativeInt(componentCounts?.skills),
+    repeatTasks: toNonNegativeInt(componentCounts?.repeatTasks),
+    knowledgeNotes: toNonNegativeInt(componentCounts?.knowledgeNotes ?? componentCounts?.memories),
+  }
+}
+
+function normalizeCatalogItem(item: unknown): HubCatalogItem | null {
+  if (!item || typeof item !== "object") {
+    return null
+  }
+
+  const raw = item as RawHubCatalogItem
+
+  if (
+    !isNonEmptyString(raw.id) ||
+    !isNonEmptyString(raw.name) ||
+    !isNonEmptyString(raw.summary) ||
+    !raw.author ||
+    typeof raw.author !== "object" ||
+    !isNonEmptyString(raw.author.displayName) ||
+    !raw.artifact ||
+    typeof raw.artifact !== "object" ||
+    !isNonEmptyString(raw.artifact.url) ||
+    !isNonEmptyString(raw.artifact.fileName) ||
+    !isNonEmptyString(raw.publishedAt) ||
+    !isNonEmptyString(raw.updatedAt)
+  ) {
+    return null
+  }
+
+  return {
+    id: raw.id.trim(),
+    name: raw.name.trim(),
+    summary: raw.summary.trim(),
+    description: isNonEmptyString(raw.description) ? raw.description.trim() : undefined,
+    author: {
+      displayName: raw.author.displayName.trim(),
+      handle: isNonEmptyString(raw.author.handle) ? raw.author.handle.trim() : undefined,
+      url: isNonEmptyString(raw.author.url) ? raw.author.url.trim() : undefined,
+    },
+    tags: normalizeTags(raw.tags),
+    bundleVersion: 1,
+    componentCounts: normalizeComponentCounts(raw.componentCounts),
+    artifact: {
+      url: raw.artifact.url.trim(),
+      fileName: raw.artifact.fileName.trim(),
+      sizeBytes: toNonNegativeInt(raw.artifact.sizeBytes),
+    },
+    publishedAt: raw.publishedAt.trim(),
+    updatedAt: raw.updatedAt.trim(),
+    compatibility: raw.compatibility,
+  }
+}
+
+export function normalizeHubCatalogResponse(rawResponse: RawHubCatalogResponse): HubCatalogResponse {
+  const items = Array.isArray(rawResponse.items)
+    ? rawResponse.items
+      .map((item) => normalizeCatalogItem(item))
+      .filter((item): item is HubCatalogItem => item !== null)
+    : []
+
+  return {
+    version: 1,
+    updatedAt: isNonEmptyString(rawResponse.updatedAt)
+      ? rawResponse.updatedAt.trim()
+      : new Date(0).toISOString(),
+    items,
+  }
+}
+
+export function buildHubCatalogRawBundleUrl(fileName: string): string {
+  return new URL(fileName, HUB_RAW_BUNDLES_BASE_URL).toString()
+}
+
+export function buildHubBundleDownloadUrls(
+  options: DownloadHubCatalogBundleOptions,
+): string[] {
+  const artifactUrl = isNonEmptyString(options.artifactUrl) ? options.artifactUrl.trim() : ""
+  const fileName = isNonEmptyString(options.fileName)
+    ? options.fileName.trim()
+    : isNonEmptyString(options.catalogId)
+      ? `${options.catalogId.trim()}.dotagents`
+      : ""
+  const rawBundleUrl = fileName ? buildHubCatalogRawBundleUrl(fileName) : ""
+
+  let preferRawBundleUrl = false
+  if (artifactUrl) {
+    try {
+      preferRawBundleUrl = new URL(artifactUrl).hostname === "hub.dotagentsprotocol.com"
+    } catch {
+      preferRawBundleUrl = false
+    }
+  }
+
+  const orderedUrls = preferRawBundleUrl
+    ? [rawBundleUrl, artifactUrl]
+    : [artifactUrl, rawBundleUrl]
+
+  return orderedUrls.filter((url, index) => isNonEmptyString(url) && orderedUrls.indexOf(url) === index)
+}
+
+export async function fetchHubCatalog(catalogUrl: string = HUB_CATALOG_URL): Promise<HubCatalogResponse> {
+  const response = await fetch(catalogUrl)
+  if (!response.ok) {
+    const statusSuffix = response.statusText ? ` ${response.statusText}` : ""
+    throw new Error(`Hub catalog request failed with ${response.status}${statusSuffix}`)
+  }
+
+  const rawCatalog = await response.json()
+  return normalizeHubCatalogResponse(rawCatalog as RawHubCatalogResponse)
+}
+
+export async function downloadHubCatalogBundle(
+  options: DownloadHubCatalogBundleOptions,
+): Promise<DownloadHubCatalogBundleResult> {
+  const downloadUrls = buildHubBundleDownloadUrls(options)
+  let lastError: unknown = null
+
+  for (const downloadUrl of downloadUrls) {
+    try {
+      const filePath = await downloadHubBundleToTempFile(downloadUrl)
+      return { filePath, downloadedFrom: downloadUrl }
+    } catch (error) {
+      lastError = error
+    }
+  }
+
+  if (lastError instanceof Error) {
+    throw lastError
+  }
+
+  throw new Error("Failed to download Hub bundle")
+}

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -4622,6 +4622,22 @@ export const router = {
     )
   }),
 
+  getHubCatalog: t.procedure.action(async () => {
+    const { fetchHubCatalog } = await import("./hub-catalog")
+    return fetchHubCatalog()
+  }),
+
+  downloadHubCatalogBundle: t.procedure
+    .input<{
+      artifactUrl: string
+      fileName?: string
+      catalogId?: string
+    }>()
+    .action(async ({ input }) => {
+      const { downloadHubCatalogBundle } = await import("./hub-catalog")
+      return downloadHubCatalogBundle(input)
+    }),
+
   exportBundle: t.procedure
     .input<{
       name?: string

--- a/apps/desktop/src/renderer/src/components/hub-catalog-browser.tsx
+++ b/apps/desktop/src/renderer/src/components/hub-catalog-browser.tsx
@@ -1,0 +1,251 @@
+import { useMemo, useState } from "react"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import type { HubCatalogItem } from "@dotagents/shared"
+import { buildHubBundleInstallUrl } from "@dotagents/shared"
+import { Badge } from "@renderer/components/ui/badge"
+import { Button } from "@renderer/components/ui/button"
+import { Input } from "@renderer/components/ui/input"
+import { copyTextToClipboard } from "@renderer/lib/clipboard"
+import { tipcClient } from "@renderer/lib/tipc-client"
+import { Download, Loader2, Package, RefreshCw, Search } from "lucide-react"
+import { toast } from "sonner"
+
+interface HubCatalogResponse {
+  version: 1
+  updatedAt: string
+  items: HubCatalogItem[]
+}
+
+interface HubCatalogBrowserProps {
+  onPreviewInstall: (input: {
+    filePath: string
+    item: HubCatalogItem
+    downloadedFrom: string
+  }) => void
+}
+
+function formatUpdatedAt(updatedAt: string): string {
+  const parsed = new Date(updatedAt)
+  if (Number.isNaN(parsed.getTime())) {
+    return "Unknown"
+  }
+
+  return parsed.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+function buildCountBadges(item: HubCatalogItem): string[] {
+  const { componentCounts } = item
+  const counts: string[] = []
+
+  if (componentCounts.agentProfiles > 0) counts.push(`${componentCounts.agentProfiles} agents`)
+  if (componentCounts.mcpServers > 0) counts.push(`${componentCounts.mcpServers} MCP`)
+  if (componentCounts.skills > 0) counts.push(`${componentCounts.skills} skills`)
+  if (componentCounts.repeatTasks > 0) counts.push(`${componentCounts.repeatTasks} tasks`)
+  if (componentCounts.knowledgeNotes > 0) counts.push(`${componentCounts.knowledgeNotes} notes`)
+
+  return counts
+}
+
+export function HubCatalogBrowser({ onPreviewInstall }: HubCatalogBrowserProps) {
+  const [searchTerm, setSearchTerm] = useState("")
+
+  const catalogQuery = useQuery({
+    queryKey: ["hubCatalog"],
+    queryFn: async () => (await tipcClient.getHubCatalog()) as HubCatalogResponse,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const previewInstallMutation = useMutation({
+    mutationFn: async (item: HubCatalogItem) => {
+      return await tipcClient.downloadHubCatalogBundle({
+        artifactUrl: item.artifact.url,
+        fileName: item.artifact.fileName,
+        catalogId: item.id,
+      })
+    },
+    onSuccess: (result, item) => {
+      onPreviewInstall({
+        filePath: result.filePath,
+        item,
+        downloadedFrom: result.downloadedFrom,
+      })
+      toast.success(`Prepared ${item.name} for preview`)
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to prepare Hub bundle: ${error.message}`)
+    },
+  })
+
+  const filteredItems = useMemo(() => {
+    const normalizedQuery = searchTerm.trim().toLowerCase()
+    const items = catalogQuery.data?.items ?? []
+
+    if (!normalizedQuery) {
+      return items
+    }
+
+    return items.filter((item) => {
+      const haystack = [
+        item.name,
+        item.summary,
+        item.author.displayName,
+        item.author.handle,
+        ...item.tags,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+
+      return haystack.includes(normalizedQuery)
+    })
+  }, [catalogQuery.data?.items, searchTerm])
+
+  const copyInstallLink = async (item: HubCatalogItem) => {
+    try {
+      await copyTextToClipboard(buildHubBundleInstallUrl(item.artifact.url))
+      toast.success(`Install link copied for ${item.name}`)
+    } catch {
+      toast.error("Failed to copy install link")
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <Package className="h-4 w-4 text-muted-foreground" />
+              Community Hub
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Browse curated starter bundles from the DotAgents Hub and preview them in the existing conflict-aware import flow.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Catalog updated: {catalogQuery.data ? formatUpdatedAt(catalogQuery.data.updatedAt) : "Loading..."}
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <div className="relative min-w-[260px]">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                className="pl-8"
+                placeholder="Search bundles, tags, or authors"
+              />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => void catalogQuery.refetch()}
+              disabled={catalogQuery.isFetching}
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${catalogQuery.isFetching ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {catalogQuery.isLoading ? (
+        <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-center text-sm text-muted-foreground">
+          <div className="flex items-center justify-center gap-2 font-medium text-foreground/80">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            <span>Loading Hub catalog...</span>
+          </div>
+        </div>
+      ) : catalogQuery.isError ? (
+        <div className="rounded-lg border border-dashed border-destructive/30 bg-destructive/5 px-4 py-5 text-center">
+          <p className="text-sm font-medium text-destructive">Failed to load the Hub catalog.</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {catalogQuery.error instanceof Error ? catalogQuery.error.message : "Please try again."}
+          </p>
+        </div>
+      ) : filteredItems.length === 0 ? (
+        <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-center">
+          <p className="text-sm font-medium">No bundles match that search.</p>
+          <p className="mt-1 text-sm text-muted-foreground">Try another keyword or clear the filter.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+          {filteredItems.map((item) => {
+            const isPreparing = previewInstallMutation.isPending && previewInstallMutation.variables?.id === item.id
+
+            return (
+              <div key={item.id} className="rounded-xl border bg-card p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="text-base font-semibold">{item.name}</h3>
+                      <Badge variant="secondary" className="text-[10px] uppercase tracking-wide">
+                        bundle
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">{item.summary}</p>
+                  </div>
+                  <Badge variant="outline" className="shrink-0 text-[10px]">
+                    {formatUpdatedAt(item.updatedAt)}
+                  </Badge>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {buildCountBadges(item).map((label) => (
+                    <Badge key={label} variant="outline" className="text-[10px]">
+                      {label}
+                    </Badge>
+                  ))}
+                </div>
+
+                {item.tags.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-1.5">
+                    {item.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary" className="text-[10px]">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+
+                <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0 text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{item.author.displayName}</span>
+                    {item.author.handle ? ` • ${item.author.handle}` : ""}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => void copyInstallLink(item)}
+                    >
+                      Copy Install Link
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => previewInstallMutation.mutate(item)}
+                      disabled={previewInstallMutation.isPending}
+                    >
+                      {isPreparing ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Download className="h-3.5 w-3.5" />
+                      )}
+                      {isPreparing ? "Preparing..." : "Preview Install"}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/pages/settings-skills.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-skills.tsx
@@ -19,15 +19,43 @@ import {
   DropdownMenuTrigger,
 } from "@renderer/components/ui/dropdown-menu"
 import { BundleImportDialog } from "@renderer/components/bundle-import-dialog"
+import { HubCatalogBrowser } from "@renderer/components/hub-catalog-browser"
 import { tipcClient, rendererHandlers } from "@renderer/lib/tipc-client"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { AgentSkill } from "@shared/types"
 import { toast } from "sonner"
 import { Plus, Pencil, Trash2, Download, Upload, FolderOpen, RefreshCw, Loader2, ChevronDown, FolderUp, Github, CheckSquare, Square, X, FileText, Package, MoreHorizontal } from "lucide-react"
 
+type SkillViewMode = "installed" | "community"
+type BundleImportComponentConfig = {
+  agentProfiles?: boolean
+  mcpServers?: boolean
+  skills?: boolean
+  repeatTasks?: boolean
+  knowledgeNotes?: boolean
+}
+
+const SKILL_ONLY_IMPORT_COMPONENTS: BundleImportComponentConfig = {
+  agentProfiles: false,
+  mcpServers: false,
+  skills: true,
+  repeatTasks: false,
+  knowledgeNotes: false,
+}
+
+const LOCAL_SKILL_BUNDLE_IMPORT_DESCRIPTION = "Preview and import skills from a local .dotagents bundle file."
+
+interface CommunityBundlePreviewInput {
+  filePath: string
+  item: {
+    name: string
+  }
+  downloadedFrom: string
+}
 
 export function Component() {
   const queryClient = useQueryClient()
+  const [activeView, setActiveView] = useState<SkillViewMode>("installed")
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
   const [editingSkill, setEditingSkill] = useState<AgentSkill | null>(null)
@@ -36,6 +64,17 @@ export function Component() {
   const [newSkillInstructions, setNewSkillInstructions] = useState("")
   const [isGitHubDialogOpen, setIsGitHubDialogOpen] = useState(false)
   const [isBundleImportDialogOpen, setIsBundleImportDialogOpen] = useState(false)
+  const [bundleImportFilePath, setBundleImportFilePath] = useState<string | undefined>()
+  const [bundleImportDialogTitle, setBundleImportDialogTitle] = useState("Import Skill Bundle")
+  const [bundleImportDialogDescription, setBundleImportDialogDescription] = useState(
+    LOCAL_SKILL_BUNDLE_IMPORT_DESCRIPTION,
+  )
+  const [bundleImportInitialComponents, setBundleImportInitialComponents] = useState<
+    BundleImportComponentConfig | undefined
+  >(SKILL_ONLY_IMPORT_COMPONENTS)
+  const [bundleImportAvailableComponents, setBundleImportAvailableComponents] = useState<
+    BundleImportComponentConfig | undefined
+  >(SKILL_ONLY_IMPORT_COMPONENTS)
   const [gitHubRepoInput, setGitHubRepoInput] = useState("")
   const [isSelectMode, setIsSelectMode] = useState(false)
   const [selectedSkillIds, setSelectedSkillIds] = useState<Set<string>>(new Set())
@@ -416,6 +455,48 @@ export function Component() {
     setSelectedSkillIds(new Set())
   }
 
+  const resetBundleImportDialogState = () => {
+    setBundleImportFilePath(undefined)
+    setBundleImportDialogTitle("Import Skill Bundle")
+    setBundleImportDialogDescription(LOCAL_SKILL_BUNDLE_IMPORT_DESCRIPTION)
+    setBundleImportInitialComponents(SKILL_ONLY_IMPORT_COMPONENTS)
+    setBundleImportAvailableComponents(SKILL_ONLY_IMPORT_COMPONENTS)
+  }
+
+  const handleBundleImportDialogOpenChange = (open: boolean) => {
+    setIsBundleImportDialogOpen(open)
+    if (!open) {
+      resetBundleImportDialogState()
+    }
+  }
+
+  const openLocalBundleImportDialog = () => {
+    resetBundleImportDialogState()
+    setIsBundleImportDialogOpen(true)
+  }
+
+  const handlePreviewCommunityBundle = ({
+    filePath,
+    item,
+    downloadedFrom,
+  }: CommunityBundlePreviewInput) => {
+    setBundleImportFilePath(filePath)
+    setBundleImportDialogTitle(`Install ${item.name}`)
+    setBundleImportDialogDescription(
+      `Preview and import the downloaded DotAgents Hub bundle. Downloaded from ${downloadedFrom}.`,
+    )
+    setBundleImportInitialComponents(undefined)
+    setBundleImportAvailableComponents(undefined)
+    setIsBundleImportDialogOpen(true)
+  }
+
+  const handleActiveViewChange = (view: SkillViewMode) => {
+    if (view !== "installed") {
+      exitSelectMode()
+    }
+    setActiveView(view)
+  }
+
   const handleEditSkill = (skill: AgentSkill) => {
     setEditingSkill({ ...skill })
     setIsEditDialogOpen(true)
@@ -424,6 +505,9 @@ export function Component() {
   const handleBundleImportComplete = () => {
     queryClient.invalidateQueries({ queryKey: ["skills"] })
     queryClient.invalidateQueries({ queryKey: ["agentProfilesSidebar"] })
+    queryClient.invalidateQueries({ queryKey: ["agentProfilesSelector"] })
+    queryClient.invalidateQueries({ queryKey: ["knowledgeNotes"] })
+    queryClient.invalidateQueries({ queryKey: ["serverStatusSidebar"] })
   }
 
   const skillsFileTemplate = `---
@@ -440,264 +524,291 @@ Write your skill instructions here.
   return (
     <div className="modern-panel h-full min-w-0 overflow-y-auto overflow-x-hidden px-6 py-4">
       <div className="min-w-0 space-y-6">
-        <div className="flex flex-wrap justify-end gap-2">
-          {isSelectMode ? (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={toggleSelectAll}
-              >
-                {selectedSkillIds.size === skills.length && skills.length > 0 ? (
-                  <CheckSquare className="h-3 w-3" />
-                ) : (
-                  <Square className="h-3 w-3" />
-                )}
-                {selectedSkillIds.size === skills.length && skills.length > 0 ? "Deselect All" : "Select All"}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={handleExportSelectedBundle}
-                disabled={selectedSkillIds.size === 0 || exportBundleMutation.isPending}
-              >
-                {exportBundleMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : (
-                  <Download className="h-3 w-3" />
-                )}
-                Export Bundle {selectedSkillIds.size > 0 ? `(${selectedSkillIds.size})` : ""}
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                className="gap-1.5"
-                onClick={handleDeleteSelected}
-                disabled={selectedSkillIds.size === 0 || deleteSkillsMutation.isPending}
-              >
-                {deleteSkillsMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : (
-                  <Trash2 className="h-3 w-3" />
-                )}
-                Delete {selectedSkillIds.size > 0 ? `(${selectedSkillIds.size})` : "Selected"}
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="gap-1.5"
-                onClick={exitSelectMode}
-              >
-                <X className="h-3 w-3" />
-                Cancel
-              </Button>
-            </>
-          ) : (
-            <>
-              {skills.length > 0 && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="gap-1.5"
-                  onClick={() => setIsSelectMode(true)}
-                >
-                  <CheckSquare className="h-3 w-3" />
-                  Select
-                </Button>
-              )}
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={() => openSkillsFolderMutation.mutate()}
-              >
-                <FolderOpen className="h-3 w-3" />
-                Open Folder
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={() => openWorkspaceSkillsFolderMutation.mutate()}
-                disabled={!agentsFoldersQuery.data?.workspace?.skillsDir || openWorkspaceSkillsFolderMutation.isPending}
-              >
-                <FolderUp className="h-3 w-3" />
-                Workspace
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={() => scanSkillsFolderMutation.mutate()}
-                disabled={scanSkillsFolderMutation.isPending}
-              >
-                <RefreshCw className={`h-3 w-3 ${scanSkillsFolderMutation.isPending ? 'animate-spin' : ''}`} />
-                Scan Folder
-              </Button>
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="inline-flex rounded-lg border bg-muted/20 p-1">
+            <button
+              type="button"
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeView === "installed" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:bg-background/60 hover:text-foreground"}`}
+              onClick={() => handleActiveViewChange("installed")}
+            >
+              Installed
+            </button>
+            <button
+              type="button"
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${activeView === "community" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:bg-background/60 hover:text-foreground"}`}
+              onClick={() => handleActiveViewChange("community")}
+            >
+              Community Hub
+            </button>
+          </div>
+
+          {activeView === "installed" && (
+            <div className="flex flex-wrap justify-end gap-2">
+              {isSelectMode ? (
+                <>
                   <Button
                     variant="outline"
                     size="sm"
                     className="gap-1.5"
-                    disabled={importSkillMutation.isPending || importSkillFolderMutation.isPending || importSkillsFromParentFolderMutation.isPending || importSkillFromGitHubMutation.isPending}
+                    onClick={toggleSelectAll}
                   >
-                    <Upload className="h-3 w-3" />
-                    Import
-                    <ChevronDown className="h-3 w-3" />
+                    {selectedSkillIds.size === skills.length && skills.length > 0 ? (
+                      <CheckSquare className="h-3 w-3" />
+                    ) : (
+                      <Square className="h-3 w-3" />
+                    )}
+                    {selectedSkillIds.size === skills.length && skills.length > 0 ? "Deselect All" : "Select All"}
                   </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onClick={() => setIsBundleImportDialogOpen(true)}>
-                    <Package />
-                    Import Bundle
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => setIsGitHubDialogOpen(true)}>
-                    <Github />
-                    Import from GitHub
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => importSkillMutation.mutate()}>
-                    <Upload />
-                    Import SKILL.md File
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => importSkillFolderMutation.mutate()}>
-                    <FolderOpen />
-                    Import Skill Folder
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => importSkillsFromParentFolderMutation.mutate()}>
-                    <FolderUp />
-                    Bulk Import from Folder
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <Button
-                size="sm"
-                className="gap-1.5"
-                onClick={() => setIsCreateDialogOpen(true)}
-              >
-                <Plus className="h-3 w-3" />
-                New Skill
-              </Button>
-            </>
-          )}
-        </div>
-
-        <p className="text-xs text-muted-foreground">
-          Enabled skills add their instructions to the system prompt.
-        </p>
-
-        <details className="rounded-lg border bg-card">
-          <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
-            Modular config (.agents) file template
-          </summary>
-          <div className="px-4 pb-4 space-y-3">
-            <p className="text-sm text-muted-foreground">
-              You can hand-author skills in <span className="font-mono">.agents/skills/&lt;id&gt;/skill.md</span>. Frontmatter
-              uses simple <span className="font-mono">key: value</span> lines (not YAML). If a workspace <span className="font-mono">.agents</span>
-              folder exists, it can override the global layer by skill <span className="font-mono">id</span>.
-            </p>
-            <div className="space-y-1">
-              <div className="text-xs text-muted-foreground">
-                Global: <span className="font-mono break-all">{agentsFoldersQuery.data?.global?.skillsDir ?? "~/.agents/skills"}</span>
-              </div>
-              <div className="text-xs text-muted-foreground">
-                Workspace:{" "}
-                <span className="font-mono break-all">
-                  {agentsFoldersQuery.data?.workspace?.skillsDir ?? "Not detected"}
-                  {agentsFoldersQuery.data?.workspace?.skillsDir && agentsFoldersQuery.data?.workspaceSource
-                    ? ` (${agentsFoldersQuery.data.workspaceSource})`
-                    : ""}
-                </span>
-              </div>
-            </div>
-            <div className="rounded-md bg-muted p-3 font-mono text-xs whitespace-pre-wrap">{skillsFileTemplate}</div>
-          </div>
-        </details>
-
-        {/* Skills List */}
-        <div className="space-y-1">
-          {skillsQuery.isLoading ? (
-            <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-center text-sm text-muted-foreground">
-              <div className="flex items-center justify-center gap-2 font-medium text-foreground/80">
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                <span>Loading skills...</span>
-              </div>
-            </div>
-          ) : skillsQuery.isError ? (
-            <div className="rounded-lg border border-dashed border-destructive/30 bg-destructive/5 px-4 py-5 text-center">
-              <p className="text-sm font-medium text-destructive">Failed to load skills.</p>
-              <p className="mt-1 text-sm text-muted-foreground">Please try again.</p>
-            </div>
-          ) : skills.length === 0 ? (
-            <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-center">
-              <p className="text-sm font-medium">No skills yet.</p>
-              <p className="mt-1 text-sm text-muted-foreground">Create your first skill or import one.</p>
-            </div>
-          ) : (
-            skills.map((skill) => (
-              <div
-                key={skill.id}
-                className={`flex items-center justify-between px-3 py-2 rounded-lg border bg-card ${isSelectMode ? "cursor-pointer hover:bg-accent/50" : ""} ${isSelectMode && selectedSkillIds.has(skill.id) ? "border-primary bg-primary/5" : ""}`}
-                onClick={isSelectMode ? () => toggleSkillSelection(skill.id) : undefined}
-              >
-                <div className="flex items-center gap-3 flex-1 min-w-0">
-                  {isSelectMode && (
-                    <button
-                      type="button"
-                      className="shrink-0 flex items-center justify-center"
-                      onClick={(e) => { e.stopPropagation(); toggleSkillSelection(skill.id) }}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={handleExportSelectedBundle}
+                    disabled={selectedSkillIds.size === 0 || exportBundleMutation.isPending}
+                  >
+                    {exportBundleMutation.isPending ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <Download className="h-3 w-3" />
+                    )}
+                    Export Bundle {selectedSkillIds.size > 0 ? `(${selectedSkillIds.size})` : ""}
+                  </Button>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={handleDeleteSelected}
+                    disabled={selectedSkillIds.size === 0 || deleteSkillsMutation.isPending}
+                  >
+                    {deleteSkillsMutation.isPending ? (
+                      <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-3 w-3" />
+                    )}
+                    Delete {selectedSkillIds.size > 0 ? `(${selectedSkillIds.size})` : "Selected"}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={exitSelectMode}
+                  >
+                    <X className="h-3 w-3" />
+                    Cancel
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {skills.length > 0 && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => setIsSelectMode(true)}
                     >
-                      {selectedSkillIds.has(skill.id) ? (
-                        <CheckSquare className="h-4 w-4 text-primary" />
-                      ) : (
-                        <Square className="h-4 w-4 text-muted-foreground" />
-                      )}
-                    </button>
+                      <CheckSquare className="h-3 w-3" />
+                      Select
+                    </Button>
                   )}
-                  <span className="font-medium truncate">{skill.name}</span>
-                </div>
-                {!isSelectMode && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => openSkillsFolderMutation.mutate()}
+                  >
+                    <FolderOpen className="h-3 w-3" />
+                    Open Folder
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => openWorkspaceSkillsFolderMutation.mutate()}
+                    disabled={!agentsFoldersQuery.data?.workspace?.skillsDir || openWorkspaceSkillsFolderMutation.isPending}
+                  >
+                    <FolderUp className="h-3 w-3" />
+                    Workspace
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => scanSkillsFolderMutation.mutate()}
+                    disabled={scanSkillsFolderMutation.isPending}
+                  >
+                    <RefreshCw className={`h-3 w-3 ${scanSkillsFolderMutation.isPending ? 'animate-spin' : ''}`} />
+                    Scan Folder
+                  </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
-                        variant="ghost"
+                        variant="outline"
                         size="sm"
-                        className="ml-2 h-7 shrink-0 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
-                        aria-label={`Actions for ${skill.name}`}
+                        className="gap-1.5"
+                        disabled={importSkillMutation.isPending || importSkillFolderMutation.isPending || importSkillsFromParentFolderMutation.isPending || importSkillFromGitHubMutation.isPending}
                       >
-                        <MoreHorizontal className="h-3.5 w-3.5" />
-                        <span>Actions</span>
+                        <Upload className="h-3 w-3" />
+                        Import
+                        <ChevronDown className="h-3 w-3" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
-                      <DropdownMenuItem onClick={() => handleEditSkill(skill)}>
-                        <Pencil className="h-3.5 w-3.5" />
-                        Edit
+                      <DropdownMenuItem onClick={openLocalBundleImportDialog}>
+                        <Package />
+                        Import Bundle
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => openSkillFileMutation.mutate(skill.id)}>
-                        <FileText className="h-3.5 w-3.5" />
-                        Reveal File
+                      <DropdownMenuItem onClick={() => setIsGitHubDialogOpen(true)}>
+                        <Github />
+                        Import from GitHub
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => exportSkillMutation.mutate(skill.id)}>
-                        <Download className="h-3.5 w-3.5" />
-                        Export
+                      <DropdownMenuItem onClick={() => importSkillMutation.mutate()}>
+                        <Upload />
+                        Import SKILL.md File
                       </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => handleDeleteSkill(skill)}
-                        className="text-destructive focus:text-destructive"
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                        Delete
+                      <DropdownMenuItem onClick={() => importSkillFolderMutation.mutate()}>
+                        <FolderOpen />
+                        Import Skill Folder
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => importSkillsFromParentFolderMutation.mutate()}>
+                        <FolderUp />
+                        Bulk Import from Folder
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
-                )}
-              </div>
-            ))
+                  <Button
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => setIsCreateDialogOpen(true)}
+                  >
+                    <Plus className="h-3 w-3" />
+                    New Skill
+                  </Button>
+                </>
+              )}
+            </div>
           )}
         </div>
+
+        {activeView === "installed" ? (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Enabled skills add their instructions to the system prompt.
+            </p>
+
+            <details className="rounded-lg border bg-card">
+              <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
+                Modular config (.agents) file template
+              </summary>
+              <div className="px-4 pb-4 space-y-3">
+                <p className="text-sm text-muted-foreground">
+                  You can hand-author skills in <span className="font-mono">.agents/skills/&lt;id&gt;/skill.md</span>. Frontmatter
+                  uses simple <span className="font-mono">key: value</span> lines (not YAML). If a workspace <span className="font-mono">.agents</span>
+                  folder exists, it can override the global layer by skill <span className="font-mono">id</span>.
+                </p>
+                <div className="space-y-1">
+                  <div className="text-xs text-muted-foreground">
+                    Global: <span className="font-mono break-all">{agentsFoldersQuery.data?.global?.skillsDir ?? "~/.agents/skills"}</span>
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    Workspace:{" "}
+                    <span className="font-mono break-all">
+                      {agentsFoldersQuery.data?.workspace?.skillsDir ?? "Not detected"}
+                      {agentsFoldersQuery.data?.workspace?.skillsDir && agentsFoldersQuery.data?.workspaceSource
+                        ? ` (${agentsFoldersQuery.data.workspaceSource})`
+                        : ""}
+                    </span>
+                  </div>
+                </div>
+                <div className="rounded-md bg-muted p-3 font-mono text-xs whitespace-pre-wrap">{skillsFileTemplate}</div>
+              </div>
+            </details>
+
+            {/* Skills List */}
+            <div className="space-y-1">
+              {skillsQuery.isLoading ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-center text-sm text-muted-foreground">
+                  <div className="flex items-center justify-center gap-2 font-medium text-foreground/80">
+                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                    <span>Loading skills...</span>
+                  </div>
+                </div>
+              ) : skillsQuery.isError ? (
+                <div className="rounded-lg border border-dashed border-destructive/30 bg-destructive/5 px-4 py-5 text-center">
+                  <p className="text-sm font-medium text-destructive">Failed to load skills.</p>
+                  <p className="mt-1 text-sm text-muted-foreground">Please try again.</p>
+                </div>
+              ) : skills.length === 0 ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 px-4 py-5 text-center">
+                  <p className="text-sm font-medium">No skills yet.</p>
+                  <p className="mt-1 text-sm text-muted-foreground">Create your first skill or import one.</p>
+                </div>
+              ) : (
+                skills.map((skill) => (
+                  <div
+                    key={skill.id}
+                    className={`flex items-center justify-between px-3 py-2 rounded-lg border bg-card ${isSelectMode ? "cursor-pointer hover:bg-accent/50" : ""} ${isSelectMode && selectedSkillIds.has(skill.id) ? "border-primary bg-primary/5" : ""}`}
+                    onClick={isSelectMode ? () => toggleSkillSelection(skill.id) : undefined}
+                  >
+                    <div className="flex items-center gap-3 flex-1 min-w-0">
+                      {isSelectMode && (
+                        <button
+                          type="button"
+                          className="shrink-0 flex items-center justify-center"
+                          onClick={(e) => { e.stopPropagation(); toggleSkillSelection(skill.id) }}
+                        >
+                          {selectedSkillIds.has(skill.id) ? (
+                            <CheckSquare className="h-4 w-4 text-primary" />
+                          ) : (
+                            <Square className="h-4 w-4 text-muted-foreground" />
+                          )}
+                        </button>
+                      )}
+                      <span className="font-medium truncate">{skill.name}</span>
+                    </div>
+                    {!isSelectMode && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="ml-2 h-7 shrink-0 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+                            aria-label={`Actions for ${skill.name}`}
+                          >
+                            <MoreHorizontal className="h-3.5 w-3.5" />
+                            <span>Actions</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => handleEditSkill(skill)}>
+                            <Pencil className="h-3.5 w-3.5" />
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => openSkillFileMutation.mutate(skill.id)}>
+                            <FileText className="h-3.5 w-3.5" />
+                            Reveal File
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => exportSkillMutation.mutate(skill.id)}>
+                            <Download className="h-3.5 w-3.5" />
+                            Export
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => handleDeleteSkill(skill)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </div>
+                ))
+              )}
+            </div>
+          </>
+        ) : (
+          <HubCatalogBrowser onPreviewInstall={handlePreviewCommunityBundle} />
+        )}
 
         {/* Create Skill Dialog */}
         <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
@@ -808,24 +919,13 @@ Write your skill instructions here.
 
         <BundleImportDialog
           open={isBundleImportDialogOpen}
-          onOpenChange={setIsBundleImportDialogOpen}
+          onOpenChange={handleBundleImportDialogOpenChange}
           onImportComplete={handleBundleImportComplete}
-          title="Import Skill Bundle"
-          description="Preview and import skills from a local .dotagents bundle file."
-          initialComponents={{
-            agentProfiles: false,
-            mcpServers: false,
-            skills: true,
-            repeatTasks: false,
-            knowledgeNotes: false,
-          }}
-          availableComponents={{
-            agentProfiles: false,
-            mcpServers: false,
-            skills: true,
-            repeatTasks: false,
-            knowledgeNotes: false,
-          }}
+          initialFilePath={bundleImportFilePath}
+          title={bundleImportDialogTitle}
+          description={bundleImportDialogDescription}
+          initialComponents={bundleImportInitialComponents}
+          availableComponents={bundleImportAvailableComponents}
         />
 
         {/* GitHub Import Dialog */}
@@ -883,4 +983,3 @@ Write your skill instructions here.
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary
- add desktop Hub catalog fetching and bundle download support in the main process
- expose Community Hub catalog/install preview flows through TIPC and the Skills settings page
- add a Community Hub browser UI for searching bundles and opening the existing import preview flow
- normalize legacy Hub bundle formats so preview/import works with `memories` fields and legacy `assistant` profile roles
- add regression tests for Hub catalog handling and legacy bundle compatibility

## Testing
- `pnpm -C apps/desktop exec vitest run src/main/hub-catalog.test.ts src/main/bundle-service.test.ts -t 'legacy Hub bundles|assistant profile role|public Hub bundles|hub-catalog'`
- `pnpm --filter @dotagents/desktop typecheck`