### PR TITLE
Keep secrets out of shareable .agents config

### DIFF
--- a/apps/desktop/src/renderer/src/components/local-only-secret-note.tsx
+++ b/apps/desktop/src/renderer/src/components/local-only-secret-note.tsx
@@ -1,0 +1,7 @@
+export function LocalOnlySecretNote({ className = "" }: { className?: string }) {
+  return (
+    <div className={`rounded-md border border-border/60 bg-muted/40 px-3 py-2 text-xs text-muted-foreground ${className}`.trim()}>
+      API keys and other secrets stay in local app config and are omitted from shareable <span className="font-mono">.agents</span> files.
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/model-preset-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/model-preset-manager.tsx
@@ -23,6 +23,7 @@ import { toast } from "sonner"
 import { Plus, Pencil, Trash2, Key, Globe, Bot, FileText, Settings2 } from "lucide-react"
 import { getBuiltInModelPresets, DEFAULT_MODEL_PRESET_ID } from "@shared/index"
 import { PresetModelSelector } from "./preset-model-selector"
+import { LocalOnlySecretNote } from "./local-only-secret-note"
 
 export function ModelPresetManager({
   showAgentModel = true,
@@ -390,6 +391,7 @@ export function ModelPresetManager({
                 onChange={(e) => setNewPreset({ ...newPreset, apiKey: e.target.value })}
                 placeholder="sk-..."
               />
+              <LocalOnlySecretNote className="mt-2" />
             </div>
 
             {/* Model Preferences Section */}
@@ -503,6 +505,7 @@ export function ModelPresetManager({
                   }
                   placeholder="sk-..."
                 />
+                <LocalOnlySecretNote className="mt-2" />
               </div>
 
               {/* Model Preferences Section */}
@@ -568,4 +571,3 @@ export function ModelPresetManager({
     </div>
   )
 }
-

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -26,6 +26,7 @@ import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "react-router-dom"
 import { Config } from "@shared/types"
 import { KeyRecorder } from "@renderer/components/key-recorder"
+import { LocalOnlySecretNote } from "@renderer/components/local-only-secret-note"
 import {
   getEffectiveShortcut,
   formatKeyComboForDisplay,
@@ -1336,14 +1337,17 @@ export function Component() {
               </Control>
 
               <Control label={<ControlLabel label="Secret Key" tooltip="Your Langfuse project's secret key" />} className="px-3">
-                <Input
-                  type="password"
-                  value={langfuseDrafts.langfuseSecretKey}
-                  onChange={(e) => updateLangfuseDraft("langfuseSecretKey", e.currentTarget.value)}
-                  onBlur={(e) => flushLangfuseSave("langfuseSecretKey", e.currentTarget.value)}
-                  placeholder="sk-lf-..."
-                  className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
-                />
+                <div className="w-full space-y-2">
+                  <Input
+                    type="password"
+                    value={langfuseDrafts.langfuseSecretKey}
+                    onChange={(e) => updateLangfuseDraft("langfuseSecretKey", e.currentTarget.value)}
+                    onBlur={(e) => flushLangfuseSave("langfuseSecretKey", e.currentTarget.value)}
+                    placeholder="sk-lf-..."
+                    className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
+                  />
+                  <LocalOnlySecretNote className="sm:max-w-[360px]" />
+                </div>
               </Control>
 
               <Control label={<ControlLabel label="Base URL" tooltip="Langfuse API endpoint. Leave empty for Langfuse Cloud (cloud.langfuse.com)" />} className="px-3">

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select"
 import { Button } from "@renderer/components/ui/button"
+import { LocalOnlySecretNote } from "@renderer/components/local-only-secret-note"
 import {
   useConfigQuery,
   useSaveConfigMutation,
@@ -903,6 +904,10 @@ export function Component() {
                   placeholder: "https://api.groq.com/openai/v1",
                 })}
 
+                <div className="px-3 py-2">
+                  <LocalOnlySecretNote />
+                </div>
+
                 <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
                   Groq model selection now lives on the Models page.
                 </p>
@@ -948,6 +953,10 @@ export function Component() {
                   type: "url",
                   placeholder: "https://generativelanguage.googleapis.com",
                 })}
+
+                <div className="px-3 py-2">
+                  <LocalOnlySecretNote />
+                </div>
 
                 <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
                   Gemini model selection now lives on the Models page.
@@ -1030,6 +1039,10 @@ export function Component() {
                   placeholder: "https://api.groq.com/openai/v1",
                 })}
 
+                <div className="px-3 py-2">
+                  <LocalOnlySecretNote />
+                </div>
+
                 <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
                   Groq model selection now lives on the Models page.
                 </p>
@@ -1073,6 +1086,10 @@ export function Component() {
                   type: "url",
                   placeholder: "https://generativelanguage.googleapis.com",
                 })}
+
+                <div className="px-3 py-2">
+                  <LocalOnlySecretNote />
+                </div>
 
                 <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
                   Gemini model selection now lives on the Models page.

--- a/packages/core/src/agents-files/modular-config.test.ts
+++ b/packages/core/src/agents-files/modular-config.test.ts
@@ -8,6 +8,7 @@ import {
   getAgentsLayerPaths,
   loadAgentsLayerConfig,
   loadMergedAgentsConfig,
+  sanitizeAgentsLayerFiles,
   writeAgentsLayerFromConfig,
   writeAgentsPrompts,
 } from "./modular-config"
@@ -74,6 +75,23 @@ describe("modular-config", () => {
       mcpMaxIterations: 99,
       openaiApiKey: "sk-test",
       themePreference: "dark",
+      remoteServerApiKey: "local-only-key",
+      modelPresets: [
+        {
+          id: "preset-a",
+          name: "Preset A",
+          baseUrl: "https://example.com/v1",
+          apiKey: "preset-secret",
+        },
+      ],
+      mcpConfig: {
+        mcpServers: {
+          demo: {
+            command: "demo-server",
+            env: { API_KEY: "secret" },
+          },
+        },
+      },
       mcpCustomSystemPrompt: "",
       mcpToolsSystemPrompt: "Extra guidelines",
     } as unknown as Config
@@ -96,8 +114,56 @@ describe("modular-config", () => {
 
     expect(settings.textInputEnabled).toBe(false)
     expect(mcp.mcpMaxIterations).toBe(99)
-    expect(models.openaiApiKey).toBe("sk-test")
+    expect(models.openaiApiKey).toBeUndefined()
+    expect(models.modelPresets[0].apiKey).toBeUndefined()
+    expect(settings.remoteServerApiKey).toBeUndefined()
+    expect(mcp.mcpConfig.mcpServers.demo.env).toBeUndefined()
     expect(layout.themePreference).toBe("dark")
+  })
+
+  it("sanitizes existing agents layer files in place", () => {
+    const dir = mkTempDir("dotagents-modular-sanitize-")
+    const agentsDir = path.join(dir, ".agents")
+    const layer = getAgentsLayerPaths(agentsDir)
+
+    writeJson(layer.settingsJsonPath, {
+      remoteServerApiKey: "local-only-key",
+      launchAtLogin: true,
+    })
+    writeJson(layer.modelsJsonPath, {
+      groqApiKey: "sk-groq",
+      modelPresets: [
+        {
+          id: "preset-a",
+          name: "Preset A",
+          apiKey: "preset-secret",
+        },
+      ],
+    })
+    writeJson(layer.mcpJsonPath, {
+      mcpConfig: {
+        mcpServers: {
+          demo: {
+            command: "demo-server",
+            env: { API_KEY: "secret" },
+          },
+        },
+      },
+      mcpMaxIterations: 5,
+    })
+
+    expect(sanitizeAgentsLayerFiles(layer)).toBe(true)
+
+    const settings = JSON.parse(fs.readFileSync(layer.settingsJsonPath, "utf8"))
+    const models = JSON.parse(fs.readFileSync(layer.modelsJsonPath, "utf8"))
+    const mcp = JSON.parse(fs.readFileSync(layer.mcpJsonPath, "utf8"))
+
+    expect(settings.remoteServerApiKey).toBeUndefined()
+    expect(settings.launchAtLogin).toBe(true)
+    expect(models.groqApiKey).toBeUndefined()
+    expect(models.modelPresets[0].apiKey).toBeUndefined()
+    expect(mcp.mcpConfig.mcpServers.demo.env).toBeUndefined()
+    expect(mcp.mcpMaxIterations).toBe(5)
   })
 
   it("finds .agents directory upward", () => {

--- a/packages/core/src/agents-files/modular-config.ts
+++ b/packages/core/src/agents-files/modular-config.ts
@@ -8,6 +8,7 @@ import {
   safeWriteJsonFileSync,
 } from "./safe-file"
 import { parseFrontmatterOrBody, stringifyFrontmatterDocument } from "./frontmatter"
+import { createShareableConfig, mergeConfigWithLocalOnlyPreference } from "../config-secrets"
 
 export const AGENTS_DIR_NAME = ".agents"
 export const AGENTS_BACKUPS_DIR_NAME = ".backups"
@@ -130,7 +131,9 @@ export function loadMergedAgentsConfig(
     : ({} as Partial<Config>)
 
   return {
-    merged: { ...globalConfig, ...workspaceConfig },
+    merged: mergeConfigWithLocalOnlyPreference(workspaceConfig, globalConfig, {
+      preferPrimaryLocalOnly: true,
+    }),
     hasAnyAgentsFiles: globalHas || workspaceHas,
   }
 }
@@ -258,7 +261,7 @@ export function writeAgentsLayerFromConfig(
   ensureDirSync(layer.agentsDir)
   ensureDirSync(layer.layoutsDir)
 
-  const split = splitConfigIntoAgentsFiles(config)
+  const split = splitConfigIntoAgentsFiles(createShareableConfig(config) as Config)
 
   const writeJsonIfNeeded = (filePath: string, value: unknown) => {
     if (onlyIfMissing && fileExists(filePath)) return
@@ -273,6 +276,42 @@ export function writeAgentsLayerFromConfig(
   writeJsonIfNeeded(layer.mcpJsonPath, split.mcp)
   writeJsonIfNeeded(layer.modelsJsonPath, split.models)
   writeJsonIfNeeded(layer.layoutJsonPath, split.layout)
+}
+
+export function sanitizeAgentsLayerFiles(
+  layer: AgentsLayerPaths,
+  options: { maxBackups?: number } = {},
+): boolean {
+  const maxBackups = options.maxBackups ?? 10
+  const filePaths = [
+    layer.settingsJsonPath,
+    layer.mcpJsonPath,
+    layer.modelsJsonPath,
+    layer.layoutJsonPath,
+  ]
+
+  let sanitized = false
+
+  for (const filePath of filePaths) {
+    if (!fileExists(filePath)) continue
+
+    const current = safeReadJsonFileSync<Partial<Config>>(filePath, {
+      backupDir: layer.backupsDir,
+      defaultValue: {},
+    })
+    const shareable = createShareableConfig(current)
+
+    if (JSON.stringify(current) === JSON.stringify(shareable)) continue
+
+    safeWriteJsonFileSync(filePath, shareable, {
+      backupDir: layer.backupsDir,
+      maxBackups,
+      pretty: true,
+    })
+    sanitized = true
+  }
+
+  return sanitized
 }
 
 /**

--- a/packages/core/src/config-secrets.test.ts
+++ b/packages/core/src/config-secrets.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest"
+import {
+  createShareableConfig,
+  hasLocalOnlyConfigValues,
+  mergeConfigWithLocalOnlyPreference,
+} from "./config-secrets"
+
+describe("config-secrets", () => {
+  it("strips local-only values from shareable config output", () => {
+    const shareable = createShareableConfig({
+      openaiApiKey: "sk-local",
+      langfuseSecretKey: "sk-langfuse",
+      pushNotificationTokens: [{ token: "expo-token" }],
+      modelPresets: [
+        { id: "preset-a", name: "Preset A", baseUrl: "https://example.com/v1", apiKey: "preset-key" },
+      ],
+      mcpConfig: {
+        mcpServers: {
+          demo: {
+            command: "demo-server",
+            env: { API_KEY: "secret" },
+            headers: { Authorization: "Bearer token" },
+            oauth: { clientSecret: "shh" },
+          },
+        },
+      },
+      acpAgents: [
+        {
+          name: "remote-agent",
+          displayName: "Remote Agent",
+          connection: {
+            type: "stdio",
+            command: "remote-agent",
+            env: { AUTH_TOKEN: "secret" },
+          },
+        },
+      ],
+    })
+
+    expect(shareable.openaiApiKey).toBeUndefined()
+    expect(shareable.langfuseSecretKey).toBeUndefined()
+    expect(shareable.pushNotificationTokens).toBeUndefined()
+    expect(shareable.modelPresets?.[0]?.apiKey).toBeUndefined()
+    expect(shareable.mcpConfig?.mcpServers.demo.env).toBeUndefined()
+    expect(shareable.mcpConfig?.mcpServers.demo.headers).toBeUndefined()
+    expect(shareable.mcpConfig?.mcpServers.demo.oauth).toBeUndefined()
+    expect(shareable.acpAgents?.[0]?.connection.env).toBeUndefined()
+  })
+
+  it("preserves local-only values from fallback config when shareable config omits them", () => {
+    const merged = mergeConfigWithLocalOnlyPreference(
+      {
+        modelPresets: [
+          { id: "preset-a", name: "Preset A", baseUrl: "https://example.com/v1", mcpToolsModel: "gpt-5.4" },
+        ],
+        mcpConfig: {
+          mcpServers: {
+            demo: {
+              command: "demo-server-v2",
+            },
+          },
+        },
+        acpAgents: [
+          {
+            name: "remote-agent",
+            displayName: "Remote Agent",
+            connection: {
+              type: "stdio",
+              command: "remote-agent-v2",
+            },
+          },
+        ],
+      },
+      {
+        openaiApiKey: "sk-local",
+        remoteServerApiKey: "remote-secret",
+        modelPresets: [
+          { id: "preset-a", name: "Preset A", baseUrl: "https://example.com/v1", apiKey: "preset-secret" },
+        ],
+        mcpConfig: {
+          mcpServers: {
+            demo: {
+              command: "demo-server-v1",
+              env: { API_KEY: "secret" },
+            },
+          },
+        },
+        acpAgents: [
+          {
+            name: "remote-agent",
+            displayName: "Remote Agent",
+            connection: {
+              type: "stdio",
+              command: "remote-agent-v1",
+              env: { AUTH_TOKEN: "secret" },
+            },
+          },
+        ],
+      },
+      { preferPrimaryLocalOnly: false },
+    )
+
+    expect(merged.openaiApiKey).toBe("sk-local")
+    expect(merged.remoteServerApiKey).toBe("remote-secret")
+    expect(merged.modelPresets?.[0]?.mcpToolsModel).toBe("gpt-5.4")
+    expect(merged.modelPresets?.[0]?.apiKey).toBe("preset-secret")
+    expect(merged.mcpConfig?.mcpServers.demo.command).toBe("demo-server-v2")
+    expect(merged.mcpConfig?.mcpServers.demo.env).toEqual({ API_KEY: "secret" })
+    expect(merged.acpAgents?.[0]?.connection.command).toBe("remote-agent-v2")
+    expect(merged.acpAgents?.[0]?.connection.env).toEqual({ AUTH_TOKEN: "secret" })
+  })
+
+  it("detects when a config still contains local-only values", () => {
+    expect(hasLocalOnlyConfigValues({
+      modelPresets: [{ id: "preset-a", name: "Preset A", baseUrl: "https://example.com/v1", apiKey: "preset-secret" }],
+    })).toBe(true)
+
+    expect(hasLocalOnlyConfigValues({
+      modelPresets: [{ id: "preset-a", name: "Preset A", baseUrl: "https://example.com/v1" }],
+    })).toBe(false)
+  })
+})

--- a/packages/core/src/config-secrets.ts
+++ b/packages/core/src/config-secrets.ts
@@ -1,0 +1,357 @@
+import type { Config } from "./types"
+
+type ConfigRecord = Record<string, unknown>
+
+const LOCAL_ONLY_TOP_LEVEL_KEYS = [
+  "openaiApiKey",
+  "groqApiKey",
+  "geminiApiKey",
+  "remoteServerApiKey",
+  "langfuseSecretKey",
+  "pushNotificationTokens",
+] as const
+
+const LOCAL_ONLY_MCP_SERVER_KEYS = ["env", "headers", "oauth"] as const
+
+function isRecordObject(value: unknown): value is ConfigRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function hasDefinedValue(value: unknown): boolean {
+  return value !== undefined
+}
+
+function hasMeaningfulLocalOnlyValue(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  if (isRecordObject(value)) return Object.keys(value).length > 0
+  return value !== undefined && value !== null
+}
+
+function pickLocalOnlyValue(
+  primaryValue: unknown,
+  secondaryValue: unknown,
+  preferPrimary: boolean,
+): unknown {
+  const preferredValue = preferPrimary ? primaryValue : secondaryValue
+  const fallbackValue = preferPrimary ? secondaryValue : primaryValue
+
+  if (hasMeaningfulLocalOnlyValue(preferredValue)) return preferredValue
+  if (hasMeaningfulLocalOnlyValue(fallbackValue)) return fallbackValue
+  if (hasDefinedValue(preferredValue)) return preferredValue
+  if (hasDefinedValue(fallbackValue)) return fallbackValue
+  return undefined
+}
+
+function mergeModelPresets(
+  primaryValue: unknown,
+  secondaryValue: unknown,
+  preferPrimaryLocalOnly: boolean,
+): unknown {
+  if (!Array.isArray(primaryValue)) return secondaryValue
+  if (!Array.isArray(secondaryValue)) {
+    return primaryValue.map((preset) => {
+      if (!isRecordObject(preset)) return preset
+      const { apiKey, ...rest } = preset
+      const mergedApiKey = pickLocalOnlyValue(apiKey, undefined, preferPrimaryLocalOnly)
+      return mergedApiKey === undefined ? rest : { ...rest, apiKey: mergedApiKey }
+    })
+  }
+
+  const secondaryById = new Map<string, ConfigRecord>()
+  for (const preset of secondaryValue) {
+    if (!isRecordObject(preset) || typeof preset.id !== "string") continue
+    secondaryById.set(preset.id, preset)
+  }
+
+  return primaryValue.map((preset) => {
+    if (!isRecordObject(preset) || typeof preset.id !== "string") return preset
+
+    const secondaryPreset = secondaryById.get(preset.id)
+    const mergedPreset = secondaryPreset ? { ...secondaryPreset, ...preset } : { ...preset }
+    const mergedApiKey = pickLocalOnlyValue(
+      preset.apiKey,
+      secondaryPreset?.apiKey,
+      preferPrimaryLocalOnly,
+    )
+
+    if (mergedApiKey === undefined) {
+      delete mergedPreset.apiKey
+    } else {
+      mergedPreset.apiKey = mergedApiKey
+    }
+
+    return mergedPreset
+  })
+}
+
+function mergeMcpConfig(
+  primaryValue: unknown,
+  secondaryValue: unknown,
+  preferPrimaryLocalOnly: boolean,
+): unknown {
+  if (!isRecordObject(primaryValue)) return secondaryValue
+  if (!isRecordObject(secondaryValue)) {
+    const primaryCopy = { ...primaryValue }
+    if (isRecordObject(primaryValue.mcpServers)) {
+      const mergedServers: ConfigRecord = {}
+      for (const [serverName, serverConfig] of Object.entries(primaryValue.mcpServers)) {
+        if (!isRecordObject(serverConfig)) {
+          mergedServers[serverName] = serverConfig
+          continue
+        }
+
+        const nextServer = { ...serverConfig }
+        for (const key of LOCAL_ONLY_MCP_SERVER_KEYS) {
+          const mergedValue = pickLocalOnlyValue(serverConfig[key], undefined, preferPrimaryLocalOnly)
+          if (mergedValue === undefined) {
+            delete nextServer[key]
+          } else {
+            nextServer[key] = mergedValue
+          }
+        }
+        mergedServers[serverName] = nextServer
+      }
+      primaryCopy.mcpServers = mergedServers
+    }
+    return primaryCopy
+  }
+
+  const mergedConfig: ConfigRecord = { ...secondaryValue, ...primaryValue }
+  if (!isRecordObject(primaryValue.mcpServers)) return mergedConfig
+
+  const secondaryServers = isRecordObject(secondaryValue.mcpServers)
+    ? secondaryValue.mcpServers
+    : {}
+
+  const mergedServers: ConfigRecord = {}
+  for (const [serverName, serverConfig] of Object.entries(primaryValue.mcpServers)) {
+    const secondaryServer = isRecordObject(secondaryServers[serverName])
+      ? secondaryServers[serverName]
+      : undefined
+
+    if (!isRecordObject(serverConfig)) {
+      mergedServers[serverName] = serverConfig
+      continue
+    }
+
+    const nextServer: ConfigRecord = secondaryServer
+      ? { ...secondaryServer, ...serverConfig }
+      : { ...serverConfig }
+
+    for (const key of LOCAL_ONLY_MCP_SERVER_KEYS) {
+      const mergedValue = pickLocalOnlyValue(
+        serverConfig[key],
+        secondaryServer?.[key],
+        preferPrimaryLocalOnly,
+      )
+      if (mergedValue === undefined) {
+        delete nextServer[key]
+      } else {
+        nextServer[key] = mergedValue
+      }
+    }
+
+    mergedServers[serverName] = nextServer
+  }
+
+  mergedConfig.mcpServers = mergedServers
+  return mergedConfig
+}
+
+function mergeAcpAgents(
+  primaryValue: unknown,
+  secondaryValue: unknown,
+  preferPrimaryLocalOnly: boolean,
+): unknown {
+  if (!Array.isArray(primaryValue)) return secondaryValue
+  if (!Array.isArray(secondaryValue)) {
+    return primaryValue.map((agent) => {
+      if (!isRecordObject(agent) || !isRecordObject(agent.connection)) return agent
+      const nextAgent = { ...agent }
+      const nextConnection = { ...agent.connection }
+      const mergedEnv = pickLocalOnlyValue(agent.connection.env, undefined, preferPrimaryLocalOnly)
+      if (mergedEnv === undefined) {
+        delete nextConnection.env
+      } else {
+        nextConnection.env = mergedEnv
+      }
+      nextAgent.connection = nextConnection
+      return nextAgent
+    })
+  }
+
+  const secondaryByName = new Map<string, ConfigRecord>()
+  for (const agent of secondaryValue) {
+    if (!isRecordObject(agent) || typeof agent.name !== "string") continue
+    secondaryByName.set(agent.name, agent)
+  }
+
+  return primaryValue.map((agent) => {
+    if (!isRecordObject(agent) || typeof agent.name !== "string") return agent
+
+    const secondaryAgent = secondaryByName.get(agent.name)
+    const nextAgent: ConfigRecord = secondaryAgent ? { ...secondaryAgent, ...agent } : { ...agent }
+
+    if (!isRecordObject(agent.connection)) return nextAgent
+
+    const secondaryConnection = secondaryAgent && isRecordObject(secondaryAgent.connection)
+      ? secondaryAgent.connection
+      : undefined
+    const nextConnection: ConfigRecord = secondaryConnection
+      ? { ...secondaryConnection, ...agent.connection }
+      : { ...agent.connection }
+
+    const mergedEnv = pickLocalOnlyValue(
+      agent.connection.env,
+      secondaryConnection?.env,
+      preferPrimaryLocalOnly,
+    )
+
+    if (mergedEnv === undefined) {
+      delete nextConnection.env
+    } else {
+      nextConnection.env = mergedEnv
+    }
+
+    nextAgent.connection = nextConnection
+    return nextAgent
+  })
+}
+
+export function mergeConfigWithLocalOnlyPreference(
+  primaryConfig: Partial<Config>,
+  secondaryConfig: Partial<Config>,
+  options: { preferPrimaryLocalOnly: boolean },
+): Partial<Config> {
+  const merged: Partial<Config> = { ...secondaryConfig, ...primaryConfig }
+
+  for (const key of LOCAL_ONLY_TOP_LEVEL_KEYS) {
+    const mergedValue = pickLocalOnlyValue(
+      (primaryConfig as ConfigRecord)[key],
+      (secondaryConfig as ConfigRecord)[key],
+      options.preferPrimaryLocalOnly,
+    )
+
+    if (mergedValue === undefined) {
+      delete (merged as ConfigRecord)[key]
+    } else {
+      ;(merged as ConfigRecord)[key] = mergedValue
+    }
+  }
+
+  const modelPresets = mergeModelPresets(
+    primaryConfig.modelPresets,
+    secondaryConfig.modelPresets,
+    options.preferPrimaryLocalOnly,
+  )
+  if (modelPresets === undefined) {
+    delete (merged as ConfigRecord).modelPresets
+  } else {
+    merged.modelPresets = modelPresets as Config["modelPresets"]
+  }
+
+  const mcpConfig = mergeMcpConfig(
+    primaryConfig.mcpConfig,
+    secondaryConfig.mcpConfig,
+    options.preferPrimaryLocalOnly,
+  )
+  if (mcpConfig === undefined) {
+    delete (merged as ConfigRecord).mcpConfig
+  } else {
+    merged.mcpConfig = mcpConfig as Config["mcpConfig"]
+  }
+
+  const acpAgents = mergeAcpAgents(
+    primaryConfig.acpAgents,
+    secondaryConfig.acpAgents,
+    options.preferPrimaryLocalOnly,
+  )
+  if (acpAgents === undefined) {
+    delete (merged as ConfigRecord).acpAgents
+  } else {
+    merged.acpAgents = acpAgents as Config["acpAgents"]
+  }
+
+  return merged
+}
+
+export function createShareableConfig(config: Partial<Config>): Partial<Config> {
+  const shareableConfig: Partial<Config> = { ...config }
+
+  for (const key of LOCAL_ONLY_TOP_LEVEL_KEYS) {
+    delete (shareableConfig as ConfigRecord)[key]
+  }
+
+  if (Array.isArray(shareableConfig.modelPresets)) {
+    shareableConfig.modelPresets = shareableConfig.modelPresets.map((preset) => {
+      if (!isRecordObject(preset)) return preset
+      const { apiKey, ...rest } = preset
+      return rest
+    }) as Config["modelPresets"]
+  }
+
+  if (isRecordObject(shareableConfig.mcpConfig) && isRecordObject(shareableConfig.mcpConfig.mcpServers)) {
+    const nextServers: ConfigRecord = {}
+    for (const [serverName, serverConfig] of Object.entries(shareableConfig.mcpConfig.mcpServers)) {
+      if (!isRecordObject(serverConfig)) {
+        nextServers[serverName] = serverConfig
+        continue
+      }
+
+      const { env, headers, oauth, ...rest } = serverConfig
+      nextServers[serverName] = rest
+    }
+
+    shareableConfig.mcpConfig = {
+      ...shareableConfig.mcpConfig,
+      mcpServers: nextServers,
+    }
+  }
+
+  if (Array.isArray(shareableConfig.acpAgents)) {
+    shareableConfig.acpAgents = shareableConfig.acpAgents.map((agent) => {
+      if (!isRecordObject(agent) || !isRecordObject(agent.connection)) return agent
+      const { env, ...connection } = agent.connection
+      return {
+        ...agent,
+        connection,
+      }
+    }) as Config["acpAgents"]
+  }
+
+  return shareableConfig
+}
+
+export function hasLocalOnlyConfigValues(config: Partial<Config>): boolean {
+  for (const key of LOCAL_ONLY_TOP_LEVEL_KEYS) {
+    if ((config as ConfigRecord)[key] !== undefined) return true
+  }
+
+  if (Array.isArray(config.modelPresets)) {
+    for (const preset of config.modelPresets) {
+      if (isRecordObject(preset) && Object.prototype.hasOwnProperty.call(preset, "apiKey")) {
+        return true
+      }
+    }
+  }
+
+  if (isRecordObject(config.mcpConfig) && isRecordObject(config.mcpConfig.mcpServers)) {
+    for (const serverConfig of Object.values(config.mcpConfig.mcpServers)) {
+      if (!isRecordObject(serverConfig)) continue
+      for (const key of LOCAL_ONLY_MCP_SERVER_KEYS) {
+        if (serverConfig[key] !== undefined) return true
+      }
+    }
+  }
+
+  if (Array.isArray(config.acpAgents)) {
+    for (const agent of config.acpAgents) {
+      if (isRecordObject(agent) && isRecordObject(agent.connection) && agent.connection.env !== undefined) {
+        return true
+      }
+    }
+  }
+
+  return false
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,11 +9,14 @@ import { getBuiltInModelPresets, DEFAULT_MODEL_PRESET_ID } from "@dotagents/shar
 import {
   findAgentsDirUpward,
   getAgentsLayerPaths,
+  loadAgentsLayerConfig,
   loadMergedAgentsConfig,
+  sanitizeAgentsLayerFiles,
   writeAgentsLayerFromConfig,
 } from "./agents-files/modular-config"
 import { safeReadJsonFileSync, safeWriteJsonFileSync } from "./agents-files/safe-file"
 import { getErrorMessage, normalizeError } from "./error-utils"
+import { hasLocalOnlyConfigValues, mergeConfigWithLocalOnlyPreference } from "./config-secrets"
 
 const DEFAULT_APP_ID = "app.dotagents"
 
@@ -346,9 +349,13 @@ const getConfig = (): LoadedConfig => {
   // Merge order: defaults ← config.json ← .agents (if present)
   // This ensures existing settings (API keys etc.) from config.json are always preserved,
   // while .agents files can selectively override specific values.
-  const mergedConfig = hasAnyAgentsFiles
-    ? { ...defaultConfig, ...savedConfig, ...mergedAgents }
-    : { ...defaultConfig, ...savedConfig }
+  const layeredConfig = hasAnyAgentsFiles
+    ? mergeConfigWithLocalOnlyPreference(mergedAgents, savedConfig, {
+      preferPrimaryLocalOnly: false,
+    })
+    : savedConfig
+
+  const mergedConfig = { ...defaultConfig, ...layeredConfig }
 
   const legacyTextInputModeSize = (mergedConfig as Record<string, unknown>).panelTextInputModeSize
   if (!mergedConfig.panelTextInputSize && legacyTextInputModeSize) {
@@ -435,6 +442,32 @@ export class ConfigStore {
     const loaded = getConfig()
     // Sync active preset credentials to legacy fields on startup
     this.config = syncPresetToLegacyFields(loaded.config) as Config
+
+    try {
+      const layers = [getAgentsLayerPaths(globalAgentsFolder)]
+      const workspaceAgentsFolder = resolveWorkspaceAgentsFolder()
+      if (workspaceAgentsFolder) {
+        layers.push(getAgentsLayerPaths(workspaceAgentsFolder))
+      }
+
+      let migratedLocalOnlyValues = false
+      for (const layer of layers) {
+        const layerConfig = loadAgentsLayerConfig(layer)
+        if (!hasLocalOnlyConfigValues(layerConfig)) continue
+        sanitizeAgentsLayerFiles(layer)
+        migratedLocalOnlyValues = true
+      }
+
+      if (migratedLocalOnlyValues) {
+        safeWriteJsonFileSync(getConfigPath(), this.config, {
+          backupDir: path.join(getDataFolder(), ".backups"),
+          maxBackups: 10,
+          pretty: false,
+        })
+      }
+    } catch {
+      // best-effort
+    }
 
     // Migration: ensure mcpVerifyCompletionEnabled and mcpUnlimitedIterations
     // default to true. These were previously false by default and may have been


### PR DESCRIPTION
Closes #155

## Summary
- strip local-only secrets from shareable `.agents` JSON writes, including provider API keys, model preset API keys, MCP env/headers/oauth, ACP env, and other local-only credential fields
- preserve local-only values when merging legacy local config with global/workspace `.agents` layers, and sanitize existing `.agents` layers in place on startup while migrating secret values into local app config
- add provider/settings UI copy to make it explicit that secrets stay local and are omitted from shareable `.agents` files

## Validation
- `pnpm --filter @dotagents/core exec vitest run src/config-secrets.test.ts src/agents-files/modular-config.test.ts src/config.persistence.test.ts src/config.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/pages/settings-providers.draft.test.tsx`

## Live Validation
- before recording: `/tmp/electron-ui-recording/before.mp4`
- after recording: `/tmp/electron-ui-recording/after.mp4`
- key comparison frames: `/tmp/electron-ui-recording/before-loaded.png` and `/tmp/electron-ui-recording/after-loaded.png`
- before state wrote `groqApiKey` plaintext into `/tmp/dotagents-test1-before-home/.agents/models.json`
- after state kept `.agents/models.json` stripped while the app saved the secret only to local app config; I restored the local config backup after validation so the test run left no dummy key behind

## Notes
- `pnpm build:core` still hits the existing DTS resolution failure for `@dotagents/shared`; runtime validation used JS build artifacts plus `electron-vite build`.