### PR TITLE
Add uninstall actions for local TTS models

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
     "test": "vitest",
     "test:run": "pnpm run pretest && vitest run",
     "test:continue-replay": "vitest run src/main/llm.continue-replay.live.test.ts",
+    "test:openai-oauth": "pnpm exec electron scripts/openai-oauth-live-check.mjs",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
     "start": "electron-vite preview",

--- a/apps/desktop/scripts/openai-oauth-live-check.mjs
+++ b/apps/desktop/scripts/openai-oauth-live-check.mjs
@@ -1,0 +1,274 @@
+import { app, safeStorage } from "electron"
+import crypto from "crypto"
+import fs from "fs"
+import path from "path"
+
+const DEFAULT_APP_ID = process.env.APP_ID?.trim() || "app.dotagents"
+const OPENAI_OAUTH_STORAGE_KEY = "provider://openai-oauth"
+const OPENAI_CHATGPT_BASE_URL = "https://chatgpt.com/backend-api"
+const OPENAI_OAUTH_ORIGINATOR = "codex_chatgpt_desktop"
+
+function parseArgs(argv) {
+  const args = {
+    model: process.env.OPENAI_OAUTH_MODEL || "gpt-5.4-mini",
+    prompt: process.env.OPENAI_OAUTH_PROMPT || "Reply with exactly: openai oauth ok",
+    accessToken: process.env.OPENAI_OAUTH_ACCESS_TOKEN || "",
+    accountId: process.env.OPENAI_OAUTH_ACCOUNT_ID || "",
+    showResponse: false,
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+
+    if (arg === "--model" && argv[i + 1]) {
+      args.model = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg === "--prompt" && argv[i + 1]) {
+      args.prompt = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg === "--access-token" && argv[i + 1]) {
+      args.accessToken = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg === "--account-id" && argv[i + 1]) {
+      args.accountId = argv[i + 1]
+      i += 1
+      continue
+    }
+
+    if (arg === "--show-response") {
+      args.showResponse = true
+      continue
+    }
+  }
+
+  return args
+}
+
+function getDataFolder() {
+  return path.join(app.getPath("appData"), DEFAULT_APP_ID)
+}
+
+function readJsonIfExists(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return null
+  }
+
+  return JSON.parse(fs.readFileSync(filePath, "utf8"))
+}
+
+function decryptOAuthStorage(encryptedData, encryptionKey) {
+  const parsed = JSON.parse(encryptedData)
+
+  if (parsed.method === "safeStorage") {
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new Error("Electron safeStorage is not available on this machine")
+    }
+
+    return safeStorage.decryptString(Buffer.from(parsed.data, "base64"))
+  }
+
+  if (parsed.method === "aes") {
+    const decipher = crypto.createDecipher("aes-256-gcm", encryptionKey)
+    decipher.setAuthTag(Buffer.from(parsed.authTag, "hex"))
+    let decrypted = decipher.update(parsed.data, "hex", "utf8")
+    decrypted += decipher.final("utf8")
+    return decrypted
+  }
+
+  throw new Error(`Unknown OAuth storage encryption method: ${String(parsed.method)}`)
+}
+
+function loadOpenAIOAuthSession(dataFolder) {
+  const oauthStoragePath = path.join(dataFolder, "oauth-storage.json")
+  const oauthKeyPath = path.join(dataFolder, ".oauth-key")
+
+  if (!fs.existsSync(oauthStoragePath)) {
+    throw new Error(`OAuth storage file not found: ${oauthStoragePath}`)
+  }
+
+  if (!fs.existsSync(oauthKeyPath)) {
+    throw new Error(`OAuth key file not found: ${oauthKeyPath}`)
+  }
+
+  const encryptedData = fs.readFileSync(oauthStoragePath, "utf8")
+  const encryptionKey = fs.readFileSync(oauthKeyPath)
+  const decryptedData = decryptOAuthStorage(encryptedData, encryptionKey)
+  const allData = JSON.parse(decryptedData)
+  const oauthConfig = allData?.[OPENAI_OAUTH_STORAGE_KEY]?.config
+  const tokens = oauthConfig?.tokens
+
+  if (!tokens?.access_token) {
+    throw new Error("OpenAI OAuth access token not found in OAuth storage")
+  }
+
+  return tokens
+}
+
+function buildHeaders(accessToken, accountId) {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    originator: OPENAI_OAUTH_ORIGINATOR,
+    ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+  }
+}
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options)
+  const text = await response.text()
+
+  let json = null
+  try {
+    json = text ? JSON.parse(text) : null
+  } catch {
+    json = null
+  }
+
+  return { response, text, json }
+}
+
+function printStep(name, details) {
+  console.log(`\n[${name}]`)
+  console.log(details)
+}
+
+function summarizeModels(payload) {
+  if (!Array.isArray(payload)) {
+    return "Unexpected models payload shape"
+  }
+
+  const names = payload
+    .map(entry => (entry && typeof entry === "object" ? entry.slug || entry.id : null))
+    .filter(value => typeof value === "string")
+
+  return `${names.length} models\n${names.slice(0, 20).join(", ")}`
+}
+
+function buildCodexRequestBody(model, prompt) {
+  return {
+    model,
+    instructions: "You are a concise assistant.",
+    input: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: prompt,
+          },
+        ],
+      },
+    ],
+    stream: false,
+    store: false,
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+
+  await app.whenReady()
+
+  const dataFolder = getDataFolder()
+  const config = readJsonIfExists(path.join(dataFolder, "config.json")) || {}
+  let tokens = null
+  let storageWarning = ""
+
+  if (args.accessToken) {
+    tokens = { access_token: args.accessToken }
+  } else {
+    try {
+      tokens = loadOpenAIOAuthSession(dataFolder)
+    } catch (error) {
+      storageWarning =
+        error instanceof Error
+          ? error.message
+          : String(error)
+    }
+  }
+
+  if (!tokens?.access_token) {
+    throw new Error(
+      `${storageWarning || "OpenAI OAuth access token not found."}\n` +
+      "Pass a token explicitly with --access-token or OPENAI_OAUTH_ACCESS_TOKEN."
+    )
+  }
+
+  const accountId = args.accountId || config.openaiOauthAccountId || ""
+  const model = config.mcpToolsOpenaiOauthModel || args.model
+
+  printStep("Context", [
+    `dataFolder=${dataFolder}`,
+    `accountId=${accountId || "missing"}`,
+    `model=${model}`,
+    `expiresAt=${tokens.expires_at || "unknown"}`,
+    ...(storageWarning ? [`storageWarning=${storageWarning}`] : []),
+  ].join("\n"))
+
+  const commonHeaders = buildHeaders(tokens.access_token, accountId)
+
+  const modelsResult = await fetchJson(`${OPENAI_CHATGPT_BASE_URL}/codex/models`, {
+    method: "GET",
+    headers: {
+      Authorization: commonHeaders.Authorization,
+      Accept: commonHeaders.Accept,
+      originator: commonHeaders.originator,
+      ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+    },
+  })
+  printStep(
+    "Models",
+    `status=${modelsResult.response.status}\n${modelsResult.response.ok ? summarizeModels(modelsResult.json) : modelsResult.text}`,
+  )
+
+  const usageResult = await fetchJson(`${OPENAI_CHATGPT_BASE_URL}/wham/usage`, {
+    method: "GET",
+    headers: {
+      Authorization: commonHeaders.Authorization,
+      Accept: commonHeaders.Accept,
+      ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+    },
+  })
+  printStep(
+    "Usage",
+    `status=${usageResult.response.status}\n${usageResult.response.ok ? JSON.stringify(usageResult.json, null, 2) : usageResult.text}`,
+  )
+
+  const requestBody = buildCodexRequestBody(model, args.prompt)
+  printStep("Request Body", JSON.stringify(requestBody, null, 2))
+
+  const responseResult = await fetchJson(`${OPENAI_CHATGPT_BASE_URL}/codex/responses`, {
+    method: "POST",
+    headers: commonHeaders,
+    body: JSON.stringify(requestBody),
+  })
+
+  printStep(
+    "Responses",
+    `status=${responseResult.response.status}\n${args.showResponse ? responseResult.text : JSON.stringify(responseResult.json ?? responseResult.text, null, 2)}`,
+  )
+
+  if (!responseResult.response.ok) {
+    process.exitCode = 1
+  }
+}
+
+main()
+  .catch(error => {
+    console.error("\n[Failure]")
+    console.error(error instanceof Error ? error.stack || error.message : String(error))
+    process.exitCode = 1
+  })
+  .finally(() => {
+    app.quit()
+  })

