### PR TITLE
Fix truncated OpenAI connection error details

### DIFF
--- a/apps/desktop/src/main/error-utils.test.ts
+++ b/apps/desktop/src/main/error-utils.test.ts
@@ -66,6 +66,14 @@ describe("error-utils", () => {
     )
   })
 
+  it("appends nested socket detail for generic terminated transport errors", () => {
+    const error = new TypeError("terminated", {
+      cause: new Error("read ECONNRESET"),
+    })
+
+    expect(getErrorMessage(error, "Fallback message")).toBe("terminated: read ECONNRESET")
+  })
+
   it("uses the fallback when a blank Error only stringifies to its constructor name", () => {
     expect(getErrorMessage(new Error(""), "Fallback message")).toBe("Fallback message")
     expect(getErrorMessage(new TypeError(""), "Fallback message")).toBe("Fallback message")

--- a/apps/desktop/src/main/error-utils.test.ts
+++ b/apps/desktop/src/main/error-utils.test.ts
@@ -39,6 +39,33 @@ describe("error-utils", () => {
     expect(getErrorMessage(error, "Fallback message")).toBe("Primary provider unavailable")
   })
 
+  it("appends nested details when an error message is truncated", () => {
+    const aggregateCause = new AggregateError(
+      [new Error("connect ECONNREFUSED ::1:44444"), new Error("connect ECONNREFUSED 127.0.0.1:44444")],
+      "",
+    )
+    const error = new Error("Cannot connect to API:") as Error & { cause?: unknown }
+    error.cause = aggregateCause
+
+    expect(getErrorMessage(error, "Fallback message")).toBe(
+      "Cannot connect to API: connect ECONNREFUSED ::1:44444",
+    )
+  })
+
+  it("pulls nested lastError details into retry wrapper messages", () => {
+    const apiError = new Error("Cannot connect to API:") as Error & { cause?: unknown }
+    apiError.cause = new AggregateError([new Error("connect ECONNREFUSED ::1:44444")], "")
+
+    const retryError = new Error("Failed after 3 attempts. Last error: Cannot connect to API:") as Error & {
+      lastError?: unknown
+    }
+    retryError.lastError = apiError
+
+    expect(getErrorMessage(retryError, "Fallback message")).toBe(
+      "Failed after 3 attempts. Last error: Cannot connect to API: connect ECONNREFUSED ::1:44444",
+    )
+  })
+
   it("uses the fallback when a blank Error only stringifies to its constructor name", () => {
     expect(getErrorMessage(new Error(""), "Fallback message")).toBe("Fallback message")
     expect(getErrorMessage(new TypeError(""), "Fallback message")).toBe("Fallback message")

--- a/packages/core/src/error-utils.ts
+++ b/packages/core/src/error-utils.ts
@@ -1,3 +1,52 @@
+function findFirstNestedMessage(values: unknown[], seen: WeakSet<object>): string | undefined {
+  for (const value of values) {
+    const nestedMessage = findNestedErrorMessage(value, seen)
+    if (nestedMessage) {
+      return nestedMessage
+    }
+  }
+
+  return undefined
+}
+
+function isIncompleteErrorMessage(message: string): boolean {
+  return /:\s*$/.test(message.trim())
+}
+
+function appendNestedErrorDetail(message: string, nestedMessage: string): string {
+  const trimmedMessage = message.trimEnd()
+  const trimmedNested = nestedMessage.trim()
+
+  if (!trimmedMessage || !trimmedNested) {
+    return trimmedMessage || trimmedNested
+  }
+
+  const lowerMessage = trimmedMessage.toLowerCase()
+  const lowerNested = trimmedNested.toLowerCase()
+
+  if (lowerMessage.includes(lowerNested)) {
+    return trimmedMessage
+  }
+
+  const lastErrorMatch = trimmedMessage.match(/last error:\s*(.+)$/i)
+  if (lastErrorMatch) {
+    const lastErrorText = lastErrorMatch[1]?.trim().replace(/:\s*$/, "")
+    if (lastErrorText) {
+      const lowerLastErrorText = lastErrorText.toLowerCase()
+      if (lowerNested.startsWith(lowerLastErrorText)) {
+        const remainder = trimmedNested.slice(lastErrorText.length).replace(/^:\s*/, "")
+        if (remainder) {
+          return `${trimmedMessage} ${remainder}`
+        }
+        return trimmedMessage
+      }
+    }
+  }
+
+  const separator = /:\s*$/.test(trimmedMessage) ? " " : ": "
+  return `${trimmedMessage}${separator}${trimmedNested}`
+}
+
 function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string | undefined {
   if (error === null || error === undefined) {
     return undefined
@@ -12,18 +61,26 @@ function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string |
   }
 
   if (error instanceof Error) {
+    const candidate = error as Error & {
+      cause?: unknown
+      errors?: unknown
+      lastError?: unknown
+    }
+    const nestedMessage = findFirstNestedMessage(
+      [candidate.cause, candidate.lastError, candidate.errors],
+      seen,
+    )
+
     if (error.message) {
+      if (nestedMessage && isIncompleteErrorMessage(error.message)) {
+        return appendNestedErrorDetail(error.message, nestedMessage)
+      }
+
       return error.message
     }
 
-    const nestedFromCause = findNestedErrorMessage((error as Error & { cause?: unknown }).cause, seen)
-    if (nestedFromCause) {
-      return nestedFromCause
-    }
-
-    const nestedFromErrors = findNestedErrorMessage((error as Error & { errors?: unknown }).errors, seen)
-    if (nestedFromErrors) {
-      return nestedFromErrors
+    if (nestedMessage) {
+      return nestedMessage
     }
   }
 
@@ -46,13 +103,15 @@ function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string |
       error?: unknown
       cause?: unknown
       errors?: unknown
+      lastError?: unknown
     }
 
-    for (const value of [candidate.message, candidate.error, candidate.cause, candidate.errors]) {
-      const nestedMessage = findNestedErrorMessage(value, seen)
-      if (nestedMessage) {
-        return nestedMessage
-      }
+    const nestedMessage = findFirstNestedMessage(
+      [candidate.message, candidate.error, candidate.cause, candidate.lastError, candidate.errors],
+      seen,
+    )
+    if (nestedMessage) {
+      return nestedMessage
     }
 
     try {

--- a/packages/core/src/error-utils.ts
+++ b/packages/core/src/error-utils.ts
@@ -9,8 +9,24 @@ function findFirstNestedMessage(values: unknown[], seen: WeakSet<object>): strin
   return undefined
 }
 
-function isIncompleteErrorMessage(message: string): boolean {
-  return /:\s*$/.test(message.trim())
+function shouldAppendNestedErrorDetail(message: string): boolean {
+  const normalized = message.trim().toLowerCase()
+
+  if (!normalized) {
+    return false
+  }
+
+  if (/:$/.test(normalized)) {
+    return true
+  }
+
+  return [
+    "terminated",
+    "aborted",
+    "fetch failed",
+    "request failed",
+    "unknown error",
+  ].includes(normalized)
 }
 
 function appendNestedErrorDetail(message: string, nestedMessage: string): string {
@@ -72,7 +88,7 @@ function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string |
     )
 
     if (error.message) {
-      if (nestedMessage && isIncompleteErrorMessage(error.message)) {
+      if (nestedMessage && shouldAppendNestedErrorDetail(error.message)) {
         return appendNestedErrorDetail(error.message, nestedMessage)
       }
 


### PR DESCRIPTION
## Summary
- append nested connection details when wrapper errors end with a truncated `:` message
- preserve retry-wrapper context while pulling `lastError` socket details into the surfaced message
- add regression tests for both direct API errors and retry wrapper errors

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/main/error-utils.test.ts`
- live desktop repro against issue #164 using `http://localhost:44444/v1`

## Evidence
- before video: `/tmp/electron-ui-recording/issue164-before.mp4`
- after video: `/tmp/electron-ui-recording/issue164-after.mp4`
- before key frame: `/tmp/electron-ui-recording/issue164-before-final.png`
- after key frame: `/tmp/electron-ui-recording/issue164-after-final.png`

Closes #164
