### PR TITLE
Fix subagent tool-call rendering in desktop and mobile delegation views

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1556,6 +1556,16 @@ const SubAgentConversationMessage: React.FC<{
 
   const isLongContent = message.content.length > 300
   const shouldShowToggle = isLongContent
+  const toolContent = useMemo(() => {
+    if (message.role !== "tool") return null
+
+    const raw = (message.content ?? "").trim()
+    const normalized = raw.replace(/^tool result:\s*/i, "").trim()
+    return {
+      summary: normalized || raw || "Tool activity",
+      rawContent: raw,
+    }
+  }, [message.content, message.role, message.toolInput])
   const roleMeta = (() => {
     switch (message.role) {
       case "user":
@@ -1614,14 +1624,47 @@ const SubAgentConversationMessage: React.FC<{
               </span>
             )}
           </div>
-          <div
-            className={cn(
-              "whitespace-pre-wrap break-words text-[13px] leading-5 text-gray-700 dark:text-gray-200",
-              !isExpanded && isLongContent && (isCompact ? "line-clamp-3" : "line-clamp-4"),
-            )}
-          >
-            {message.content}
-          </div>
+          {message.role === "tool" ? (
+            <div className="space-y-2">
+              <div
+                className={cn(
+                  "whitespace-pre-wrap break-words text-[13px] leading-5 text-gray-700 dark:text-gray-200",
+                  !isExpanded && isLongContent && (isCompact ? "line-clamp-3" : "line-clamp-4"),
+                )}
+              >
+                {toolContent?.summary}
+              </div>
+              {message.toolInput && (
+                <div className="space-y-1.5 rounded-md border border-amber-200/70 bg-white/60 p-2 dark:border-amber-800/60 dark:bg-black/20">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-amber-700/90 dark:text-amber-300/90">
+                    Tool Input
+                  </div>
+                  <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded bg-amber-50/80 p-2 text-[11px] text-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+                    {JSON.stringify(message.toolInput, null, 2)}
+                  </pre>
+                </div>
+              )}
+              {isExpanded && toolContent?.rawContent && toolContent.rawContent !== toolContent.summary && (
+                <div className="space-y-1.5 rounded-md border border-border/60 bg-muted/30 p-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    Raw Payload
+                  </div>
+                  <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/40 p-2 text-[11px] text-foreground/90">
+                    {toolContent.rawContent}
+                  </pre>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div
+              className={cn(
+                "whitespace-pre-wrap break-words text-[13px] leading-5 text-gray-700 dark:text-gray-200",
+                !isExpanded && isLongContent && (isCompact ? "line-clamp-3" : "line-clamp-4"),
+              )}
+            >
+              {message.content}
+            </div>
+          )}
           {shouldShowToggle && (
             <button
               onClick={(e) => { e.stopPropagation(); onToggleExpand() }}

--- a/apps/mobile/src/lib/delegationProgress.test.ts
+++ b/apps/mobile/src/lib/delegationProgress.test.ts
@@ -65,4 +65,50 @@ describe('createDelegationProgressMessages', () => {
     expect(messages[1].content).toContain('Delegated to Research · Failed');
     expect(messages[1].content).toContain('Timeout');
   });
+
+  it('maps delegated tool messages to structured tool metadata', () => {
+    const steps: AgentProgressStep[] = [
+      {
+        id: 'delegation-tools',
+        type: 'thinking',
+        title: 'Delegating',
+        status: 'in_progress',
+        timestamp: 300,
+        delegation: {
+          runId: 'run-tools',
+          agentName: 'Worker',
+          task: 'Inspect files',
+          status: 'running',
+          startTime: 300,
+          conversation: [
+            {
+              role: 'tool',
+              toolName: 'read_file',
+              toolInput: { path: 'README.md' },
+              content: 'Using tool: read_file\nInput: {"path":"README.md"}',
+              timestamp: 301,
+            },
+            {
+              role: 'tool',
+              toolName: 'read_file',
+              content: 'Tool result: {"ok":true}',
+              timestamp: 302,
+            },
+          ],
+        },
+      },
+    ];
+
+    const messages = createDelegationProgressMessages(steps);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toBe('Delegated to Worker · Running');
+    expect(messages[0].toolCalls).toEqual([
+      { name: 'read_file', arguments: { path: 'README.md' } },
+      { name: 'read_file', arguments: {} },
+    ]);
+    expect(messages[0].toolResults).toEqual([
+      { success: true, content: 'Using tool: read_file\nInput: {"path":"README.md"}' },
+      { success: true, content: '{"ok":true}' },
+    ]);
+  });
 });

--- a/apps/mobile/src/lib/delegationProgress.ts
+++ b/apps/mobile/src/lib/delegationProgress.ts
@@ -32,6 +32,39 @@ const summarizeDelegation = (delegation: ACPDelegationProgress): string => {
   return delegation.progressMessage || conversationSnippet || delegation.task;
 };
 
+const TOOL_RESULT_PREFIX = /^tool result:\s*/i;
+
+const getDelegationToolMetadata = (delegation: ACPDelegationProgress): Pick<ChatMessage, 'toolCalls' | 'toolResults'> => {
+  const toolCalls: NonNullable<ChatMessage['toolCalls']> = [];
+  const toolResults: NonNullable<ChatMessage['toolResults']> = [];
+
+  for (const message of delegation.conversation ?? []) {
+    if (message.role !== 'tool' || !message.toolName) {
+      continue;
+    }
+
+    toolCalls.push({
+      name: message.toolName,
+      arguments: (message.toolInput && typeof message.toolInput === 'object')
+        ? message.toolInput as Record<string, unknown>
+        : {},
+    });
+
+    const normalizedContent = (message.content ?? '').replace(TOOL_RESULT_PREFIX, '').trim();
+    if (normalizedContent.length > 0) {
+      toolResults.push({
+        success: true,
+        content: normalizedContent,
+      });
+    }
+  }
+
+  return {
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    toolResults: toolResults.length > 0 ? toolResults : undefined,
+  };
+};
+
 export const createDelegationProgressMessages = (steps?: AgentProgressStep[]): ChatMessage[] => {
   if (!steps || steps.length === 0) {
     return [];
@@ -57,11 +90,20 @@ export const createDelegationProgressMessages = (steps?: AgentProgressStep[]): C
 
   return Array.from(latestDelegationsByRunId.values())
     .sort((a, b) => a.timestamp - b.timestamp)
-    .map(({ delegation, timestamp }) => ({
-      id: `delegation-${delegation.runId}`,
-      role: 'assistant' as const,
-      variant: 'delegation' as const,
-      timestamp,
-      content: `Delegated to ${delegation.agentName} · ${formatStatus(delegation.status)}\n${summarizeDelegation(delegation)}`,
-    }));
+    .map(({ delegation, timestamp }) => {
+      const summary = summarizeDelegation(delegation);
+      const hasConversation = (delegation.conversation?.length ?? 0) > 0;
+      const fallbackContent = hasConversation
+        ? `Delegated to ${delegation.agentName} · ${formatStatus(delegation.status)}`
+        : `Delegated to ${delegation.agentName} · ${formatStatus(delegation.status)}\n${summary}`;
+
+      return {
+        id: `delegation-${delegation.runId}`,
+        role: 'assistant' as const,
+        variant: 'delegation' as const,
+        timestamp,
+        content: fallbackContent,
+        ...getDelegationToolMetadata(delegation),
+      };
+    });
 };


### PR DESCRIPTION
### Motivation
- Subagent tool-call payloads were surfacing as raw/plain text (or not rendering) in the delegated subagent views, producing a poor UX and losing structured tool metadata.
- Ensure delegated `tool` messages are rendered consistently with other tool executions on desktop and that mobile delegation updates surface structured `toolCalls`/`toolResults` so UI components can render them.

### Description
- Desktop: enhance `SubAgentConversationMessage` rendering in `apps/desktop/src/renderer/src/components/agent-progress.tsx` to detect `message.role === 'tool'` and render a normalized summary, a formatted `Tool Input` block when `toolInput` exists, and an expandable `Raw Payload` section instead of displaying raw plain text.
- Mobile: update `createDelegationProgressMessages` in `apps/mobile/src/lib/delegationProgress.ts` to extract delegated `tool` conversation entries and emit them as structured `toolCalls` and `toolResults` (using `TOOL_RESULT_PREFIX` normalization); also keep a non-empty fallback delegation header when a conversation exists so delegation rows remain visible even when the latest snippet is tool payload text.
- Tests: add a unit test in `apps/mobile/src/lib/delegationProgress.test.ts` that validates mapping delegated tool messages into `toolCalls`/`toolResults`.
- Misc: built the shared package (`@dotagents/shared`) to ensure consumers can resolve the updated types used by mobile/desktop.

### Testing
- Ran mobile unit tests: `pnpm -s vitest run apps/mobile/src/lib/delegationProgress.test.ts` and the mobile delegation tests passed (2 tests passed).
- Built shared package: `pnpm build:shared` completed successfully.
- Ran combined desktop+mobile tests: `pnpm -s vitest run apps/mobile/src/lib/delegationProgress.test.ts apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts` and the desktop test file failed (16 failures) due to a test environment issue reading `pinnedSessionIds` (not related to the delegation rendering changes); mobile tests in that run remained green.
- Typecheck: `pnpm typecheck` failed in this environment due to existing package resolution errors for `@dotagents/core` in the desktop typecheck step (pre-existing workspace configuration issue, not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c435b705dc83309679c53339a7b915)