### PR TITLE
Add video attachments to mobile chat

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -43,6 +43,9 @@ import { RecoveryState, formatConnectionStatus } from '../lib/connectionRecovery
 import * as Speech from 'expo-speech';
 import * as ImagePicker from 'expo-image-picker';
 import {
+  buildMarkdownMediaTag,
+  countMarkdownMedia,
+  replaceMarkdownMedia,
   extractRespondToUserResponseEvents,
   preprocessTextForTTS,
   shouldCollapseMessage,
@@ -84,22 +87,27 @@ import { useSpeechRecognizer } from '../lib/voice/useSpeechRecognizer';
 import { useHandsFreeController } from '../lib/voice/useHandsFreeController';
 import { createDelegationProgressMessages } from '../lib/delegationProgress';
 
-interface PendingImageAttachment {
+interface PendingMessageAttachment {
   id: string;
+  kind: 'image' | 'video';
   name: string;
   previewUri: string;
-  dataUrl: string;
+  messageUri: string;
+  mimeType: string;
+  durationMs?: number | null;
 }
 
-const MAX_PENDING_IMAGES = 4;
+const PICKABLE_MEDIA_TYPES: ImagePicker.MediaType[] = ['images', 'videos'];
+const MAX_PENDING_ATTACHMENTS = 4;
 const MAX_PENDING_IMAGE_FILE_SIZE_BYTES = 4 * 1024 * 1024;
+const MAX_PENDING_VIDEO_FILE_SIZE_BYTES = 20 * 1024 * 1024;
 const MAX_TOTAL_PENDING_IMAGE_EMBEDDED_BYTES = 900 * 1024;
 const INITIAL_VISIBLE_CHAT_MESSAGES = 80;
 const VISIBLE_CHAT_MESSAGES_INCREMENT = 60;
 const CHAT_COMPOSER_HINT_NATIVE_ID = 'chat-composer-hint';
 const CHAT_VOICE_STATUS_LIVE_REGION_NATIVE_ID = 'chat-voice-status-live-region';
 
-const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+const ATTACHMENT_MIME_BY_EXTENSION: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
   '.jpeg': 'image/jpeg',
@@ -109,9 +117,13 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   '.svg': 'image/svg+xml',
   '.heic': 'image/heic',
   '.heif': 'image/heif',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.webm': 'video/webm',
+  '.m4v': 'video/x-m4v',
+  '.3gp': 'video/3gpp',
+  '.ogv': 'video/ogg',
 };
-
-const escapeMarkdownImageAlt = (value: string) => value.replace(/[\[\]\\]/g, '').trim();
 
 const getApproxBase64Bytes = (base64: string) => {
   const normalized = base64.replace(/\s+/g, '');
@@ -127,13 +139,13 @@ const getApproxDataUrlBytes = (dataUrl: string) => {
 
 const formatMb = (bytes: number) => `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
 
-const inferImageMimeType = (asset: {
+const inferAttachmentMimeType = (asset: {
   mimeType?: string | null;
   fileName?: string | null;
   uri?: string | null;
 }) => {
   const mimeType = asset.mimeType?.trim().toLowerCase();
-  if (mimeType?.startsWith('image/')) {
+  if (mimeType?.startsWith('image/') || mimeType?.startsWith('video/')) {
     return mimeType;
   }
 
@@ -142,20 +154,49 @@ const inferImageMimeType = (asset: {
   if (!extensionMatch) {
     return null;
   }
-  return IMAGE_MIME_BY_EXTENSION[`.${extensionMatch[1].toLowerCase()}`] || null;
+  return ATTACHMENT_MIME_BY_EXTENSION[`.${extensionMatch[1].toLowerCase()}`] || null;
 };
 
-const buildMessageWithPendingImages = (text: string, images: PendingImageAttachment[]) => {
+const inferPickedAttachmentKind = (asset: {
+  type?: 'image' | 'video' | 'livePhoto' | 'pairedVideo' | null;
+  mimeType?: string | null;
+  fileName?: string | null;
+  uri?: string | null;
+}): 'image' | 'video' | null => {
+  if (asset.type === 'video' || asset.type === 'pairedVideo') {
+    return 'video';
+  }
+  if (asset.type === 'image' || asset.type === 'livePhoto') {
+    return 'image';
+  }
+
+  const mimeType = inferAttachmentMimeType(asset);
+  if (!mimeType) {
+    return null;
+  }
+  if (mimeType.startsWith('video/')) {
+    return 'video';
+  }
+  if (mimeType.startsWith('image/')) {
+    return 'image';
+  }
+  return null;
+};
+
+const buildMessageWithPendingAttachments = (text: string, attachments: PendingMessageAttachment[]) => {
   const trimmed = text.trim();
-  const imageMarkdown = images
-    .map((image, index) => {
-      const fallbackName = `Image ${index + 1}`;
-      const safeName = escapeMarkdownImageAlt(image.name || fallbackName) || fallbackName;
-      return `![${safeName}](${image.dataUrl})`;
+  const attachmentMarkdown = attachments
+    .map((attachment, index) => {
+      const fallbackName = `${attachment.kind === 'video' ? 'Video' : 'Image'} ${index + 1}`;
+      return buildMarkdownMediaTag(
+        attachment.kind,
+        attachment.name || fallbackName,
+        attachment.messageUri
+      );
     })
     .join('\n\n');
 
-  return [trimmed, imageMarkdown].filter(Boolean).join('\n\n');
+  return [trimmed, attachmentMarkdown].filter(Boolean).join('\n\n');
 };
 
 type QuickStartShortcut = {
@@ -213,15 +254,13 @@ const STARTER_PACK_SHORTCUTS: QuickStartShortcut[] = [
 
 const isSlashCommandPrompt = (prompt: PredefinedPromptSummary) => /^\/[\S]+/.test(prompt.name.trim());
 
-const INLINE_DATA_IMAGE_MARKDOWN_REGEX = /!\[([^\]]*)\]\((data:image\/[^)]+)\)/gi;
-
 /** Meta-tools whose results are already shown as visible message content or are purely internal */
 const HIDDEN_META_TOOLS = new Set([RESPOND_TO_USER_TOOL, 'mark_work_complete']);
 
 const sanitizeMessageContentForModel = (content: string) =>
-  content.replace(INLINE_DATA_IMAGE_MARKDOWN_REGEX, (_match, altText: string) => {
-    const cleanedAlt = altText?.trim();
-    return cleanedAlt ? `[Image: ${cleanedAlt}]` : '[Image]';
+  replaceMarkdownMedia(content, ({ kind, label }) => {
+    const prefix = kind === 'video' ? 'Video' : 'Image';
+    return label ? `[${prefix}: ${label}]` : `[${prefix}]`;
   });
 
 const sanitizeMessagesForModel = (messages: ChatMessage[]): ChatMessage[] =>
@@ -269,10 +308,14 @@ const sortResponseEvents = (events: AgentUserResponseEvent[]): AgentUserResponse
 const getNextResponseEventOrdinal = (events: AgentUserResponseEvent[]): number =>
   events.reduce((maxOrdinal, event) => Math.max(maxOrdinal, event.ordinal), 0) + 1;
 
-const getMessageLogMeta = (content: string) => ({
-  length: content.length,
-  inlineImageCount: (content.match(/!\[[^\]]*\]\((?:data:image\/[^)]+)\)/gi) || []).length,
-});
+const getMessageLogMeta = (content: string) => {
+  const counts = countMarkdownMedia(content);
+  return {
+    length: content.length,
+    inlineImageCount: counts.images,
+    inlineVideoCount: counts.videos,
+  };
+};
 
 const normalizeVoiceText = (text?: string) => (text || '').replace(/\s+/g, ' ').trim();
 
@@ -298,8 +341,10 @@ const mergeVoiceText = (base?: string, live?: string) => {
 };
 
 const getCollapsedMessagePreview = (content: string) =>
-  content
-    .replace(/!\[[^\]]*\]\((?:data:image\/[^)]+|[^)]+)\)/gi, '[Image]')
+  replaceMarkdownMedia(content, ({ kind, label }) => {
+    const prefix = kind === 'video' ? 'Video' : 'Image';
+    return label ? `[${prefix}: ${label}]` : `[${prefix}]`;
+  })
     .replace(/\s+/g, ' ')
     .trim();
 
@@ -892,7 +937,7 @@ export default function ChatScreen({ route, navigation }: any) {
 	// Stable ref to the latest send() to avoid stale closures in speech callbacks
 	const sendRef = useRef<(text: string) => Promise<void>>(async () => {});
 	  const [input, setInput] = useState('');
-	  const [pendingImages, setPendingImages] = useState<PendingImageAttachment[]>([]);
+	  const [pendingAttachments, setPendingAttachments] = useState<PendingMessageAttachment[]>([]);
 	  const inputRef = useRef<TextInput>(null);
   const [debugInfo, setDebugInfo] = useState<string>('');
   const [expandedMessages, setExpandedMessages] = useState<Record<number, boolean>>({});
@@ -1793,14 +1838,16 @@ export default function ChatScreen({ route, navigation }: any) {
   const queuedMessages = messageQueue.getQueue(currentConversationId);
   const nextQueuedMessage = !responding ? messageQueue.peek(currentConversationId) : null;
 
-  const handlePickImages = useCallback(async () => {
-    if (pendingImages.length >= MAX_PENDING_IMAGES) {
-      Alert.alert('Image limit reached', `You can attach up to ${MAX_PENDING_IMAGES} images per message.`);
+  const handlePickMedia = useCallback(async () => {
+    if (pendingAttachments.length >= MAX_PENDING_ATTACHMENTS) {
+      Alert.alert('Attachment limit reached', `You can attach up to ${MAX_PENDING_ATTACHMENTS} images or videos per message.`);
       return;
     }
 
-    const existingEmbeddedBytes = pendingImages.reduce(
-      (sum, image) => sum + getApproxDataUrlBytes(image.dataUrl),
+    const existingEmbeddedBytes = pendingAttachments.reduce(
+      (sum, attachment) => attachment.kind === 'image'
+        ? sum + getApproxDataUrlBytes(attachment.messageUri)
+        : sum,
       0
     );
     if (existingEmbeddedBytes >= MAX_TOTAL_PENDING_IMAGE_EMBEDDED_BYTES) {
@@ -1813,26 +1860,62 @@ export default function ChatScreen({ route, navigation }: any) {
 
     try {
       const result = await ImagePicker.launchImageLibraryAsync({
-        mediaTypes: ImagePicker.MediaTypeOptions.Images,
+        mediaTypes: PICKABLE_MEDIA_TYPES,
         allowsMultipleSelection: true,
-        selectionLimit: MAX_PENDING_IMAGES - pendingImages.length,
+        selectionLimit: MAX_PENDING_ATTACHMENTS - pendingAttachments.length,
         quality: 0.8,
         base64: true,
       });
 
       if (result.canceled || !result.assets || result.assets.length === 0) return;
 
-      const slotsRemaining = MAX_PENDING_IMAGES - pendingImages.length;
+      const slotsRemaining = MAX_PENDING_ATTACHMENTS - pendingAttachments.length;
       const selectedAssets = result.assets.slice(0, slotsRemaining);
-      const nextImages: PendingImageAttachment[] = [];
+      const nextAttachments: PendingMessageAttachment[] = [];
       const missingBase64Names: string[] = [];
       const oversizedImageNames: string[] = [];
+      const oversizedVideoNames: string[] = [];
       const unknownMimeNames: string[] = [];
       const budgetExceededNames: string[] = [];
+      const missingVideoUriNames: string[] = [];
       let runningEmbeddedBytes = existingEmbeddedBytes;
 
       selectedAssets.forEach((asset, index) => {
-        const displayName = asset.fileName || `Image ${index + 1}`;
+        const kind = inferPickedAttachmentKind(asset);
+        const displayName = asset.fileName || `${kind === 'video' ? 'Video' : 'Image'} ${index + 1}`;
+        const mimeType = inferAttachmentMimeType(asset);
+
+        if (!kind || !mimeType) {
+          unknownMimeNames.push(displayName);
+          return;
+        }
+
+        if (kind === 'video') {
+          const fileSizeBytes = typeof asset.fileSize === 'number' && asset.fileSize > 0
+            ? asset.fileSize
+            : 0;
+          if (fileSizeBytes > MAX_PENDING_VIDEO_FILE_SIZE_BYTES) {
+            oversizedVideoNames.push(displayName);
+            return;
+          }
+          if (!asset.uri) {
+            missingVideoUriNames.push(displayName);
+            return;
+          }
+
+          const fileName = asset.fileName || `video-${Date.now()}-${index + 1}`;
+          nextAttachments.push({
+            id: `${Date.now()}-${index}-${asset.uri}`,
+            kind,
+            name: fileName,
+            previewUri: asset.uri,
+            messageUri: encodeURI(asset.uri),
+            mimeType,
+            durationMs: asset.duration ?? null,
+          });
+          return;
+        }
+
         if (!asset.base64) {
           missingBase64Names.push(displayName);
           return;
@@ -1847,12 +1930,6 @@ export default function ChatScreen({ route, navigation }: any) {
           return;
         }
 
-        const mimeType = inferImageMimeType(asset);
-        if (!mimeType) {
-          unknownMimeNames.push(displayName);
-          return;
-        }
-
         const dataUrl = `data:${mimeType};base64,${asset.base64}`;
         const embeddedBytes = getApproxDataUrlBytes(dataUrl) || inferredBytes;
         if (runningEmbeddedBytes + embeddedBytes > MAX_TOTAL_PENDING_IMAGE_EMBEDDED_BYTES) {
@@ -1862,22 +1939,32 @@ export default function ChatScreen({ route, navigation }: any) {
         runningEmbeddedBytes += embeddedBytes;
 
         const fileName = asset.fileName || `image-${Date.now()}-${index + 1}`;
-        nextImages.push({
+        nextAttachments.push({
           id: `${Date.now()}-${index}-${asset.uri}`,
+          kind,
           name: fileName,
           previewUri: asset.uri,
-          dataUrl,
+          messageUri: dataUrl,
+          mimeType,
+          durationMs: asset.duration ?? null,
         });
       });
 
-      if (nextImages.length > 0) {
-        setPendingImages((prev) => [...prev, ...nextImages]);
+      if (nextAttachments.length > 0) {
+        setPendingAttachments((prev) => [...prev, ...nextAttachments]);
       }
 
       if (missingBase64Names.length > 0) {
         Alert.alert(
           'Some images were skipped',
           `${missingBase64Names.join(', ')} could not be attached. Please try again.`
+        );
+      }
+
+      if (missingVideoUriNames.length > 0) {
+        Alert.alert(
+          'Some videos were skipped',
+          `${missingVideoUriNames.join(', ')} could not be attached. Please try again.`
         );
       }
 
@@ -1888,10 +1975,17 @@ export default function ChatScreen({ route, navigation }: any) {
         );
       }
 
+      if (oversizedVideoNames.length > 0) {
+        Alert.alert(
+          'Video too large',
+          `${oversizedVideoNames.join(', ')} exceed the 20MB limit.`
+        );
+      }
+
       if (unknownMimeNames.length > 0) {
         Alert.alert(
-          'Unsupported image format',
-          `${unknownMimeNames.join(', ')} could not be attached because the image type could not be determined.`
+          'Unsupported media format',
+          `${unknownMimeNames.join(', ')} could not be attached because the file type could not be determined.`
         );
       }
 
@@ -1902,12 +1996,12 @@ export default function ChatScreen({ route, navigation }: any) {
         );
       }
     } catch (error: any) {
-      Alert.alert('Image picker error', error?.message || 'Unable to select images right now.');
+      Alert.alert('Media picker error', error?.message || 'Unable to select media right now.');
     }
-  }, [pendingImages]);
+  }, [pendingAttachments]);
 
-  const removePendingImage = useCallback((attachmentId: string) => {
-    setPendingImages((prev) => prev.filter((image) => image.id !== attachmentId));
+  const removePendingAttachment = useCallback((attachmentId: string) => {
+    setPendingAttachments((prev) => prev.filter((attachment) => attachment.id !== attachmentId));
   }, []);
 
   const send = async (text: string, options?: { fromComposer?: boolean }) => {
@@ -1919,7 +2013,7 @@ export default function ChatScreen({ route, navigation }: any) {
       messageQueue.enqueue(currentConversationId, text);
       setInput('');
       if (options?.fromComposer) {
-        setPendingImages([]);
+        setPendingAttachments([]);
       }
       return;
     }
@@ -1969,7 +2063,7 @@ export default function ChatScreen({ route, navigation }: any) {
 
     setInput('');
 	    if (options?.fromComposer) {
-	      setPendingImages([]);
+	      setPendingAttachments([]);
 	    }
 
     // Capture the session ID at request start to guard against session changes
@@ -2744,23 +2838,23 @@ export default function ChatScreen({ route, navigation }: any) {
     return sections;
   }, [commandQuickStarts, savedPromptQuickStarts, starterPackQuickStarts]);
 
-  const composerHasContent = input.trim().length > 0 || pendingImages.length > 0;
+  const composerHasContent = input.trim().length > 0 || pendingAttachments.length > 0;
 
   const sendComposerInput = useCallback(() => {
-    const composedMessage = buildMessageWithPendingImages(input, pendingImages);
+    const composedMessage = buildMessageWithPendingAttachments(input, pendingAttachments);
     if (!composedMessage.trim()) return;
     void send(composedMessage, { fromComposer: true });
-  }, [input, pendingImages, send]);
+  }, [input, pendingAttachments, send]);
 
   const queueComposerInput = useCallback(() => {
-    const composedMessage = buildMessageWithPendingImages(input, pendingImages);
+    const composedMessage = buildMessageWithPendingAttachments(input, pendingAttachments);
     if (!composedMessage.trim()) return;
 
     messageQueue.enqueue(currentConversationId, composedMessage);
     setInput('');
-    setPendingImages([]);
+    setPendingAttachments([]);
     setDebugInfo('Message queued. Use Send Next when you are ready.');
-  }, [currentConversationId, input, messageQueue, pendingImages]);
+  }, [currentConversationId, input, messageQueue, pendingAttachments]);
 
   // Track modifier keys for keyboard shortcut handling
   const modifierKeysRef = useRef<{ shift: boolean; ctrl: boolean; meta: boolean }>({
@@ -3667,21 +3761,42 @@ export default function ChatScreen({ route, navigation }: any) {
 		              <Text style={styles.sttPreviewText}>{sttPreview}</Text>
 	            </View>
 	          )}
-	          {pendingImages.length > 0 && (
+	          {pendingAttachments.length > 0 && (
 	            <ScrollView
 	              horizontal
 	              showsHorizontalScrollIndicator={false}
-	              contentContainerStyle={styles.pendingImagesRow}
+	              contentContainerStyle={styles.pendingAttachmentsRow}
 	            >
-	              {pendingImages.map((image) => (
-	                <View key={image.id} style={styles.pendingImageCard}>
-	                  <Image source={{ uri: image.previewUri }} style={styles.pendingImagePreview} />
+	              {pendingAttachments.map((attachment) => (
+	                <View key={attachment.id} style={styles.pendingAttachmentCard}>
+	                  {attachment.kind === 'image' ? (
+	                    <Image source={{ uri: attachment.previewUri }} style={styles.pendingAttachmentPreview} />
+	                  ) : isWebPlatform ? (
+	                    // Web uses the browser's native video element for preview playback.
+	                    // @ts-ignore - React Native Web supports intrinsic video elements.
+	                    <video
+	                      src={attachment.previewUri}
+	                      controls
+	                      playsInline
+	                      preload="metadata"
+	                      style={styles.pendingVideoPreview as any}
+	                    />
+	                  ) : (
+	                    <View style={styles.pendingVideoFallback}>
+	                      <Text style={styles.pendingVideoFallbackText}>Video</Text>
+	                    </View>
+	                  )}
+	                  <View style={styles.pendingAttachmentBadge}>
+	                    <Text style={styles.pendingAttachmentBadgeText}>
+	                      {attachment.kind === 'video' ? 'Video' : 'Image'}
+	                    </Text>
+	                  </View>
 	                  <TouchableOpacity
-	                    style={styles.pendingImageRemoveButton}
-	                    onPress={() => removePendingImage(image.id)}
+	                    style={styles.pendingAttachmentRemoveButton}
+	                    onPress={() => removePendingAttachment(attachment.id)}
 	                    activeOpacity={0.8}
 	                  >
-	                    <Text style={styles.pendingImageRemoveButtonText}>✕</Text>
+	                    <Text style={styles.pendingAttachmentRemoveButtonText}>✕</Text>
 	                  </TouchableOpacity>
 	                </View>
 	              ))}
@@ -3739,14 +3854,14 @@ export default function ChatScreen({ route, navigation }: any) {
 	          {/* Top row: TTS toggle, text input, send button */}
 	          <View style={styles.inputRow}>
 	            <TouchableOpacity
-	              style={[styles.ttsToggle, pendingImages.length > 0 && styles.ttsToggleOn]}
-	              onPress={handlePickImages}
+	              style={[styles.ttsToggle, pendingAttachments.length > 0 && styles.ttsToggleOn]}
+	              onPress={handlePickMedia}
 	              activeOpacity={0.7}
 	              accessibilityRole="button"
-	              accessibilityLabel="Attach images"
-	              accessibilityHint="Select one or more images to include with your next message."
+	              accessibilityLabel="Attach media"
+	              accessibilityHint="Select one or more images or videos to include with your next message."
 	            >
-	              <Text style={styles.ttsToggleText}>🖼️</Text>
+	              <Text style={styles.ttsToggleText}>📎</Text>
 	            </TouchableOpacity>
             <TouchableOpacity
               style={[styles.ttsToggle, ttsEnabled && styles.ttsToggleOn]}
@@ -3810,7 +3925,7 @@ export default function ChatScreen({ route, navigation }: any) {
                 disabled={!composerHasContent}
                 accessibilityRole="button"
                 accessibilityLabel={createButtonAccessibilityLabel('Queue message')}
-                accessibilityHint="Adds your typed text and attached images to the queued-messages list without sending immediately."
+                accessibilityHint="Adds your typed text and attached media to the queued-messages list without sending immediately."
                 accessibilityState={{ disabled: !composerHasContent }}
               >
                 <Text style={styles.queueButtonText}>Queue</Text>
@@ -3823,7 +3938,7 @@ export default function ChatScreen({ route, navigation }: any) {
 	              disabled={!composerHasContent}
               accessibilityRole="button"
               accessibilityLabel={createButtonAccessibilityLabel('Send message')}
-	              accessibilityHint="Sends your typed text and any attached images to the selected agent."
+	              accessibilityHint="Sends your typed text and any attached media to the selected agent."
               accessibilityState={{ disabled: !composerHasContent }}
 	            >
               <Text style={styles.sendButtonText}>Send</Text>
@@ -4047,13 +4162,13 @@ function createStyles(theme: Theme, screenHeight: number) {
       borderColor: theme.colors.border,
       backgroundColor: theme.colors.card,
     },
-    pendingImagesRow: {
+    pendingAttachmentsRow: {
       paddingHorizontal: spacing.sm,
       paddingTop: spacing.xs,
       paddingBottom: 2,
       gap: spacing.xs,
     },
-    pendingImageCard: {
+    pendingAttachmentCard: {
       width: 64,
       height: 64,
       borderRadius: radius.md,
@@ -4063,11 +4178,45 @@ function createStyles(theme: Theme, screenHeight: number) {
       backgroundColor: theme.colors.muted,
       position: 'relative',
     },
-    pendingImagePreview: {
+    pendingAttachmentPreview: {
       width: '100%',
       height: '100%',
     },
-    pendingImageRemoveButton: {
+    pendingVideoPreview: {
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover',
+      backgroundColor: '#000000',
+    },
+    pendingVideoFallback: {
+      width: '100%',
+      height: '100%',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.muted,
+    },
+    pendingVideoFallbackText: {
+      ...theme.typography.caption,
+      color: theme.colors.foreground,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+    },
+    pendingAttachmentBadge: {
+      position: 'absolute',
+      left: 4,
+      bottom: 4,
+      borderRadius: radius.sm,
+      backgroundColor: 'rgba(0,0,0,0.7)',
+      paddingHorizontal: 5,
+      paddingVertical: 2,
+    },
+    pendingAttachmentBadgeText: {
+      color: '#FFFFFF',
+      fontSize: 9,
+      fontWeight: '700',
+      lineHeight: 10,
+    },
+    pendingAttachmentRemoveButton: {
       position: 'absolute',
       top: 4,
       right: 4,
@@ -4078,7 +4227,7 @@ function createStyles(theme: Theme, screenHeight: number) {
       alignItems: 'center',
       justifyContent: 'center',
     },
-    pendingImageRemoveButtonText: {
+    pendingAttachmentRemoveButtonText: {
       color: '#FFFFFF',
       fontSize: 11,
       fontWeight: '700',

--- a/apps/mobile/src/ui/MarkdownRenderer.tsx
+++ b/apps/mobile/src/ui/MarkdownRenderer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
+import { splitContentByMarkdownVideos } from '@dotagents/shared';
 import { useTheme } from './ThemeProvider';
 import { spacing, radius } from './theme';
 
@@ -150,14 +151,92 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
       height: 1,
       marginVertical: spacing.xs,
     },
+    videoBlock: {
+      marginBottom: spacing.xs,
+    },
+    videoCaption: {
+      color: theme.colors.mutedForeground,
+      fontSize: 11,
+      lineHeight: 16,
+      marginTop: 4,
+    },
+    videoFallback: {
+      minHeight: 140,
+      maxHeight: 320,
+      borderRadius: radius.md,
+      backgroundColor: theme.colors.muted,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingHorizontal: spacing.sm,
+      paddingVertical: spacing.md,
+    },
+    videoFallbackLabel: {
+      color: theme.colors.foreground,
+      fontSize: 13,
+      lineHeight: 18,
+      fontWeight: '700',
+      marginBottom: 4,
+    },
+    videoFallbackMeta: {
+      color: theme.colors.mutedForeground,
+      fontSize: 11,
+      lineHeight: 16,
+      textAlign: 'center',
+    },
   });
 
+  const segments = splitContentByMarkdownVideos(content);
+
   return (
-    <Markdown style={markdownStyles}>
-      {content}
-    </Markdown>
+    <>
+      {segments.map((segment, index) => {
+        if (segment.kind === 'markdown') {
+          if (!segment.content) {
+            return null;
+          }
+          return (
+            <Markdown key={`markdown-${index}`} style={markdownStyles}>
+              {segment.content}
+            </Markdown>
+          );
+        }
+
+        return (
+          <View key={`video-${index}`} style={markdownStyles.videoBlock}>
+            {Platform.OS === 'web' ? (
+              // React Native Web supports rendering intrinsic media elements.
+              // @ts-ignore - intrinsic video elements are web-only here.
+              <video
+                src={segment.url}
+                controls
+                playsInline
+                preload="metadata"
+                style={{
+                  width: '100%',
+                  minHeight: 140,
+                  maxHeight: 320,
+                  borderRadius: radius.md,
+                  backgroundColor: theme.colors.muted,
+                } as any}
+              />
+            ) : (
+              <View style={markdownStyles.videoFallback}>
+                <Text style={markdownStyles.videoFallbackLabel}>Video attachment</Text>
+                <Text style={markdownStyles.videoFallbackMeta}>
+                  {segment.label || 'Play this video on web or keep it in the transcript as an attachment.'}
+                </Text>
+              </View>
+            )}
+            {!!segment.label && (
+              <Text style={markdownStyles.videoCaption}>{segment.label}</Text>
+            )}
+          </View>
+        );
+      })}
+    </>
   );
 };
 
 export default MarkdownRenderer;
-

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from './hub';
 export * from './conversation-state';
 export * from './agent-progress';
 export * from './message-display-utils';
+export * from './message-media';
 export * from './stt-models';
 export * from './api-key-error-utils';
 export * from './tool-activity-grouping';

--- a/packages/shared/src/message-display-utils.test.ts
+++ b/packages/shared/src/message-display-utils.test.ts
@@ -47,6 +47,11 @@ describe('sanitizeMessageContentForDisplay', () => {
     const content = '![a](data:image/png;base64,x) text ![b](data:image/jpeg;base64,y)'
     expect(sanitizeMessageContentForDisplay(content)).toBe('[Image: a] text [Image: b]')
   })
+
+  it('replaces markdown video tokens with video placeholders', () => {
+    const content = 'Watch this ![video: demo clip](blob:http://localhost/demo)'
+    expect(sanitizeMessageContentForDisplay(content)).toBe('Watch this [Video: demo clip]')
+  })
 })
 
 describe('sanitizeMessageContentForSpeech', () => {
@@ -69,6 +74,11 @@ describe('sanitizeMessageContentForSpeech', () => {
     expect(sanitizeMessageContentForSpeech(content)).toBe('Image')
   })
 
+  it('strips markdown video tokens', () => {
+    const content = 'Review ![video: demo clip](blob:http://localhost/demo) please'
+    expect(sanitizeMessageContentForSpeech(content)).toBe('Review Video: demo clip please')
+  })
+
   it('leaves plain text unchanged', () => {
     const content = 'Just regular text with no images'
     expect(sanitizeMessageContentForSpeech(content)).toBe(content)
@@ -89,6 +99,14 @@ describe('sanitizeConversationHistoryForDisplay', () => {
     const result = sanitizeConversationHistoryForDisplay(history)!
     expect(result[0].content).toBe('[Image: img]')
     expect(result[1].content).toBe('plain text')
+  })
+
+  it('sanitizes markdown videos in conversation history entries', () => {
+    const history = [
+      { role: 'user' as const, content: '![video: preview](blob:http://localhost/demo)' },
+    ]
+    const result = sanitizeConversationHistoryForDisplay(history)!
+    expect(result[0].content).toBe('[Video: preview]')
   })
 
   it('returns same reference when no changes are needed', () => {
@@ -129,5 +147,16 @@ describe('sanitizeAgentProgressUpdateForDisplay', () => {
     expect(result).not.toBe(update)
     expect(result.conversationHistory![0].content).toBe('Here: [Image: pic]')
     expect(result.sessionId).toBe('test')
+  })
+
+  it('sanitizes video history content', () => {
+    const update: AgentProgressUpdate = {
+      ...baseUpdate,
+      conversationHistory: [
+        { role: 'assistant', content: 'Here: ![video: clip](blob:http://localhost/demo)' },
+      ],
+    }
+    const result = sanitizeAgentProgressUpdateForDisplay(update)
+    expect(result.conversationHistory![0].content).toBe('Here: [Video: clip]')
   })
 })

--- a/packages/shared/src/message-display-utils.ts
+++ b/packages/shared/src/message-display-utils.ts
@@ -1,22 +1,32 @@
 import type { AgentProgressUpdate } from "./agent-progress"
+import { replaceMarkdownMedia } from "./message-media"
 
 // Inline data URLs can be megabytes long; replace them in display/budget text.
-const INLINE_DATA_IMAGE_REGEX = /!\[([^\]]*)\]\((data:image\/[^)]+)\)/gi
-const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/gi
+const hasMarkdownVideo = (content: string): boolean => /!\[\s*video:/i.test(content)
 
 export function hasInlineDataImage(content: string): boolean {
   return !!content && /data:image\//i.test(content)
 }
 
 export function sanitizeMessageContentForDisplay(content: string): string {
-  if (!hasInlineDataImage(content)) {
+  if (!hasInlineDataImage(content) && !hasMarkdownVideo(content)) {
     return content
   }
 
-  return content.replace(INLINE_DATA_IMAGE_REGEX, (_match, altText: string) => {
-    const cleanedAlt = altText?.trim()
-    return cleanedAlt ? `[Image: ${cleanedAlt}]` : "[Image]"
+  let changed = false
+  const sanitized = replaceMarkdownMedia(content, ({ kind, label, match, url }) => {
+    if (kind === "video") {
+      changed = true
+      return label ? `[Video: ${label}]` : "[Video]"
+    }
+    if (!/^data:image\//i.test(url)) {
+      return match
+    }
+    changed = true
+    return label ? `[Image: ${label}]` : "[Image]"
   })
+
+  return changed ? sanitized : content
 }
 
 export function sanitizeMessageContentForSpeech(content: string): string {
@@ -24,11 +34,11 @@ export function sanitizeMessageContentForSpeech(content: string): string {
     return content
   }
 
-  // Strip markdown image payloads (including inline data URLs) before TTS.
+  // Strip markdown media payloads before TTS.
   // This keeps speech requests small and avoids reading non-verbal content.
-  return content.replace(MARKDOWN_IMAGE_REGEX, (_match, altText: string) => {
-    const cleanedAlt = altText?.trim()
-    return cleanedAlt ? `Image: ${cleanedAlt}` : "Image"
+  return replaceMarkdownMedia(content, ({ kind, label }) => {
+    const prefix = kind === "video" ? "Video" : "Image"
+    return label ? `${prefix}: ${label}` : prefix
   })
 }
 

--- a/packages/shared/src/message-media.test.ts
+++ b/packages/shared/src/message-media.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMarkdownMediaTag,
+  countMarkdownMedia,
+  escapeMarkdownMediaAltText,
+  getMarkdownMediaKind,
+  getMarkdownMediaLabel,
+  isVideoMarkdownAltText,
+  replaceMarkdownMedia,
+  splitContentByMarkdownVideos,
+} from './message-media'
+
+describe('message-media', () => {
+  it('detects video alt text prefixes', () => {
+    expect(isVideoMarkdownAltText('video: demo')).toBe(true)
+    expect(isVideoMarkdownAltText('Video: demo')).toBe(true)
+    expect(isVideoMarkdownAltText('demo')).toBe(false)
+  })
+
+  it('normalizes media labels and kinds', () => {
+    expect(getMarkdownMediaKind('video: clip')).toBe('video')
+    expect(getMarkdownMediaKind('diagram')).toBe('image')
+    expect(getMarkdownMediaLabel('video: clip')).toBe('clip')
+    expect(getMarkdownMediaLabel('diagram')).toBe('diagram')
+  })
+
+  it('escapes markdown alt text', () => {
+    expect(escapeMarkdownMediaAltText('[demo] \\ clip')).toBe('demo  clip')
+  })
+
+  it('builds image and video markdown tags', () => {
+    expect(buildMarkdownMediaTag('image', 'photo', 'https://example.com/photo.png')).toBe(
+      '![photo](https://example.com/photo.png)'
+    )
+    expect(buildMarkdownMediaTag('video', 'clip', 'blob:http://localhost/demo')).toBe(
+      '![video: clip](blob:http://localhost/demo)'
+    )
+  })
+
+  it('counts image and video markdown tags', () => {
+    const counts = countMarkdownMedia(
+      '![photo](https://example.com/photo.png) ![video: clip](blob:http://localhost/demo)'
+    )
+    expect(counts).toEqual({ images: 1, videos: 1 })
+  })
+
+  it('replaces media tokens while preserving metadata', () => {
+    const result = replaceMarkdownMedia(
+      'Look ![photo](https://example.com/photo.png) and ![video: clip](blob:http://localhost/demo)',
+      ({ kind, label }) => `[${kind}:${label}]`
+    )
+    expect(result).toBe('Look [image:photo] and [video:clip]')
+  })
+
+  it('splits markdown content around video tags', () => {
+    const segments = splitContentByMarkdownVideos(
+      'Before ![video: clip](blob:http://localhost/demo) after ![photo](https://example.com/photo.png)'
+    )
+    expect(segments).toEqual([
+      { kind: 'markdown', content: 'Before ' },
+      { kind: 'video', label: 'clip', url: 'blob:http://localhost/demo' },
+      { kind: 'markdown', content: ' after ![photo](https://example.com/photo.png)' },
+    ])
+  })
+})

--- a/packages/shared/src/message-media.ts
+++ b/packages/shared/src/message-media.ts
@@ -1,0 +1,121 @@
+export type MarkdownMediaKind = 'image' | 'video'
+
+export type MarkdownMediaMatch = {
+  match: string
+  altText: string
+  label: string
+  url: string
+  kind: MarkdownMediaKind
+}
+
+export type MarkdownVideoSegment =
+  | { kind: 'markdown'; content: string }
+  | { kind: 'video'; label: string; url: string }
+
+const MARKDOWN_MEDIA_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/gi
+
+export const VIDEO_MARKDOWN_ALT_PREFIX = 'video:'
+
+const normalizeMarkdownAltText = (altText?: string | null) => (altText || '').trim()
+
+export function escapeMarkdownMediaAltText(value: string): string {
+  return value.replace(/[\[\]\\]/g, '').trim()
+}
+
+export function isVideoMarkdownAltText(altText?: string | null): boolean {
+  return normalizeMarkdownAltText(altText).toLowerCase().startsWith(VIDEO_MARKDOWN_ALT_PREFIX)
+}
+
+export function getMarkdownMediaKind(altText?: string | null): MarkdownMediaKind {
+  return isVideoMarkdownAltText(altText) ? 'video' : 'image'
+}
+
+export function getMarkdownMediaLabel(altText?: string | null): string {
+  const normalized = normalizeMarkdownAltText(altText)
+  if (!normalized) {
+    return ''
+  }
+  if (!isVideoMarkdownAltText(normalized)) {
+    return normalized
+  }
+  return normalized.slice(VIDEO_MARKDOWN_ALT_PREFIX.length).trim()
+}
+
+export function buildMarkdownMediaTag(kind: MarkdownMediaKind, label: string, url: string): string {
+  const safeLabel = escapeMarkdownMediaAltText(label)
+  if (kind === 'video') {
+    return `![${safeLabel ? `video: ${safeLabel}` : 'video'}](${url})`
+  }
+  return `![${safeLabel}](${url})`
+}
+
+export function replaceMarkdownMedia(
+  content: string,
+  replacer: (match: MarkdownMediaMatch) => string
+): string {
+  if (!content) {
+    return content
+  }
+
+  return content.replace(MARKDOWN_MEDIA_REGEX, (match, altText: string, url: string) => (
+    replacer({
+      match,
+      altText,
+      label: getMarkdownMediaLabel(altText),
+      url,
+      kind: getMarkdownMediaKind(altText),
+    })
+  ))
+}
+
+export function countMarkdownMedia(content: string): { images: number; videos: number } {
+  const counts = { images: 0, videos: 0 }
+  replaceMarkdownMedia(content, ({ kind, match }) => {
+    if (kind === 'video') {
+      counts.videos += 1
+    } else {
+      counts.images += 1
+    }
+    return match
+  })
+  return counts
+}
+
+export function splitContentByMarkdownVideos(content: string): MarkdownVideoSegment[] {
+  if (!content) {
+    return [{ kind: 'markdown', content }]
+  }
+
+  const segments: MarkdownVideoSegment[] = []
+  const regex = new RegExp(MARKDOWN_MEDIA_REGEX.source, 'gi')
+  let lastIndex = 0
+  let match: RegExpExecArray | null = null
+
+  while ((match = regex.exec(content)) !== null) {
+    const [fullMatch, altText = '', url = ''] = match
+    if (!isVideoMarkdownAltText(altText)) {
+      continue
+    }
+
+    if (match.index > lastIndex) {
+      segments.push({ kind: 'markdown', content: content.slice(lastIndex, match.index) })
+    }
+
+    segments.push({
+      kind: 'video',
+      label: getMarkdownMediaLabel(altText),
+      url,
+    })
+    lastIndex = match.index + fullMatch.length
+  }
+
+  if (segments.length === 0) {
+    return [{ kind: 'markdown', content }]
+  }
+
+  if (lastIndex < content.length) {
+    segments.push({ kind: 'markdown', content: content.slice(lastIndex) })
+  }
+
+  return segments
+}

--- a/packages/shared/src/session.test.ts
+++ b/packages/shared/src/session.test.ts
@@ -71,6 +71,13 @@ describe('generateSessionTitle', () => {
     expect(title).toContain('[Image]')
     expect(title).not.toContain('data:image')
   })
+
+  it('sanitizes markdown videos in title', () => {
+    const msg = 'Check this ![video: demo](blob:http://localhost/demo)'
+    const title = generateSessionTitle(msg)
+    expect(title).toContain('[Video]')
+    expect(title).not.toContain('blob:http')
+  })
 })
 
 // ── createSession ────────────────────────────────────────────────────────────
@@ -157,6 +164,10 @@ describe('sanitizeSessionText', () => {
 
   it('replaces data URL images with [Image]', () => {
     expect(sanitizeSessionText('![](data:image/png;base64,abc)')).toBe('[Image]')
+  })
+
+  it('replaces markdown videos with [Video]', () => {
+    expect(sanitizeSessionText('See ![video: demo](blob:http://localhost/demo) now')).toBe('See [Video] now')
   })
 })
 

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -3,12 +3,10 @@
  */
 
 import type { ToolCall, ToolResult } from './types';
-
-const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\((?:data:image\/[^)]+|[^)]+)\)/gi;
+import { replaceMarkdownMedia } from './message-media';
 
 export function sanitizeSessionText(content: string): string {
-  return content
-    .replace(MARKDOWN_IMAGE_REGEX, '[Image]')
+  return replaceMarkdownMedia(content, ({ kind }) => (kind === 'video' ? '[Video]' : '[Image]'))
     .replace(/\s+/g, ' ')
     .trim();
 }
@@ -163,4 +161,3 @@ export function sessionToListItem(session: Session): SessionListItem {
 export function isStubSession(session: Session): boolean {
   return session.messages.length === 0 && !!session.serverConversationId && !!session.serverMetadata;
 }
-


### PR DESCRIPTION
## Summary
- add shared markdown media helpers so mobile can distinguish image vs video attachments cleanly
- expand the mobile chat composer from image-only attachments to image/video attachments with safer placeholder sanitization
- render attached videos directly in the mobile transcript on web, with a fallback attachment card on native

Closes #208.

## Validation
- `pnpm --filter @dotagents/shared test`
- `pnpm --filter @dotagents/mobile exec tsc --noEmit`
- validated on live Expo Web before/after using Playwright recordings
