### PR TITLE
Retry transient TLS bad record MAC stream failures

### DIFF
--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -987,4 +987,45 @@ describe('LLM Fetch with AI SDK', () => {
       )
     ).rejects.toThrow('provider returned malformed chunk')
   })
+
+  it('should retry streaming TLS transport errors even when AI SDK marks them non-retryable', async () => {
+    const { streamText } = await import('ai')
+    const streamTextMock = vi.mocked(streamText)
+
+    let callCount = 0
+    streamTextMock.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        const error = new Error('remote error: tls: bad record MAC') as any
+        error.statusCode = 400
+        error.isRetryable = false
+
+        return {
+          fullStream: (async function* () {
+            yield { type: 'error', error }
+          })(),
+        } as any
+      }
+
+      return {
+        fullStream: (async function* () {
+          yield { type: 'text-delta', text: 'Recovered after TLS retry.' }
+          yield { type: 'finish', totalUsage: { inputTokens: 10, outputTokens: 5 } }
+        })(),
+      } as any
+    })
+
+    const { makeLLMCallWithStreamingAndTools } = await import('./llm-fetch')
+    const onChunk = vi.fn()
+
+    const result = await makeLLMCallWithStreamingAndTools(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+      'openai',
+    )
+
+    expect(callCount).toBe(2)
+    expect(onChunk).toHaveBeenCalledWith('Recovered after TLS retry.', 'Recovered after TLS retry.')
+    expect(result.content).toBe('Recovered after TLS retry.')
+  })
 })

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -887,6 +887,67 @@ describe('LLM Fetch with AI SDK', () => {
     shouldStopSpy.mockRestore()
   })
 
