### PR TITLE
Set a default user agent for Playwright MCP sessions

### DIFF
--- a/apps/desktop/src/main/mcp-service.playwright-user-agent.test.ts
+++ b/apps/desktop/src/main/mcp-service.playwright-user-agent.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+let currentConfig: any
+let currentProfileEnabledRuntimeTools: string[] | undefined
+
+const originalPlaywrightMcpUserAgent = process.env.PLAYWRIGHT_MCP_USER_AGENT
+const originalPlaywrightMcpConfig = process.env.PLAYWRIGHT_MCP_CONFIG
+
+const mockConfigSave = vi.fn()
+const mockSaveCurrentMcpStateToProfile = vi.fn()
+const mockExecuteRuntimeTool = vi.fn(async (name: string) => ({
+  content: [{ type: "text", text: `ran ${name}` }],
+  isError: false,
+}))
+
+const runtimeTools = [
+  { name: "mark_work_complete", description: "essential", inputSchema: {} },
+]
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/tmp"),
+    getAppPath: vi.fn(() => "/tmp/app"),
+  },
+  dialog: { showMessageBox: vi.fn(async () => ({ response: 0 })) },
+}))
+vi.mock("./config", () => ({
+  dataFolder: "/tmp/dotagents-test",
+  configStore: { get: () => currentConfig, save: mockConfigSave },
+}))
+vi.mock("./debug", () => ({
+  isDebugTools: () => false,
+  logTools: vi.fn(),
+  logMCP: vi.fn(),
+}))
+vi.mock("./diagnostics", () => ({
+  diagnosticsService: { logError: vi.fn(), logWarning: vi.fn(), logInfo: vi.fn() },
+}))
+vi.mock("./state", () => ({ state: {}, agentProcessManager: {} }))
+vi.mock("./oauth-client", () => ({ OAuthClient: class {} }))
+vi.mock("./oauth-storage", () => ({ oauthStorage: {} }))
+vi.mock("./mcp-elicitation", () => ({
+  requestElicitation: vi.fn(),
+  handleElicitationComplete: vi.fn(),
+  cancelAllElicitations: vi.fn(),
+}))
+vi.mock("./mcp-sampling", () => ({
+  requestSampling: vi.fn(),
+  cancelAllSamplingRequests: vi.fn(),
+}))
+vi.mock("./langfuse-service", () => ({
+  isLangfuseEnabled: vi.fn(() => false),
+  createToolSpan: vi.fn(),
+  endToolSpan: vi.fn(),
+  getAgentTrace: vi.fn(() => null),
+}))
+vi.mock("./agent-profile-service", () => ({
+  agentProfileService: {
+    getCurrentProfile: () => ({
+      id: "profile_1",
+      toolConfig: { enabledRuntimeTools: currentProfileEnabledRuntimeTools },
+    }),
+    saveCurrentMcpStateToProfile: mockSaveCurrentMcpStateToProfile,
+  },
+}))
+vi.mock("./runtime-tools", () => ({
+  runtimeTools,
+  isRuntimeTool: (name: string) => runtimeTools.some((tool) => tool.name === name),
+  executeRuntimeTool: mockExecuteRuntimeTool,
+}))
+
+describe("MCPService Playwright MCP user agent", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    currentProfileEnabledRuntimeTools = undefined
+    currentConfig = {
+      mcpRequireApprovalBeforeToolCall: false,
+      mcpConfig: { mcpServers: {} },
+      mcpRuntimeDisabledServers: [],
+      mcpDisabledTools: [],
+    }
+
+    delete process.env.PLAYWRIGHT_MCP_USER_AGENT
+    delete process.env.PLAYWRIGHT_MCP_CONFIG
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+
+    if (originalPlaywrightMcpUserAgent === undefined) {
+      delete process.env.PLAYWRIGHT_MCP_USER_AGENT
+    } else {
+      process.env.PLAYWRIGHT_MCP_USER_AGENT = originalPlaywrightMcpUserAgent
+    }
+
+    if (originalPlaywrightMcpConfig === undefined) {
+      delete process.env.PLAYWRIGHT_MCP_CONFIG
+    } else {
+      process.env.PLAYWRIGHT_MCP_CONFIG = originalPlaywrightMcpConfig
+    }
+  })
+
+  it("injects a default UA for Playwright MCP launches", async () => {
+    const { mcpService } = await import("./mcp-service")
+
+    const environment = await mcpService.prepareEnvironment("browser", {
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@playwright/mcp@latest", "--headless"],
+      env: { EXTRA_FLAG: "1" },
+    })
+
+    expect(environment.EXTRA_FLAG).toBe("1")
+    expect(environment.PLAYWRIGHT_MCP_USER_AGENT).toMatch(/^Mozilla\/5\.0 \(/)
+    expect(environment.PLAYWRIGHT_MCP_USER_AGENT).toContain("Chrome/")
+    expect(environment.PLAYWRIGHT_MCP_USER_AGENT).not.toContain("HeadlessChrome")
+  })
+
+  it("preserves an explicit Playwright MCP UA from server env", async () => {
+    const { mcpService } = await import("./mcp-service")
+
+    const environment = await mcpService.prepareEnvironment("playwright", {
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@playwright/mcp@latest"],
+      env: { PLAYWRIGHT_MCP_USER_AGENT: "Custom UA" },
+    })
+
+    expect(environment.PLAYWRIGHT_MCP_USER_AGENT).toBe("Custom UA")
+  })
+
+  it("does not inject a default UA when Playwright args already set one", async () => {
+    const { mcpService } = await import("./mcp-service")
+
+    const environment = await mcpService.prepareEnvironment("playwright", {
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@playwright/mcp@latest", "--user-agent", "CLI UA"],
+      env: {},
+    })
+
+    expect(environment.PLAYWRIGHT_MCP_USER_AGENT).toBeUndefined()
+  })
+
+  it("does not inject a default UA when a Playwright config file is provided", async () => {
+    const { mcpService } = await import("./mcp-service")
+
+    const environment = await mcpService.prepareEnvironment("playwright", {
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@playwright/mcp@latest", "--config", "/tmp/playwright.json"],
+      env: {},
+    })
+
+    expect(environment.PLAYWRIGHT_MCP_USER_AGENT).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -71,11 +71,48 @@ export const WHATSAPP_DEFAULT_ENABLED_TOOLS = [
 
 const RUNTIME_BUILTIN_TOOL_SOURCE_NAME = "dotagents-runtime-tools"
 const RUNTIME_BUILTIN_TOOL_SOURCE_LABEL = "DotAgents Runtime Tools"
+const PLAYWRIGHT_MCP_SERVER_NAME = "playwright"
+const PLAYWRIGHT_MCP_PACKAGE_NAME = "@playwright/mcp"
+const PLAYWRIGHT_MCP_USER_AGENT_ENV = "PLAYWRIGHT_MCP_USER_AGENT"
+const PLAYWRIGHT_MCP_CONFIG_ENV = "PLAYWRIGHT_MCP_CONFIG"
+const PLAYWRIGHT_MCP_DEFAULT_CHROME_VERSION = "133.0.6943.127"
 
 const ESSENTIAL_RUNTIME_TOOL_NAMES = new Set<string>(["mark_work_complete"])
 
 function isEssentialRuntimeTool(toolName: string): boolean {
   return ESSENTIAL_RUNTIME_TOOL_NAMES.has(toolName)
+}
+
+function hasCliFlag(args: string[] | undefined, flagName: string): boolean {
+  return (args || []).some((arg) => arg === flagName || arg.startsWith(`${flagName}=`))
+}
+
+function isPlaywrightMcpServer(serverName: string, serverConfig: MCPServerConfig): boolean {
+  if (serverName === PLAYWRIGHT_MCP_SERVER_NAME) {
+    return true
+  }
+
+  if (serverConfig.command?.includes(PLAYWRIGHT_MCP_PACKAGE_NAME)) {
+    return true
+  }
+
+  return (serverConfig.args || []).some((arg) => arg.includes(PLAYWRIGHT_MCP_PACKAGE_NAME))
+}
+
+function getPlaywrightMcpPlatformToken(): string {
+  switch (process.platform) {
+    case "darwin":
+      return "Macintosh; Intel Mac OS X 10_15_7"
+    case "win32":
+      return "Windows NT 10.0; Win64; x64"
+    default:
+      return "X11; Linux x86_64"
+  }
+}
+
+function getDefaultPlaywrightMcpUserAgent(): string {
+  const chromeVersion = process.versions.chrome || PLAYWRIGHT_MCP_DEFAULT_CHROME_VERSION
+  return `Mozilla/5.0 (${getPlaywrightMcpPlatformToken()}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`
 }
 
 /**
@@ -634,7 +671,7 @@ export class MCPService {
         const resolvedCommand = await this.resolveCommandPath(
           serverConfig.command,
         )
-        let environment = await this.prepareEnvironment(serverName, serverConfig.env)
+        let environment = await this.prepareEnvironment(serverName, serverConfig)
 
         // For internal servers (like WhatsApp), always use the bundled path
         // This prevents stale paths from external workspaces from being used
@@ -2908,7 +2945,7 @@ export class MCPService {
    */
   async prepareEnvironment(
     serverName: string,
-    serverEnv?: Record<string, string>,
+    serverConfig: MCPServerConfig,
   ): Promise<Record<string, string>> {
     // Create a clean environment with only string values
     const environment: Record<string, string> = {}
@@ -2943,8 +2980,19 @@ export class MCPService {
     }
 
     // Add server-specific environment variables
-    if (serverEnv) {
-      Object.assign(environment, serverEnv)
+    if (serverConfig.env) {
+      Object.assign(environment, serverConfig.env)
+    }
+
+    if (
+      isPlaywrightMcpServer(serverName, serverConfig) &&
+      !environment[PLAYWRIGHT_MCP_USER_AGENT_ENV] &&
+      !environment[PLAYWRIGHT_MCP_CONFIG_ENV] &&
+      !hasCliFlag(serverConfig.args, "--user-agent") &&
+      // Config files can already define browser.contextOptions.userAgent.
+      !hasCliFlag(serverConfig.args, "--config")
+    ) {
+      environment[PLAYWRIGHT_MCP_USER_AGENT_ENV] = getDefaultPlaywrightMcpUserAgent()
     }
 
     // Inject WhatsApp configuration for the WhatsApp MCP server


### PR DESCRIPTION
## Summary
- inject a default Mozilla-style user agent for Playwright MCP stdio launches
- preserve explicit user-agent and config-file overrides
- add focused coverage for the new environment preparation cases

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/main/mcp-service.playwright-user-agent.test.ts src/main/mcp-service.option-b.test.ts`
- live Electron repro before: `/tmp/electron-ui-recording/issue221-before.mp4` and `/tmp/electron-ui-recording/issue221-before-loaded.png`
- live Electron repro after: `/tmp/electron-ui-recording/issue221-after.mp4` and `/tmp/electron-ui-recording/issue221-after-loaded.png`
- critical frame diff: before showed `UA CHECK FAIL` with `HeadlessChrome/146.0.0.0`; after showed `UA CHECK PASS` with `Chrome/126.0.6478.234`
- attempted `pnpm --filter @dotagents/desktop exec tsc --noEmit -p tsconfig.node.json`, but the worktree already has unrelated `TS6307` project-include failures under `src/main/agents-files`

Fixes #221