### PR TITLE
Fix queued mobile failed tool-call rendering

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "pnpm run test:node && pnpm run test:vitest",
     "test:node": "node --test \"tests/*.js\"",
-    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
+    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/conversationHistory.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
   },
   "dependencies": {
     "@dotagents/shared": "workspace:^",

--- a/apps/mobile/src/lib/conversationHistory.test.ts
+++ b/apps/mobile/src/lib/conversationHistory.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { buildChatMessagesFromHistory } from './conversationHistory';
+
+describe('buildChatMessagesFromHistory', () => {
+  it('merges queued failed tool results into the preceding assistant tool call', () => {
+    const messages = buildChatMessagesFromHistory([
+      { role: 'user', content: 'First queued request', timestamp: 100 },
+      { role: 'assistant', content: 'First request complete.', timestamp: 200 },
+      { role: 'user', content: 'Second queued request', timestamp: 300 },
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 400,
+        toolCalls: [{ name: 'read_file', arguments: { path: 'package.json.missing' } }],
+      },
+      {
+        role: 'tool',
+        content: 'ENOENT: package.json.missing',
+        timestamp: 500,
+        toolResults: [{ success: false, content: '', error: 'ENOENT: package.json.missing' }],
+      },
+    ], { latestTurnOnly: true });
+
+    expect(messages).toEqual([
+      {
+        id: undefined,
+        role: 'assistant',
+        content: '',
+        timestamp: 400,
+        toolCalls: [{ name: 'read_file', arguments: { path: 'package.json.missing' } }],
+        toolResults: [{ success: false, content: '', error: 'ENOENT: package.json.missing' }],
+      },
+    ]);
+  });
+
+  it('includes user messages when requested for full conversation recovery', () => {
+    const messages = buildChatMessagesFromHistory([
+      { id: 'user-1', role: 'user', content: 'hello', timestamp: 100 },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '',
+        timestamp: 200,
+        toolCalls: [{ name: 'read_file', arguments: { path: 'README.md' } }],
+      },
+      {
+        id: 'tool-1',
+        role: 'tool',
+        content: '',
+        timestamp: 300,
+        toolResults: [{ success: true, content: '# README' }],
+      },
+    ], { includeUsers: true });
+
+    expect(messages).toEqual([
+      { id: 'user-1', role: 'user', content: 'hello', timestamp: 100, toolCalls: undefined, toolResults: undefined },
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: '',
+        timestamp: 200,
+        toolCalls: [{ name: 'read_file', arguments: { path: 'README.md' } }],
+        toolResults: [{ success: true, content: '# README' }],
+      },
+    ]);
+  });
+});
+

