### PR TITLE
Harden mobile tunnel metadata persistence (optional secure storage + tests)

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "test": "pnpm run test:node && pnpm run test:vitest",
     "test:node": "node --test \"tests/*.js\"",
-    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
+    "test:vitest": "vitest run src/lib/accessibility.test.ts src/lib/tunnelPersistence.test.ts src/lib/voice/phraseMatcher.test.ts src/lib/voice/useHandsFreeController.test.ts src/lib/voice/useSpeechRecognizer.test.ts src/store/config.test.ts src/screens/agent-edit-connection-utils.test.ts src/screens/connection-settings-qr.test.ts src/screens/session-list-search.test.ts src/screens/split-chat-utils.test.ts"
   },
   "dependencies": {
     "@dotagents/shared": "workspace:^",

--- a/apps/mobile/src/lib/tunnelPersistence.test.ts
+++ b/apps/mobile/src/lib/tunnelPersistence.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAsyncStorage } = vi.hoisted(() => ({
+  mockAsyncStorage: {
+    setItem: vi.fn(),
+    getItem: vi.fn(),
+    removeItem: vi.fn(),
+  },
+}));
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: mockAsyncStorage,
+}));
+
+import {
+  clearTunnelMetadata,
+  loadTunnelMetadata,
+  saveTunnelMetadata,
+  TunnelMetadata,
+} from './tunnelPersistence';
+
+describe('tunnelPersistence', () => {
+  const metadata: TunnelMetadata = {
+    baseUrl: 'https://example.com',
+    apiKey: 'test-api-key',
+    lastConnectedAt: 123456789,
+    sessionId: 'session-1',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stores metadata in async storage when secure storage is unavailable', async () => {
+    mockAsyncStorage.setItem.mockResolvedValue(undefined);
+
+    await saveTunnelMetadata(metadata);
+
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      'dotagents_tunnel_metadata_v1',
+      JSON.stringify(metadata),
+    );
+  });
+
+  it('loads legacy metadata with apiKey from async storage', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue(JSON.stringify(metadata));
+
+    const loaded = await loadTunnelMetadata();
+
+    expect(loaded).toEqual(metadata);
+  });
+
+  it('clears persisted tunnel metadata', async () => {
+    mockAsyncStorage.removeItem.mockResolvedValue(undefined);
+
+    await clearTunnelMetadata();
+
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('dotagents_tunnel_metadata_v1');
+  });
+});