+  it('retries transient TLS stream errors such as bad record MAC and succeeds on the next attempt', async () => {
+    const { streamText } = await import('ai')
+    const streamTextMock = vi.mocked(streamText)
+
+    let callCount = 0
+    streamTextMock.mockImplementation(() => {
+      callCount++
+
+      if (callCount === 1) {
+        return {
+          fullStream: (async function* () {
+            yield { type: 'error', error: { message: 'remote error: tls: bad record MAC', type: 'server_error' } }
+          })(),
+        } as any
+      }
+
+      return {
+        fullStream: (async function* () {
+          yield { type: 'text-delta', text: 'Recovered after retry.' }
+          yield { type: 'finish', totalUsage: { inputTokens: 5, outputTokens: 3 } }
+        })(),
+      } as any
+    })
+
+    const onChunk = vi.fn()
+    const { makeLLMCallWithStreamingAndTools } = await import('./llm-fetch')
+
+    const result = await makeLLMCallWithStreamingAndTools(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+      'openai'
+    )
+
+    expect(callCount).toBe(2)
+    expect(result.content).toBe('Recovered after retry.')
+    expect(onChunk).toHaveBeenCalledWith('Recovered after retry.', 'Recovered after retry.')
+  })
+
+  it('does not retry non-transient TLS certificate failures', async () => {
+    const { streamText } = await import('ai')
+    const streamTextMock = vi.mocked(streamText)
+
+    streamTextMock.mockReturnValue({
+      fullStream: (async function* () {
+        yield { type: 'error', error: { message: 'tls: self signed certificate', type: 'server_error' } }
+      })(),
+    } as any)
+
+    const { makeLLMCallWithStreamingAndTools } = await import('./llm-fetch')
+
+    await expect(
+      makeLLMCallWithStreamingAndTools(
+        [{ role: 'user', content: 'test' }],
+        vi.fn(),
+        'openai'
+      )
+    ).rejects.toThrow('tls: self signed certificate')
+
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+  })
+
   it('should surface string stream errors instead of "Unknown error"', async () => {
     const { streamText } = await import('ai')
     const streamTextMock = vi.mocked(streamText)

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -1028,4 +1028,35 @@ describe('LLM Fetch with AI SDK', () => {
     expect(onChunk).toHaveBeenCalledWith('Recovered after TLS retry.', 'Recovered after TLS retry.')
     expect(result.content).toBe('Recovered after TLS retry.')
   })
+
+  it('should not retry non-TLS errors that only contain tls inside another token', async () => {
+    const { streamText } = await import('ai')
+    const streamTextMock = vi.mocked(streamText)
+
+    let callCount = 0
+    streamTextMock.mockImplementation(() => {
+      callCount++
+      const error = new Error('notls: internal error') as any
+      error.statusCode = 400
+      error.isRetryable = false
+
+      return {
+        fullStream: (async function* () {
+          yield { type: 'error', error }
+        })(),
+      } as any
+    })
+
+    const { makeLLMCallWithStreamingAndTools } = await import('./llm-fetch')
+
+    await expect(
+      makeLLMCallWithStreamingAndTools(
+        [{ role: 'user', content: 'test' }],
+        vi.fn(),
+        'openai',
+      )
+    ).rejects.toThrow('notls: internal error')
+
+    expect(callCount).toBe(1)
+  })
 })

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -324,7 +324,12 @@ function isEmptyResponseError(error: unknown): boolean {
 }
 
 function isRetryableTlsTransportMessage(message: string): boolean {
-  if (!message.includes("tls")) {
+  const hasTlsTransportMarker =
+    /\btls\b/.test(message) ||
+    /\bssl\b/.test(message) ||
+    message.includes("bad record mac")
+
+  if (!hasTlsTransportMarker) {
     return false
   }
 

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -344,6 +344,7 @@ function isRetryableTlsTransportMessage(message: string): boolean {
   }
 
   return (
+    message.includes("remote error: tls:") ||
     message.includes("bad record mac") ||
     message.includes("alert internal error") ||
     message.includes("internal error")
@@ -360,10 +361,12 @@ function isRetryableTlsTransportMessage(message: string): boolean {
  */
 function isRetryableError(error: unknown): boolean {
   if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+
     // Abort errors should never be retried
     if (
       error.name === "AbortError" ||
-      error.message.toLowerCase().includes("abort")
+      message.includes("abort")
     ) {
       return false
     }
@@ -371,6 +374,12 @@ function isRetryableError(error: unknown): boolean {
     // Empty response errors are retryable but WITHOUT backoff
     // They are handled specially in withRetry - return true here so they're not rejected outright
     if (isEmptyResponseError(error)) {
+      return true
+    }
+
+    // Some gateways surface transient TLS transport failures as 400s with
+    // isRetryable=false even though retrying the same request can recover.
+    if (isRetryableTlsTransportMessage(message)) {
       return true
     }
 
@@ -406,11 +415,6 @@ function isRetryableError(error: unknown): boolean {
 
     // Fallback: message-based detection for transient network issues
     // NOTE: empty response/content removed - handled separately without backoff
-    const message = error.message.toLowerCase()
-    if (isRetryableTlsTransportMessage(message)) {
-      return true
-    }
-
     return (
       message.includes("rate limit") ||
       message.includes("429") ||

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -323,6 +323,33 @@ function isEmptyResponseError(error: unknown): boolean {
   return false
 }
 
+function isRetryableTlsTransportMessage(message: string): boolean {
+  if (!message.includes("tls")) {
+    return false
+  }
+
+  const nonRetryableTlsPatterns = [
+    "certificate",
+    "self signed",
+    "unknown ca",
+    "hostname",
+    "expired",
+    "not yet valid",
+    "bad certificate",
+    "wrong version number",
+  ]
+
+  if (nonRetryableTlsPatterns.some(pattern => message.includes(pattern))) {
+    return false
+  }
+
+  return (
+    message.includes("bad record mac") ||
+    message.includes("alert internal error") ||
+    message.includes("internal error")
+  )
+}
+
 /**
  * Check if an error is retryable.
  * Uses AI SDK structured error fields (statusCode, isRetryable) when available,
@@ -380,6 +407,10 @@ function isRetryableError(error: unknown): boolean {
     // Fallback: message-based detection for transient network issues
     // NOTE: empty response/content removed - handled separately without backoff
     const message = error.message.toLowerCase()
+    if (isRetryableTlsTransportMessage(message)) {
+      return true
+    }
+
     return (
       message.includes("rate limit") ||
       message.includes("429") ||


### PR DESCRIPTION
Closes #163

## Summary
- treat transient TLS transport errors such as `bad record MAC` as retryable in the desktop LLM fetch path
- keep TLS certificate and configuration failures non-retryable so bad credentials still fail fast
- add regression tests covering retry success and non-retryable certificate failures

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/main/llm-fetch.test.ts`
- `pnpm --filter @dotagents/desktop typecheck`
- live Electron validation against a local OpenAI-compatible mock: before the fix the UI surfaced `Error: remote error: tls: bad record MAC`; after the fix the UI showed `Attempt 1/3 Retrying in 0s` and then completed with a successful streamed reply