--- a/apps/mobile/src/lib/conversationHistory.ts
+++ b/apps/mobile/src/lib/conversationHistory.ts
@@ -1,0 +1,72 @@
+import type { ChatMessage } from './openaiClient';
+
+type ConversationHistoryLikeMessage = {
+  id?: string;
+  role: ChatMessage['role'];
+  content?: string;
+  timestamp?: number;
+  toolCalls?: ChatMessage['toolCalls'];
+  toolResults?: ChatMessage['toolResults'];
+};
+
+export interface BuildChatMessagesFromHistoryOptions {
+  includeUsers?: boolean;
+  latestTurnOnly?: boolean;
+}
+
+export function buildChatMessagesFromHistory(
+  history: ConversationHistoryLikeMessage[] | undefined,
+  options: BuildChatMessagesFromHistoryOptions = {}
+): ChatMessage[] {
+  if (!history?.length) {
+    return [];
+  }
+
+  const { includeUsers = false, latestTurnOnly = false } = options;
+  let startIndex = 0;
+
+  if (latestTurnOnly) {
+    for (let i = 0; i < history.length; i++) {
+      if (history[i]?.role === 'user') {
+        startIndex = i;
+      }
+    }
+  }
+
+  const messages: ChatMessage[] = [];
+  for (let i = startIndex; i < history.length; i++) {
+    const historyMsg = history[i];
+    if (!historyMsg) {
+      continue;
+    }
+
+    if (!includeUsers && historyMsg.role === 'user') {
+      continue;
+    }
+
+    if (historyMsg.role === 'tool' && messages.length > 0) {
+      const lastMessage = messages[messages.length - 1];
+      if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
+        const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
+        if (hasToolResults) {
+          lastMessage.toolResults = [
+            ...(lastMessage.toolResults || []),
+            ...(historyMsg.toolResults || []),
+          ];
+          continue;
+        }
+      }
+    }
+
+    messages.push({
+      id: historyMsg.id,
+      role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
+      content: historyMsg.content || '',
+      timestamp: historyMsg.timestamp,
+      toolCalls: historyMsg.toolCalls,
+      toolResults: historyMsg.toolResults,
+    });
+  }
+
+  return messages;
+}

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -83,6 +83,7 @@ import { formatVoiceDebugEntry, useVoiceDebug } from '../lib/voice/voiceDebug';
 import { useSpeechRecognizer } from '../lib/voice/useSpeechRecognizer';
 import { useHandsFreeController } from '../lib/voice/useHandsFreeController';
 import { createDelegationProgressMessages } from '../lib/delegationProgress';
+import { buildChatMessagesFromHistory } from '../lib/conversationHistory';
 
 interface PendingImageAttachment {
   id: string;
@@ -1719,48 +1720,11 @@ export default function ChatScreen({ route, navigation }: any) {
     }
 
     if (update.conversationHistory && update.conversationHistory.length > 0) {
-      let currentTurnStartIndex = 0;
-      for (let i = 0; i < update.conversationHistory.length; i++) {
-        if (update.conversationHistory[i].role === 'user') {
-          currentTurnStartIndex = i;
-        }
-      }
-
-      const hasAssistantMessages = currentTurnStartIndex + 1 < update.conversationHistory.length;
+      const assistantMessages = buildChatMessagesFromHistory(update.conversationHistory, { latestTurnOnly: true });
+      const hasAssistantMessages = assistantMessages.length > 0;
       if (hasAssistantMessages) {
         messages.length = 0;
-
-        for (let i = currentTurnStartIndex + 1; i < update.conversationHistory.length; i++) {
-          const historyMsg = update.conversationHistory[i];
-
-          // Merge tool results into the preceding assistant message to avoid duplication
-          // The server sends: assistant (with toolCalls) -> tool (with toolResults)
-          // We want to display them as a single message with both toolCalls and toolResults
-          if (historyMsg.role === 'tool' && messages.length > 0) {
-            const lastMessage = messages[messages.length - 1];
-            if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-
-              if (hasToolResults) {
-                // Merge toolResults into the existing assistant message
-                lastMessage.toolResults = [
-                  ...(lastMessage.toolResults || []),
-                  ...(historyMsg.toolResults || []),
-                ];
-                // Skip adding this as a separate message only when we merged results
-                continue;
-              }
-              // If tool message has content but no toolResults, fall through to add it as a message
-            }
-          }
-
-          messages.push({
-            role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-            content: historyMsg.content || '',
-            toolCalls: historyMsg.toolCalls,
-            toolResults: historyMsg.toolResults,
-          });
-        }
+        messages.push(...assistantMessages);
       }
     }
 