--- a/apps/mobile/src/lib/tunnelPersistence.ts
+++ b/apps/mobile/src/lib/tunnelPersistence.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const TUNNEL_METADATA_KEY = 'dotagents_tunnel_metadata_v1';
+const TUNNEL_API_KEY_SECURE_KEY = 'dotagents_tunnel_api_key_v1';
 
 /**
  * Tunnel metadata for connection persistence.
@@ -21,6 +22,85 @@ export interface TunnelMetadata {
   isCloudflareTunnel?: boolean;
 }
 
+type StoredTunnelMetadata = Omit<TunnelMetadata, 'apiKey'> & {
+  apiKey?: string;
+};
+
+interface SecureStoreLike {
+  isAvailableAsync: () => Promise<boolean>;
+  setItemAsync: (key: string, value: string) => Promise<void>;
+  getItemAsync: (key: string) => Promise<string | null>;
+  deleteItemAsync: (key: string) => Promise<void>;
+}
+
+function getSecureStore(): SecureStoreLike | null {
+  try {
+    // Keep SecureStore optional so mobile web/dev environments without the module
+    // still work without crashing.
+    const optionalRequire = Function('return require')() as (moduleName: string) => unknown;
+    return optionalRequire('expo-secure-store') as SecureStoreLike;
+  } catch {
+    return null;
+  }
+}
+
+async function saveApiKey(apiKey: string): Promise<boolean> {
+  const secureStore = getSecureStore();
+  if (!secureStore) {
+    return false;
+  }
+
+  try {
+    const isSecureStoreAvailable = await secureStore.isAvailableAsync();
+    if (!isSecureStoreAvailable) {
+      return false;
+    }
+
+    await secureStore.setItemAsync(TUNNEL_API_KEY_SECURE_KEY, apiKey);
+    return true;
+  } catch (error) {
+    console.warn('[TunnelPersistence] Failed to save API key to secure storage, falling back to AsyncStorage:', error);
+    return false;
+  }
+}
+
+async function loadApiKey(): Promise<string | null> {
+  const secureStore = getSecureStore();
+  if (!secureStore) {
+    return null;
+  }
+
+  try {
+    const isSecureStoreAvailable = await secureStore.isAvailableAsync();
+    if (!isSecureStoreAvailable) {
+      return null;
+    }
+
+    return await secureStore.getItemAsync(TUNNEL_API_KEY_SECURE_KEY);
+  } catch (error) {
+    console.warn('[TunnelPersistence] Failed to load API key from secure storage:', error);
+    return null;
+  }
+}
+
+async function clearApiKey(): Promise<void> {
+  const secureStore = getSecureStore();
+  if (!secureStore) {
+    return;
+  }
+
+  try {
+    const isSecureStoreAvailable = await secureStore.isAvailableAsync();
+    if (!isSecureStoreAvailable) {
+      return;
+    }
+
+    await secureStore.deleteItemAsync(TUNNEL_API_KEY_SECURE_KEY);
+  } catch (error) {
+    console.warn('[TunnelPersistence] Failed to clear API key from secure storage:', error);
+  }
+}
+
 /**
  * Save tunnel metadata for later reconnection.
  *
@@ -30,12 +110,21 @@ export interface TunnelMetadata {
  */
 export async function saveTunnelMetadata(metadata: TunnelMetadata): Promise<void> {
   try {
-    await AsyncStorage.setItem(TUNNEL_METADATA_KEY, JSON.stringify(metadata));
+    const savedInSecureStore = await saveApiKey(metadata.apiKey);
+    const metadataForStorage: StoredTunnelMetadata = savedInSecureStore
+      ? {
+          ...metadata,
+          apiKey: undefined,
+        }
+      : metadata;
+
+    await AsyncStorage.setItem(TUNNEL_METADATA_KEY, JSON.stringify(metadataForStorage));
     console.log('[TunnelPersistence] Saved tunnel metadata:', {
       baseUrl: metadata.baseUrl,
       hasApiKey: !!metadata.apiKey,
       hasSessionId: !!metadata.sessionId,
       hasResumeToken: !!metadata.resumeToken,
+      apiKeyStorage: savedInSecureStore ? 'secure-store' : 'async-storage',
     });
   } catch (error) {
     console.error('[TunnelPersistence] Failed to save tunnel metadata:', error);
@@ -53,19 +142,24 @@ export async function loadTunnelMetadata(): Promise<TunnelMetadata | null> {
       return null;
     }
 
-    const parsed = JSON.parse(stored);
+    const parsed = JSON.parse(stored) as StoredTunnelMetadata;
+    const secureStoreApiKey = await loadApiKey();
+    const apiKey = secureStoreApiKey ?? parsed.apiKey;
 
     // Validate required fields exist and have correct types
     if (
       typeof parsed.baseUrl !== 'string' ||
-      typeof parsed.apiKey !== 'string' ||
+      typeof apiKey !== 'string' ||
       typeof parsed.lastConnectedAt !== 'number'
     ) {
       console.warn('[TunnelPersistence] Invalid stored metadata: missing required fields or incorrect types');
       return null;
     }
 
-    return parsed as TunnelMetadata;
+    return {
+      ...parsed,
+      apiKey,
+    };
   } catch (error) {
     console.error('[TunnelPersistence] Failed to load tunnel metadata:', error);
     return null;
@@ -99,7 +193,7 @@ export async function updateTunnelMetadata(
  */
 export async function clearTunnelMetadata(): Promise<void> {
   try {
-    await AsyncStorage.removeItem(TUNNEL_METADATA_KEY);
+    await Promise.all([AsyncStorage.removeItem(TUNNEL_METADATA_KEY), clearApiKey()]);
     console.log('[TunnelPersistence] Cleared tunnel metadata');
   } catch (error) {
     console.error('[TunnelPersistence] Failed to clear tunnel metadata:', error);
@@ -127,4 +221,3 @@ export async function isTunnelMetadataFresh(maxAgeMs: number = 24 * 60 * 60 * 10
   const age = Date.now() - metadata.lastConnectedAt;
   return age < maxAgeMs;
 }
-


### PR DESCRIPTION
### Motivation
- Improve security and robustness of mobile tunnel persistence by moving sensitive API keys to secure storage when available while preserving existing AsyncStorage behavior.
- Maintain backwards compatibility with legacy metadata that still includes `apiKey` in AsyncStorage.
- Provide a small unit test suite to prevent regressions around save/load/clear behavior.

### Description
- Added optional runtime-safe secure-store integration to `apps/mobile/src/lib/tunnelPersistence.ts` that saves the `apiKey` to `expo-secure-store` when available and falls back to `AsyncStorage` otherwise.
- Kept stored metadata shape backwards-compatible by saving a `StoredTunnelMetadata` entry (omitting `apiKey` when it was moved to secure storage) and loading API key from secure store first, then fallback to legacy `apiKey` in AsyncStorage.
- Updated `clearTunnelMetadata` to remove both AsyncStorage metadata and the secure-store API key when present.
- Added `apps/mobile/src/lib/tunnelPersistence.test.ts` with unit tests covering save/load/clear behavior and wired the test into the mobile `vitest` script in `apps/mobile/package.json`.

### Testing
- Ran the new unit tests with `pnpm --filter @dotagents/mobile exec vitest run src/lib/tunnelPersistence.test.ts` and the suite passed (3 tests passed).
- Ran typecheck with `pnpm --filter @dotagents/mobile exec tsc --noEmit` which failed due to existing workspace/mobile type errors unrelated to this change (errors referencing `@dotagents/shared` and other pre-existing issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40c45c1dc8330a88c71cd81d76cf3)