### PR TITLE
Surface nested transport details in OpenAI errors

### DIFF
--- a/packages/core/src/error-utils.test.ts
+++ b/packages/core/src/error-utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { getErrorMessage } from "./error-utils"
+
+describe("error-utils", () => {
+  it("appends nested transport details when the top-level API connection error is truncated", () => {
+    const error = new Error("Cannot connect to API:", {
+      cause: new Error("connect ECONNREFUSED 127.0.0.1:12345"),
+    })
+
+    expect(getErrorMessage(error, "Fallback message")).toBe(
+      "Cannot connect to API: connect ECONNREFUSED 127.0.0.1:12345",
+    )
+  })
+
+  it("keeps nested detail from generic error-like objects", () => {
+    const error = {
+      message: "Cannot connect to API:",
+      cause: { message: "connect ECONNREFUSED 127.0.0.1:12345" },
+    }
+
+    expect(getErrorMessage(error, "Fallback message")).toBe(
+      "Cannot connect to API: connect ECONNREFUSED 127.0.0.1:12345",
+    )
+  })
+
+  it("does not duplicate nested detail already present in the top-level message", () => {
+    const error = new Error("Cannot connect to API: connect ECONNREFUSED 127.0.0.1:12345", {
+      cause: new Error("connect ECONNREFUSED 127.0.0.1:12345"),
+    })
+
+    expect(getErrorMessage(error, "Fallback message")).toBe(
+      "Cannot connect to API: connect ECONNREFUSED 127.0.0.1:12345",
+    )
+  })
+
+  it("appends nested socket detail for terminated transport errors", () => {
+    const error = new TypeError("terminated", {
+      cause: new Error("read ECONNRESET"),
+    })
+
+    expect(getErrorMessage(error, "Fallback message")).toBe("terminated: read ECONNRESET")
+  })
+})

--- a/packages/core/src/error-utils.ts
+++ b/packages/core/src/error-utils.ts
@@ -1,3 +1,68 @@
+function normalizeMessage(message: string | undefined): string | undefined {
+  const trimmed = message?.trim()
+  return trimmed || undefined
+}
+
+function shouldAppendNestedErrorMessage(message: string): boolean {
+  const normalized = message.trim().toLowerCase()
+
+  if (!normalized) {
+    return false
+  }
+
+  if (normalized.endsWith(":")) {
+    return true
+  }
+
+  return [
+    /^cannot connect to api\b/,
+    /^failed after \d+ attempts\b/,
+    /\brequest failed\b/,
+    /\bstreaming request failed\b/,
+    /\bfetch failed\b/,
+    /\bnetwork error\b/,
+    /\bconnection failed\b/,
+    /^terminated$/,
+    /^aborted$/,
+    /\bunknown error\b/,
+  ].some((pattern) => pattern.test(normalized))
+}
+
+function mergeNestedErrorMessage(
+  message: string | undefined,
+  nestedMessage: string | undefined,
+): string | undefined {
+  const normalizedMessage = normalizeMessage(message)
+  const normalizedNestedMessage = normalizeMessage(nestedMessage)
+
+  if (!normalizedMessage) {
+    return normalizedNestedMessage
+  }
+
+  if (!normalizedNestedMessage) {
+    return normalizedMessage
+  }
+
+  if (normalizedMessage === normalizedNestedMessage) {
+    return normalizedMessage
+  }
+
+  if (normalizedMessage.includes(normalizedNestedMessage)) {
+    return normalizedMessage
+  }
+
+  if (normalizedNestedMessage.includes(normalizedMessage)) {
+    return normalizedNestedMessage
+  }
+
+  if (!shouldAppendNestedErrorMessage(normalizedMessage)) {
+    return normalizedMessage
+  }
+
+  const separator = normalizedMessage.endsWith(":") ? " " : ": "
+  return `${normalizedMessage}${separator}${normalizedNestedMessage}`
+}
+
 function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string | undefined {
   if (error === null || error === undefined) {
     return undefined
@@ -12,18 +77,15 @@ function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string |
   }
 
   if (error instanceof Error) {
-    if (error.message) {
-      return error.message
-    }
-
     const nestedFromCause = findNestedErrorMessage((error as Error & { cause?: unknown }).cause, seen)
-    if (nestedFromCause) {
-      return nestedFromCause
-    }
-
     const nestedFromErrors = findNestedErrorMessage((error as Error & { errors?: unknown }).errors, seen)
-    if (nestedFromErrors) {
-      return nestedFromErrors
+
+    const mergedMessage = mergeNestedErrorMessage(
+      error.message,
+      nestedFromCause || nestedFromErrors,
+    )
+    if (mergedMessage) {
+      return mergedMessage
     }
   }
 
@@ -48,11 +110,14 @@ function findNestedErrorMessage(error: unknown, seen: WeakSet<object>): string |
       errors?: unknown
     }
 
-    for (const value of [candidate.message, candidate.error, candidate.cause, candidate.errors]) {
-      const nestedMessage = findNestedErrorMessage(value, seen)
-      if (nestedMessage) {
-        return nestedMessage
-      }
+    const messageField = findNestedErrorMessage(candidate.message, seen)
+    const nestedField = [candidate.error, candidate.cause, candidate.errors]
+      .map((value) => findNestedErrorMessage(value, seen))
+      .find((value): value is string => Boolean(value))
+
+    const mergedMessage = mergeNestedErrorMessage(messageField, nestedField)
+    if (mergedMessage) {
+      return mergedMessage
     }
 
     try {


### PR DESCRIPTION
## Summary
- surface nested transport details when OpenAI/network errors are wrapped in generic top-level messages like `Cannot connect to API:` or `terminated`
- keep existing messages unchanged when they already include the lower-level detail
- add focused core regressions for truncated API errors and terminated socket resets

## Validation
- `pnpm --filter @dotagents/core exec vitest run src/error-utils.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/main/error-utils.test.ts`
- live Electron capture against a partial-response OpenAI endpoint: before `Error: terminated`, after `Error: terminated: read ECONNRESET`

Refs #164