--- a/apps/desktop/scripts/openai-oauth-live-check.mjs
+++ b/apps/desktop/scripts/openai-oauth-live-check.mjs
@@ -77,7 +77,8 @@ function decryptOAuthStorage(encryptedData, encryptionKey) {
   }
 
   if (parsed.method === "aes") {
-    const decipher = crypto.createDecipher("aes-256-gcm", encryptionKey)
+    const iv = Buffer.from(parsed.iv, "hex")
+    const decipher = crypto.createDecipheriv("aes-256-gcm", encryptionKey, iv)
     decipher.setAuthTag(Buffer.from(parsed.authTag, "hex"))
     let decrypted = decipher.update(parsed.data, "hex", "utf8")
     decrypted += decipher.final("utf8")

--- a/apps/desktop/src/main/agent-profile-service.ts
+++ b/apps/desktop/src/main/agent-profile-service.ts
@@ -62,7 +62,7 @@ const legacyPersonasPath = path.join(app.getPath("userData"), "personas.json")
 // ============================================================================
 
 const RESERVED_SERVER_NAMES = [...RESERVED_RUNTIME_TOOL_SERVER_NAMES]
-const VALID_PROVIDER_IDS = ["openai", "groq", "gemini"]
+const VALID_PROVIDER_IDS = ["openai", "openai-oauth", "groq", "gemini"]
 const VALID_STT_PROVIDER_IDS = ["openai", "groq", "parakeet"]
 const VALID_TTS_PROVIDER_IDS = ["openai", "groq", "gemini", "kitten", "supertonic"]
 
@@ -130,7 +130,7 @@ function isValidModelConfig(config: unknown): boolean {
   }
   if (c.sttProviderId !== undefined && (typeof c.sttProviderId !== "string" || !VALID_STT_PROVIDER_IDS.includes(c.sttProviderId as string))) return false
   if (c.ttsProviderId !== undefined && (typeof c.ttsProviderId !== "string" || !VALID_TTS_PROVIDER_IDS.includes(c.ttsProviderId as string))) return false
-  for (const field of ["mcpToolsOpenaiModel", "mcpToolsGroqModel", "mcpToolsGeminiModel", "currentModelPresetId", "openaiSttModel", "groqSttModel", "transcriptPostProcessingOpenaiModel", "transcriptPostProcessingGroqModel", "transcriptPostProcessingGeminiModel"]) {
+  for (const field of ["mcpToolsOpenaiModel", "mcpToolsOpenaiOauthModel", "mcpToolsGroqModel", "mcpToolsGeminiModel", "currentModelPresetId", "openaiSttModel", "groqSttModel", "transcriptPostProcessingOpenaiModel", "transcriptPostProcessingOpenaiOauthModel", "transcriptPostProcessingGroqModel", "transcriptPostProcessingGeminiModel"]) {
     if (c[field] !== undefined && typeof c[field] !== "string") return false
   }
   return true
@@ -880,6 +880,7 @@ class AgentProfileService {
       ...(profile.modelConfig ?? {}),
       ...(modelConfig.mcpToolsProviderId !== undefined && { mcpToolsProviderId: modelConfig.mcpToolsProviderId }),
       ...(modelConfig.mcpToolsOpenaiModel !== undefined && { mcpToolsOpenaiModel: modelConfig.mcpToolsOpenaiModel }),
+      ...(modelConfig.mcpToolsOpenaiOauthModel !== undefined && { mcpToolsOpenaiOauthModel: modelConfig.mcpToolsOpenaiOauthModel }),
       ...(modelConfig.mcpToolsGroqModel !== undefined && { mcpToolsGroqModel: modelConfig.mcpToolsGroqModel }),
       ...(modelConfig.mcpToolsGeminiModel !== undefined && { mcpToolsGeminiModel: modelConfig.mcpToolsGeminiModel }),
       ...(modelConfig.currentModelPresetId !== undefined && { currentModelPresetId: modelConfig.currentModelPresetId }),
@@ -888,6 +889,7 @@ class AgentProfileService {
       ...(modelConfig.groqSttModel !== undefined && { groqSttModel: modelConfig.groqSttModel }),
       ...(modelConfig.transcriptPostProcessingProviderId !== undefined && { transcriptPostProcessingProviderId: modelConfig.transcriptPostProcessingProviderId }),
       ...(modelConfig.transcriptPostProcessingOpenaiModel !== undefined && { transcriptPostProcessingOpenaiModel: modelConfig.transcriptPostProcessingOpenaiModel }),
+      ...(modelConfig.transcriptPostProcessingOpenaiOauthModel !== undefined && { transcriptPostProcessingOpenaiOauthModel: modelConfig.transcriptPostProcessingOpenaiOauthModel }),
       ...(modelConfig.transcriptPostProcessingGroqModel !== undefined && { transcriptPostProcessingGroqModel: modelConfig.transcriptPostProcessingGroqModel }),
       ...(modelConfig.transcriptPostProcessingGeminiModel !== undefined && { transcriptPostProcessingGeminiModel: modelConfig.transcriptPostProcessingGeminiModel }),
       ...(modelConfig.ttsProviderId !== undefined && { ttsProviderId: modelConfig.ttsProviderId }),

--- a/apps/desktop/src/main/ai-sdk-provider.ts
+++ b/apps/desktop/src/main/ai-sdk-provider.ts
@@ -9,13 +9,23 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import type { LanguageModel } from "ai"
 import { configStore } from "./config"
 import { isDebugLLM, logLLM } from "./debug"
+import {
+  createOpenAIOAuthFetch,
+  ensureOpenAIOAuthSession,
+  getOpenAIOAuthBaseUrl,
+  getOpenAIOAuthOriginator,
+} from "./openai-oauth-provider"
 
-export type ProviderType = "openai" | "groq" | "gemini"
+export type ProviderType = "openai" | "openai-oauth" | "groq" | "gemini"
 
 const DEFAULT_CHAT_MODELS = {
   openai: {
     mcp: "gpt-4.1-mini",
     transcript: "gpt-4.1-mini",
+  },
+  "openai-oauth": {
+    mcp: "gpt-5.4-mini",
+    transcript: "gpt-5.4-mini",
   },
   groq: {
     mcp: "openai/gpt-oss-120b",
@@ -36,6 +46,7 @@ interface ProviderConfig {
   apiKey: string
   baseURL?: string
   model: string
+  headers?: Record<string, string>
 }
 
 export interface PromptCachingConfig {
@@ -122,6 +133,18 @@ function getProviderConfig(
             : config.transcriptPostProcessingGeminiModel || DEFAULT_CHAT_MODELS.gemini.transcript,
       }
 
+    case "openai-oauth": {
+      const model = modelContext === "mcp"
+        ? config.mcpToolsOpenaiOauthModel || DEFAULT_CHAT_MODELS["openai-oauth"].mcp
+        : config.transcriptPostProcessingOpenaiOauthModel || DEFAULT_CHAT_MODELS["openai-oauth"].transcript
+
+      return {
+        apiKey: "oauth-session",
+        baseURL: getOpenAIOAuthBaseUrl(),
+        model,
+      }
+    }
+
     default:
       throw new Error(`Unknown provider: ${providerId}`)
   }
@@ -152,6 +175,10 @@ export function createLanguageModel(
   }
 
   switch (effectiveProviderId) {
+    case "openai-oauth": {
+      throw new Error("OpenAI OAuth provider requires async model creation")
+    }
+
     case "openai":
     case "groq": {
       // Both OpenAI and Groq use OpenAI-compatible API
@@ -176,6 +203,35 @@ export function createLanguageModel(
     default:
       throw new Error(`Unknown provider: ${effectiveProviderId}`)
   }
+}
+
+export async function createLanguageModelAsync(
+  providerId?: ProviderType,
+  modelContext: "mcp" | "transcript" = "mcp",
+): Promise<LanguageModel> {
+  const config = configStore.get()
+  const effectiveProviderId =
+    providerId || (config.mcpToolsProviderId as ProviderType) || "openai"
+
+  if (effectiveProviderId !== "openai-oauth") {
+    return createLanguageModel(effectiveProviderId, modelContext)
+  }
+
+  const providerConfig = getProviderConfig(effectiveProviderId, modelContext)
+  const session = await ensureOpenAIOAuthSession()
+
+  const openai = createOpenAI({
+    apiKey: session.accessToken,
+    baseURL: providerConfig.baseURL,
+    fetch: createOpenAIOAuthFetch(),
+    headers: {
+      ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
+      originator: getOpenAIOAuthOriginator(),
+      ...(providerConfig.headers || {}),
+    },
+  })
+
+  return openai.responses(providerConfig.model)
 }
 
 /**
@@ -230,6 +286,12 @@ export function getPromptCachingConfig(
   }
 
   if (effectiveProviderId === "openai" && (!normalizedBaseURL || normalizedBaseURL.includes("api.openai.com"))) {
+    return {
+      strategy: "openai-implicit-prefix",
+    }
+  }
+
+  if (effectiveProviderId === "openai-oauth") {
     return {
       strategy: "openai-implicit-prefix",
     }

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -740,6 +740,8 @@ export function getProviderAndModel(): { providerId: string; model: string } {
   let model = "gpt-4.1-mini"
   if (providerId === "openai") {
     model = config.mcpToolsOpenaiModel || "gpt-4.1-mini"
+  } else if (providerId === "openai-oauth") {
+    model = config.mcpToolsOpenaiOauthModel || "gpt-5.4-mini"
   } else if (providerId === "groq") {
     model = config.mcpToolsGroqModel || "openai/gpt-oss-120b"
   } else if (providerId === "gemini") {

--- a/apps/desktop/src/main/headless-cli.ts
+++ b/apps/desktop/src/main/headless-cli.ts
@@ -70,6 +70,7 @@ function printStatus() {
   const provider = cfg.mcpToolsProviderId || "openai"
   let modelName = "default"
   if (provider === "openai") modelName = cfg.mcpToolsOpenaiModel || "gpt-4.1-mini"
+  else if (provider === "openai-oauth") modelName = cfg.mcpToolsOpenaiOauthModel || "gpt-5.4-mini"
   else if (provider === "groq") modelName = cfg.mcpToolsGroqModel || "openai/gpt-oss-120b"
   else if (provider === "gemini") modelName = cfg.mcpToolsGeminiModel || "gemini-2.5-flash"
 

--- a/apps/desktop/src/main/kitten-tts.ts
+++ b/apps/desktop/src/main/kitten-tts.ts
@@ -567,6 +567,27 @@ export async function downloadKittenModel(
 }
 
 /**
+ * Remove the downloaded Kitten model and reset any loaded engine state.
+ */
+export function uninstallKittenModel(): void {
+  if (downloadState.downloading) {
+    throw new Error("Cannot remove Kitten model while download is in progress")
+  }
+
+  ttsInstance = null
+  downloadState.progress = 0
+  downloadState.error = undefined
+
+  try {
+    fs.rmSync(getModelsPath(), { recursive: true, force: true })
+  } catch (error) {
+    throw new Error(
+      `Failed to remove Kitten model: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+/**
  * Initialize the TTS instance with the downloaded model
  */
 async function initializeTts(): Promise<OfflineTtsType> {

--- a/apps/desktop/src/main/kitten-tts.ts
+++ b/apps/desktop/src/main/kitten-tts.ts
@@ -575,6 +575,9 @@ export function uninstallKittenModel(): void {
   }
 
   ttsInstance = null
+  sherpaModule = null
+  nativeAddon = null
+  sherpaLoadError = null
   downloadState.progress = 0
   downloadState.error = undefined
 

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -14,7 +14,7 @@ import { generateText, streamText, tool as aiTool } from "ai"
 import { jsonSchema } from "ai"
 import { randomUUID } from "crypto"
 import {
-  createLanguageModel,
+  createLanguageModelAsync,
   getCurrentProviderId,
   getCurrentModelName,
   getPromptCachingConfig,
@@ -682,7 +682,7 @@ export async function makeLLMCallWithFetch(
 
   return withRetry(
     async () => {
-      const model = createLanguageModel(effectiveProviderId)
+      const model = await createLanguageModelAsync(effectiveProviderId)
       const { system, messages: convertedMessages } = convertMessages(messages)
       const promptCaching = getPromptCachingConfig(effectiveProviderId)
       const abortController = createSessionAbortController(sessionId)
@@ -886,7 +886,7 @@ export async function makeLLMCallWithStreaming(
 ): Promise<LLMToolCallResponse> {
   const effectiveProviderId = (providerId ||
     getCurrentProviderId()) as ProviderType
-  const model = createLanguageModel(effectiveProviderId)
+  const model = await createLanguageModelAsync(effectiveProviderId)
   const { system, messages: convertedMessages } = convertMessages(messages)
   const promptCaching = getPromptCachingConfig(effectiveProviderId)
 
@@ -993,7 +993,7 @@ export async function makeLLMCallWithStreamingAndTools(
 
   return withRetry(
     async () => {
-      const model = createLanguageModel(effectiveProviderId)
+      const model = await createLanguageModelAsync(effectiveProviderId)
       const { system, messages: convertedMessages } = convertMessages(messages)
       const promptCaching = getPromptCachingConfig(effectiveProviderId)
       const abortController = createSessionAbortController(sessionId)
@@ -1170,7 +1170,7 @@ export async function makeTextCompletionWithFetch(
           abortController.abort()
         }
 
-        const model = createLanguageModel(effectiveProviderId, "transcript")
+        const model = await createLanguageModelAsync(effectiveProviderId, "transcript")
         const promptCaching = getPromptCachingConfig(effectiveProviderId, "transcript")
 
         if (isDebugLLM()) {
@@ -1242,7 +1242,7 @@ export async function verifyCompletionWithFetch(
           abortController.abort()
         }
 
-        const model = createLanguageModel(effectiveProviderId)
+        const model = await createLanguageModelAsync(effectiveProviderId)
         const modelName = getCurrentModelName(effectiveProviderId)
         const { system, messages: convertedMessages } = convertMessages(messages)
 

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -568,6 +568,8 @@ export async function processTranscriptWithAgentMode(
   const providerId = config.mcpToolsProviderId || "openai"
   const modelName = providerId === "openai"
     ? config.mcpToolsOpenaiModel || "gpt-4.1-mini"
+    : providerId === "openai-oauth"
+    ? config.mcpToolsOpenaiOauthModel || "gpt-5.4-mini"
     : providerId === "groq"
     ? config.mcpToolsGroqModel || "openai/gpt-oss-120b"
     : providerId === "gemini"
@@ -576,6 +578,8 @@ export async function processTranscriptWithAgentMode(
   // For OpenAI provider, use the preset name (e.g., "OpenRouter", "Together AI")
   const providerDisplayName = providerId === "openai"
     ? getCurrentPresetName(config.currentModelPresetId, config.modelPresets)
+    : providerId === "openai-oauth"
+    ? "OpenAI OAuth"
     : providerId === "groq" ? "Groq" : providerId === "gemini" ? "Gemini" : providerId
   const modelInfoRef = { provider: providerDisplayName, model: modelName }
   // Seed lastEmittedUserResponse with the latest respond_to_user content from

--- a/apps/desktop/src/main/mcp-sampling.ts
+++ b/apps/desktop/src/main/mcp-sampling.ts
@@ -88,7 +88,10 @@ export async function executeSampling(
     // Determine which provider to use
     // Use modelPreferences hints if provided, otherwise use configured defaults
     let providerId = config.mcpToolsProviderId || "openai"
-    let model = config.mcpToolsOpenaiModel || "gpt-4.1-mini"
+    let model =
+      providerId === "openai-oauth"
+        ? config.mcpToolsOpenaiOauthModel || "gpt-5.4-mini"
+        : config.mcpToolsOpenaiModel || "gpt-4.1-mini"
 
     if (request.modelPreferences?.hints) {
       const hint = request.modelPreferences.hints[0]

--- a/apps/desktop/src/main/models-service.ts
+++ b/apps/desktop/src/main/models-service.ts
@@ -139,57 +139,20 @@ async function fetchOpenAIOAuthModels(): Promise<ModelInfo[]> {
     ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
   }
 
-  console.log(`[OpenAI OAuth Models] Fetching from ${url}, hasAccountId=${!!session.accountId}`)
-
   const response = await fetch(url, { headers })
 
   if (!response.ok) {
     const errorText = await response.text()
-    console.error(`[OpenAI OAuth Models] API failed: HTTP ${response.status}`, errorText.slice(0, 500))
     throw new Error(`HTTP ${response.status}: ${errorText}`)
   }
 
-  const rawText = await response.text()
-  let data: Record<string, unknown>
-  try {
-    data = JSON.parse(rawText) as Record<string, unknown>
-  } catch {
-    console.error(`[OpenAI OAuth Models] Failed to parse response:`, rawText.slice(0, 500))
-    throw new Error("Failed to parse OpenAI OAuth models response as JSON")
-  }
-
-  // Log the raw response structure to aid debugging
-  const topLevelKeys = Object.keys(data)
-  console.log(`[OpenAI OAuth Models] Response keys: ${topLevelKeys.join(", ")}`)
-  console.log(`[OpenAI OAuth Models] Is models array: ${Array.isArray(data.models)}, count: ${Array.isArray(data.models) ? data.models.length : "N/A"}`)
-
-  if (Array.isArray(data.models)) {
-    const allSlugs = data.models.map((m: any) => m?.slug || m?.id || `[no-slug: keys=${Object.keys(m || {}).join(",")}]`)
-    console.log(`[OpenAI OAuth Models] All slugs from API:`, JSON.stringify(allSlugs))
-  } else {
-    console.log(`[OpenAI OAuth Models] Raw response snippet:`, rawText.slice(0, 2000))
-  }
-
+  const data = await response.json() as { models?: Array<Record<string, unknown>> }
   if (!Array.isArray(data.models)) {
     throw new Error("Missing 'models' in OpenAI OAuth models response")
   }
 
-  const allModels = data.models as Array<Record<string, unknown>>
-  const filtered = allModels.filter(
-    (model): model is Record<string, unknown> & { slug: string } =>
-      typeof model.slug === "string" && model.slug.length > 0,
-  )
-
-  if (filtered.length < allModels.length) {
-    const dropped = allModels
-      .filter((m) => typeof m.slug !== "string" || m.slug.length === 0)
-      .map((m) => ({ slug: m.slug, id: m.id, keys: Object.keys(m) }))
-    console.warn(`[OpenAI OAuth Models] Dropped ${dropped.length} models without slug:`, JSON.stringify(dropped))
-  }
-
-  console.log(`[OpenAI OAuth Models] Final: ${filtered.length} models -> ${filtered.map(m => m.slug).join(", ")}`)
-
-  return filtered
+  return data.models
+    .filter((model): model is Record<string, unknown> & { slug: string } => typeof model.slug === "string" && model.slug.length > 0)
     .map((model) => ({
       id: model.slug,
       name: typeof model.display_name === "string" && model.display_name.length > 0 ? model.display_name : formatModelName(model.slug),
@@ -628,7 +591,12 @@ export async function fetchAvailableModels(
   const cacheKey = cacheKeyParts.join("|")
   const cached = modelsCache.get(cacheKey)
   const now = Date.now()
+  // Don't use cache if accountId is missing for openai-oauth — we need to
+  // call ensureOpenAIOAuthSession so it can discover the accountId from /me.
+  const skipCacheDueToMissingAccount =
+    providerId === "openai-oauth" && !config.openaiOauthAccountId
   const cacheValid =
+    !skipCacheDueToMissingAccount &&
     !!cached &&
     now - cached.timestamp < CACHE_DURATION &&
     cached.models.length > 0

--- a/apps/desktop/src/main/models-service.ts
+++ b/apps/desktop/src/main/models-service.ts
@@ -4,6 +4,11 @@ import { fetchModelsDevData, getModelFromModelsDevByProviderId } from "./models-
 import type { ModelsDevModel } from "./models-dev-service"
 import { isKnownSttModel, KNOWN_STT_MODEL_IDS } from "@dotagents/shared"
 import type { ModelInfo, EnhancedModelInfo } from "../shared/types"
+import {
+  ensureOpenAIOAuthSession,
+  getOpenAIOAuthBaseUrl,
+  getOpenAIOAuthOriginator,
+} from "./openai-oauth-provider"
 
 // Re-export ModelInfo for backward compatibility
 export type { ModelInfo, EnhancedModelInfo } from "../shared/types"
@@ -103,6 +108,57 @@ function enhanceModelWithModelsDevData(
   }
 
   return enhanced
+}
+
+function getOpenAIOAuthModels(): ModelInfo[] {
+  const models: ModelInfo[] = [
+    { id: "gpt-5.4", name: "gpt-5.4", context_length: 272000 },
+    { id: "gpt-5.4-mini", name: "GPT-5.4-Mini", context_length: 272000 },
+    { id: "gpt-5.3-codex", name: "gpt-5.3-codex", context_length: 272000 },
+    { id: "gpt-5.2-codex", name: "gpt-5.2-codex", context_length: 272000 },
+    { id: "gpt-5.2", name: "gpt-5.2", context_length: 272000 },
+    { id: "gpt-5.1-codex-max", name: "gpt-5.1-codex-max", context_length: 272000 },
+    { id: "gpt-5.1-codex", name: "gpt-5.1-codex", context_length: 272000 },
+    { id: "gpt-5.1", name: "gpt-5.1", context_length: 272000 },
+    { id: "gpt-5-codex", name: "gpt-5-codex", context_length: 272000 },
+    { id: "gpt-5", name: "gpt-5", context_length: 272000 },
+    { id: "gpt-5.1-codex-mini", name: "gpt-5.1-codex-mini", context_length: 272000 },
+    { id: "gpt-5-codex-mini", name: "gpt-5-codex-mini", context_length: 272000 },
+  ]
+
+  return models.map((model) => enhanceModelWithModelsDevData(model, "openai"))
+}
+
+async function fetchOpenAIOAuthModels(): Promise<ModelInfo[]> {
+  const session = await ensureOpenAIOAuthSession()
+  const response = await fetch(`${getOpenAIOAuthBaseUrl()}/codex/models`, {
+    headers: {
+      Authorization: `Bearer ${session.accessToken}`,
+      Accept: "application/json",
+      originator: getOpenAIOAuthOriginator(),
+      ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
+    },
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`HTTP ${response.status}: ${errorText}`)
+  }
+
+  const data = await response.json() as { models?: Array<Record<string, unknown>> }
+  if (!Array.isArray(data.models)) {
+    throw new Error("Missing 'models' in OpenAI OAuth models response")
+  }
+
+  return data.models
+    .filter((model): model is Record<string, unknown> & { slug: string } => typeof model.slug === "string" && model.slug.length > 0)
+    .map((model) => ({
+      id: model.slug,
+      name: typeof model.display_name === "string" && model.display_name.length > 0 ? model.display_name : formatModelName(model.slug),
+      description: typeof model.description === "string" ? model.description : undefined,
+      context_length: typeof model.context_window === "number" ? model.context_window : undefined,
+    }))
+    .map((model) => enhanceModelWithModelsDevData(model, "openai"))
 }
 
 async function fetchOpenAIModels(
@@ -527,6 +583,8 @@ export async function fetchAvailableModels(
     if (apiKey) {
       cacheKeyParts.push(apiKey.slice(0, 8))
     }
+  } else if (providerId === "openai-oauth") {
+    cacheKeyParts.push(config.openaiOauthAccountId || "no-account")
   }
 
   const cacheKey = cacheKeyParts.join("|")
@@ -582,6 +640,17 @@ export async function fetchAvailableModels(
       case "openai":
         baseUrl = config.openaiBaseUrl
         models = await fetchOpenAIModels(baseUrl, config.openaiApiKey)
+        break
+      case "openai-oauth":
+        try {
+          models = await fetchOpenAIOAuthModels()
+        } catch (error) {
+          diagnosticsService.logWarning(
+            "models-service",
+            `Falling back to static OpenAI OAuth model list: ${error instanceof Error ? error.message : String(error)}`,
+          )
+          models = getOpenAIOAuthModels()
+        }
         break
       case "groq":
         baseUrl = config.groqBaseUrl
@@ -691,6 +760,9 @@ const HARDCODED_FALLBACK_MODELS: Record<string, ModelInfo[]> = {
   openrouter: [
     { id: "openai/gpt-4.1-mini", name: "GPT-4.1 Mini (OpenAI)" },
     { id: "anthropic/claude-sonnet-4", name: "Claude Sonnet 4 (Anthropic)" },
+  ],
+  "openai-oauth": [
+    { id: "gpt-5.4-mini", name: "GPT-5.4-Mini", context_length: 272000 },
   ],
   groq: [
     { id: "openai/gpt-oss-120b", name: "GPT-OSS 120B (OpenAI)" },

--- a/apps/desktop/src/main/models-service.ts
+++ b/apps/desktop/src/main/models-service.ts
@@ -131,27 +131,65 @@ function getOpenAIOAuthModels(): ModelInfo[] {
 
 async function fetchOpenAIOAuthModels(): Promise<ModelInfo[]> {
   const session = await ensureOpenAIOAuthSession()
-  const response = await fetch(`${getOpenAIOAuthBaseUrl()}/codex/models`, {
-    headers: {
-      Authorization: `Bearer ${session.accessToken}`,
-      Accept: "application/json",
-      originator: getOpenAIOAuthOriginator(),
-      ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
-    },
-  })
+  const url = `${getOpenAIOAuthBaseUrl()}/codex/models`
+  const headers = {
+    Authorization: `Bearer ${session.accessToken}`,
+    Accept: "application/json",
+    originator: getOpenAIOAuthOriginator(),
+    ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
+  }
+
+  console.log(`[OpenAI OAuth Models] Fetching from ${url}, hasAccountId=${!!session.accountId}`)
+
+  const response = await fetch(url, { headers })
 
   if (!response.ok) {
     const errorText = await response.text()
+    console.error(`[OpenAI OAuth Models] API failed: HTTP ${response.status}`, errorText.slice(0, 500))
     throw new Error(`HTTP ${response.status}: ${errorText}`)
   }
 
-  const data = await response.json() as { models?: Array<Record<string, unknown>> }
+  const rawText = await response.text()
+  let data: Record<string, unknown>
+  try {
+    data = JSON.parse(rawText) as Record<string, unknown>
+  } catch {
+    console.error(`[OpenAI OAuth Models] Failed to parse response:`, rawText.slice(0, 500))
+    throw new Error("Failed to parse OpenAI OAuth models response as JSON")
+  }
+
+  // Log the raw response structure to aid debugging
+  const topLevelKeys = Object.keys(data)
+  console.log(`[OpenAI OAuth Models] Response keys: ${topLevelKeys.join(", ")}`)
+  console.log(`[OpenAI OAuth Models] Is models array: ${Array.isArray(data.models)}, count: ${Array.isArray(data.models) ? data.models.length : "N/A"}`)
+
+  if (Array.isArray(data.models)) {
+    const allSlugs = data.models.map((m: any) => m?.slug || m?.id || `[no-slug: keys=${Object.keys(m || {}).join(",")}]`)
+    console.log(`[OpenAI OAuth Models] All slugs from API:`, JSON.stringify(allSlugs))
+  } else {
+    console.log(`[OpenAI OAuth Models] Raw response snippet:`, rawText.slice(0, 2000))
+  }
+
   if (!Array.isArray(data.models)) {
     throw new Error("Missing 'models' in OpenAI OAuth models response")
   }
 
-  return data.models
-    .filter((model): model is Record<string, unknown> & { slug: string } => typeof model.slug === "string" && model.slug.length > 0)
+  const allModels = data.models as Array<Record<string, unknown>>
+  const filtered = allModels.filter(
+    (model): model is Record<string, unknown> & { slug: string } =>
+      typeof model.slug === "string" && model.slug.length > 0,
+  )
+
+  if (filtered.length < allModels.length) {
+    const dropped = allModels
+      .filter((m) => typeof m.slug !== "string" || m.slug.length === 0)
+      .map((m) => ({ slug: m.slug, id: m.id, keys: Object.keys(m) }))
+    console.warn(`[OpenAI OAuth Models] Dropped ${dropped.length} models without slug:`, JSON.stringify(dropped))
+  }
+
+  console.log(`[OpenAI OAuth Models] Final: ${filtered.length} models -> ${filtered.map(m => m.slug).join(", ")}`)
+
+  return filtered
     .map((model) => ({
       id: model.slug,
       name: typeof model.display_name === "string" && model.display_name.length > 0 ? model.display_name : formatModelName(model.slug),

--- a/apps/desktop/src/main/oauth-callback-server.ts
+++ b/apps/desktop/src/main/oauth-callback-server.ts
@@ -60,7 +60,7 @@ export class OAuthCallbackServer {
     try {
       const url = new URL(req.url || '', `http://localhost:${this.port}`)
 
-      if (url.pathname === '/callback') {
+      if (url.pathname === '/callback' || url.pathname === '/auth/callback') {
         this.handleOAuthCallback(url, res)
       } else if (url.pathname === '/') {
         this.handleRootRequest(res)

--- a/apps/desktop/src/main/oauth-storage.ts
+++ b/apps/desktop/src/main/oauth-storage.ts
@@ -56,7 +56,7 @@ export class OAuthStorage {
       })
     } else {
       const iv = crypto.randomBytes(16)
-      const cipher = crypto.createCipher('aes-256-gcm', this.encryptionKey!)
+      const cipher = crypto.createCipheriv('aes-256-gcm', this.encryptionKey!, iv)
       let encrypted = cipher.update(data, 'utf8', 'hex')
       encrypted += cipher.final('hex')
       const authTag = cipher.getAuthTag()
@@ -78,7 +78,8 @@ export class OAuthStorage {
         const buffer = Buffer.from(parsed.data, 'base64')
         return safeStorage.decryptString(buffer)
       } else if (parsed.method === 'aes') {
-        const decipher = crypto.createDecipher('aes-256-gcm', this.encryptionKey!)
+        const iv = Buffer.from(parsed.iv, 'hex')
+        const decipher = crypto.createDecipheriv('aes-256-gcm', this.encryptionKey!, iv)
         decipher.setAuthTag(Buffer.from(parsed.authTag, 'hex'))
         let decrypted = decipher.update(parsed.data, 'hex', 'utf8')
         decrypted += decipher.final('utf8')

--- a/apps/desktop/src/main/openai-oauth-provider.ts
+++ b/apps/desktop/src/main/openai-oauth-provider.ts
@@ -224,10 +224,62 @@ export async function ensureOpenAIOAuthSession(): Promise<OpenAIOAuthSession> {
   }
 
   const config = configStore.get()
+  let accountId = config.openaiOauthAccountId || undefined
+
+  // If accountId is missing (e.g. id_token didn't contain it), fetch from /me endpoint
+  if (!accountId) {
+    try {
+      accountId = await fetchAndPersistAccountId(tokens.access_token)
+    } catch {
+      // best-effort: continue without accountId
+    }
+  }
+
   return {
     accessToken: tokens.access_token,
-    accountId: config.openaiOauthAccountId || undefined,
+    accountId,
   }
+}
+
+/**
+ * Fetch account info from /me and persist the accountId to config.
+ * This covers cases where the id_token JWT didn't include chatgpt_account_id.
+ */
+async function fetchAndPersistAccountId(accessToken: string): Promise<string | undefined> {
+  const response = await fetch(`${OPENAI_CHATGPT_BASE_URL}/me`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/json",
+    },
+  })
+
+  if (!response.ok) {
+    return undefined
+  }
+
+  const data = await response.json() as Record<string, unknown>
+
+  // /me returns accounts array; pick the first one
+  let accountId: string | undefined
+  if (Array.isArray(data.accounts)) {
+    const first = data.accounts[0] as Record<string, unknown> | undefined
+    accountId = typeof first?.account_id === "string" ? first.account_id : undefined
+  }
+  // Fallback: top-level account_user_id or id
+  if (!accountId && typeof data.account_user_id === "string") {
+    accountId = data.account_user_id
+  }
+
+  if (accountId) {
+    const account: OpenAIOAuthAccount = {
+      email: typeof data.email === "string" ? data.email : undefined,
+      accountId,
+      planType: typeof data.plan_type === "string" ? data.plan_type : undefined,
+    }
+    persistAccountMetadata(account)
+  }
+
+  return accountId
 }
 
 function rewriteResponsesUrl(url: string): string {

--- a/apps/desktop/src/main/openai-oauth-provider.ts
+++ b/apps/desktop/src/main/openai-oauth-provider.ts
@@ -1,0 +1,560 @@
+import crypto from "crypto"
+import { shell } from "electron"
+import { configStore } from "./config"
+import { oauthStorage } from "./oauth-storage"
+import { OAuthTokens, OpenAIOAuthUsageBucket, OpenAIOAuthUsageSnapshot } from "../shared/types"
+import { OAuthCallbackServer } from "./oauth-callback-server"
+
+const OPENAI_OAUTH_STORAGE_KEY = "provider://openai-oauth"
+const OPENAI_AUTH_BASE_URL = "https://auth.openai.com"
+const OPENAI_CHATGPT_BASE_URL = "https://chatgpt.com/backend-api"
+const OPENAI_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+const OPENAI_OAUTH_SCOPE = "openid profile email offline_access"
+const OPENAI_OAUTH_ORIGINATOR = "codex_chatgpt_desktop"
+const OPENAI_OAUTH_CALLBACK_PORT = 1455
+const OPENAI_OAUTH_CALLBACK_PATH = "/auth/callback"
+const OPENAI_OAUTH_TIMEOUT_MS = 5 * 60 * 1000
+const OPENAI_OAUTH_REFRESH_BUFFER_MS = 60 * 1000
+
+type OpenAIOAuthAccount = {
+  email?: string
+  accountId?: string
+  planType?: string
+}
+
+type OpenAIOAuthSession = {
+  accessToken: string
+  accountId?: string
+}
+
+function getRedirectUri(): string {
+  return `http://localhost:${OPENAI_OAUTH_CALLBACK_PORT}${OPENAI_OAUTH_CALLBACK_PATH}`
+}
+
+function generatePkcePair(): { codeVerifier: string; codeChallenge: string } {
+  const codeVerifier = crypto.randomBytes(32).toString("base64url")
+  const codeChallenge = crypto
+    .createHash("sha256")
+    .update(codeVerifier)
+    .digest("base64url")
+
+  return { codeVerifier, codeChallenge }
+}
+
+function decodeJwtPayload(token?: string): Record<string, unknown> | null {
+  if (!token) return null
+
+  const parts = token.split(".")
+  if (parts.length < 2) return null
+
+  try {
+    const payload = parts[1]
+    const normalized = payload.replace(/-/g, "+").replace(/_/g, "/")
+    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4)
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf8")) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+function extractAccountFromIdToken(idToken?: string): OpenAIOAuthAccount {
+  const claims = decodeJwtPayload(idToken)
+  if (!claims) {
+    return {}
+  }
+
+  const nestedClaims =
+    claims["https://api.openai.com/auth"] &&
+    typeof claims["https://api.openai.com/auth"] === "object" &&
+    !Array.isArray(claims["https://api.openai.com/auth"])
+      ? (claims["https://api.openai.com/auth"] as Record<string, unknown>)
+      : undefined
+
+  const accountId =
+    (typeof claims.chatgpt_account_id === "string" ? claims.chatgpt_account_id : undefined) ||
+    (typeof nestedClaims?.chatgpt_account_id === "string" ? nestedClaims.chatgpt_account_id : undefined)
+
+  const planType =
+    (typeof claims.chatgpt_plan_type === "string" ? claims.chatgpt_plan_type : undefined) ||
+    (typeof nestedClaims?.chatgpt_plan_type === "string" ? nestedClaims.chatgpt_plan_type : undefined)
+
+  return {
+    email: typeof claims.email === "string" ? claims.email : undefined,
+    accountId,
+    planType,
+  }
+}
+
+function mergeTokenResponse(previousTokens: OAuthTokens | null, payload: Record<string, unknown>): OAuthTokens {
+  const expiresIn =
+    typeof payload.expires_in === "number"
+      ? payload.expires_in
+      : typeof payload.expires_in === "string"
+        ? Number(payload.expires_in)
+        : undefined
+
+  return {
+    access_token: typeof payload.access_token === "string" ? payload.access_token : "",
+    token_type: typeof payload.token_type === "string" ? payload.token_type : "Bearer",
+    expires_in: Number.isFinite(expiresIn) ? expiresIn : undefined,
+    refresh_token:
+      typeof payload.refresh_token === "string"
+        ? payload.refresh_token
+        : previousTokens?.refresh_token,
+    scope: typeof payload.scope === "string" ? payload.scope : previousTokens?.scope,
+    expires_at:
+      Number.isFinite(expiresIn) && expiresIn !== undefined
+        ? Date.now() + expiresIn * 1000
+        : previousTokens?.expires_at,
+  }
+}
+
+function isTokenExpired(tokens: OAuthTokens | null): boolean {
+  if (!tokens?.access_token) return true
+  if (!tokens.expires_at) return false
+  return Date.now() >= tokens.expires_at - OPENAI_OAUTH_REFRESH_BUFFER_MS
+}
+
+function persistAccountMetadata(account: OpenAIOAuthAccount, usage?: OpenAIOAuthUsageSnapshot): void {
+  const config = configStore.get()
+  configStore.save({
+    ...config,
+    ...(account.email !== undefined ? { openaiOauthEmail: account.email } : {}),
+    ...(account.accountId !== undefined ? { openaiOauthAccountId: account.accountId } : {}),
+    ...(account.planType !== undefined ? { openaiOauthPlanType: account.planType } : {}),
+    openaiOauthConnectedAt: config.openaiOauthConnectedAt || Date.now(),
+    ...(usage !== undefined ? { openaiOauthUsage: usage } : {}),
+  })
+}
+
+function clearAccountMetadata(): void {
+  const config = configStore.get()
+  configStore.save({
+    ...config,
+    openaiOauthEmail: undefined,
+    openaiOauthAccountId: undefined,
+    openaiOauthPlanType: undefined,
+    openaiOauthConnectedAt: undefined,
+    openaiOauthUsage: undefined,
+  })
+}
+
+function buildAuthorizationUrl(state: string, codeChallenge: string): string {
+  const url = new URL(`${OPENAI_AUTH_BASE_URL}/oauth/authorize`)
+  url.searchParams.set("response_type", "code")
+  url.searchParams.set("client_id", OPENAI_OAUTH_CLIENT_ID)
+  url.searchParams.set("redirect_uri", getRedirectUri())
+  url.searchParams.set("scope", OPENAI_OAUTH_SCOPE)
+  url.searchParams.set("code_challenge", codeChallenge)
+  url.searchParams.set("code_challenge_method", "S256")
+  url.searchParams.set("state", state)
+  url.searchParams.set("id_token_add_organizations", "true")
+  url.searchParams.set("codex_cli_simplified_flow", "true")
+  url.searchParams.set("originator", OPENAI_OAUTH_ORIGINATOR)
+  return url.toString()
+}
+
+async function exchangeToken(payload: URLSearchParams): Promise<Record<string, unknown>> {
+  const response = await fetch(`${OPENAI_AUTH_BASE_URL}/oauth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json",
+    },
+    body: payload.toString(),
+  })
+
+  const bodyText = await response.text()
+  let parsed: Record<string, unknown> = {}
+
+  try {
+    parsed = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {}
+  } catch {
+    parsed = {}
+  }
+
+  if (!response.ok) {
+    const errorMessage =
+      (typeof parsed.error_description === "string" && parsed.error_description) ||
+      (typeof parsed.error === "string" && parsed.error) ||
+      bodyText ||
+      `HTTP ${response.status}`
+    throw new Error(`OpenAI OAuth token request failed: ${errorMessage}`)
+  }
+
+  return parsed
+}
+
+async function saveTokens(tokens: OAuthTokens): Promise<void> {
+  await oauthStorage.storeTokens(OPENAI_OAUTH_STORAGE_KEY, tokens)
+}
+
+async function loadTokens(): Promise<OAuthTokens | null> {
+  return oauthStorage.getTokens(OPENAI_OAUTH_STORAGE_KEY)
+}
+
+async function refreshTokens(existingTokens: OAuthTokens): Promise<OAuthTokens> {
+  if (!existingTokens.refresh_token) {
+    throw new Error("OpenAI OAuth refresh token is missing")
+  }
+
+  const payload = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: OPENAI_OAUTH_CLIENT_ID,
+    refresh_token: existingTokens.refresh_token,
+    scope: OPENAI_OAUTH_SCOPE,
+  })
+
+  const tokenResponse = await exchangeToken(payload)
+  const mergedTokens = mergeTokenResponse(existingTokens, tokenResponse)
+  await saveTokens(mergedTokens)
+  persistAccountMetadata(extractAccountFromIdToken(typeof tokenResponse.id_token === "string" ? tokenResponse.id_token : undefined))
+  return mergedTokens
+}
+
+export async function ensureOpenAIOAuthSession(): Promise<OpenAIOAuthSession> {
+  let tokens = await loadTokens()
+
+  if (!tokens?.access_token) {
+    throw new Error("OpenAI OAuth is not connected")
+  }
+
+  if (isTokenExpired(tokens)) {
+    tokens = await refreshTokens(tokens)
+  }
+
+  const config = configStore.get()
+  return {
+    accessToken: tokens.access_token,
+    accountId: config.openaiOauthAccountId || undefined,
+  }
+}
+
+function rewriteResponsesUrl(url: string): string {
+  return url.replace(/\/responses(\?|$)/, "/codex/responses$1")
+}
+
+function extractInstructionText(content: unknown): string {
+  if (typeof content === "string") {
+    return content
+  }
+
+  if (Array.isArray(content)) {
+    const parts = content
+      .map(part => {
+        if (typeof part === "string") {
+          return part
+        }
+
+        if (!part || typeof part !== "object") {
+          return ""
+        }
+
+        const text = (part as Record<string, unknown>).text
+        return typeof text === "string" ? text : ""
+      })
+      .filter(Boolean)
+
+    return parts.join("\n")
+  }
+
+  if (content && typeof content === "object") {
+    const text = (content as Record<string, unknown>).text
+    return typeof text === "string" ? text : ""
+  }
+
+  return ""
+}
+
+function normalizeOpenAIOAuthResponsesBody(body: unknown): unknown {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return body
+  }
+
+  const payload = { ...(body as Record<string, unknown>) }
+  payload.store = false
+  const existingInstructions = typeof payload.instructions === "string" ? payload.instructions : ""
+
+  if (!Array.isArray(payload.input)) {
+    if (payload.instructions === undefined) {
+      payload.instructions = existingInstructions
+    }
+    return payload
+  }
+
+  const instructionParts: string[] = []
+  const normalizedInput = payload.input.filter(item => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return true
+    }
+
+    const record = item as Record<string, unknown>
+    const role = record.role
+
+    if (role !== "system" && role !== "developer") {
+      return true
+    }
+
+    const text = extractInstructionText(record.content)
+    if (text) {
+      instructionParts.push(text)
+    }
+    return false
+  })
+
+  const mergedInstructions = [existingInstructions, ...instructionParts].filter(Boolean).join("\n")
+  payload.instructions = mergedInstructions
+  payload.input = normalizedInput
+
+  return payload
+}
+
+async function normalizeOpenAIOAuthRequestInit(init?: RequestInit): Promise<RequestInit | undefined> {
+  if (!init?.body || typeof init.body !== "string") {
+    return init
+  }
+
+  try {
+    const parsed = JSON.parse(init.body) as unknown
+    const normalized = normalizeOpenAIOAuthResponsesBody(parsed)
+    return {
+      ...init,
+      body: JSON.stringify(normalized),
+    }
+  } catch {
+    return init
+  }
+}
+
+async function normalizeOpenAIOAuthRequest(input: Request): Promise<Request> {
+  const contentType = input.headers.get("content-type") || ""
+
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return new Request(rewriteResponsesUrl(input.url), input)
+  }
+
+  const rawBody = await input.clone().text()
+  if (!rawBody) {
+    return new Request(rewriteResponsesUrl(input.url), input)
+  }
+
+  try {
+    const parsed = JSON.parse(rawBody) as unknown
+    const normalized = normalizeOpenAIOAuthResponsesBody(parsed)
+    return new Request(rewriteResponsesUrl(input.url), {
+      method: input.method,
+      headers: input.headers,
+      body: JSON.stringify(normalized),
+      redirect: input.redirect,
+      signal: input.signal,
+    })
+  } catch {
+    return new Request(rewriteResponsesUrl(input.url), input)
+  }
+}
+
+export function createOpenAIOAuthFetch(): typeof fetch {
+  return async (input, init) => {
+    const normalizedInit = await normalizeOpenAIOAuthRequestInit(init)
+
+    if (typeof input === "string") {
+      return fetch(rewriteResponsesUrl(input), normalizedInit)
+    }
+
+    if (input instanceof URL) {
+      return fetch(new URL(rewriteResponsesUrl(input.toString())), normalizedInit)
+    }
+
+    const request = await normalizeOpenAIOAuthRequest(input)
+    return fetch(request, normalizedInit)
+  }
+}
+
+export function getOpenAIOAuthBaseUrl(): string {
+  return OPENAI_CHATGPT_BASE_URL
+}
+
+export function getOpenAIOAuthOriginator(): string {
+  return OPENAI_OAUTH_ORIGINATOR
+}
+
+function tryExtractUsageBuckets(value: unknown, buckets: OpenAIOAuthUsageBucket[], path: string[] = []): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => tryExtractUsageBuckets(entry, buckets, [...path, String(index)]))
+    return
+  }
+
+  if (!value || typeof value !== "object") {
+    return
+  }
+
+  const record = value as Record<string, unknown>
+  const used =
+    typeof record.used === "number" ? record.used :
+    typeof record.consumed === "number" ? record.consumed :
+    typeof record.current === "number" ? record.current :
+    undefined
+  const limit =
+    typeof record.limit === "number" ? record.limit :
+    typeof record.max === "number" ? record.max :
+    typeof record.total === "number" ? record.total :
+    undefined
+
+  if (used !== undefined || limit !== undefined) {
+    buckets.push({
+      label:
+        (typeof record.label === "string" && record.label) ||
+        (typeof record.name === "string" && record.name) ||
+        path[path.length - 1] ||
+        "Usage",
+      used: used ?? null,
+      limit: limit ?? null,
+      unit:
+        typeof record.unit === "string"
+          ? record.unit
+          : typeof record.units === "string"
+            ? record.units
+            : null,
+      resetsAt:
+        typeof record.resets_at === "string"
+          ? record.resets_at
+          : typeof record.reset_at === "string"
+            ? record.reset_at
+            : typeof record.renews_at === "string"
+              ? record.renews_at
+              : null,
+    })
+  }
+
+  for (const [key, child] of Object.entries(record)) {
+    if (["used", "consumed", "current", "limit", "max", "total", "label", "name", "unit", "units", "resets_at", "reset_at", "renews_at"].includes(key)) {
+      continue
+    }
+    tryExtractUsageBuckets(child, buckets, [...path, key])
+  }
+}
+
+function normalizeUsageSnapshot(payload: Record<string, unknown>): OpenAIOAuthUsageSnapshot {
+  const buckets: OpenAIOAuthUsageBucket[] = []
+  tryExtractUsageBuckets(payload, buckets)
+
+  const uniqueBuckets = buckets.filter((bucket, index) => {
+    return buckets.findIndex(candidate =>
+      candidate.label === bucket.label &&
+      candidate.used === bucket.used &&
+      candidate.limit === bucket.limit &&
+      candidate.unit === bucket.unit &&
+      candidate.resetsAt === bucket.resetsAt,
+    ) === index
+  })
+
+  return {
+    fetchedAt: Date.now(),
+    buckets: uniqueBuckets,
+    raw: payload,
+  }
+}
+
+export async function refreshOpenAIOAuthUsage(): Promise<OpenAIOAuthUsageSnapshot> {
+  const session = await ensureOpenAIOAuthSession()
+  const response = await fetch(`${OPENAI_CHATGPT_BASE_URL}/wham/usage`, {
+    headers: {
+      "Authorization": `Bearer ${session.accessToken}`,
+      "Accept": "application/json",
+      ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
+    },
+  })
+
+  const bodyText = await response.text()
+  let payload: Record<string, unknown> = {}
+
+  try {
+    payload = bodyText ? (JSON.parse(bodyText) as Record<string, unknown>) : {}
+  } catch {
+    payload = {}
+  }
+
+  if (!response.ok) {
+    const errorMessage =
+      (typeof payload.message === "string" && payload.message) ||
+      (typeof payload.error_description === "string" && payload.error_description) ||
+      bodyText ||
+      `HTTP ${response.status}`
+    throw new Error(`Failed to fetch OpenAI OAuth usage: ${errorMessage}`)
+  }
+
+  const usage = normalizeUsageSnapshot(payload)
+  const account: OpenAIOAuthAccount = {
+    email: configStore.get().openaiOauthEmail || undefined,
+    accountId: session.accountId,
+    planType: configStore.get().openaiOauthPlanType || undefined,
+  }
+  persistAccountMetadata(account, usage)
+  return usage
+}
+
+export async function startOpenAIOAuthFlow(): Promise<OpenAIOAuthAccount> {
+  const { codeVerifier, codeChallenge } = generatePkcePair()
+  const state = crypto.randomBytes(16).toString("base64url")
+  const callbackServer = new OAuthCallbackServer(OPENAI_OAUTH_CALLBACK_PORT)
+
+  await callbackServer.startServer()
+
+  try {
+    const callbackPromise = callbackServer.waitForCallback(OPENAI_OAUTH_TIMEOUT_MS)
+    await shell.openExternal(buildAuthorizationUrl(state, codeChallenge))
+    const callbackResult = await callbackPromise
+
+    if (callbackResult.error) {
+      throw new Error(callbackResult.error_description || callbackResult.error)
+    }
+
+    if (!callbackResult.code) {
+      throw new Error("No authorization code received from OpenAI OAuth")
+    }
+
+    if (callbackResult.state !== state) {
+      throw new Error("OpenAI OAuth state mismatch")
+    }
+
+    const tokenResponse = await exchangeToken(new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: OPENAI_OAUTH_CLIENT_ID,
+      code: callbackResult.code,
+      code_verifier: codeVerifier,
+      redirect_uri: getRedirectUri(),
+    }))
+
+    const tokens = mergeTokenResponse(null, tokenResponse)
+    await saveTokens(tokens)
+
+    const account = extractAccountFromIdToken(typeof tokenResponse.id_token === "string" ? tokenResponse.id_token : undefined)
+    persistAccountMetadata(account)
+
+    return account
+  } finally {
+    callbackServer.stop()
+  }
+}
+
+export async function disconnectOpenAIOAuth(): Promise<void> {
+  await oauthStorage.delete(OPENAI_OAUTH_STORAGE_KEY)
+  clearAccountMetadata()
+}
+
+export async function getOpenAIOAuthConnectionState(): Promise<{
+  connected: boolean
+  email?: string
+  accountId?: string
+  planType?: string
+}> {
+  const tokens = await loadTokens()
+  const config = configStore.get()
+
+  return {
+    connected: !!tokens?.access_token,
+    email: config.openaiOauthEmail || undefined,
+    accountId: config.openaiOauthAccountId || undefined,
+    planType: config.openaiOauthPlanType || undefined,
+  }
+}

--- a/apps/desktop/src/main/openai-oauth-provider.ts
+++ b/apps/desktop/src/main/openai-oauth-provider.ts
@@ -378,6 +378,85 @@ export function getOpenAIOAuthOriginator(): string {
   return OPENAI_OAUTH_ORIGINATOR
 }
 
+function normalizeResetValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value * 1000).toISOString()
+  }
+
+  return null
+}
+
+function normalizeResetAfterSeconds(value: unknown): string | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(Date.now() + value * 1000).toISOString()
+  }
+
+  return null
+}
+
+function pushUsageBucket(
+  buckets: OpenAIOAuthUsageBucket[],
+  label: string,
+  used: number | null,
+  limit: number | null,
+  unit?: string | null,
+  resetsAt?: string | null,
+): void {
+  buckets.push({
+    label,
+    used,
+    limit,
+    unit: unit ?? null,
+    resetsAt: resetsAt ?? null,
+  })
+}
+
+function extractRateLimitBuckets(
+  labelPrefix: string,
+  rateLimit: unknown,
+  buckets: OpenAIOAuthUsageBucket[],
+): void {
+  if (!rateLimit || typeof rateLimit !== "object" || Array.isArray(rateLimit)) {
+    return
+  }
+
+  const record = rateLimit as Record<string, unknown>
+  const windows: Array<{ key: "primary_window" | "secondary_window"; label: string }> = [
+    { key: "primary_window", label: "Primary" },
+    { key: "secondary_window", label: "Secondary" },
+  ]
+
+  for (const windowInfo of windows) {
+    const windowValue = record[windowInfo.key]
+    if (!windowValue || typeof windowValue !== "object" || Array.isArray(windowValue)) {
+      continue
+    }
+
+    const windowRecord = windowValue as Record<string, unknown>
+    const usedPercent = typeof windowRecord.used_percent === "number"
+      ? windowRecord.used_percent
+      : null
+    const resetAt = normalizeResetValue(windowRecord.reset_at) || normalizeResetAfterSeconds(windowRecord.reset_after_seconds)
+
+    if (usedPercent === null && !resetAt) {
+      continue
+    }
+
+    pushUsageBucket(
+      buckets,
+      `${labelPrefix} ${windowInfo.label}`.trim(),
+      usedPercent,
+      usedPercent !== null ? 100 : null,
+      "%",
+      resetAt,
+    )
+  }
+}
+
 function tryExtractUsageBuckets(value: unknown, buckets: OpenAIOAuthUsageBucket[], path: string[] = []): void {
   if (Array.isArray(value)) {
     value.forEach((entry, index) => tryExtractUsageBuckets(entry, buckets, [...path, String(index)]))
@@ -436,6 +515,35 @@ function tryExtractUsageBuckets(value: unknown, buckets: OpenAIOAuthUsageBucket[
 
 function normalizeUsageSnapshot(payload: Record<string, unknown>): OpenAIOAuthUsageSnapshot {
   const buckets: OpenAIOAuthUsageBucket[] = []
+
+  extractRateLimitBuckets("Usage", payload.rate_limit, buckets)
+
+  if (Array.isArray(payload.additional_rate_limits)) {
+    for (const additional of payload.additional_rate_limits) {
+      if (!additional || typeof additional !== "object" || Array.isArray(additional)) {
+        continue
+      }
+
+      const record = additional as Record<string, unknown>
+      const label =
+        (typeof record.display_label === "string" && record.display_label) ||
+        (typeof record.limit_name === "string" && record.limit_name) ||
+        (typeof record.metered_feature === "string" && record.metered_feature) ||
+        "Additional"
+
+      extractRateLimitBuckets(label, record.rate_limit, buckets)
+    }
+  }
+
+  if (payload.credits && typeof payload.credits === "object" && !Array.isArray(payload.credits)) {
+    const credits = payload.credits as Record<string, unknown>
+    if (typeof credits.balance === "string" && credits.balance) {
+      pushUsageBucket(buckets, "Credits", null, null, credits.balance, null)
+    } else if (typeof credits.unlimited === "boolean") {
+      pushUsageBucket(buckets, "Credits", credits.unlimited ? 1 : 0, 1, credits.unlimited ? "unlimited" : "limited", null)
+    }
+  }
+
   tryExtractUsageBuckets(payload, buckets)
 
   const uniqueBuckets = buckets.filter((bucket, index) => {

--- a/apps/desktop/src/main/openai-oauth-provider.ts
+++ b/apps/desktop/src/main/openai-oauth-provider.ts
@@ -265,9 +265,12 @@ async function fetchAndPersistAccountId(accessToken: string): Promise<string | u
     const first = data.accounts[0] as Record<string, unknown> | undefined
     accountId = typeof first?.account_id === "string" ? first.account_id : undefined
   }
-  // Fallback: top-level account_user_id or id
+  // Fallback: top-level account_user_id or chatgpt_account_id
   if (!accountId && typeof data.account_user_id === "string") {
     accountId = data.account_user_id
+  }
+  if (!accountId && typeof data.chatgpt_account_id === "string") {
+    accountId = data.chatgpt_account_id
   }
 
   if (accountId) {

--- a/apps/desktop/src/main/profile-service.ts
+++ b/apps/desktop/src/main/profile-service.ts
@@ -10,7 +10,7 @@ import { getRuntimeToolNames } from "./runtime-tool-definitions"
 const RESERVED_SERVER_NAMES = [...RESERVED_RUNTIME_TOOL_SERVER_NAMES]
 
 // Valid provider IDs that are supported by the application
-const VALID_PROVIDER_IDS = ["openai", "groq", "gemini"]
+const VALID_PROVIDER_IDS = ["openai", "openai-oauth", "groq", "gemini"]
 // STT supports openai, groq, and parakeet (local)
 const VALID_STT_PROVIDER_IDS = ["openai", "groq", "parakeet"]
 // TTS supports openai, groq, gemini, kitten (local), and supertonic (local)
@@ -223,12 +223,14 @@ function isValidModelConfig(config: unknown): boolean {
   // Other string fields that don't need enum validation
   const stringFields = [
     "mcpToolsOpenaiModel",
+    "mcpToolsOpenaiOauthModel",
     "mcpToolsGroqModel",
     "mcpToolsGeminiModel",
     "currentModelPresetId",
     "openaiSttModel",
     "groqSttModel",
     "transcriptPostProcessingOpenaiModel",
+    "transcriptPostProcessingOpenaiOauthModel",
     "transcriptPostProcessingGroqModel",
     "transcriptPostProcessingGeminiModel",
   ]
@@ -525,6 +527,7 @@ class ProfileService {
       // Agent/MCP Tools settings
       ...(modelConfig.mcpToolsProviderId !== undefined && { mcpToolsProviderId: modelConfig.mcpToolsProviderId }),
       ...(modelConfig.mcpToolsOpenaiModel !== undefined && { mcpToolsOpenaiModel: modelConfig.mcpToolsOpenaiModel }),
+      ...(modelConfig.mcpToolsOpenaiOauthModel !== undefined && { mcpToolsOpenaiOauthModel: modelConfig.mcpToolsOpenaiOauthModel }),
       ...(modelConfig.mcpToolsGroqModel !== undefined && { mcpToolsGroqModel: modelConfig.mcpToolsGroqModel }),
       ...(modelConfig.mcpToolsGeminiModel !== undefined && { mcpToolsGeminiModel: modelConfig.mcpToolsGeminiModel }),
       ...(modelConfig.currentModelPresetId !== undefined && { currentModelPresetId: modelConfig.currentModelPresetId }),
@@ -535,6 +538,7 @@ class ProfileService {
       // Transcript Post-Processing settings
       ...(modelConfig.transcriptPostProcessingProviderId !== undefined && { transcriptPostProcessingProviderId: modelConfig.transcriptPostProcessingProviderId }),
       ...(modelConfig.transcriptPostProcessingOpenaiModel !== undefined && { transcriptPostProcessingOpenaiModel: modelConfig.transcriptPostProcessingOpenaiModel }),
+      ...(modelConfig.transcriptPostProcessingOpenaiOauthModel !== undefined && { transcriptPostProcessingOpenaiOauthModel: modelConfig.transcriptPostProcessingOpenaiOauthModel }),
       ...(modelConfig.transcriptPostProcessingGroqModel !== undefined && { transcriptPostProcessingGroqModel: modelConfig.transcriptPostProcessingGroqModel }),
       ...(modelConfig.transcriptPostProcessingGeminiModel !== undefined && { transcriptPostProcessingGeminiModel: modelConfig.transcriptPostProcessingGeminiModel }),
       // TTS Provider settings

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -418,6 +418,7 @@ function getConnectableBaseUrlForMobilePairing(
 function resolveActiveModelId(cfg: any): string {
   const provider = cfg.mcpToolsProviderId || "openai"
   if (provider === "openai") return cfg.mcpToolsOpenaiModel || "openai"
+  if (provider === "openai-oauth") return cfg.mcpToolsOpenaiOauthModel || "gpt-5.4-mini"
   if (provider === "groq") return cfg.mcpToolsGroqModel || "groq"
   if (provider === "gemini") return cfg.mcpToolsGeminiModel || "gemini"
   return String(provider)
@@ -1262,6 +1263,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         // Model settings
         mcpToolsProviderId: cfg.mcpToolsProviderId || "openai",
         mcpToolsOpenaiModel: cfg.mcpToolsOpenaiModel,
+        mcpToolsOpenaiOauthModel: cfg.mcpToolsOpenaiOauthModel,
         mcpToolsGroqModel: cfg.mcpToolsGroqModel,
         mcpToolsGeminiModel: cfg.mcpToolsGeminiModel,
         // OpenAI compatible preset settings
@@ -1326,6 +1328,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         ttsProviderId: cfg.ttsProviderId || "openai",
         transcriptPostProcessingProviderId: cfg.transcriptPostProcessingProviderId || "openai",
         transcriptPostProcessingOpenaiModel: cfg.transcriptPostProcessingOpenaiModel || "",
+        transcriptPostProcessingOpenaiOauthModel: cfg.transcriptPostProcessingOpenaiOauthModel || "",
         transcriptPostProcessingGroqModel: cfg.transcriptPostProcessingGroqModel || "",
         transcriptPostProcessingGeminiModel: cfg.transcriptPostProcessingGeminiModel || "",
         // ACP Agent settings
@@ -1378,12 +1381,15 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         updates.mcpMaxIterations = Math.floor(body.mcpMaxIterations)
       }
       // Model settings
-      const validProviders = ["openai", "groq", "gemini"]
+      const validProviders = ["openai", "openai-oauth", "groq", "gemini"]
       if (typeof body.mcpToolsProviderId === "string" && validProviders.includes(body.mcpToolsProviderId)) {
-        updates.mcpToolsProviderId = body.mcpToolsProviderId as "openai" | "groq" | "gemini"
+        updates.mcpToolsProviderId = body.mcpToolsProviderId as "openai" | "openai-oauth" | "groq" | "gemini"
       }
       if (typeof body.mcpToolsOpenaiModel === "string") {
         updates.mcpToolsOpenaiModel = body.mcpToolsOpenaiModel
+      }
+      if (typeof body.mcpToolsOpenaiOauthModel === "string") {
+        updates.mcpToolsOpenaiOauthModel = body.mcpToolsOpenaiOauthModel
       }
       if (typeof body.mcpToolsGroqModel === "string") {
         updates.mcpToolsGroqModel = body.mcpToolsGroqModel
@@ -1509,12 +1515,15 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         updates.ttsProviderId = body.ttsProviderId as "openai" | "groq" | "gemini" | "kitten" | "supertonic"
       }
       // Transcript Post-Processing Provider
-      const validPostProcessingProviders = ["openai", "groq", "gemini"]
+      const validPostProcessingProviders = ["openai", "openai-oauth", "groq", "gemini"]
       if (typeof body.transcriptPostProcessingProviderId === "string" && validPostProcessingProviders.includes(body.transcriptPostProcessingProviderId)) {
-        updates.transcriptPostProcessingProviderId = body.transcriptPostProcessingProviderId as "openai" | "groq" | "gemini"
+        updates.transcriptPostProcessingProviderId = body.transcriptPostProcessingProviderId as "openai" | "openai-oauth" | "groq" | "gemini"
       }
       if (typeof body.transcriptPostProcessingOpenaiModel === "string") {
         updates.transcriptPostProcessingOpenaiModel = body.transcriptPostProcessingOpenaiModel
+      }
+      if (typeof body.transcriptPostProcessingOpenaiOauthModel === "string") {
+        updates.transcriptPostProcessingOpenaiOauthModel = body.transcriptPostProcessingOpenaiOauthModel
       }
       if (typeof body.transcriptPostProcessingGroqModel === "string") {
         updates.transcriptPostProcessingGroqModel = body.transcriptPostProcessingGroqModel

--- a/apps/desktop/src/main/supertonic-tts.ts
+++ b/apps/desktop/src/main/supertonic-tts.ts
@@ -275,6 +275,8 @@ export function uninstallSupertonicModel(): void {
   }
 
   ttsEngine = null
+  ortModule = null
+  ortLoadError = null
   downloadState.progress = 0
   downloadState.error = undefined
 

--- a/apps/desktop/src/main/supertonic-tts.ts
+++ b/apps/desktop/src/main/supertonic-tts.ts
@@ -266,6 +266,27 @@ export async function downloadSupertonicModel(
   }
 }
 
+/**
+ * Remove the downloaded Supertonic model and reset any loaded engine state.
+ */
+export function uninstallSupertonicModel(): void {
+  if (downloadState.downloading) {
+    throw new Error("Cannot remove Supertonic model while download is in progress")
+  }
+
+  ttsEngine = null
+  downloadState.progress = 0
+  downloadState.error = undefined
+
+  try {
+    fs.rmSync(getModelsPath(), { recursive: true, force: true })
+  } catch (error) {
+    throw new Error(
+      `Failed to remove Supertonic model: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
 // --- ONNX Runtime loading ---
 
 async function loadOrt(): Promise<OrtModule> {

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1460,6 +1460,12 @@ export const router = {
     return { success: true }
   }),
 
+  uninstallKittenModel: t.procedure.action(async () => {
+    const { uninstallKittenModel } = await import('./kitten-tts')
+    uninstallKittenModel()
+    return { success: true }
+  }),
+
   synthesizeWithKitten: t.procedure
     .input<{
       text: string
@@ -1492,6 +1498,12 @@ export const router = {
         }
       })
     })
+    return { success: true }
+  }),
+
+  uninstallSupertonicModel: t.procedure.action(async () => {
+    const { uninstallSupertonicModel } = await import('./supertonic-tts')
+    uninstallSupertonicModel()
     return { success: true }
   }),
 

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2292,6 +2292,40 @@ export const router = {
     return configStore.get()
   }),
 
+  getOpenAIOAuthStatus: t.procedure.action(async () => {
+    const { getOpenAIOAuthConnectionState } = await import("./openai-oauth-provider")
+    const config = configStore.get()
+    const connection = await getOpenAIOAuthConnectionState()
+    return {
+      ...connection,
+      usage: config.openaiOauthUsage,
+      connectedAt: config.openaiOauthConnectedAt,
+    }
+  }),
+
+  startOpenAIOAuth: t.procedure.action(async () => {
+    const { startOpenAIOAuthFlow, refreshOpenAIOAuthUsage } = await import("./openai-oauth-provider")
+    const account = await startOpenAIOAuthFlow()
+    let usage: import("../shared/types").OpenAIOAuthUsageSnapshot | undefined
+    try {
+      usage = await refreshOpenAIOAuthUsage()
+    } catch {
+      // best-effort only
+    }
+    return { ...account, usage }
+  }),
+
+  disconnectOpenAIOAuth: t.procedure.action(async () => {
+    const { disconnectOpenAIOAuth } = await import("./openai-oauth-provider")
+    await disconnectOpenAIOAuth()
+    return { success: true }
+  }),
+
+  refreshOpenAIOAuthUsage: t.procedure.action(async () => {
+    const { refreshOpenAIOAuthUsage } = await import("./openai-oauth-provider")
+    return refreshOpenAIOAuthUsage()
+  }),
+
   // ============================================================================
   // .agents (modular config) helpers
   // ============================================================================
@@ -3527,6 +3561,9 @@ export const router = {
         ...(profile.modelConfig?.mcpToolsOpenaiModel && {
           mcpToolsOpenaiModel: profile.modelConfig.mcpToolsOpenaiModel,
         }),
+        ...(profile.modelConfig?.mcpToolsOpenaiOauthModel && {
+          mcpToolsOpenaiOauthModel: profile.modelConfig.mcpToolsOpenaiOauthModel,
+        }),
         ...(profile.modelConfig?.mcpToolsGroqModel && {
           mcpToolsGroqModel: profile.modelConfig.mcpToolsGroqModel,
         }),
@@ -3552,6 +3589,9 @@ export const router = {
         }),
         ...(profile.modelConfig?.transcriptPostProcessingOpenaiModel && {
           transcriptPostProcessingOpenaiModel: profile.modelConfig.transcriptPostProcessingOpenaiModel,
+        }),
+        ...(profile.modelConfig?.transcriptPostProcessingOpenaiOauthModel && {
+          transcriptPostProcessingOpenaiOauthModel: profile.modelConfig.transcriptPostProcessingOpenaiOauthModel,
         }),
         ...(profile.modelConfig?.transcriptPostProcessingGroqModel && {
           transcriptPostProcessingGroqModel: profile.modelConfig.transcriptPostProcessingGroqModel,
@@ -3637,6 +3677,7 @@ export const router = {
         // Agent/MCP Tools settings
         mcpToolsProviderId: config.mcpToolsProviderId,
         mcpToolsOpenaiModel: config.mcpToolsOpenaiModel,
+        mcpToolsOpenaiOauthModel: config.mcpToolsOpenaiOauthModel,
         mcpToolsGroqModel: config.mcpToolsGroqModel,
         mcpToolsGeminiModel: config.mcpToolsGeminiModel,
         currentModelPresetId: config.currentModelPresetId,
@@ -3647,6 +3688,7 @@ export const router = {
         // Transcript Post-Processing settings
         transcriptPostProcessingProviderId: config.transcriptPostProcessingProviderId,
         transcriptPostProcessingOpenaiModel: config.transcriptPostProcessingOpenaiModel,
+        transcriptPostProcessingOpenaiOauthModel: config.transcriptPostProcessingOpenaiOauthModel,
         transcriptPostProcessingGroqModel: config.transcriptPostProcessingGroqModel,
         transcriptPostProcessingGeminiModel: config.transcriptPostProcessingGeminiModel,
         // TTS Provider settings
@@ -3659,8 +3701,9 @@ export const router = {
     .input<{
       profileId: string
       // Agent/MCP Tools settings
-      mcpToolsProviderId?: "openai" | "groq" | "gemini"
+      mcpToolsProviderId?: "openai" | "openai-oauth" | "groq" | "gemini"
       mcpToolsOpenaiModel?: string
+      mcpToolsOpenaiOauthModel?: string
       mcpToolsGroqModel?: string
       mcpToolsGeminiModel?: string
       currentModelPresetId?: string
@@ -3669,8 +3712,9 @@ export const router = {
       openaiSttModel?: string
       groqSttModel?: string
       // Transcript Post-Processing settings
-      transcriptPostProcessingProviderId?: "openai" | "groq" | "gemini"
+      transcriptPostProcessingProviderId?: "openai" | "openai-oauth" | "groq" | "gemini"
       transcriptPostProcessingOpenaiModel?: string
+      transcriptPostProcessingOpenaiOauthModel?: string
       transcriptPostProcessingGroqModel?: string
       transcriptPostProcessingGeminiModel?: string
       // TTS Provider settings
@@ -3681,6 +3725,7 @@ export const router = {
         // Agent/MCP Tools settings
         mcpToolsProviderId: input.mcpToolsProviderId,
         mcpToolsOpenaiModel: input.mcpToolsOpenaiModel,
+        mcpToolsOpenaiOauthModel: input.mcpToolsOpenaiOauthModel,
         mcpToolsGroqModel: input.mcpToolsGroqModel,
         mcpToolsGeminiModel: input.mcpToolsGeminiModel,
         currentModelPresetId: input.currentModelPresetId,
@@ -3691,6 +3736,7 @@ export const router = {
         // Transcript Post-Processing settings
         transcriptPostProcessingProviderId: input.transcriptPostProcessingProviderId,
         transcriptPostProcessingOpenaiModel: input.transcriptPostProcessingOpenaiModel,
+        transcriptPostProcessingOpenaiOauthModel: input.transcriptPostProcessingOpenaiOauthModel,
         transcriptPostProcessingGroqModel: input.transcriptPostProcessingGroqModel,
         transcriptPostProcessingGeminiModel: input.transcriptPostProcessingGeminiModel,
         // TTS Provider settings

--- a/apps/desktop/src/renderer/src/components/model-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/model-selector.tsx
@@ -414,7 +414,7 @@ export function ProviderModelSelector({
   disabled = false,
 }: ProviderModelSelectorProps) {
   const providerNames: Record<string, string> = {
-    openai: "OpenAI",
+    openai: "OpenAI Compatible",
     "openai-oauth": "OpenAI OAuth",
     groq: "Groq",
     gemini: "Gemini",

--- a/apps/desktop/src/renderer/src/components/model-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/model-selector.tsx
@@ -415,6 +415,7 @@ export function ProviderModelSelector({
 }: ProviderModelSelectorProps) {
   const providerNames: Record<string, string> = {
     openai: "OpenAI",
+    "openai-oauth": "OpenAI OAuth",
     groq: "Groq",
     gemini: "Gemini",
   }

--- a/apps/desktop/src/renderer/src/lib/queries.ts
+++ b/apps/desktop/src/renderer/src/lib/queries.ts
@@ -98,6 +98,17 @@ export const useAvailableModelsQuery = (
     retry: 1,
   })
 
+export const useOpenAIOAuthStatusQuery = () =>
+  useQuery({
+    queryKey: ["openai-oauth-status"],
+    queryFn: async () => {
+      return tipcClient.getOpenAIOAuthStatus()
+    },
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: false,
+  })
+
 export const useSaveConversationMutation = () =>
   useMutation({
     mutationFn: async ({ conversation }: { conversation: any }) => {
@@ -197,6 +208,35 @@ export const useUpdateConfigMutation = () =>
       queryClient.invalidateQueries({ queryKey: ["config"] })
     },
     onError: reportConfigSaveError,
+  })
+
+export const useStartOpenAIOAuthMutation = () =>
+  useMutation({
+    mutationFn: async () => tipcClient.startOpenAIOAuth(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["config"] })
+      queryClient.invalidateQueries({ queryKey: ["openai-oauth-status"] })
+      queryClient.invalidateQueries({ queryKey: ["available-models", "openai-oauth"] })
+    },
+  })
+
+export const useDisconnectOpenAIOAuthMutation = () =>
+  useMutation({
+    mutationFn: async () => tipcClient.disconnectOpenAIOAuth(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["config"] })
+      queryClient.invalidateQueries({ queryKey: ["openai-oauth-status"] })
+      queryClient.invalidateQueries({ queryKey: ["available-models", "openai-oauth"] })
+    },
+  })
+
+export const useRefreshOpenAIOAuthUsageMutation = () =>
+  useMutation({
+    mutationFn: async () => tipcClient.refreshOpenAIOAuthUsage(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["config"] })
+      queryClient.invalidateQueries({ queryKey: ["openai-oauth-status"] })
+    },
   })
 
 export const useLoadMcpConfigFile = () =>

--- a/apps/desktop/src/renderer/src/pages/settings-agents.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.tsx
@@ -924,7 +924,7 @@ export function SettingsAgents() {
                     <SelectTrigger><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="__global__">Use global default</SelectItem>
-                      <SelectItem value="openai">OpenAI</SelectItem>
+                      <SelectItem value="openai">OpenAI Compatible</SelectItem>
                       <SelectItem value="openai-oauth">OpenAI OAuth</SelectItem>
                       <SelectItem value="groq">Groq</SelectItem>
                       <SelectItem value="gemini">Gemini</SelectItem>

--- a/apps/desktop/src/renderer/src/pages/settings-agents.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.tsx
@@ -917,7 +917,7 @@ export function SettingsAgents() {
                       if (v === "__global__") {
                         setEditing({ ...editing, modelConfig: undefined })
                       } else {
-                        updateModelConfig({ mcpToolsProviderId: v as "openai" | "groq" | "gemini" })
+                        updateModelConfig({ mcpToolsProviderId: v as "openai" | "openai-oauth" | "groq" | "gemini" })
                       }
                     }}
                   >
@@ -925,6 +925,7 @@ export function SettingsAgents() {
                     <SelectContent>
                       <SelectItem value="__global__">Use global default</SelectItem>
                       <SelectItem value="openai">OpenAI</SelectItem>
+                      <SelectItem value="openai-oauth">OpenAI OAuth</SelectItem>
                       <SelectItem value="groq">Groq</SelectItem>
                       <SelectItem value="gemini">Gemini</SelectItem>
                     </SelectContent>
@@ -935,12 +936,14 @@ export function SettingsAgents() {
                     providerId={editing.modelConfig.mcpToolsProviderId}
                     value={
                       editing.modelConfig.mcpToolsProviderId === "openai" ? editing.modelConfig.mcpToolsOpenaiModel :
+                      editing.modelConfig.mcpToolsProviderId === "openai-oauth" ? editing.modelConfig.mcpToolsOpenaiOauthModel :
                       editing.modelConfig.mcpToolsProviderId === "groq" ? editing.modelConfig.mcpToolsGroqModel :
                       editing.modelConfig.mcpToolsGeminiModel
                     }
                     onValueChange={model => {
                       const p = editing.modelConfig?.mcpToolsProviderId
                       if (p === "openai") updateModelConfig({ mcpToolsOpenaiModel: model })
+                      else if (p === "openai-oauth") updateModelConfig({ mcpToolsOpenaiOauthModel: model })
                       else if (p === "groq") updateModelConfig({ mcpToolsGroqModel: model })
                       else if (p === "gemini") updateModelConfig({ mcpToolsGeminiModel: model })
                     }}

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -158,6 +158,8 @@ export function Component() {
     (config.dualModelEnabled ?? false)
   const transcriptProcessingModel = transcriptProcessingProviderId === "openai"
     ? config.transcriptPostProcessingOpenaiModel
+    : transcriptProcessingProviderId === "openai-oauth"
+      ? config.transcriptPostProcessingOpenaiOauthModel
     : transcriptProcessingProviderId === "groq"
       ? config.transcriptPostProcessingGroqModel
       : config.transcriptPostProcessingGeminiModel
@@ -243,7 +245,9 @@ export function Component() {
                     providerId={transcriptProcessingProviderId}
                     value={transcriptProcessingModel}
                     onValueChange={(value) => {
-                      if (transcriptProcessingProviderId === "groq") {
+                      if (transcriptProcessingProviderId === "openai-oauth") {
+                        saveConfig({ transcriptPostProcessingOpenaiOauthModel: value })
+                      } else if (transcriptProcessingProviderId === "groq") {
                         saveConfig({ transcriptPostProcessingGroqModel: value })
                       } else {
                         saveConfig({ transcriptPostProcessingGeminiModel: value })
@@ -495,12 +499,24 @@ export function Component() {
             </div>
           )}
 
-          {(agentProviderId === "groq" || agentProviderId === "gemini") && (
+          {(agentProviderId === "openai-oauth" || agentProviderId === "groq" || agentProviderId === "gemini") && (
             <div className="px-3 py-2">
               <ProviderModelSelector
                 providerId={agentProviderId}
-                mcpModel={agentProviderId === "groq" ? config.mcpToolsGroqModel : config.mcpToolsGeminiModel}
-                onMcpModelChange={(value) => saveConfig(agentProviderId === "groq" ? { mcpToolsGroqModel: value } : { mcpToolsGeminiModel: value })}
+                mcpModel={
+                  agentProviderId === "openai-oauth"
+                    ? config.mcpToolsOpenaiOauthModel
+                    : agentProviderId === "groq"
+                      ? config.mcpToolsGroqModel
+                      : config.mcpToolsGeminiModel
+                }
+                onMcpModelChange={(value) => saveConfig(
+                  agentProviderId === "openai-oauth"
+                    ? { mcpToolsOpenaiOauthModel: value }
+                    : agentProviderId === "groq"
+                      ? { mcpToolsGroqModel: value }
+                      : { mcpToolsGeminiModel: value }
+                )}
                 showMcpModel={true}
                 showTranscriptModel={false}
               />

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -21,7 +21,7 @@ import {
 } from "@renderer/lib/query-client"
 import { Config } from "@shared/types"
 
-import { Mic, Bot, Volume2, FileText, CheckCircle2, ChevronDown, ChevronRight, Cpu, Download, Loader2 } from "lucide-react"
+import { Mic, Bot, Volume2, FileText, CheckCircle2, ChevronDown, ChevronRight, Cpu, Download, Loader2, Trash2 } from "lucide-react"
 
 import { getSelectableMainAcpAgents } from "./settings-general-main-agent-options"
 
@@ -234,6 +234,7 @@ function ParakeetProviderSection({
 function KittenModelDownload() {
   const queryClient = useQueryClient()
   const [isDownloading, setIsDownloading] = useState(false)
+  const [isRemoving, setIsRemoving] = useState(false)
   const [downloadProgress, setDownloadProgress] = useState(0)
 
   const modelStatusQuery = useQuery({
@@ -260,6 +261,18 @@ function KittenModelDownload() {
     }
   }
 
+  const handleRemove = async () => {
+    setIsRemoving(true)
+    try {
+      await window.electron.ipcRenderer.invoke("uninstallKittenModel")
+    } catch (error) {
+      console.error("Failed to remove Kitten model:", error)
+    } finally {
+      setIsRemoving(false)
+      queryClient.invalidateQueries({ queryKey: ["kittenModelStatus"] })
+    }
+  }
+
   const status = modelStatusQuery.data as { downloaded: boolean; downloading: boolean; progress: number; error?: string } | undefined
 
   if (modelStatusQuery.isLoading) {
@@ -268,10 +281,20 @@ function KittenModelDownload() {
 
   if (status?.downloaded) {
     return (
-      <span className="inline-flex items-center gap-1.5 text-xs text-green-600">
-        <CheckCircle2 className="h-3.5 w-3.5" />
-        Ready
-      </span>
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 text-xs text-green-600">
+          <CheckCircle2 className="h-3.5 w-3.5" />
+          Ready
+        </span>
+        <Button size="sm" variant="outline" onClick={handleRemove} disabled={isRemoving}>
+          {isRemoving ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Remove
+        </Button>
+      </div>
     )
   }
 
@@ -435,6 +458,7 @@ function KittenProviderSection({
 function SupertonicModelDownload() {
   const queryClient = useQueryClient()
   const [isDownloading, setIsDownloading] = useState(false)
+  const [isRemoving, setIsRemoving] = useState(false)
   const [downloadProgress, setDownloadProgress] = useState(0)
 
   const modelStatusQuery = useQuery({
@@ -459,6 +483,18 @@ function SupertonicModelDownload() {
     }
   }
 
+  const handleRemove = async () => {
+    setIsRemoving(true)
+    try {
+      await window.electron.ipcRenderer.invoke("uninstallSupertonicModel")
+    } catch (error) {
+      console.error("Failed to remove Supertonic model:", error)
+    } finally {
+      setIsRemoving(false)
+      queryClient.invalidateQueries({ queryKey: ["supertonicModelStatus"] })
+    }
+  }
+
   const status = modelStatusQuery.data as { downloaded: boolean; downloading: boolean; progress: number; error?: string } | undefined
 
   if (modelStatusQuery.isLoading) {
@@ -467,10 +503,20 @@ function SupertonicModelDownload() {
 
   if (status?.downloaded) {
     return (
-      <span className="inline-flex items-center gap-1.5 text-xs text-green-600">
-        <CheckCircle2 className="h-3.5 w-3.5" />
-        Ready
-      </span>
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 text-xs text-green-600">
+          <CheckCircle2 className="h-3.5 w-3.5" />
+          Ready
+        </span>
+        <Button size="sm" variant="outline" onClick={handleRemove} disabled={isRemoving}>
+          {isRemoving ? (
+            <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+          ) : (
+            <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+          )}
+          Remove
+        </Button>
+      </div>
     )
   }
 

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -12,7 +12,11 @@ import {
 import { Button } from "@renderer/components/ui/button"
 import {
   useConfigQuery,
+  useDisconnectOpenAIOAuthMutation,
+  useOpenAIOAuthStatusQuery,
+  useRefreshOpenAIOAuthUsageMutation,
   useSaveConfigMutation,
+  useStartOpenAIOAuthMutation,
 } from "@renderer/lib/query-client"
 import { Config } from "@shared/types"
 
@@ -634,7 +638,10 @@ function SupertonicProviderSection({
 
 export function Component() {
   const configQuery = useConfigQuery()
-
+  const openAiOauthStatusQuery = useOpenAIOAuthStatusQuery()
+  const startOpenAiOauthMutation = useStartOpenAIOAuthMutation()
+  const disconnectOpenAiOauthMutation = useDisconnectOpenAIOAuthMutation()
+  const refreshOpenAiOauthUsageMutation = useRefreshOpenAIOAuthUsageMutation()
   const saveConfigMutation = useSaveConfigMutation()
   const cfgRef = useRef(configQuery.data)
   const providerSaveTimeoutsRef = useRef<Partial<Record<ProviderDraftKey, ReturnType<typeof setTimeout>>>>({})
@@ -708,7 +715,7 @@ export function Component() {
 
   // Compute which providers are actively being used for each function
   const activeProviders = useMemo(() => {
-    if (!configQuery.data) return { openai: [], groq: [], gemini: [], parakeet: [], kitten: [], supertonic: [] }
+    if (!configQuery.data) return { openai: [], "openai-oauth": [], groq: [], gemini: [], parakeet: [], kitten: [], supertonic: [] }
 
     const isMainAgentAcpMode = configQuery.data.mainAgentMode === "acp"
     const stt = configQuery.data.sttProviderId || "openai"
@@ -722,6 +729,10 @@ export function Component() {
         ...(transcript === "openai" ? [{ label: "Cleanup", icon: FileText }] : []),
         ...(mcp === "openai" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
         ...(tts === "openai" ? [{ label: "TTS", icon: Volume2 }] : []),
+      ],
+      "openai-oauth": [
+        ...(transcript === "openai-oauth" ? [{ label: "Cleanup", icon: FileText }] : []),
+        ...(mcp === "openai-oauth" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
       ],
       groq: [
         ...(stt === "groq" ? [{ label: "STT", icon: Mic }] : []),
@@ -760,6 +771,7 @@ export function Component() {
   const isMainAgentAcpMode = configQuery.data?.mainAgentMode === "acp"
 
   // Determine which providers are active (selected for at least one feature)
+  const isOpenAiOauthActive = activeProviders["openai-oauth"].length > 0
   const isGroqActive = activeProviders.groq.length > 0
   const isGeminiActive = activeProviders.gemini.length > 0
   const isParakeetActive = activeProviders.parakeet.length > 0
@@ -794,6 +806,9 @@ export function Component() {
       />
     </Control>
   )
+
+  const openAiOauthStatus = openAiOauthStatusQuery.data
+  const openAiOauthConnected = openAiOauthStatus?.connected ?? false
 
   return (
     <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-4 py-4 sm:px-6">
@@ -860,6 +875,132 @@ export function Component() {
                 <p className="text-sm text-muted-foreground">
                   OpenAI-compatible presets, agent models, and transcript cleanup models are now managed on the Models page.
                 </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className={`rounded-lg border ${isOpenAiOauthActive ? 'border-primary/30 bg-primary/5' : ''}`}>
+          <button
+            type="button"
+            className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
+            onClick={() => saveConfig({ providerSectionCollapsedOpenaiOauth: !configQuery.data.providerSectionCollapsedOpenaiOauth })}
+            aria-expanded={!configQuery.data.providerSectionCollapsedOpenaiOauth}
+            aria-controls="openai-oauth-provider-content"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedOpenaiOauth ? (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              )}
+              OpenAI OAuth
+              {(isOpenAiOauthActive || openAiOauthConnected) && (
+                <CheckCircle2 className="h-4 w-4 text-primary" />
+              )}
+            </span>
+            {activeProviders["openai-oauth"].length > 0 && (
+              <div className="flex gap-1.5 flex-wrap justify-end">
+                {activeProviders["openai-oauth"].map((badge) => (
+                  <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+                ))}
+              </div>
+            )}
+          </button>
+          {!configQuery.data.providerSectionCollapsedOpenaiOauth && (
+            <div id="openai-oauth-provider-content" className="divide-y border-t">
+              {!isOpenAiOauthActive && (
+                <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+                  Not selected above. You can still connect it here.
+                </p>
+              )}
+
+              <div className="px-3 py-3 space-y-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium">ChatGPT account connection</p>
+                    <p className="text-xs text-muted-foreground">
+                      Uses OpenAI OAuth for ChatGPT-backed agent and transcript processing requests.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {openAiOauthConnected ? (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => refreshOpenAiOauthUsageMutation.mutate()}
+                          disabled={refreshOpenAiOauthUsageMutation.isPending}
+                        >
+                          {refreshOpenAiOauthUsageMutation.isPending ? "Refreshing..." : "Refresh Usage"}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => disconnectOpenAiOauthMutation.mutate()}
+                          disabled={disconnectOpenAiOauthMutation.isPending}
+                        >
+                          {disconnectOpenAiOauthMutation.isPending ? "Disconnecting..." : "Disconnect"}
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        size="sm"
+                        onClick={() => startOpenAiOauthMutation.mutate()}
+                        disabled={startOpenAiOauthMutation.isPending}
+                      >
+                        {startOpenAiOauthMutation.isPending ? "Connecting..." : "Connect"}
+                      </Button>
+                    )}
+                  </div>
+                </div>
+
+                <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-3">
+                  <div className="rounded-md border bg-muted/20 px-3 py-2">
+                    <div className="font-medium text-foreground">Email</div>
+                    <div>{openAiOauthStatus?.email || "Not connected"}</div>
+                  </div>
+                  <div className="rounded-md border bg-muted/20 px-3 py-2">
+                    <div className="font-medium text-foreground">Plan</div>
+                    <div>{openAiOauthStatus?.planType || "Unknown"}</div>
+                  </div>
+                  <div className="rounded-md border bg-muted/20 px-3 py-2">
+                    <div className="font-medium text-foreground">Account ID</div>
+                    <div className="truncate">{openAiOauthStatus?.accountId || "Unavailable"}</div>
+                  </div>
+                </div>
+
+                {openAiOauthStatus?.usage?.buckets && openAiOauthStatus.usage.buckets.length > 0 ? (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-foreground">Usage</p>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {openAiOauthStatus.usage.buckets.map((bucket) => (
+                        <div key={`${bucket.label}-${bucket.unit || "unit"}`} className="rounded-md border bg-muted/20 px-3 py-2 text-xs">
+                          <div className="font-medium text-foreground">{bucket.label}</div>
+                          <div className="text-muted-foreground">
+                            {bucket.used ?? "?"}
+                            {bucket.limit !== null && bucket.limit !== undefined ? ` / ${bucket.limit}` : ""}
+                            {bucket.unit ? ` ${bucket.unit}` : ""}
+                          </div>
+                          {bucket.resetsAt && (
+                            <div className="mt-1 text-[11px] text-muted-foreground">Resets: {bucket.resetsAt}</div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                    {openAiOauthStatus.usage.fetchedAt && (
+                      <p className="text-[11px] text-muted-foreground">
+                        Last updated: {new Date(openAiOauthStatus.usage.fetchedAt).toLocaleString()}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    {openAiOauthConnected
+                      ? "Usage is available after you refresh it."
+                      : "Connect your ChatGPT account to view usage."}
+                  </p>
+                )}
               </div>
             </div>
           )}

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select"
 import { Button } from "@renderer/components/ui/button"
+import { ModelPresetManager } from "@renderer/components/model-preset-manager"
 import {
   useConfigQuery,
   useDisconnectOpenAIOAuthMutation,
@@ -873,8 +874,22 @@ export function Component() {
 
               <div className="px-3 py-2">
                 <p className="text-sm text-muted-foreground">
-                  OpenAI-compatible presets, agent models, and transcript cleanup models are now managed on the Models page.
+                  Manage OpenAI-compatible presets here, including custom API base URLs and API keys. The selected preset is then used by
+                  Agent/MCP Tools and Transcript Processing when they choose OpenAI Compatible.
                 </p>
+              </div>
+
+              <div className="px-3 py-3 border-t">
+                <div className="pb-3">
+                  <span className="text-sm font-medium">OpenAI-Compatible Presets</span>
+                  <p className="text-xs text-muted-foreground">
+                    Add custom OpenAI-compatible endpoints like OpenRouter or self-hosted gateways, then select the preset from the Models page.
+                  </p>
+                </div>
+                <ModelPresetManager
+                  showAgentModel={false}
+                  showTranscriptCleanupModel={false}
+                />
               </div>
             </div>
           )}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -82,6 +82,20 @@ export interface OAuthConfig {
   }
 }
 
+export interface OpenAIOAuthUsageBucket {
+  label: string
+  used?: number | null
+  limit?: number | null
+  unit?: string | null
+  resetsAt?: string | null
+}
+
+export interface OpenAIOAuthUsageSnapshot {
+  fetchedAt: number
+  buckets: OpenAIOAuthUsageBucket[]
+  raw?: Record<string, unknown>
+}
+
 export interface MCPServerConfig {
   // Transport configuration
   transport?: MCPTransportType // defaults to "stdio" for backward compatibility
@@ -253,8 +267,9 @@ export type ProfileMcpServerConfig = {
 
 export type ProfileModelConfig = {
   // Agent/MCP Tools settings
-  mcpToolsProviderId?: "openai" | "groq" | "gemini"
+  mcpToolsProviderId?: "openai" | "openai-oauth" | "groq" | "gemini"
   mcpToolsOpenaiModel?: string
+  mcpToolsOpenaiOauthModel?: string
   mcpToolsGroqModel?: string
   mcpToolsGeminiModel?: string
   currentModelPresetId?: string
@@ -263,8 +278,9 @@ export type ProfileModelConfig = {
   openaiSttModel?: string
   groqSttModel?: string
   // Transcript Post-Processing settings
-  transcriptPostProcessingProviderId?: "openai" | "groq" | "gemini"
+  transcriptPostProcessingProviderId?: "openai" | "openai-oauth" | "groq" | "gemini"
   transcriptPostProcessingOpenaiModel?: string
+  transcriptPostProcessingOpenaiOauthModel?: string
   transcriptPostProcessingGroqModel?: string
   transcriptPostProcessingGeminiModel?: string
   // TTS Provider settings
@@ -1081,8 +1097,15 @@ export type Config = {
   transcriptPostProcessingProviderId?: CHAT_PROVIDER_ID
   transcriptPostProcessingPrompt?: string
   transcriptPostProcessingOpenaiModel?: string
+  transcriptPostProcessingOpenaiOauthModel?: string
   transcriptPostProcessingGroqModel?: string
   transcriptPostProcessingGeminiModel?: string
+
+  openaiOauthEmail?: string
+  openaiOauthAccountId?: string
+  openaiOauthPlanType?: string
+  openaiOauthConnectedAt?: number
+  openaiOauthUsage?: OpenAIOAuthUsageSnapshot
 
   // Audio Device Selection
   audioInputDeviceId?: string   // Microphone device ID (from enumerateDevices)
@@ -1115,6 +1138,7 @@ export type Config = {
   customMcpToolsShortcutMode?: "hold" | "toggle" // Mode for custom MCP tools shortcut
   mcpToolsProviderId?: CHAT_PROVIDER_ID
   mcpToolsOpenaiModel?: string
+  mcpToolsOpenaiOauthModel?: string
   mcpToolsGroqModel?: string
   mcpToolsGeminiModel?: string
   /** @deprecated Kept for backward compatibility but ignored */
@@ -1152,6 +1176,7 @@ export type Config = {
 
   // Provider Section Collapse Configuration
   providerSectionCollapsedOpenai?: boolean
+  providerSectionCollapsedOpenaiOauth?: boolean
   providerSectionCollapsedGroq?: boolean
   providerSectionCollapsedGemini?: boolean
   providerSectionCollapsedParakeet?: boolean

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:shared": "pnpm --filter @dotagents/shared build",
     "build:core": "pnpm --filter @dotagents/core build",
     "test": "pnpm -r test",
+    "test:openai-oauth": "pnpm --filter @dotagents/desktop test:openai-oauth",
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
     "format": "pnpm -r format"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,16 +79,18 @@ export type ProfileMcpServerConfig = {
 }
 
 export type ProfileModelConfig = {
-  mcpToolsProviderId?: "openai" | "groq" | "gemini"
+  mcpToolsProviderId?: "openai" | "openai-oauth" | "groq" | "gemini"
   mcpToolsOpenaiModel?: string
+  mcpToolsOpenaiOauthModel?: string
   mcpToolsGroqModel?: string
   mcpToolsGeminiModel?: string
   currentModelPresetId?: string
   sttProviderId?: "openai" | "groq" | "parakeet"
   openaiSttModel?: string
   groqSttModel?: string
-  transcriptPostProcessingProviderId?: "openai" | "groq" | "gemini"
+  transcriptPostProcessingProviderId?: "openai" | "openai-oauth" | "groq" | "gemini"
   transcriptPostProcessingOpenaiModel?: string
+  transcriptPostProcessingOpenaiOauthModel?: string
   transcriptPostProcessingGroqModel?: string
   transcriptPostProcessingGeminiModel?: string
   ttsProviderId?: "openai" | "groq" | "gemini" | "kitten" | "supertonic"

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -27,6 +27,7 @@ export type STT_PROVIDER_ID = (typeof STT_PROVIDERS)[number]["value"];
 
 export const CHAT_PROVIDERS = [
   { label: "OpenAI", value: "openai" },
+  { label: "OpenAI OAuth", value: "openai-oauth" },
   { label: "Groq", value: "groq" },
   { label: "Gemini", value: "gemini" },
 ] as const;

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -26,7 +26,7 @@ export const STT_PROVIDERS = [
 export type STT_PROVIDER_ID = (typeof STT_PROVIDERS)[number]["value"];
 
 export const CHAT_PROVIDERS = [
-  { label: "OpenAI", value: "openai" },
+  { label: "OpenAI Compatible", value: "openai" },
   { label: "OpenAI OAuth", value: "openai-oauth" },
   { label: "Groq", value: "groq" },
   { label: "Gemini", value: "gemini" },


### PR DESCRIPTION
 - add end-to-end uninstall support for locally downloaded TTS models
  - allow users to remove Kitten and Supertonic models directly from the Providers page

  ## Changes
  - add `uninstallKittenModel()` to clear the loaded Kitten engine and remove downloaded model files
  - add `uninstallSupertonicModel()` to clear the loaded Supertonic engine and remove downloaded model files
  - expose both uninstall actions through desktop IPC/TIPC
  - update the Providers UI to show a `Remove` action once a model is installed
  - refresh model status after uninstall so the UI immediately reflects removal

  ## Validation
  - typechecked desktop main build
  - typechecked desktop renderer build
  - verified the uninstall flow is isolated to the local TTS provider setup