@@ -2131,49 +2095,8 @@ export default function ChatScreen({ route, navigation }: any) {
       if (response.conversationHistory && response.conversationHistory.length > 0) {
         console.log('[ChatScreen] Processing final conversationHistory:', response.conversationHistory.length, 'messages');
         console.log('[ChatScreen] ConversationHistory roles:', response.conversationHistory.map(m => m.role).join(', '));
-
-        let currentTurnStartIndex = 0;
-        for (let i = 0; i < response.conversationHistory.length; i++) {
-          if (response.conversationHistory[i].role === 'user') {
-            currentTurnStartIndex = i;
-          }
-        }
-        console.log('[ChatScreen] currentTurnStartIndex:', currentTurnStartIndex);
-
-        const newMessages: ChatMessage[] = [];
-        for (let i = currentTurnStartIndex; i < response.conversationHistory.length; i++) {
-          const historyMsg = response.conversationHistory[i];
-          if (historyMsg.role === 'user') continue;
-
-          // Merge tool results into the preceding assistant message to avoid duplication
-          // The server sends: assistant (with toolCalls) -> tool (with toolResults)
-          // We want to display them as a single message with both toolCalls and toolResults
-          if (historyMsg.role === 'tool' && newMessages.length > 0) {
-            const lastMessage = newMessages[newMessages.length - 1];
-            if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-              const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-
-              if (hasToolResults) {
-                // Merge toolResults into the existing assistant message
-                lastMessage.toolResults = [
-                  ...(lastMessage.toolResults || []),
-                  ...(historyMsg.toolResults || []),
-                ];
-                // Skip adding this as a separate message only when we merged results
-                continue;
-              }
-              // If tool message has content but no toolResults, fall through to add it as a message
-            }
-          }
-
-          newMessages.push({
-            role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-            content: historyMsg.content || '',
-            toolCalls: historyMsg.toolCalls,
-            toolResults: historyMsg.toolResults,
-          });
-        }
-		        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
+        const newMessages = buildChatMessagesFromHistory(response.conversationHistory, { latestTurnOnly: true });
+        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
 	        console.log('[ChatScreen] newMessages count:', finalTurnMessages.length);
 	        console.log('[ChatScreen] newMessages roles:', finalTurnMessages.map(m => `${m.role}(toolCalls:${m.toolCalls?.length || 0},toolResults:${m.toolResults?.length || 0})`).join(', '));
         console.log('[ChatScreen] messageCountBeforeTurn:', messageCountBeforeTurn);
@@ -2540,25 +2463,8 @@ export default function ChatScreen({ route, navigation }: any) {
       }
 
       if (response.conversationHistory && response.conversationHistory.length > 0) {
-        let currentTurnStartIndex = 0;
-        for (let i = 0; i < response.conversationHistory.length; i++) {
-          if (response.conversationHistory[i].role === 'user') {
-            currentTurnStartIndex = i;
-          }
-        }
-
-        const newMessages: ChatMessage[] = [];
-        for (let i = currentTurnStartIndex; i < response.conversationHistory.length; i++) {
-          const historyMsg = response.conversationHistory[i];
-          if (historyMsg.role === 'user') continue;
-          newMessages.push({
-            role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-            content: historyMsg.content || '',
-            toolCalls: historyMsg.toolCalls,
-            toolResults: historyMsg.toolResults,
-          });
-        }
-	        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
+        const newMessages = buildChatMessagesFromHistory(response.conversationHistory, { latestTurnOnly: true });
+        const finalTurnMessages = applyUserResponseToMessages(newMessages, finalResponseEvent?.text || lastUserResponse);
 
         setMessages((m) => {
           const beforePlaceholder = m.slice(0, messageCountBeforeTurn + 1);
@@ -3592,33 +3498,10 @@ export default function ChatScreen({ route, navigation }: any) {
 
                           // Convert server messages to ChatMessage format, filtering out tool messages
                           // and merging their toolResults into the preceding assistant message
-                          const recoveredMessages: ChatMessage[] = [];
-                          for (const msg of serverMessages) {
-                            // Only include 'user' and 'assistant' roles
-                            if (msg.role === 'user' || msg.role === 'assistant') {
-                              recoveredMessages.push({
-                                id: msg.id,
-                                role: msg.role,
-                                content: msg.content,
-                                toolCalls: msg.toolCalls,
-                                toolResults: msg.toolResults,
-                              });
-                            } else if (msg.role === 'tool' && recoveredMessages.length > 0) {
-                              // Merge tool message toolResults into the preceding assistant message
-                              const lastMessage = recoveredMessages[recoveredMessages.length - 1];
-                              if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-                                const hasToolResults = msg.toolResults && msg.toolResults.length > 0;
-
-                                if (hasToolResults) {
-                                  // Merge toolResults into the existing assistant message
-                                  lastMessage.toolResults = [
-                                    ...(lastMessage.toolResults || []),
-                                    ...(msg.toolResults || []),
-                                  ];
-                                }
-                              }
-                            }
-                          }
+                          const recoveredMessages = buildChatMessagesFromHistory(
+                            serverMessages as Array<ChatMessage & { id?: string }>,
+                            { includeUsers: true }
+                          );
 
                           // Replace local messages with server state
                           setMessages(recoveredMessages);

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -15,6 +15,7 @@ import { ChatMessage, AgentProgressUpdate } from '../lib/openaiClient';
 import { SettingsApiClient } from '../lib/settingsApi';
 import { SessionListItem, isStubSession } from '../types/session';
 import { createButtonAccessibilityLabel, createMinimumTouchTargetStyle, createTextInputAccessibilityLabel } from '../lib/accessibility';
+import { buildChatMessagesFromHistory } from '../lib/conversationHistory';
 import { filterSessionSearchResults, type SessionSearchResult } from './session-list-search';
 
 const darkSpinner = require('../../assets/loading-spinner.gif');
@@ -93,44 +94,7 @@ export default function SessionListScreen({ navigation }: Props) {
   }, [normalizeVoiceText]);
 
   const rfBuildMessagesFromHistory = useCallback((history: any[]): ChatMessage[] => {
-    if (!history || history.length === 0) return [];
-
-    let currentTurnStartIndex = 0;
-    for (let i = 0; i < history.length; i++) {
-      if (history[i]?.role === 'user') {
-        currentTurnStartIndex = i;
-      }
-    }
-
-    const messages: ChatMessage[] = [];
-    for (let i = currentTurnStartIndex + 1; i < history.length; i++) {
-      const historyMsg = history[i];
-      if (!historyMsg) continue;
-
-      // Merge tool results into the preceding assistant message, matching ChatScreen behavior.
-      if (historyMsg.role === 'tool' && messages.length > 0) {
-        const lastMessage = messages[messages.length - 1];
-        if (lastMessage.role === 'assistant' && lastMessage.toolCalls && lastMessage.toolCalls.length > 0) {
-          const hasToolResults = historyMsg.toolResults && historyMsg.toolResults.length > 0;
-          if (hasToolResults) {
-            lastMessage.toolResults = [
-              ...(lastMessage.toolResults || []),
-              ...(historyMsg.toolResults || []),
-            ];
-            continue;
-          }
-        }
-      }
-
-      messages.push({
-        role: historyMsg.role === 'tool' ? 'assistant' : historyMsg.role,
-        content: historyMsg.content || '',
-        toolCalls: historyMsg.toolCalls,
-        toolResults: historyMsg.toolResults,
-      });
-    }
-
-    return messages;
+    return buildChatMessagesFromHistory(history, { latestTurnOnly: true });
   }, []);
 
   const rfRunBackgroundSend = useCallback(async (sessionId: string, userText: string) => {


### PR DESCRIPTION
## Summary
- add a shared mobile conversation-history builder that merges tool results back into the originating assistant tool-call message
- reuse that builder in ChatScreen progress/final/recovery flows and SessionListScreen rapid-fire sync so queued and non-queued paths stay aligned
- add a regression test for the queued failed-tool case and include it in the mobile Vitest script

## Validation
- pnpm --filter @dotagents/mobile exec tsc --noEmit
- pnpm --filter @dotagents/mobile run test:vitest
- validated the issue live in Expo web with CDP before/after recordings for the queued failed-tool repro

Closes #210