### PR TITLE
Fix sidebar elapsed-time/layout (237) and mobile tool-call rendering fallback (210)

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -80,7 +80,15 @@ function getSessionLastMessageTimestamp(
 function formatMinutesAgo(timestamp: number): string | null {
   if (!timestamp || !Number.isFinite(timestamp)) return null
   const minutesAgo = Math.max(Math.floor((Date.now() - timestamp) / 60_000), 0)
-  return minutesAgo === 1 ? "1m ago" : `${minutesAgo}m ago`
+  if (minutesAgo < 60) {
+    return minutesAgo === 1 ? "1m ago" : `${minutesAgo}m ago`
+  }
+
+  const hours = Math.floor(minutesAgo / 60)
+  const remainderMinutes = minutesAgo % 60
+  const hourLabel = `${hours}h`
+  const minuteLabel = remainderMinutes > 0 ? ` ${remainderMinutes}m` : ""
+  return `${hourLabel}${minuteLabel} ago`
 }
 
 const MIN_VISIBLE_SIDEBAR_SESSIONS = 5
@@ -799,8 +807,8 @@ export function ActiveAgentsSidebar({
                       navigate(`/${session.conversationId}`)
                     }
                   }}
-                  className={cn(
-                    "text-muted-foreground group relative flex items-center gap-1.5 rounded px-1.5 py-1 pr-8 text-xs transition-all",
+                className={cn(
+                    "text-muted-foreground group relative flex items-center gap-1.5 rounded px-1.5 py-1 pr-2 text-xs transition-all",
                     session.conversationId &&
                       "hover:bg-accent/50 cursor-pointer",
                   )}
@@ -815,7 +823,7 @@ export function ActiveAgentsSidebar({
                   />
                   {renderEditableTitle(session, "flex-1")}
                   {lastMessageMinutesAgo && (
-                    <span className="text-[10px] tabular-nums text-muted-foreground group-hover:hidden group-focus-within:hidden">
+                    <span className="shrink-0 pr-5 text-[10px] tabular-nums text-muted-foreground group-hover:hidden group-focus-within:hidden">
                       {lastMessageMinutesAgo}
                     </span>
                   )}
@@ -876,7 +884,7 @@ export function ActiveAgentsSidebar({
                 key={key}
                 onClick={() => handleSessionClick(session.id)}
                 className={cn(
-                  "group relative flex cursor-pointer items-center gap-1.5 rounded px-1.5 py-1 pr-16 text-xs transition-all",
+                  "group relative flex cursor-pointer items-center gap-1.5 rounded px-1.5 py-1 pr-2 text-xs transition-all",
                   hasPendingApproval
                     ? "bg-amber-500/10"
                     : isFocused
@@ -917,7 +925,7 @@ export function ActiveAgentsSidebar({
                 {lastMessageMinutesAgo && (
                   <span
                     className={cn(
-                      "shrink-0 text-[10px] tabular-nums text-muted-foreground",
+                      "shrink-0 pr-10 text-[10px] tabular-nums text-muted-foreground",
                       "group-hover:hidden group-focus-within:hidden",
                     )}
                   >

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -3085,15 +3085,29 @@ export default function ChatScreen({ route, navigation }: any) {
                 result: NonNullable<ChatMessage['toolResults']>[number] | undefined;
               }>
             );
-            const displayToolCallCount = displayToolEntries.length;
+            const fallbackToolEntries =
+              displayToolEntries.length === 0 && toolResults.length > 0
+                ? toolResults.map((result, idx) => ({
+                    toolCall: {
+                      name: 'tool_call',
+                      arguments: {},
+                    },
+                    origIdx: idx,
+                    result,
+                  }))
+                : [];
+            const renderedToolEntries = fallbackToolEntries.length > 0
+              ? fallbackToolEntries
+              : displayToolEntries;
+            const displayToolCallCount = renderedToolEntries.length;
             const toolResultCount = toolResults.length;
-            const hasToolResults = displayToolEntries.some(entry => !!entry.result);
+            const hasToolResults = renderedToolEntries.some(entry => !!entry.result);
             const allSuccess =
-              hasToolResults && displayToolEntries.every(entry => entry.result?.success === true);
-            const hasErrors = displayToolEntries.some(entry => entry.result?.success === false);
+              hasToolResults && renderedToolEntries.every(entry => entry.result?.success === true);
+            const hasErrors = renderedToolEntries.some(entry => entry.result?.success === false);
             // isPending is true when any displayed tool call has not received its result yet.
             const isPending =
-              displayToolEntries.some(entry => !entry.result && entry.origIdx >= toolResultCount);
+              renderedToolEntries.some(entry => !entry.result && entry.origIdx >= toolResultCount);
 
             // Skip empty messages: no visible content AND no tool calls to display
             // Also skip messages that only have toolResults but no toolCalls (raw result blobs)
@@ -3240,7 +3254,7 @@ export default function ChatScreen({ route, navigation }: any) {
                               pressed && styles.toolCallCompactPressed,
                             ]}
                           >
-                            {displayToolEntries.map(({ toolCall, origIdx, result: tcResult }, tcIdx) => {
+                            {renderedToolEntries.map(({ toolCall, origIdx, result: tcResult }, tcIdx) => {
                               const tcPending = !tcResult && origIdx >= toolResultCount;
                               const tcSuccess = tcResult?.success === true;
                               const tcError = tcResult?.success === false;
@@ -3300,7 +3314,7 @@ export default function ChatScreen({ route, navigation }: any) {
                             allSuccess && styles.toolExecutionSuccess,
                             hasErrors && styles.toolExecutionError,
                           ]}>
-                            {displayToolEntries.map(({ toolCall, origIdx, result }, idx) => {
+                            {renderedToolEntries.map(({ toolCall, origIdx, result }, idx) => {
                               const isResultPending = !result && origIdx >= toolResultCount;
                               // Use message id or fallback to array index to ensure stable, unique keys
                               // that won't collide when m.id is undefined (which is common)


### PR DESCRIPTION
### Motivation

- Address UI bug #237 where the active sessions sidebar showed only minutes and left a persistent right-side gap for elapsed times; improve readability for long-running sessions. 
- Address mobile bug #210 where messages with `toolResults` but missing `toolCalls` fell back to plain text instead of rendering in the structured tool-call UI.

### Description

- Updated `apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx` by changing `formatMinutesAgo` to return `Xm ago` for under 60 minutes and `Hh Mm ago` for 60+ minutes, and adjusted right-padding and elapsed-time span classes so the timestamp occupies the right slot and only hides when row actions appear on hover/focus. 
- Updated `apps/mobile/src/screens/ChatScreen.tsx` to synthesize fallback tool-call entries when `toolResults` exist but `toolCalls` are missing, introducing `fallbackToolEntries` and `renderedToolEntries` and using them for all tool-display logic so failed or partial tool responses render in the unified tool UI. 
- Changes are limited to rendering/formatting behavior and do not alter protocol or backend contracts.

### Testing

- Ran the desktop unit test file with `pnpm --filter @dotagents/desktop test -- sessions.in-app-actions.test.ts`, which passed. 
- Ran the mobile Vitest suite with `pnpm --filter @dotagents/mobile test:vitest`, which passed (all specified tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4135446088330a58fe8a04a922213)