### PR TITLE
Allow desktop repeat tasks to use dedicated agent profiles

### DIFF
--- a/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { fileURLToPath } from "node:url"
 
 type StateSetter<T> = (update: T | ((prev: T) => T)) => void
 
@@ -8,10 +9,18 @@ function createHookRuntime() {
 
   const useState = <T,>(initial: T | (() => T)) => {
     const idx = stateIndex++
-    if (states[idx] === undefined) states[idx] = typeof initial === "function" ? (initial as () => T)() : initial
-    return [states[idx] as T, ((update: T | ((prev: T) => T)) => {
-      states[idx] = typeof update === "function" ? (update as (prev: T) => T)(states[idx]) : update
-    }) as StateSetter<T>] as const
+    if (states[idx] === undefined)
+      states[idx] =
+        typeof initial === "function" ? (initial as () => T)() : initial
+    return [
+      states[idx] as T,
+      ((update: T | ((prev: T) => T)) => {
+        states[idx] =
+          typeof update === "function"
+            ? (update as (prev: T) => T)(states[idx])
+            : update
+      }) as StateSetter<T>,
+    ] as const
   }
 
   const reactMock: any = {
@@ -26,16 +35,24 @@ function createHookRuntime() {
   const Fragment = Symbol.for("react.fragment")
   const invoke = (type: any, props: any) => {
     if (type === Fragment) return props?.children ?? null
-    return typeof type === "function" ? type(props ?? {}) : { type, props: props ?? {} }
+    return typeof type === "function"
+      ? type(props ?? {})
+      : { type, props: props ?? {} }
   }
 
   return {
-    render<P,>(Component: (props: P) => any, props: P) {
+    render<P>(Component: (props: P) => any, props: P) {
       stateIndex = 0
       return Component(props)
     },
     reactMock,
-    jsxRuntimeMock: { __esModule: true, Fragment, jsx: invoke, jsxs: invoke, jsxDEV: invoke },
+    jsxRuntimeMock: {
+      __esModule: true,
+      Fragment,
+      jsx: invoke,
+      jsxs: invoke,
+      jsxDEV: invoke,
+    },
   }
 }
 
@@ -64,32 +81,59 @@ function textContent(node: any, results: string[] = []): string {
     for (const child of node) textContent(child, results)
     return results.join("")
   }
-  if (node && typeof node === "object") return textContent(node.props?.children, results)
+  if (node && typeof node === "object")
+    return textContent(node.props?.children, results)
   return results.join("")
 }
 
 function findButtonWithText(node: any, label: string) {
-  return findNode(node, (candidate) => candidate.type === "Button" && textContent(candidate.props?.children).includes(label))
+  return findNode(
+    node,
+    (candidate) =>
+      candidate.type === "Button" &&
+      textContent(candidate.props?.children).includes(label),
+  )
+}
+
+function findButtonByTitle(node: any, title: string) {
+  return findNode(
+    node,
+    (candidate) =>
+      candidate.type === "Button" && candidate.props?.title === title,
+  )
 }
 
 function findInputById(node: any, id: string) {
-  return findNode(node, (candidate) => candidate.type === "Input" && candidate.props?.id === id)
+  return findNode(
+    node,
+    (candidate) => candidate.type === "Input" && candidate.props?.id === id,
+  )
 }
 
 function findTextareaById(node: any, id: string) {
-  return findNode(node, (candidate) => candidate.type === "Textarea" && candidate.props?.id === id)
+  return findNode(
+    node,
+    (candidate) => candidate.type === "Textarea" && candidate.props?.id === id,
+  )
 }
 
 function findSelectByTestId(node: any, testId: string) {
-  return findNode(node, (candidate) => candidate.type === "Select" && findNode(
-    candidate.props?.children,
-    (child) => child.type === "SelectTrigger" && child.props?.["data-testid"] === testId,
-  ))
+  return findNode(
+    node,
+    (candidate) =>
+      candidate.type === "Select" &&
+      findNode(
+        candidate.props?.children,
+        (child) =>
+          child.type === "SelectTrigger" &&
+          child.props?.["data-testid"] === testId,
+      ),
+  )
 }
 
 async function loadSettingsLoops(
   runtime: ReturnType<typeof createHookRuntime>,
-  options: { agentProfiles?: any[] } = {},
+  options: { agentProfiles?: any[]; loops?: any[]; loopStatuses?: any[] } = {},
 ) {
   vi.resetModules()
 
@@ -111,7 +155,9 @@ async function loadSettingsLoops(
     SelectValue: (props: any) => ({ type: "SelectValue", props }),
   }
   const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
-  const textareaMock = { Textarea: (props: any) => ({ type: "Textarea", props }) }
+  const textareaMock = {
+    Textarea: (props: any) => ({ type: "Textarea", props }),
+  }
   const cardMock = {
     Card: (props: any) => ({ type: "Card", props }),
     CardContent: (props: any) => ({ type: "CardContent", props }),
@@ -122,8 +168,8 @@ async function loadSettingsLoops(
   const badgeMock = { Badge: (props: any) => ({ type: "Badge", props }) }
   const tipcClientMock = {
     tipcClient: {
-      getLoops: vi.fn(async () => []),
-      getLoopStatuses: vi.fn(async () => []),
+      getLoops: vi.fn(async () => options.loops || []),
+      getLoopStatuses: vi.fn(async () => options.loopStatuses || []),
       getAgentProfiles: vi.fn(async () => options.agentProfiles || []),
       saveLoop,
       startLoop,
@@ -133,15 +179,33 @@ async function loadSettingsLoops(
       openLoopTaskFile: vi.fn(async () => ({ success: true })),
     },
   }
-  const buttonModulePath = new URL("../components/ui/button.tsx", import.meta.url).pathname
-  const inputModulePath = new URL("../components/ui/input.tsx", import.meta.url).pathname
-  const labelModulePath = new URL("../components/ui/label.tsx", import.meta.url).pathname
-  const selectModulePath = new URL("../components/ui/select.tsx", import.meta.url).pathname
-  const switchModulePath = new URL("../components/ui/switch.tsx", import.meta.url).pathname
-  const textareaModulePath = new URL("../components/ui/textarea.tsx", import.meta.url).pathname
-  const cardModulePath = new URL("../components/ui/card.tsx", import.meta.url).pathname
-  const badgeModulePath = new URL("../components/ui/badge.tsx", import.meta.url).pathname
-  const tipcClientModulePath = new URL("../lib/tipc-client.ts", import.meta.url).pathname
+  const buttonModulePath = fileURLToPath(
+    new URL("../components/ui/button.tsx", import.meta.url),
+  )
+  const inputModulePath = fileURLToPath(
+    new URL("../components/ui/input.tsx", import.meta.url),
+  )
+  const labelModulePath = fileURLToPath(
+    new URL("../components/ui/label.tsx", import.meta.url),
+  )
+  const selectModulePath = fileURLToPath(
+    new URL("../components/ui/select.tsx", import.meta.url),
+  )
+  const switchModulePath = fileURLToPath(
+    new URL("../components/ui/switch.tsx", import.meta.url),
+  )
+  const textareaModulePath = fileURLToPath(
+    new URL("../components/ui/textarea.tsx", import.meta.url),
+  )
+  const cardModulePath = fileURLToPath(
+    new URL("../components/ui/card.tsx", import.meta.url),
+  )
+  const badgeModulePath = fileURLToPath(
+    new URL("../components/ui/badge.tsx", import.meta.url),
+  )
+  const tipcClientModulePath = fileURLToPath(
+    new URL("../lib/tipc-client.ts", import.meta.url),
+  )
 
   vi.doMock("react", () => runtime.reactMock)
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
@@ -166,14 +230,31 @@ async function loadSettingsLoops(
   vi.doMock(tipcClientModulePath, () => tipcClientMock)
   vi.doMock("@tanstack/react-query", () => ({
     useQuery: ({ queryKey }: any) => ({
-      data: queryKey?.[0] === "loop-agent-profiles"
-        ? (options.agentProfiles || [])
-        : [],
+      data:
+        queryKey?.[0] === "loops"
+          ? options.loops || []
+          : queryKey?.[0] === "loop-statuses"
+            ? options.loopStatuses || []
+            : queryKey?.[0] === "loop-agent-profiles"
+              ? options.agentProfiles || []
+              : [],
     }),
     useQueryClient: () => ({ invalidateQueries }),
   }))
-  vi.doMock("@renderer/lib/utils", () => ({ cn: (...values: Array<string | undefined | false | null>) => values.filter(Boolean).join(" ") }))
-  vi.doMock("lucide-react", () => ({ Trash2: Null, Plus: Null, Edit2: Null, Save: Null, X: Null, Play: Null, Clock: Null, FileText: Null }))
+  vi.doMock("@renderer/lib/utils", () => ({
+    cn: (...values: Array<string | undefined | false | null>) =>
+      values.filter(Boolean).join(" "),
+  }))
+  vi.doMock("lucide-react", () => ({
+    Trash2: Null,
+    Plus: Null,
+    Edit2: Null,
+    Save: Null,
+    X: Null,
+    Play: Null,
+    Clock: Null,
+    FileText: Null,
+  }))
   vi.doMock("sonner", () => ({ toast: { success, error } }))
 
   const mod = await import("./settings-loops")
@@ -184,6 +265,8 @@ afterEach(() => {
   vi.restoreAllMocks()
   vi.resetModules()
 })
+
+const encodeProfileSelectValue = (profileId: string) => `profile:${profileId}`
 
 describe("desktop repeat-task interval editing", () => {
   it("keeps an empty interval draft local so backspace edits do not snap back to 15", async () => {
@@ -217,9 +300,13 @@ describe("desktop repeat-task interval editing", () => {
     findButtonWithText(tree, "Add Task").props.onClick()
 
     tree = runtime.render(Component, {} as any)
-    findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    findInputById(tree, "name").props.onChange({
+      target: { value: "Daily Summary" },
+    })
     tree = runtime.render(Component, {} as any)
-    findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    findTextareaById(tree, "prompt").props.onChange({
+      target: { value: "Summarize recent activity" },
+    })
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "" } })
 
@@ -227,20 +314,27 @@ describe("desktop repeat-task interval editing", () => {
     await findButtonWithText(tree, "Save").props.onClick()
 
     expect(saveLoop).not.toHaveBeenCalled()
-    expect(error).toHaveBeenCalledWith("Interval must be a positive whole number of minutes")
+    expect(error).toHaveBeenCalledWith(
+      "Interval must be a positive whole number of minutes",
+    )
   })
 
   it("parses a valid interval draft to a number before saving", async () => {
     const runtime = createHookRuntime()
-    const { Component, saveLoop, startLoop, success } = await loadSettingsLoops(runtime)
+    const { Component, saveLoop, startLoop, success } =
+      await loadSettingsLoops(runtime)
 
     let tree = runtime.render(Component, {} as any)
     findButtonWithText(tree, "Add Task").props.onClick()
 
     tree = runtime.render(Component, {} as any)
-    findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    findInputById(tree, "name").props.onChange({
+      target: { value: "Daily Summary" },
+    })
     tree = runtime.render(Component, {} as any)
-    findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    findTextareaById(tree, "prompt").props.onChange({
+      target: { value: "Summarize recent activity" },
+    })
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "60" } })
 
@@ -277,15 +371,19 @@ describe("desktop repeat-task interval editing", () => {
     findButtonWithText(tree, "Add Task").props.onClick()
 
     tree = runtime.render(Component, {} as any)
-    findInputById(tree, "name").props.onChange({ target: { value: "Langfuse Monitor" } })
+    findInputById(tree, "name").props.onChange({
+      target: { value: "Langfuse Monitor" },
+    })
     tree = runtime.render(Component, {} as any)
-    findTextareaById(tree, "prompt").props.onChange({ target: { value: "Review recent Langfuse failures" } })
+    findTextareaById(tree, "prompt").props.onChange({
+      target: { value: "Review recent Langfuse failures" },
+    })
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "120" } })
 
     tree = runtime.render(Component, {} as any)
     const select = findSelectByTestId(tree, "loop-profile-select-trigger")
-    select.props.onValueChange("budget-monitor")
+    select.props.onValueChange(encodeProfileSelectValue("budget-monitor"))
 
     tree = runtime.render(Component, {} as any)
     await findButtonWithText(tree, "Save").props.onClick()
@@ -296,6 +394,83 @@ describe("desktop repeat-task interval editing", () => {
         prompt: "Review recent Langfuse failures",
         intervalMinutes: 120,
         profileId: "budget-monitor",
+      }),
+    })
+  })
+
+  it("shows a disabled agent selection clearly when editing an existing loop", async () => {
+    const runtime = createHookRuntime()
+    const { Component } = await loadSettingsLoops(runtime, {
+      loops: [
+        {
+          id: "disabled-agent-loop",
+          name: "Disabled Agent Loop",
+          prompt: "Review recent Langfuse failures",
+          intervalMinutes: 15,
+          enabled: true,
+          profileId: "budget-monitor",
+        },
+      ],
+      agentProfiles: [
+        {
+          id: "budget-monitor",
+          name: "budget-monitor",
+          displayName: "Budget Monitor",
+          enabled: false,
+        },
+      ],
+    })
+
+    let tree = runtime.render(Component, {} as any)
+    findButtonByTitle(tree, "Edit task").props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    const select = findSelectByTestId(tree, "loop-profile-select-trigger")
+    expect(select.props.value).toBe(encodeProfileSelectValue("budget-monitor"))
+
+    const content = textContent(tree)
+    expect(content).toContain("Budget Monitor (disabled)")
+    expect(content).toContain(
+      "This task still references Budget Monitor, but that agent is currently disabled.",
+    )
+    expect(content).not.toContain("Use the default active agent")
+  })
+
+  it("preserves and explains missing agent selections when saving an existing loop", async () => {
+    const runtime = createHookRuntime()
+    const { Component, saveLoop } = await loadSettingsLoops(runtime, {
+      loops: [
+        {
+          id: "missing-agent-loop",
+          name: "Missing Agent Loop",
+          prompt: "Summarize recent activity",
+          intervalMinutes: 30,
+          enabled: true,
+          profileId: "ghost-agent",
+        },
+      ],
+      agentProfiles: [],
+    })
+
+    let tree = runtime.render(Component, {} as any)
+    findButtonByTitle(tree, "Edit task").props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    const select = findSelectByTestId(tree, "loop-profile-select-trigger")
+    expect(select.props.value).toBe(encodeProfileSelectValue("ghost-agent"))
+
+    const content = textContent(tree)
+    expect(content).toContain("Missing agent (ghost-agent)")
+    expect(content).toContain(
+      'This task still references agent "ghost-agent", but it is no longer available.',
+    )
+
+    await findButtonWithText(tree, "Save").props.onClick()
+
+    expect(saveLoop).toHaveBeenCalledWith({
+      loop: expect.objectContaining({
+        id: "missing-agent-loop",
+        profileId: "ghost-agent",
       }),
     })
   })

--- a/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
@@ -19,6 +19,7 @@ function createHookRuntime() {
     default: {} as any,
     useState,
     useCallback: (fn: any) => fn,
+    forwardRef: (render: any) => (props: any) => render(props, null),
   }
   reactMock.default = reactMock
 
@@ -79,7 +80,17 @@ function findTextareaById(node: any, id: string) {
   return findNode(node, (candidate) => candidate.type === "Textarea" && candidate.props?.id === id)
 }
 
-async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) {
+function findSelectByTestId(node: any, testId: string) {
+  return findNode(node, (candidate) => candidate.type === "Select" && findNode(
+    candidate.props?.children,
+    (child) => child.type === "SelectTrigger" && child.props?.["data-testid"] === testId,
+  ))
+}
+
+async function loadSettingsLoops(
+  runtime: ReturnType<typeof createHookRuntime>,
+  options: { agentProfiles?: any[] } = {},
+) {
   vi.resetModules()
 
   const saveLoop = vi.fn(async () => undefined)
@@ -89,27 +100,31 @@ async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) 
   const error = vi.fn()
   const invalidateQueries = vi.fn()
   const Null = () => null
-
-  vi.doMock("react", () => runtime.reactMock)
-  vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
-  vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
-  vi.doMock("@renderer/components/ui/button", () => ({ Button: (props: any) => ({ type: "Button", props }) }))
-  vi.doMock("@renderer/components/ui/input", () => ({ Input: (props: any) => ({ type: "Input", props }) }))
-  vi.doMock("@renderer/components/ui/label", () => ({ Label: (props: any) => ({ type: "Label", props }) }))
-  vi.doMock("@renderer/components/ui/switch", () => ({ Switch: (props: any) => ({ type: "Switch", props }) }))
-  vi.doMock("@renderer/components/ui/textarea", () => ({ Textarea: (props: any) => ({ type: "Textarea", props }) }))
-  vi.doMock("@renderer/components/ui/card", () => ({
+  const buttonMock = { Button: (props: any) => ({ type: "Button", props }) }
+  const inputMock = { Input: (props: any) => ({ type: "Input", props }) }
+  const labelMock = { Label: (props: any) => ({ type: "Label", props }) }
+  const selectMock = {
+    Select: (props: any) => ({ type: "Select", props }),
+    SelectContent: (props: any) => ({ type: "SelectContent", props }),
+    SelectItem: (props: any) => ({ type: "SelectItem", props }),
+    SelectTrigger: (props: any) => ({ type: "SelectTrigger", props }),
+    SelectValue: (props: any) => ({ type: "SelectValue", props }),
+  }
+  const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
+  const textareaMock = { Textarea: (props: any) => ({ type: "Textarea", props }) }
+  const cardMock = {
     Card: (props: any) => ({ type: "Card", props }),
     CardContent: (props: any) => ({ type: "CardContent", props }),
     CardDescription: (props: any) => ({ type: "CardDescription", props }),
     CardHeader: (props: any) => ({ type: "CardHeader", props }),
     CardTitle: (props: any) => ({ type: "CardTitle", props }),
-  }))
-  vi.doMock("@renderer/components/ui/badge", () => ({ Badge: (props: any) => ({ type: "Badge", props }) }))
-  vi.doMock("@renderer/lib/tipc-client", () => ({
+  }
+  const badgeMock = { Badge: (props: any) => ({ type: "Badge", props }) }
+  const tipcClientMock = {
     tipcClient: {
       getLoops: vi.fn(async () => []),
       getLoopStatuses: vi.fn(async () => []),
+      getAgentProfiles: vi.fn(async () => options.agentProfiles || []),
       saveLoop,
       startLoop,
       stopLoop,
@@ -117,9 +132,44 @@ async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) 
       triggerLoop: vi.fn(async () => ({ success: true })),
       openLoopTaskFile: vi.fn(async () => ({ success: true })),
     },
-  }))
+  }
+  const buttonModulePath = new URL("../components/ui/button.tsx", import.meta.url).pathname
+  const inputModulePath = new URL("../components/ui/input.tsx", import.meta.url).pathname
+  const labelModulePath = new URL("../components/ui/label.tsx", import.meta.url).pathname
+  const selectModulePath = new URL("../components/ui/select.tsx", import.meta.url).pathname
+  const switchModulePath = new URL("../components/ui/switch.tsx", import.meta.url).pathname
+  const textareaModulePath = new URL("../components/ui/textarea.tsx", import.meta.url).pathname
+  const cardModulePath = new URL("../components/ui/card.tsx", import.meta.url).pathname
+  const badgeModulePath = new URL("../components/ui/badge.tsx", import.meta.url).pathname
+  const tipcClientModulePath = new URL("../lib/tipc-client.ts", import.meta.url).pathname
+
+  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("@renderer/components/ui/button", () => buttonMock)
+  vi.doMock(buttonModulePath, () => buttonMock)
+  vi.doMock("@renderer/components/ui/input", () => inputMock)
+  vi.doMock(inputModulePath, () => inputMock)
+  vi.doMock("@renderer/components/ui/label", () => labelMock)
+  vi.doMock(labelModulePath, () => labelMock)
+  vi.doMock("@renderer/components/ui/select", () => selectMock)
+  vi.doMock(selectModulePath, () => selectMock)
+  vi.doMock("@renderer/components/ui/switch", () => switchMock)
+  vi.doMock(switchModulePath, () => switchMock)
+  vi.doMock("@renderer/components/ui/textarea", () => textareaMock)
+  vi.doMock(textareaModulePath, () => textareaMock)
+  vi.doMock("@renderer/components/ui/card", () => cardMock)
+  vi.doMock(cardModulePath, () => cardMock)
+  vi.doMock("@renderer/components/ui/badge", () => badgeMock)
+  vi.doMock(badgeModulePath, () => badgeMock)
+  vi.doMock("@renderer/lib/tipc-client", () => tipcClientMock)
+  vi.doMock(tipcClientModulePath, () => tipcClientMock)
   vi.doMock("@tanstack/react-query", () => ({
-    useQuery: ({ queryKey }: any) => ({ data: queryKey?.[0] === "loops" ? [] : [] }),
+    useQuery: ({ queryKey }: any) => ({
+      data: queryKey?.[0] === "loop-agent-profiles"
+        ? (options.agentProfiles || [])
+        : [],
+    }),
     useQueryClient: () => ({ invalidateQueries }),
   }))
   vi.doMock("@renderer/lib/utils", () => ({ cn: (...values: Array<string | undefined | false | null>) => values.filter(Boolean).join(" ") }))
@@ -168,7 +218,9 @@ describe("desktop repeat-task interval editing", () => {
 
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
     findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "" } })
 
     tree = runtime.render(Component, {} as any)
@@ -187,7 +239,9 @@ describe("desktop repeat-task interval editing", () => {
 
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
     findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "60" } })
 
     tree = runtime.render(Component, {} as any)
@@ -204,5 +258,45 @@ describe("desktop repeat-task interval editing", () => {
     })
     expect(startLoop).toHaveBeenCalledWith({ loopId: "daily-summary" })
     expect(success).toHaveBeenCalledWith("Task created")
+  })
+
+  it("persists a dedicated agent profile selection when saving", async () => {
+    const runtime = createHookRuntime()
+    const { Component, saveLoop } = await loadSettingsLoops(runtime, {
+      agentProfiles: [
+        {
+          id: "budget-monitor",
+          name: "budget-monitor",
+          displayName: "Budget Monitor",
+          enabled: true,
+        },
+      ],
+    })
+
+    let tree = runtime.render(Component, {} as any)
+    findButtonWithText(tree, "Add Task").props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    findInputById(tree, "name").props.onChange({ target: { value: "Langfuse Monitor" } })
+    tree = runtime.render(Component, {} as any)
+    findTextareaById(tree, "prompt").props.onChange({ target: { value: "Review recent Langfuse failures" } })
+    tree = runtime.render(Component, {} as any)
+    findInputById(tree, "interval").props.onChange({ target: { value: "120" } })
+
+    tree = runtime.render(Component, {} as any)
+    const select = findSelectByTestId(tree, "loop-profile-select-trigger")
+    select.props.onValueChange("budget-monitor")
+
+    tree = runtime.render(Component, {} as any)
+    await findButtonWithText(tree, "Save").props.onClick()
+
+    expect(saveLoop).toHaveBeenCalledWith({
+      loop: expect.objectContaining({
+        name: "Langfuse Monitor",
+        prompt: "Review recent Langfuse failures",
+        intervalMinutes: 120,
+        profileId: "budget-monitor",
+      }),
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -2,6 +2,13 @@ import { useState } from "react"
 import { Button } from "@renderer/components/ui/button"
 import { Input } from "@renderer/components/ui/input"
 import { Label } from "@renderer/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select"
 import { Switch } from "@renderer/components/ui/switch"
 import { Textarea } from "@renderer/components/ui/textarea"
 
@@ -11,7 +18,7 @@ import { Trash2, Plus, Edit2, Save, X, Play, Clock, FileText } from "lucide-reac
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { cn } from "@renderer/lib/utils"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { LoopConfig } from "@shared/types"
+import type { AgentProfile, LoopConfig } from "@shared/types"
 import { toast } from "sonner"
 
 interface EditingLoop {
@@ -20,6 +27,7 @@ interface EditingLoop {
   prompt: string
   intervalMinutesDraft: string
   enabled: boolean
+  profileId: string
   runOnStartup: boolean
 }
 
@@ -35,6 +43,7 @@ const emptyLoop: EditingLoop = {
   prompt: "",
   intervalMinutesDraft: "15",
   enabled: true,
+  profileId: "",
   runOnStartup: false,
 }
 
@@ -105,7 +114,16 @@ export function SettingsLoops() {
     refetchInterval: 5000,
   })
 
+  const agentProfilesQuery = useQuery({
+    queryKey: ["loop-agent-profiles"],
+    queryFn: async () => tipcClient.getAgentProfiles() as Promise<AgentProfile[]>,
+  })
+
   const loops: LoopConfig[] = loopsQuery.data || []
+  const availableAgentProfiles = (agentProfilesQuery.data || []).filter((profile) => profile.enabled)
+  const profileById = new Map(
+    availableAgentProfiles.map((profile) => [profile.id, profile] as const)
+  )
   const statusByLoopId = new Map(
     (loopStatusesQuery.data || []).map((s) => [s.id, s] as const)
   )
@@ -128,6 +146,7 @@ export function SettingsLoops() {
       prompt: loop.prompt,
       intervalMinutesDraft: formatLoopIntervalDraft(loop.intervalMinutes),
       enabled: loop.enabled,
+      profileId: loop.profileId ?? "",
       runOnStartup: loop.runOnStartup ?? false,
     })
   }
@@ -163,6 +182,7 @@ export function SettingsLoops() {
       prompt: editing.prompt.trim(),
       intervalMinutes: parsedIntervalMinutes,
       enabled: editing.enabled,
+      profileId: editing.profileId.trim() || undefined,
       runOnStartup: editing.runOnStartup,
     }
 
@@ -242,6 +262,8 @@ export function SettingsLoops() {
         const isRunning = runtime?.isRunning ?? false
         const nextRunAt = runtime?.nextRunAt
         const lastRunAt = runtime?.lastRunAt ?? loop.lastRunAt
+        const assignedProfile = loop.profileId ? profileById.get(loop.profileId) : undefined
+        const assignedProfileLabel = assignedProfile?.displayName || assignedProfile?.name || loop.profileId
         return (
           <div
             key={loop.id}
@@ -263,6 +285,18 @@ export function SettingsLoops() {
                 <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
                   {loop.prompt}
                 </p>
+                {assignedProfileLabel && (
+                  <div className="mt-2">
+                    <Badge
+                      variant="outline"
+                      className="h-5 max-w-full truncate text-[11px] font-normal"
+                      data-testid={`loop-profile-badge-${loop.id}`}
+                      title={`Runs as ${assignedProfileLabel}`}
+                    >
+                      Agent: {assignedProfileLabel}
+                    </Badge>
+                  </div>
+                )}
               </div>
               <div className="flex shrink-0 items-center gap-1">
                 <Button
@@ -334,6 +368,7 @@ export function SettingsLoops() {
 
   const renderEditForm = () => {
     if (!editing) return null
+    const selectedProfile = editing.profileId ? profileById.get(editing.profileId) : undefined
     return (
       <Card className="max-w-3xl">
         <CardHeader className="space-y-1 pb-2">
@@ -359,6 +394,34 @@ export function SettingsLoops() {
               placeholder="Enter the prompt to send to the agent..."
               rows={4}
             />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="loop-profile-trigger">Agent</Label>
+            <Select
+              value={editing.profileId || "__default__"}
+              onValueChange={(value) => setEditing({ ...editing, profileId: value === "__default__" ? "" : value })}
+            >
+              <SelectTrigger
+                id="loop-profile-trigger"
+                data-testid="loop-profile-select-trigger"
+                className="w-full sm:max-w-sm"
+              >
+                <SelectValue placeholder="No dedicated agent" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__default__">No dedicated agent</SelectItem>
+                {availableAgentProfiles.map((profile) => (
+                  <SelectItem key={profile.id} value={profile.id}>
+                    {profile.displayName || profile.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              {selectedProfile
+                ? `This task will run as ${selectedProfile.displayName || selectedProfile.name}, so it can use that agent's model and tools instead of the default active agent.`
+                : "Use the default active agent, or pick a dedicated agent if this repeat task should run with a cheaper model or different tools."}
+            </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="interval">Interval</Label>

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -12,9 +12,24 @@ import {
 import { Switch } from "@renderer/components/ui/switch"
 import { Textarea } from "@renderer/components/ui/textarea"
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@renderer/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@renderer/components/ui/card"
 import { Badge } from "@renderer/components/ui/badge"
-import { Trash2, Plus, Edit2, Save, X, Play, Clock, FileText } from "lucide-react"
+import {
+  Trash2,
+  Plus,
+  Edit2,
+  Save,
+  X,
+  Play,
+  Clock,
+  FileText,
+} from "lucide-react"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { cn } from "@renderer/lib/utils"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
@@ -81,9 +96,10 @@ function formatInterval(minutes: number): string {
 }
 
 function formatLoopIntervalDraft(minutes?: number): string {
-  const normalizedMinutes = typeof minutes === "number" && Number.isFinite(minutes)
-    ? Math.floor(minutes)
-    : 0
+  const normalizedMinutes =
+    typeof minutes === "number" && Number.isFinite(minutes)
+      ? Math.floor(minutes)
+      : 0
 
   return normalizedMinutes >= 1 ? String(normalizedMinutes) : "1"
 }
@@ -98,6 +114,27 @@ function parseLoopIntervalDraft(draft: string): number | null {
   return parsed
 }
 
+const NO_DEDICATED_AGENT_VALUE = "none"
+
+function encodeProfileSelectValue(profileId?: string): string {
+  return profileId ? `profile:${profileId}` : NO_DEDICATED_AGENT_VALUE
+}
+
+function decodeProfileSelectValue(value: string): string {
+  return value === NO_DEDICATED_AGENT_VALUE
+    ? ""
+    : value.startsWith("profile:")
+      ? value.slice("profile:".length)
+      : value
+}
+
+function getAgentProfileLabel(
+  profile?: Pick<AgentProfile, "id" | "name" | "displayName">,
+  fallbackId?: string,
+): string {
+  return profile?.displayName || profile?.name || fallbackId || ""
+}
+
 export function SettingsLoops() {
   const queryClient = useQueryClient()
   const [editing, setEditing] = useState<EditingLoop | null>(null)
@@ -110,22 +147,27 @@ export function SettingsLoops() {
 
   const loopStatusesQuery = useQuery({
     queryKey: ["loop-statuses"],
-    queryFn: async () => tipcClient.getLoopStatuses() as Promise<LoopRuntimeStatus[]>,
+    queryFn: async () =>
+      tipcClient.getLoopStatuses() as Promise<LoopRuntimeStatus[]>,
     refetchInterval: 5000,
   })
 
   const agentProfilesQuery = useQuery({
     queryKey: ["loop-agent-profiles"],
-    queryFn: async () => tipcClient.getAgentProfiles() as Promise<AgentProfile[]>,
+    queryFn: async () =>
+      tipcClient.getAgentProfiles() as Promise<AgentProfile[]>,
   })
 
   const loops: LoopConfig[] = loopsQuery.data || []
-  const availableAgentProfiles = (agentProfilesQuery.data || []).filter((profile) => profile.enabled)
+  const allAgentProfiles = agentProfilesQuery.data || []
+  const availableAgentProfiles = allAgentProfiles.filter(
+    (profile) => profile.enabled,
+  )
   const profileById = new Map(
-    availableAgentProfiles.map((profile) => [profile.id, profile] as const)
+    allAgentProfiles.map((profile) => [profile.id, profile] as const),
   )
   const statusByLoopId = new Map(
-    (loopStatusesQuery.data || []).map((s) => [s.id, s] as const)
+    (loopStatusesQuery.data || []).map((s) => [s.id, s] as const),
   )
 
   const handleCreate = () => {
@@ -169,13 +211,21 @@ export function SettingsLoops() {
       return
     }
 
-    const parsedIntervalMinutes = parseLoopIntervalDraft(editing.intervalMinutesDraft)
+    const parsedIntervalMinutes = parseLoopIntervalDraft(
+      editing.intervalMinutesDraft,
+    )
     if (parsedIntervalMinutes === null) {
       toast.error("Interval must be a positive whole number of minutes")
       return
     }
 
-    const slugify = (s: string) => s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64) || crypto.randomUUID()
+    const slugify = (s: string) =>
+      s
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 64) || crypto.randomUUID()
     const loopData: LoopConfig = {
       id: editing.id || slugify(editing.name),
       name: editing.name.trim(),
@@ -262,13 +312,18 @@ export function SettingsLoops() {
         const isRunning = runtime?.isRunning ?? false
         const nextRunAt = runtime?.nextRunAt
         const lastRunAt = runtime?.lastRunAt ?? loop.lastRunAt
-        const assignedProfile = loop.profileId ? profileById.get(loop.profileId) : undefined
-        const assignedProfileLabel = assignedProfile?.displayName || assignedProfile?.name || loop.profileId
+        const assignedProfile = loop.profileId
+          ? profileById.get(loop.profileId)
+          : undefined
+        const assignedProfileLabel = getAgentProfileLabel(
+          assignedProfile,
+          loop.profileId,
+        )
         return (
           <div
             key={loop.id}
             className={cn(
-              "rounded-lg border bg-card px-3 py-2",
+              "bg-card rounded-lg border px-3 py-2",
               !loop.enabled && "opacity-60",
             )}
           >
@@ -282,7 +337,7 @@ export function SettingsLoops() {
                     <Badge variant="outline">Disabled</Badge>
                   ) : null}
                 </div>
-                <p className="mt-1 line-clamp-1 text-xs text-muted-foreground">
+                <p className="text-muted-foreground mt-1 line-clamp-1 text-xs">
                   {loop.prompt}
                 </p>
                 {assignedProfileLabel && (
@@ -305,7 +360,8 @@ export function SettingsLoops() {
                   className="h-7 gap-1.5 px-2"
                   onClick={() => handleRunNow(loop)}
                 >
-                  <Play className="h-3.5 w-3.5" />Run
+                  <Play className="h-3.5 w-3.5" />
+                  Run
                 </Button>
                 <Button
                   variant="outline"
@@ -313,7 +369,8 @@ export function SettingsLoops() {
                   className="h-7 gap-1.5 px-2"
                   onClick={() => handleOpenTaskFile(loop)}
                 >
-                  <FileText className="h-3.5 w-3.5" />File
+                  <FileText className="h-3.5 w-3.5" />
+                  File
                 </Button>
                 <Button
                   variant="ghost"
@@ -336,7 +393,7 @@ export function SettingsLoops() {
               </div>
             </div>
 
-            <div className="mt-2 flex flex-wrap gap-3 text-xs text-muted-foreground">
+            <div className="text-muted-foreground mt-2 flex flex-wrap gap-3 text-xs">
               <div className="flex items-center gap-1">
                 <Clock className="h-3.5 w-3.5" />
                 Every {formatInterval(loop.intervalMinutes)}
@@ -353,13 +410,15 @@ export function SettingsLoops() {
                 checked={loop.enabled}
                 onCheckedChange={() => handleToggleEnabled(loop)}
               />
-              <Label className="text-xs">{loop.enabled ? "Enabled" : "Disabled"}</Label>
+              <Label className="text-xs">
+                {loop.enabled ? "Enabled" : "Disabled"}
+              </Label>
             </div>
           </div>
         )
       })}
       {loops.length === 0 && (
-        <div className="py-8 text-center text-muted-foreground">
+        <div className="text-muted-foreground py-8 text-center">
           No repeat tasks configured. Click &quot;Add Task&quot; to create one.
         </div>
       )}
@@ -368,12 +427,31 @@ export function SettingsLoops() {
 
   const renderEditForm = () => {
     if (!editing) return null
-    const selectedProfile = editing.profileId ? profileById.get(editing.profileId) : undefined
+    const selectedProfile = editing.profileId
+      ? profileById.get(editing.profileId)
+      : undefined
+    const selectedProfileLabel = getAgentProfileLabel(
+      selectedProfile,
+      editing.profileId,
+    )
+    const selectedProfileValue = encodeProfileSelectValue(editing.profileId)
+    const selectedProfileIsDisabled =
+      !!selectedProfile && !selectedProfile.enabled
+    const selectedProfileIsMissing = !!editing.profileId && !selectedProfile
+    const selectedProfileIsUnavailable =
+      selectedProfileIsDisabled || selectedProfileIsMissing
+    const unavailableProfileLabel = selectedProfileIsMissing
+      ? `Missing agent (${editing.profileId})`
+      : `${selectedProfileLabel} (disabled)`
     return (
       <Card className="max-w-3xl">
         <CardHeader className="space-y-1 pb-2">
-          <CardTitle className="text-lg">{isCreating ? "Add Repeat Task" : "Edit Repeat Task"}</CardTitle>
-          <CardDescription>Set the prompt, interval, and startup behavior.</CardDescription>
+          <CardTitle className="text-lg">
+            {isCreating ? "Add Repeat Task" : "Edit Repeat Task"}
+          </CardTitle>
+          <CardDescription>
+            Set the prompt, interval, and startup behavior.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="space-y-2">
@@ -390,7 +468,9 @@ export function SettingsLoops() {
             <Textarea
               id="prompt"
               value={editing.prompt}
-              onChange={(e) => setEditing({ ...editing, prompt: e.target.value })}
+              onChange={(e) =>
+                setEditing({ ...editing, prompt: e.target.value })
+              }
               placeholder="Enter the prompt to send to the agent..."
               rows={4}
             />
@@ -398,8 +478,13 @@ export function SettingsLoops() {
           <div className="space-y-2">
             <Label htmlFor="loop-profile-trigger">Agent</Label>
             <Select
-              value={editing.profileId || "__default__"}
-              onValueChange={(value) => setEditing({ ...editing, profileId: value === "__default__" ? "" : value })}
+              value={selectedProfileValue}
+              onValueChange={(value) =>
+                setEditing({
+                  ...editing,
+                  profileId: decodeProfileSelectValue(value),
+                })
+              }
             >
               <SelectTrigger
                 id="loop-profile-trigger"
@@ -409,18 +494,32 @@ export function SettingsLoops() {
                 <SelectValue placeholder="No dedicated agent" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__default__">No dedicated agent</SelectItem>
+                {selectedProfileIsUnavailable && (
+                  <SelectItem value={selectedProfileValue}>
+                    {unavailableProfileLabel}
+                  </SelectItem>
+                )}
+                <SelectItem value={NO_DEDICATED_AGENT_VALUE}>
+                  No dedicated agent
+                </SelectItem>
                 {availableAgentProfiles.map((profile) => (
-                  <SelectItem key={profile.id} value={profile.id}>
-                    {profile.displayName || profile.name}
+                  <SelectItem
+                    key={profile.id}
+                    value={encodeProfileSelectValue(profile.id)}
+                  >
+                    {getAgentProfileLabel(profile)}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
-            <p className="text-xs text-muted-foreground">
-              {selectedProfile
-                ? `This task will run as ${selectedProfile.displayName || selectedProfile.name}, so it can use that agent's model and tools instead of the default active agent.`
-                : "Use the default active agent, or pick a dedicated agent if this repeat task should run with a cheaper model or different tools."}
+            <p className="text-muted-foreground text-xs">
+              {selectedProfileIsMissing
+                ? `This task still references agent "${editing.profileId}", but it is no longer available. Keeping this selection preserves the saved agent until you choose another agent or no dedicated agent.`
+                : selectedProfileIsDisabled
+                  ? `This task still references ${selectedProfileLabel}, but that agent is currently disabled. Keeping this selection preserves the saved agent until you choose another agent or no dedicated agent.`
+                  : selectedProfile
+                    ? `This task will run as ${selectedProfileLabel}, so it can use that agent's model and tools instead of the default active agent.`
+                    : "Use the default active agent, or pick a dedicated agent if this repeat task should run with a cheaper model or different tools."}
             </p>
           </div>
           <div className="space-y-2">
@@ -431,19 +530,36 @@ export function SettingsLoops() {
                 type="number"
                 min={1}
                 value={editing.intervalMinutesDraft}
-                onChange={(e) => setEditing({ ...editing, intervalMinutesDraft: e.target.value })}
+                onChange={(e) =>
+                  setEditing({
+                    ...editing,
+                    intervalMinutesDraft: e.target.value,
+                  })
+                }
                 className="h-8 w-20"
               />
-              <span className="self-center text-xs text-muted-foreground">minutes</span>
+              <span className="text-muted-foreground self-center text-xs">
+                minutes
+              </span>
             </div>
             <div className="mt-1 flex flex-wrap gap-1.5">
               {INTERVAL_PRESETS.map((preset) => (
                 <Button
                   key={preset.value}
-                  variant={parseLoopIntervalDraft(editing.intervalMinutesDraft) === preset.value ? "secondary" : "ghost"}
+                  variant={
+                    parseLoopIntervalDraft(editing.intervalMinutesDraft) ===
+                    preset.value
+                      ? "secondary"
+                      : "ghost"
+                  }
                   size="sm"
                   className="h-7 px-2 text-xs"
-                  onClick={() => setEditing({ ...editing, intervalMinutesDraft: String(preset.value) })}
+                  onClick={() =>
+                    setEditing({
+                      ...editing,
+                      intervalMinutesDraft: String(preset.value),
+                    })
+                  }
                 >
                   {preset.label}
                 </Button>
@@ -463,17 +579,26 @@ export function SettingsLoops() {
               <Switch
                 id="runOnStartup"
                 checked={editing.runOnStartup}
-                onCheckedChange={(v) => setEditing({ ...editing, runOnStartup: v })}
+                onCheckedChange={(v) =>
+                  setEditing({ ...editing, runOnStartup: v })
+                }
               />
               <Label htmlFor="runOnStartup">Run on Startup</Label>
             </div>
           </div>
           <div className="flex justify-end gap-2 pt-3">
-            <Button size="sm" variant="outline" className="gap-1.5" onClick={handleCancel}>
-              <X className="h-4 w-4" />Cancel
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              onClick={handleCancel}
+            >
+              <X className="h-4 w-4" />
+              Cancel
             </Button>
             <Button size="sm" className="gap-1.5" onClick={handleSave}>
-              <Save className="h-4 w-4" />Save
+              <Save className="h-4 w-4" />
+              Save
             </Button>
           </div>
         </CardContent>
@@ -485,7 +610,8 @@ export function SettingsLoops() {
     <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-6 py-4">
       <div className="mb-3 flex flex-wrap items-center justify-end gap-2">
         <Button size="sm" className="gap-1.5" onClick={handleCreate}>
-          <Plus className="h-3.5 w-3.5" />Add Task
+          <Plus className="h-3.5 w-3.5" />
+          Add Task
         </Button>
       </div>
       {editing ? renderEditForm() : renderLoopList()}


### PR DESCRIPTION
## Summary
- add a dedicated agent selector to desktop Settings > Repeat Tasks so loops can run with a chosen agent profile instead of always using the default active agent
- persist `profileId` from the desktop editor and show the assigned agent on saved repeat-task cards
- add renderer regression coverage for dedicated agent selection alongside the existing interval draft tests

Closes #169

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/pages/settings-loops.interval-draft.test.tsx src/renderer/src/pages/settings-loops.save-loop-result.test.tsx`
- `pnpm --filter @dotagents/desktop run typecheck:web`
- Live Electron before/after recordings:
  - before: `/tmp/electron-ui-recording/issue169-before.mp4`
  - after: `/tmp/electron-ui-recording/issue169-after.mp4`
  - key frames: `/tmp/electron-ui-recording/issue169-before-loaded.png`, `/tmp/electron-ui-recording/issue169-after-loaded.png`

## Notes
- `pnpm install` hit the existing desktop native postinstall failure for `@egoist/electron-panel-window`, so this run used `pnpm install --ignore-scripts`.
- `pnpm build:shared` passed. `pnpm build:core` still fails on the pre-existing `@dotagents/shared` DTS resolution issue, but the JS build artifacts were sufficient for the live Electron validation.