### PR TITLE
Fix stale browser selector retries

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -60,6 +60,10 @@ import {
   resolveIterationLimitFinalContent,
 } from "./llm-continuation-guards"
 import { buildVerificationMessagesFromAgentState } from "./llm-verification-replay"
+import {
+  extractLatestReusableSelectorRef,
+  getToolRetryHeuristic,
+} from "./tool-retry-heuristics"
 import { loadWorkingKnowledgeNotesForPrompt } from "./working-notes-runtime"
 import {
   normalizeAgentConversationState,
@@ -368,6 +372,7 @@ interface ToolExecutionResult {
   result: MCPToolResult
   retryCount: number
   cancelledByKill: boolean
+  recoveryMessage?: string
 }
 
 /**
@@ -391,6 +396,7 @@ async function executeToolWithRetries(
       },
       retryCount: 0,
       cancelledByKill: true,
+      recoveryMessage: undefined,
     }
   }
 
@@ -427,12 +433,13 @@ async function executeToolWithRetries(
       result,
       retryCount: 0,
       cancelledByKill: true,
+      recoveryMessage: undefined,
     }
   }
 
-  // Enhanced retry logic for specific error types
   let retryCount = 0
-  while (result.isError && retryCount < maxRetries) {
+  let recoveryMessage: string | undefined
+  while (result.isError) {
     // Check kill switch before retrying
     if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
       return {
@@ -443,34 +450,27 @@ async function executeToolWithRetries(
         },
         retryCount,
         cancelledByKill: true,
+        recoveryMessage,
       }
     }
 
-    const errorText = result.content
-      .map((c) => c.text)
-      .join(" ")
-      .toLowerCase()
-
-    // Check if this is a retryable error
-    const isRetryableError =
-      errorText.includes("timeout") ||
-      errorText.includes("connection") ||
-      errorText.includes("network") ||
-      errorText.includes("temporary") ||
-      errorText.includes("busy")
-
-    if (isRetryableError) {
-      retryCount++
-
-      // Wait before retry (exponential backoff)
-      await new Promise((resolve) =>
-        setTimeout(resolve, Math.pow(2, retryCount) * 1000),
-      )
-
-      result = await executeToolCall(toolCall, onToolProgress)
-    } else {
-      break // Don't retry non-transient errors
+    const retryDecision = getToolRetryHeuristic(toolCall, result)
+    if (retryDecision.recoveryMessage && !recoveryMessage) {
+      recoveryMessage = retryDecision.recoveryMessage
     }
+
+    if (!retryDecision.shouldAutoRetry || retryCount >= maxRetries) {
+      break
+    }
+
+    retryCount++
+
+    // Wait before retry (exponential backoff)
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.pow(2, retryCount) * 1000),
+    )
+
+    result = await executeToolCall(toolCall, onToolProgress)
   }
 
   return {
@@ -478,6 +478,7 @@ async function executeToolWithRetries(
     result,
     retryCount,
     cancelledByKill: false,
+    recoveryMessage,
   }
 }
 
@@ -1033,19 +1034,8 @@ export async function processTranscriptWithAgentMode(
       : baseMessage
   }
 
-  const extractLatestSelectorRefFromHistory = () => {
-    for (let i = conversationHistory.length - 1; i >= currentPromptIndex; i--) {
-      const content = typeof conversationHistory[i]?.content === "string"
-        ? conversationHistory[i].content
-        : ""
-      const selectorRef = content.match(/@[a-z][0-9]+/i)?.[0]
-      if (selectorRef) return selectorRef
-    }
-    return undefined
-  }
-
   const buildGarbledToolCallNudge = () => {
-    const selectorRef = extractLatestSelectorRefFromHistory()
+    const selectorRef = extractLatestReusableSelectorRef(conversationHistory, currentPromptIndex)
     const baseMessage = "Your previous response contained text like \"[Calling tools: ...]\" instead of an actual tool call. Do NOT write tool call names as text. Instead, invoke tools using the structured function-calling interface."
     return selectorRef
       ? `${baseMessage} The latest successful step already identified ${selectorRef}; use it in the next tool call if it is still the correct selector. If you cannot call tools, provide your final answer directly.`
@@ -2282,6 +2272,7 @@ export async function processTranscriptWithAgentMode(
     // Default is parallel execution when multiple tools are called
     const forceSequential = config.mcpParallelToolExecution === false
     const useParallelExecution = !forceSequential && toolCallsArray.length > 1
+    const recoveryMessages: string[] = []
 
     if (useParallelExecution) {
       // PARALLEL EXECUTION: Execute all tool calls concurrently
@@ -2379,6 +2370,9 @@ export async function processTranscriptWithAgentMode(
         toolResults.push(execResult.result)
         toolsExecutedInSession = true
         garbledToolCallCount = 0 // Reset on successful tool execution
+        if (execResult.recoveryMessage) {
+          recoveryMessages.push(execResult.recoveryMessage)
+        }
         if (execResult.result.isError) {
           failedTools.push(execResult.toolCall.name)
         }
@@ -2475,6 +2469,9 @@ export async function processTranscriptWithAgentMode(
 
         toolResults.push(execResult.result)
         toolsExecutedInSession = true
+        if (execResult.recoveryMessage) {
+          recoveryMessages.push(execResult.recoveryMessage)
+        }
 
         // Track failed tools for better error reporting
         if (execResult.result.isError) {
@@ -2656,6 +2653,10 @@ export async function processTranscriptWithAgentMode(
         content: errorSummary,
         timestamp: Date.now(),
       })
+
+      for (const recoveryMessage of Array.from(new Set(recoveryMessages))) {
+        addEphemeralMessage("user", recoveryMessage)
+      }
     }
 
     // Check if agent indicated completion after executing tools.

--- a/apps/desktop/src/main/tool-retry-heuristics.test.ts
+++ b/apps/desktop/src/main/tool-retry-heuristics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  extractLatestReusableSelectorRef,
+  getToolRetryHeuristic,
+} from "./tool-retry-heuristics"
+
+describe("tool retry heuristics", () => {
+  it("blocks blind auto-retries for selector timeouts and suggests a snapshot", () => {
+    expect(getToolRetryHeuristic(
+      {
+        name: "browser:click",
+        arguments: { selector: "@e59" },
+      } as any,
+      {
+        isError: true,
+        content: [{ type: "text", text: 'Timeout: @e59 is blocked, still loading, or not interactable.' }],
+      } as any,
+    )).toEqual({
+      shouldAutoRetry: false,
+      recoveryMessage: "Browser interaction using @e59 failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call, and only reuse @e59 if the refreshed page confirms it is still valid.",
+    })
+  })
+
+  it("does not auto-retry unsupported selector token failures", () => {
+    expect(getToolRetryHeuristic(
+      {
+        name: "browser:click",
+        arguments: { selector: "@e91" },
+      } as any,
+      {
+        isError: true,
+        content: [{ type: "text", text: 'Unsupported token "@e91" while parsing css selector' }],
+      } as any,
+    )).toEqual({
+      shouldAutoRetry: false,
+      recoveryMessage: "Browser interaction using @e91 failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call, and only reuse @e91 if the refreshed page confirms it is still valid.",
+    })
+  })
+
+  it("keeps infrastructure failures retryable", () => {
+    expect(getToolRetryHeuristic(
+      {
+        name: "filesystem:read_file",
+        arguments: { path: "/tmp/demo.txt" },
+      } as any,
+      {
+        isError: true,
+        content: [{ type: "text", text: "Connection reset by peer while calling remote server" }],
+      } as any,
+    )).toEqual({
+      shouldAutoRetry: true,
+    })
+  })
+
+  it("ignores selectors that only appear in error or recovery messages", () => {
+    const history = [
+      { role: "assistant", content: "The submit button is @e41." },
+      { role: "tool", content: "[browser:click] ERROR: Timeout while clicking @e59." },
+      { role: "user", content: "Browser interaction using @e59 failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call, and only reuse @e59 if the refreshed page confirms it is still valid.", ephemeral: true },
+    ] as const
+
+    expect(extractLatestReusableSelectorRef(history as any, 0)).toBe("@e41")
+  })
+})

--- a/apps/desktop/src/main/tool-retry-heuristics.test.ts
+++ b/apps/desktop/src/main/tool-retry-heuristics.test.ts
@@ -53,11 +53,35 @@ describe("tool retry heuristics", () => {
     })
   })
 
+  it("does not emit browser recovery guidance for non-browser tools", () => {
+    expect(getToolRetryHeuristic(
+      {
+        name: "filesystem:read_file",
+        arguments: { selector: "@e59" },
+      } as any,
+      {
+        isError: true,
+        content: [{ type: "text", text: 'Timeout: @e59 is blocked, still loading, or not interactable.' }],
+      } as any,
+    )).toEqual({
+      shouldAutoRetry: true,
+    })
+  })
+
   it("ignores selectors that only appear in error or recovery messages", () => {
     const history = [
       { role: "assistant", content: "The submit button is @e41." },
       { role: "tool", content: "[browser:click] ERROR: Timeout while clicking @e59." },
       { role: "user", content: "Browser interaction using @e59 failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call, and only reuse @e59 if the refreshed page confirms it is still valid.", ephemeral: true },
+    ] as const
+
+    expect(extractLatestReusableSelectorRef(history as any, 0)).toBe("@e41")
+  })
+
+  it("keeps successful selector references even when they say selector", () => {
+    const history = [
+      { role: "assistant", content: "The selector is @e41. Reuse it if the page stays the same." },
+      { role: "tool", content: '[browser:click] ERROR: Unsupported token "@e59" while parsing css selector.' },
     ] as const
 
     expect(extractLatestReusableSelectorRef(history as any, 0)).toBe("@e41")

--- a/apps/desktop/src/main/tool-retry-heuristics.ts
+++ b/apps/desktop/src/main/tool-retry-heuristics.ts
@@ -1,0 +1,112 @@
+import type { MCPToolCall, MCPToolResult } from "./mcp-service"
+
+const SELECTOR_REF_REGEX = /@[a-z][0-9]+\b/i
+const SELECTOR_FAILURE_REGEX = /\b(timeout|unsupported token|not interactable|still loading|locator\.|selector|stale element|element is detached)\b/i
+const INFRA_RETRY_REGEX = /\b(timeout|connection|network|temporary|busy|econnreset|socket hang up|gateway timeout|service unavailable)\b/i
+const INFRA_ONLY_REGEX = /\b(connection|network|temporary|busy|econnreset|socket hang up|gateway timeout|service unavailable)\b/i
+const INTERNAL_RECOVERY_SIGNAL = "Take a fresh browser snapshot"
+const ERROR_CONTEXT_REGEX = /\b(error|failed|timeout|unsupported token|not interactable|still loading|locator\.|selector)\b/i
+
+type SelectorHistoryEntry = {
+  role?: "user" | "assistant" | "tool"
+  content?: string
+  ephemeral?: boolean
+}
+
+function collectStringValues(value: unknown, bucket: string[]): void {
+  if (typeof value === "string") {
+    bucket.push(value)
+    return
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStringValues(item, bucket)
+    }
+    return
+  }
+
+  if (value && typeof value === "object") {
+    for (const nested of Object.values(value)) {
+      collectStringValues(nested, bucket)
+    }
+  }
+}
+
+function extractSelectorRefFromUnknown(value: unknown): string | undefined {
+  const strings: string[] = []
+  collectStringValues(value, strings)
+
+  for (const candidate of strings) {
+    const match = candidate.match(SELECTOR_REF_REGEX)?.[0]
+    if (match) return match
+  }
+
+  return undefined
+}
+
+function getToolErrorText(result: Pick<MCPToolResult, "content" | "isError">): string {
+  if (!result.isError) return ""
+  return result.content?.map((item) => item.text).join(" ").trim() || ""
+}
+
+function buildRecoveryMessage(selectorRef?: string): string {
+  if (selectorRef) {
+    return `Browser interaction using ${selectorRef} failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call, and only reuse ${selectorRef} if the refreshed page confirms it is still valid.`
+  }
+
+  return "Browser interaction failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call."
+}
+
+export function getToolRetryHeuristic(
+  toolCall: Pick<MCPToolCall, "name" | "arguments">,
+  result: Pick<MCPToolResult, "content" | "isError">,
+): {
+  shouldAutoRetry: boolean
+  recoveryMessage?: string
+} {
+  const errorText = getToolErrorText(result)
+  if (!errorText) {
+    return { shouldAutoRetry: false }
+  }
+
+  const normalizedError = errorText.toLowerCase()
+  const selectorRef = extractSelectorRefFromUnknown(toolCall.arguments)
+    ?? errorText.match(SELECTOR_REF_REGEX)?.[0]
+
+  const hasSelectorSpecificFailure =
+    Boolean(selectorRef) &&
+    SELECTOR_FAILURE_REGEX.test(normalizedError) &&
+    !INFRA_ONLY_REGEX.test(normalizedError)
+
+  if (hasSelectorSpecificFailure) {
+    return {
+      shouldAutoRetry: false,
+      recoveryMessage: buildRecoveryMessage(selectorRef),
+    }
+  }
+
+  return {
+    shouldAutoRetry: INFRA_RETRY_REGEX.test(normalizedError),
+  }
+}
+
+export function extractLatestReusableSelectorRef(
+  history: SelectorHistoryEntry[],
+  currentPromptIndex: number,
+): string | undefined {
+  for (let i = history.length - 1; i >= currentPromptIndex; i--) {
+    const entry = history[i]
+    const content = typeof entry?.content === "string" ? entry.content : ""
+    if (!content) continue
+    if (entry?.ephemeral) continue
+    if (entry?.role === "tool") continue
+    if (content.includes(INTERNAL_RECOVERY_SIGNAL)) continue
+    if (ERROR_CONTEXT_REGEX.test(content)) continue
+
+    const selectorRef = content.match(SELECTOR_REF_REGEX)?.[0]
+    if (selectorRef) return selectorRef
+  }
+
+  return undefined
+}

--- a/apps/desktop/src/main/tool-retry-heuristics.ts
+++ b/apps/desktop/src/main/tool-retry-heuristics.ts
@@ -5,7 +5,7 @@ const SELECTOR_FAILURE_REGEX = /\b(timeout|unsupported token|not interactable|st
 const INFRA_RETRY_REGEX = /\b(timeout|connection|network|temporary|busy|econnreset|socket hang up|gateway timeout|service unavailable)\b/i
 const INFRA_ONLY_REGEX = /\b(connection|network|temporary|busy|econnreset|socket hang up|gateway timeout|service unavailable)\b/i
 const INTERNAL_RECOVERY_SIGNAL = "Take a fresh browser snapshot"
-const ERROR_CONTEXT_REGEX = /\b(error|failed|timeout|unsupported token|not interactable|still loading|locator\.|selector)\b/i
+const ERROR_CONTEXT_REGEX = /\b(error|failed|timeout|unsupported token|not interactable|still loading|locator\.|stale element|element is detached)\b/i
 
 type SelectorHistoryEntry = {
   role?: "user" | "assistant" | "tool"
@@ -50,6 +50,10 @@ function getToolErrorText(result: Pick<MCPToolResult, "content" | "isError">): s
   return result.content?.map((item) => item.text).join(" ").trim() || ""
 }
 
+function isBrowserToolName(name: string): boolean {
+  return name.toLowerCase().startsWith("browser:")
+}
+
 function buildRecoveryMessage(selectorRef?: string): string {
   if (selectorRef) {
     return `Browser interaction using ${selectorRef} failed. Do not retry the same selector blindly. Take a fresh browser snapshot before the next browser tool call, and only reuse ${selectorRef} if the refreshed page confirms it is still valid.`
@@ -71,8 +75,12 @@ export function getToolRetryHeuristic(
   }
 
   const normalizedError = errorText.toLowerCase()
-  const selectorRef = extractSelectorRefFromUnknown(toolCall.arguments)
-    ?? errorText.match(SELECTOR_REF_REGEX)?.[0]
+  const selectorRef = isBrowserToolName(toolCall.name)
+    ? (
+        extractSelectorRefFromUnknown(toolCall.arguments)
+        ?? errorText.match(SELECTOR_REF_REGEX)?.[0]
+      )
+    : undefined
 
   const hasSelectorSpecificFailure =
     Boolean(selectorRef) &&


### PR DESCRIPTION
## Summary
- stop auto-retrying selector-specific browser failures when the error points to a stale or invalid selector handle
- add a recovery nudge that tells the agent to take a fresh browser snapshot before reusing the selector
- avoid reusing selector refs from tool error text when building follow-up nudges, and cover the retry heuristic with unit tests

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/main/tool-retry-heuristics.test.ts src/main/conversation-history-utils.test.ts src/main/llm.continuation-guards.test.ts`
- live Electron recording against a mocked browser MCP/OpenAI loop: before reproduced repeated `@e59` reuse and CSS selector parse failure; after recovered via `browser:snapshot` then clicked fresh selector `@e71`

Fixes #170