### PR TITLE
Retry TLS transport failures for streamed LLM calls

### DIFF
--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -926,4 +926,45 @@ describe('LLM Fetch with AI SDK', () => {
       )
     ).rejects.toThrow('provider returned malformed chunk')
   })
+
+  it('should retry streaming TLS transport errors even when AI SDK marks them non-retryable', async () => {
+    const { streamText } = await import('ai')
+    const streamTextMock = vi.mocked(streamText)
+
+    let callCount = 0
+    streamTextMock.mockImplementation(() => {
+      callCount++
+      if (callCount === 1) {
+        const error = new Error('remote error: tls: bad record MAC') as any
+        error.statusCode = 400
+        error.isRetryable = false
+
+        return {
+          fullStream: (async function* () {
+            yield { type: 'error', error }
+          })(),
+        } as any
+      }
+
+      return {
+        fullStream: (async function* () {
+          yield { type: 'text-delta', text: 'Recovered after TLS retry.' }
+          yield { type: 'finish', totalUsage: { inputTokens: 10, outputTokens: 5 } }
+        })(),
+      } as any
+    })
+
+    const { makeLLMCallWithStreamingAndTools } = await import('./llm-fetch')
+    const onChunk = vi.fn()
+
+    const result = await makeLLMCallWithStreamingAndTools(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+      'openai',
+    )
+
+    expect(callCount).toBe(2)
+    expect(onChunk).toHaveBeenCalledWith('Recovered after TLS retry.', 'Recovered after TLS retry.')
+    expect(result.content).toBe('Recovered after TLS retry.')
+  })
 })

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -323,6 +323,13 @@ function isEmptyResponseError(error: unknown): boolean {
   return false
 }
 
+function isRetryableTlsTransportMessage(message: string): boolean {
+  return (
+    message.includes("remote error: tls:") ||
+    message.includes("bad record mac")
+  )
+}
+
 /**
  * Check if an error is retryable.
  * Uses AI SDK structured error fields (statusCode, isRetryable) when available,
@@ -333,10 +340,12 @@ function isEmptyResponseError(error: unknown): boolean {
  */
 function isRetryableError(error: unknown): boolean {
   if (error instanceof Error) {
+    const message = error.message.toLowerCase()
+
     // Abort errors should never be retried
     if (
       error.name === "AbortError" ||
-      error.message.toLowerCase().includes("abort")
+      message.includes("abort")
     ) {
       return false
     }
@@ -344,6 +353,12 @@ function isRetryableError(error: unknown): boolean {
     // Empty response errors are retryable but WITHOUT backoff
     // They are handled specially in withRetry - return true here so they're not rejected outright
     if (isEmptyResponseError(error)) {
+      return true
+    }
+
+    // Some gateways surface transient TLS transport failures as 400s with
+    // isRetryable=false even though retrying the same request can recover.
+    if (isRetryableTlsTransportMessage(message)) {
       return true
     }
 
@@ -379,7 +394,6 @@ function isRetryableError(error: unknown): boolean {
 
     // Fallback: message-based detection for transient network issues
     // NOTE: empty response/content removed - handled separately without backoff
-    const message = error.message.toLowerCase()
     return (
       message.includes("rate limit") ||
       message.includes("429") ||


### PR DESCRIPTION
## Summary
- treat surfaced TLS transport failures like `remote error: tls: bad record MAC` as retryable even when an OpenAI-compatible gateway marks them `isRetryable=false`
- keep the existing retry/backoff flow intact so streamed desktop agent calls recover on the next attempt instead of failing immediately
- add a streaming `llm-fetch` regression test that matches the live Electron repro path

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/main/llm-fetch.test.ts`
- live Electron repro against a local OpenAI-compatible mock endpoint that fails the first streamed completion with `remote error: tls: bad record MAC` and succeeds on retry

## Evidence
- before video: `/tmp/electron-ui-recording/issue163-before.mp4`
- after video: `/tmp/electron-ui-recording/issue163-after.mp4`
- before key frame: `/tmp/electron-ui-recording/issue163-before-final.png`
- after key frame: `/tmp/electron-ui-recording/issue163-after-final.png`

## Visual Check
- before: the session stops at `Error: remote error: tls: bad record MAC` with no retry banner or recovery content
- after: the same session shows the retry banner (`Attempt 1/4`, `Retrying in 0s`) and then renders `Recovered after TLS retry.`

Closes #163
