### PR TITLE
Fix main-agent delegation latency for local repo tasks

### DIFF
--- a/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
+++ b/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
@@ -32,7 +32,7 @@ export const acpRouterToolDefinitions = [
   {
     name: 'delegate_to_agent',
     description:
-      'Delegate a sub-task to a specialized ACP agent. The agent will work autonomously and return results. Use this when a task is better suited for a specialist.',
+      'Delegate a sub-task to a specialized ACP agent. Use this when a specialist has a clear advantage or the user explicitly asked for that agent; keep local repo/workspace coding and debugging in the current agent unless delegating a narrow parallel subtask.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -146,7 +146,7 @@ export const acpRouterToolDefinitions = [
   {
     name: 'send_to_agent',
     description:
-      'Send a task to an agent. Alias for delegate_to_agent. The agent will process the task and return results.',
+      'Send a task to an agent. Alias for delegate_to_agent. Use this when a specialist has a clear advantage or the user explicitly asked for that agent; keep local repo/workspace coding and debugging in the current agent unless delegating a narrow parallel subtask.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -208,4 +208,3 @@ export function resolveToolName(toolName: string): string {
 export function isRouterTool(toolName: string): boolean {
   return acpRouterToolDefinitions.some(def => def.name === toolName);
 }
-

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -213,4 +213,39 @@ describe("handleDelegateToAgent", () => {
       workingDirectory: undefined,
     })
   })
+
+  it("allows delegation for generic snippet tasks that only mention a file extension", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "profile-main-agent",
+      profileName: "Main Agent",
+      guidelines: "",
+    })
+
+    mockGetByName.mockReturnValue({
+      id: "augustus-profile",
+      name: "augustus",
+      displayName: "augustus",
+      enabled: true,
+      connection: { type: "stdio" },
+      createdAt: 0,
+      updatedAt: 0,
+    })
+
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "augustus",
+      task: "Debug this .ts snippet and tell me what is wrong.",
+      waitForResult: true,
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({
+      success: true,
+      status: "completed",
+      output: "Final user-facing answer",
+    }))
+    expect(mockAcpService.spawnAgent).toHaveBeenCalledWith("augustus", {
+      workingDirectory: undefined,
+    })
+  })
 })

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -151,7 +151,7 @@ describe("handleDelegateToAgent", () => {
   it("blocks main-agent delegation for local workspace coding tasks", async () => {
     mockGetSessionProfileSnapshot.mockReturnValue({
       profileId: "profile-main-agent",
-      profileName: "main-agent",
+      profileName: "Main Agent",
       guidelines: "",
     })
 
@@ -182,7 +182,7 @@ describe("handleDelegateToAgent", () => {
   it("allows explicit user requests for a specific specialist agent", async () => {
     mockGetSessionProfileSnapshot.mockReturnValue({
       profileId: "profile-main-agent",
-      profileName: "main-agent",
+      profileName: "Main Agent",
       guidelines: "",
     })
 

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 let sessionUpdateHandler: ((event: any) => void) | undefined
 const mockGetByName = vi.fn((): any => undefined)
+const mockGetById = vi.fn((): any => undefined)
 const mockGetSessionProfileSnapshot = vi.fn((): any => undefined)
 
 const mockAcpService = {
@@ -79,6 +80,7 @@ vi.mock("../acp-session-state", () => ({
 vi.mock("../agent-profile-service", () => ({
   agentProfileService: {
     getByName: mockGetByName,
+    getById: mockGetById,
     getAll: vi.fn(() => []),
   },
 }))
@@ -103,6 +105,7 @@ describe("handleDelegateToAgent", () => {
     vi.clearAllMocks()
     sessionUpdateHandler = undefined
     mockGetByName.mockReturnValue(undefined)
+    mockGetById.mockReturnValue(undefined)
     mockGetSessionProfileSnapshot.mockReturnValue(undefined)
   })
 
@@ -155,6 +158,12 @@ describe("handleDelegateToAgent", () => {
       guidelines: "",
     })
 
+    mockGetById.mockReturnValue({
+      id: "profile-main-agent",
+      name: "main-agent",
+      displayName: "Main Agent",
+    })
+
     mockGetByName.mockReturnValue({
       id: "augustus-profile",
       name: "augustus",
@@ -184,6 +193,12 @@ describe("handleDelegateToAgent", () => {
       profileId: "profile-main-agent",
       profileName: "Main Agent",
       guidelines: "",
+    })
+
+    mockGetById.mockReturnValue({
+      id: "profile-main-agent",
+      name: "main-agent",
+      displayName: "Main Agent",
     })
 
     mockGetByName.mockReturnValue({
@@ -219,6 +234,12 @@ describe("handleDelegateToAgent", () => {
       profileId: "profile-main-agent",
       profileName: "Main Agent",
       guidelines: "",
+    })
+
+    mockGetById.mockReturnValue({
+      id: "profile-main-agent",
+      name: "main-agent",
+      displayName: "Main Agent",
     })
 
     mockGetByName.mockReturnValue({

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -269,4 +269,106 @@ describe("handleDelegateToAgent", () => {
       workingDirectory: undefined,
     })
   })
+
+  it("blocks local workspace delegation even when the main agent display name is customized", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "profile-main-agent",
+      profileName: "Pair Driver",
+      guidelines: "",
+    })
+
+    mockGetById.mockReturnValue({
+      id: "profile-main-agent",
+      name: "main-agent",
+      displayName: "Pair Driver",
+    })
+
+    mockGetByName.mockReturnValue({
+      id: "augustus-profile",
+      name: "augustus",
+      displayName: "augustus",
+      enabled: true,
+      connection: { type: "stdio" },
+      createdAt: 0,
+      updatedAt: 0,
+    })
+
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "augustus",
+      task: "Inspect /Users/dev/dotagents-mono/src/main.ts and fix the bug.",
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({ success: false }))
+    expect(mockAcpService.spawnAgent).not.toHaveBeenCalled()
+  })
+
+  it("blocks local workspace coding tasks that use Linux home paths", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "profile-main-agent",
+      profileName: "Main Agent",
+      guidelines: "",
+    })
+
+    mockGetById.mockReturnValue({
+      id: "profile-main-agent",
+      name: "main-agent",
+      displayName: "Main Agent",
+    })
+
+    mockGetByName.mockReturnValue({
+      id: "augustus-profile",
+      name: "augustus",
+      displayName: "augustus",
+      enabled: true,
+      connection: { type: "stdio" },
+      createdAt: 0,
+      updatedAt: 0,
+    })
+
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "augustus",
+      task: "Debug /home/ubuntu/worktree/dotagents-mono/apps/mobile/src/app.tsx and fix the failure.",
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({ success: false }))
+    expect(mockAcpService.spawnAgent).not.toHaveBeenCalled()
+  })
+
+  it("blocks local workspace coding tasks that use Windows-style relative paths", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "profile-main-agent",
+      profileName: "Main Agent",
+      guidelines: "",
+    })
+
+    mockGetById.mockReturnValue({
+      id: "profile-main-agent",
+      name: "main-agent",
+      displayName: "Main Agent",
+    })
+
+    mockGetByName.mockReturnValue({
+      id: "augustus-profile",
+      name: "augustus",
+      displayName: "augustus",
+      enabled: true,
+      connection: { type: "stdio" },
+      createdAt: 0,
+      updatedAt: 0,
+    })
+
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "augustus",
+      task: "Fix src\\main\\app.ts in the workspace before the release.",
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({ success: false }))
+    expect(mockAcpService.spawnAgent).not.toHaveBeenCalled()
+  })
 })

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 let sessionUpdateHandler: ((event: any) => void) | undefined
+const mockGetByName = vi.fn((): any => undefined)
+const mockGetSessionProfileSnapshot = vi.fn((): any => undefined)
 
 const mockAcpService = {
   on: vi.fn((eventName: string, handler: (event: any) => void) => {
@@ -65,6 +67,7 @@ vi.mock("../emit-agent-progress", () => ({
 vi.mock("../state", () => ({
   agentSessionStateManager: {
     getSessionRunId: vi.fn(() => 7),
+    getSessionProfileSnapshot: mockGetSessionProfileSnapshot,
   },
 }))
 
@@ -75,7 +78,7 @@ vi.mock("../acp-session-state", () => ({
 
 vi.mock("../agent-profile-service", () => ({
   agentProfileService: {
-    getByName: vi.fn(() => undefined),
+    getByName: mockGetByName,
     getAll: vi.fn(() => []),
   },
 }))
@@ -99,6 +102,8 @@ describe("handleDelegateToAgent", () => {
     vi.resetModules()
     vi.clearAllMocks()
     sessionUpdateHandler = undefined
+    mockGetByName.mockReturnValue(undefined)
+    mockGetSessionProfileSnapshot.mockReturnValue(undefined)
   })
 
   it("prefers ACP respond_to_user tool-call content over trailing plain text", async () => {
@@ -141,5 +146,71 @@ describe("handleDelegateToAgent", () => {
       { appSessionId: "parent-session-1" },
     )
     expect(mockSetAcpToAppSessionMapping).toHaveBeenCalledWith("acp-session-1", "parent-session-1", 7)
+  })
+
+  it("blocks main-agent delegation for local workspace coding tasks", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "profile-main-agent",
+      profileName: "main-agent",
+      guidelines: "",
+    })
+
+    mockGetByName.mockReturnValue({
+      id: "augustus-profile",
+      name: "augustus",
+      displayName: "augustus",
+      enabled: true,
+      connection: { type: "stdio" },
+      createdAt: 0,
+      updatedAt: 0,
+    })
+
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "augustus",
+      task: "Find and fix a bug in the mobile app at /Users/ajjoobandi/.codex/worktrees/23f7/dotagents-mono. Inspect the codebase and fix it.",
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+    }))
+    expect(result.error).toContain("Main Agent should handle local repo/workspace coding or debugging directly")
+    expect(mockAcpService.spawnAgent).not.toHaveBeenCalled()
+  })
+
+  it("allows explicit user requests for a specific specialist agent", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "profile-main-agent",
+      profileName: "main-agent",
+      guidelines: "",
+    })
+
+    mockGetByName.mockReturnValue({
+      id: "augustus-profile",
+      name: "augustus",
+      displayName: "augustus",
+      enabled: true,
+      connection: { type: "stdio" },
+      createdAt: 0,
+      updatedAt: 0,
+    })
+
+    const { handleDelegateToAgent } = await import("./acp-router-tools")
+
+    const result = await handleDelegateToAgent({
+      agentName: "augustus",
+      task: "Use augustus to debug /Users/ajjoobandi/.codex/worktrees/23f7/dotagents-mono/apps/mobile and report back.",
+      waitForResult: true,
+    }, "parent-session-1") as any
+
+    expect(result).toEqual(expect.objectContaining({
+      success: true,
+      status: "completed",
+      output: "Final user-facing answer",
+    }))
+    expect(mockAcpService.spawnAgent).toHaveBeenCalledWith("augustus", {
+      workingDirectory: undefined,
+    })
   })
 })

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -288,7 +288,7 @@ const MAX_CONVERSATION_SIZE_FOR_UI = 50000;
 
 const MAIN_AGENT_PROFILE_NAME = 'main-agent';
 
-const LOCAL_WORKSPACE_SIGNAL_PATTERN = /(?:\/users\/|[a-z]:\\|(^|[\s"'`])\.\.?(?:\/|\\)|\b(?:repo|repository|codebase|workspace|worktree|local files|source tree|project files)\b|\b(?:apps|packages|src|tests?)\/|\b(?:package\.json|pnpm-lock\.yaml|tsconfig(?:\.[^/\s]+)?\.json|vite\.config(?:\.[^/\s]+)?\.[a-z]+|README\.md)\b)/i;
+const LOCAL_WORKSPACE_SIGNAL_PATTERN = /(?:\/(?:users|home|root)\/|[a-z]:\/|(^|[\s"'`])\.\.?\/|\b(?:repo|repository|codebase|workspace|worktree|local files|source tree|project files)\b|\b(?:apps|packages|src|tests?)\/|\b(?:package\.json|pnpm-lock\.yaml|tsconfig(?:\.[^/\s]+)?\.json|vite\.config(?:\.[^/\s]+)?\.[a-z]+|README\.md)\b)/i;
 const LOCAL_CODING_ACTION_PATTERN = /\b(?:fix|debug|diagnose|investigate|inspect|implement|edit|modify|patch|update|refactor|repair|reproduce|run|test|typecheck|lint|build|compile|search|read files?)\b/i;
 
 function normalizeProfileName(profileName?: string): string {
@@ -322,7 +322,8 @@ function looksLikeLocalWorkspaceCodingTask(args: {
 }): boolean {
   const combinedText = [args.task, args.context, args.workingDirectory]
     .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
-    .join('\n');
+    .join('\n')
+    .replace(/\\+/g, '/');
 
   return LOCAL_WORKSPACE_SIGNAL_PATTERN.test(combinedText)
     && LOCAL_CODING_ACTION_PATTERN.test(combinedText);

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -286,6 +286,86 @@ const MAX_MESSAGE_CONTENT_SIZE = 10000;
 /** Maximum total conversation size to send to UI (characters) */
 const MAX_CONVERSATION_SIZE_FOR_UI = 50000;
 
+const MAIN_AGENT_PROFILE_NAME = 'main-agent';
+
+const LOCAL_WORKSPACE_SIGNAL_PATTERN = /(?:\/users\/|[a-z]:\\|(^|[\s"'`])\.\.?(?:\/|\\)|\b(?:repo|repository|codebase|workspace|worktree|local files|source tree|project files)\b|\b(?:apps|packages|src|tests?)\/|\b(?:package\.json|pnpm-lock\.yaml|tsconfig(?:\.[^/\s]+)?\.json|vite\.config(?:\.[^/\s]+)?\.[a-z]+|README\.md)\b|\.(?:ts|tsx|js|jsx|mjs|cjs|json|py|go|rs|java|swift|kt|rb|php|cs)\b)/i;
+const LOCAL_CODING_ACTION_PATTERN = /\b(?:fix|debug|diagnose|investigate|inspect|implement|edit|modify|patch|update|refactor|repair|reproduce|run|test|typecheck|lint|build|compile|search|read files?)\b/i;
+
+function isMainAgentSession(parentSessionId?: string): boolean {
+  if (!parentSessionId) return false;
+
+  const profileSnapshot = agentSessionStateManager.getSessionProfileSnapshot(parentSessionId);
+  return profileSnapshot?.profileName === MAIN_AGENT_PROFILE_NAME;
+}
+
+function looksLikeLocalWorkspaceCodingTask(args: {
+  task: string;
+  context?: string;
+  workingDirectory?: string;
+}): boolean {
+  const combinedText = [args.task, args.context, args.workingDirectory]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n');
+
+  return LOCAL_WORKSPACE_SIGNAL_PATTERN.test(combinedText)
+    && LOCAL_CODING_ACTION_PATTERN.test(combinedText);
+}
+
+function explicitlyRequestsAgent(args: {
+  agentName: string;
+  task: string;
+  context?: string;
+}, displayName?: string): boolean {
+  const combinedText = [args.task, args.context]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n')
+    .toLowerCase();
+
+  const candidateNames = [args.agentName, displayName]
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => value.trim().toLowerCase());
+
+  return candidateNames.some((candidate) => {
+    return [
+      `use ${candidate}`,
+      `ask ${candidate}`,
+      `delegate to ${candidate}`,
+      `send to ${candidate}`,
+      `${candidate} should`,
+      `${candidate} can`,
+      `${candidate} agent`,
+    ].some((phrase) => combinedText.includes(phrase));
+  });
+}
+
+function createBlockedMainAgentDelegationResult(agentName: string): object {
+  return {
+    success: false,
+    error: `Main Agent should handle local repo/workspace coding or debugging directly instead of delegating the full task to "${agentName}". Inspect the files and use local tools yourself first; if you need parallel help, delegate only narrow side work to "internal".`,
+  };
+}
+
+function shouldBlockMainAgentDelegation(
+  args: {
+    agentName: string;
+    task: string;
+    context?: string;
+    prepareOnly?: boolean;
+    workingDirectory?: string;
+  },
+  parentSessionId: string | undefined,
+  targetConnectionType?: AgentProfile['connection']['type'],
+  targetDisplayName?: string,
+): boolean {
+  if (args.prepareOnly) return false;
+  if (!isMainAgentSession(parentSessionId)) return false;
+  if (targetConnectionType === 'internal' || args.agentName === 'internal') return false;
+  if (!looksLikeLocalWorkspaceCodingTask(args)) return false;
+  if (explicitlyRequestsAgent(args, targetDisplayName)) return false;
+
+  return true;
+}
+
 // Initialize background notifier with our delegated runs map
 acpBackgroundNotifier.setDelegatedRunsMap(delegatedRuns);
 
@@ -755,6 +835,15 @@ export async function handleDelegateToAgent(
   // Try unified agent profile lookup first
   const profile = agentProfileService.getByName(normalizedArgs.agentName);
   if (profile) {
+    if (shouldBlockMainAgentDelegation(
+      normalizedArgs,
+      parentSessionId,
+      profile.connection.type,
+      profile.displayName,
+    )) {
+      return createBlockedMainAgentDelegationResult(normalizedArgs.agentName);
+    }
+
     // Check if agent is enabled
     if (!profile.enabled) {
       return {
@@ -770,6 +859,10 @@ export async function handleDelegateToAgent(
   // BACKWARD COMPATIBILITY: Handle explicit 'internal' agent name
   if (normalizedArgs.agentName === 'internal') {
     return executeInternalAgent(normalizedArgs, parentSessionId, waitForResult);
+  }
+
+  if (shouldBlockMainAgentDelegation(normalizedArgs, parentSessionId)) {
+    return createBlockedMainAgentDelegationResult(normalizedArgs.agentName);
   }
 
   // BACKWARD COMPATIBILITY: Fall back to legacy ACP agent lookup from config

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -291,11 +291,19 @@ const MAIN_AGENT_PROFILE_NAME = 'main-agent';
 const LOCAL_WORKSPACE_SIGNAL_PATTERN = /(?:\/users\/|[a-z]:\\|(^|[\s"'`])\.\.?(?:\/|\\)|\b(?:repo|repository|codebase|workspace|worktree|local files|source tree|project files)\b|\b(?:apps|packages|src|tests?)\/|\b(?:package\.json|pnpm-lock\.yaml|tsconfig(?:\.[^/\s]+)?\.json|vite\.config(?:\.[^/\s]+)?\.[a-z]+|README\.md)\b|\.(?:ts|tsx|js|jsx|mjs|cjs|json|py|go|rs|java|swift|kt|rb|php|cs)\b)/i;
 const LOCAL_CODING_ACTION_PATTERN = /\b(?:fix|debug|diagnose|investigate|inspect|implement|edit|modify|patch|update|refactor|repair|reproduce|run|test|typecheck|lint|build|compile|search|read files?)\b/i;
 
+function normalizeProfileName(profileName?: string): string {
+  return profileName
+    ?.trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    ?? '';
+}
+
 function isMainAgentSession(parentSessionId?: string): boolean {
   if (!parentSessionId) return false;
 
   const profileSnapshot = agentSessionStateManager.getSessionProfileSnapshot(parentSessionId);
-  return profileSnapshot?.profileName === MAIN_AGENT_PROFILE_NAME;
+  return normalizeProfileName(profileSnapshot?.profileName) === MAIN_AGENT_PROFILE_NAME;
 }
 
 function looksLikeLocalWorkspaceCodingTask(args: {

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -288,7 +288,7 @@ const MAX_CONVERSATION_SIZE_FOR_UI = 50000;
 
 const MAIN_AGENT_PROFILE_NAME = 'main-agent';
 
-const LOCAL_WORKSPACE_SIGNAL_PATTERN = /(?:\/users\/|[a-z]:\\|(^|[\s"'`])\.\.?(?:\/|\\)|\b(?:repo|repository|codebase|workspace|worktree|local files|source tree|project files)\b|\b(?:apps|packages|src|tests?)\/|\b(?:package\.json|pnpm-lock\.yaml|tsconfig(?:\.[^/\s]+)?\.json|vite\.config(?:\.[^/\s]+)?\.[a-z]+|README\.md)\b|\.(?:ts|tsx|js|jsx|mjs|cjs|json|py|go|rs|java|swift|kt|rb|php|cs)\b)/i;
+const LOCAL_WORKSPACE_SIGNAL_PATTERN = /(?:\/users\/|[a-z]:\\|(^|[\s"'`])\.\.?(?:\/|\\)|\b(?:repo|repository|codebase|workspace|worktree|local files|source tree|project files)\b|\b(?:apps|packages|src|tests?)\/|\b(?:package\.json|pnpm-lock\.yaml|tsconfig(?:\.[^/\s]+)?\.json|vite\.config(?:\.[^/\s]+)?\.[a-z]+|README\.md)\b)/i;
 const LOCAL_CODING_ACTION_PATTERN = /\b(?:fix|debug|diagnose|investigate|inspect|implement|edit|modify|patch|update|refactor|repair|reproduce|run|test|typecheck|lint|build|compile|search|read files?)\b/i;
 
 function normalizeProfileName(profileName?: string): string {

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -303,7 +303,16 @@ function isMainAgentSession(parentSessionId?: string): boolean {
   if (!parentSessionId) return false;
 
   const profileSnapshot = agentSessionStateManager.getSessionProfileSnapshot(parentSessionId);
-  return normalizeProfileName(profileSnapshot?.profileName) === MAIN_AGENT_PROFILE_NAME;
+  if (!profileSnapshot) return false;
+
+  if (profileSnapshot.profileId) {
+    const profile = agentProfileService.getById(profileSnapshot.profileId);
+    if (profile) {
+      return profile.name === MAIN_AGENT_PROFILE_NAME;
+    }
+  }
+
+  return normalizeProfileName(profileSnapshot.profileName) === MAIN_AGENT_PROFILE_NAME;
 }
 
 function looksLikeLocalWorkspaceCodingTask(args: {

--- a/apps/desktop/src/main/acp/acp-smart-router.test.ts
+++ b/apps/desktop/src/main/acp/acp-smart-router.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+
+import { acpSmartRouter } from "./acp-smart-router"
+
+describe("acpSmartRouter", () => {
+  it("discourages delegating local workspace coding away from the current agent", () => {
+    const prompt = acpSmartRouter.generateDelegationPromptAddition([
+      {
+        definition: {
+          name: "augustus",
+          displayName: "augustus",
+          description: "Coding specialist",
+        },
+      },
+    ])
+
+    expect(prompt).toContain("Keep local repo/workspace coding and debugging in the current agent")
+    expect(prompt).toContain("user explicitly asked for a specialist")
+    expect(prompt).toContain("clear specialty advantage")
+  })
+})

--- a/apps/desktop/src/main/acp/acp-smart-router.ts
+++ b/apps/desktop/src/main/acp/acp-smart-router.ts
@@ -51,7 +51,8 @@ ${agentDescriptions}
 
 ### When to Delegate
 - Use the **research** agent for information gathering, web searches, and fact-finding
-- Use the **coding** agent for complex programming tasks, debugging, or code generation
+- Keep local repo/workspace coding and debugging in the current agent unless the user explicitly asked for a specialist or you are offloading a narrow parallel subtask
+- Use the **coding** agent when it has a clear specialty advantage for non-local work or when the user explicitly asked for it
 - Use the **analysis** agent for data analysis, comparisons, and evaluations
 - Use the **writing** agent for document creation, summarization, and content drafting
 

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -183,7 +183,9 @@ describe("constructSystemPrompt", () => {
     const prompt = getAgentsPromptAddition()
 
     expect(prompt).toContain("Prefer doing the work directly")
+    expect(prompt).toContain("For local repo/workspace coding or debugging tasks")
     expect(prompt).toContain("Delegate when the user explicitly asks for a specific agent")
+    expect(prompt).toContain('prefer the internal agent for bounded parallel help')
     expect(prompt).toContain("incorporate the result into a complete answer")
     expect(prompt).not.toContain("ALWAYS delegate")
     expect(prompt).not.toContain("Only respond directly if NO agent matches")

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -246,8 +246,9 @@ export function getAgentsPromptAddition(excludeAgentId?: string): string {
   return `
 DELEGATION RULES (PRIORITY — check BEFORE responding):
   - Prefer doing the work directly when you can answer well with your own available tools, especially for simple questions, local lookups, and small tasks
+  - For local repo/workspace coding or debugging tasks, inspect files and use your own tools first instead of delegating the whole task to an external agent
   - Delegate when the user explicitly asks for a specific agent or when an agent has a clear specialty advantage for the task
-  - Use delegation for substantial specialized work or for independent subtasks that can run in parallel
+  - Use delegation for substantial specialized work or for independent subtasks that can run in parallel; for local coding side work, prefer the internal agent for bounded parallel help
   - Match user intent to agent capabilities — e.g., web browsing tasks go to a web browsing agent
   - After delegating, incorporate the result into a complete answer instead of stopping at raw delegate output
 


### PR DESCRIPTION
## Summary
- teach the main-agent prompt and ACP router to keep local repo/workspace coding and debugging in the current agent
- add a runtime guard that blocks Main Agent from delegating full local coding/debug tasks to external agents unless the user explicitly asked for that specialist
- add tests for the prompt copy, smart-router guidance, and blocked-vs-allowed delegation behavior

## Validation
- pnpm --filter @dotagents/desktop exec vitest run src/main/system-prompts.test.ts src/main/acp/acp-smart-router.test.ts src/main/acp/acp-router-tools.test.ts
- pnpm --filter @dotagents/desktop typecheck

Closes #168