### PR TITLE
fix(desktop): correct sidebar status dots for active and idle agents

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.status-colors.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.status-colors.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const sidebarSource = readFileSync(new URL("./active-agents-sidebar.tsx", import.meta.url), "utf8")
+
+describe("active agents sidebar status colors", () => {
+  it("uses green for running sessions and gray for idle sessions", () => {
+    expect(sidebarSource).toContain(': conversationState === "running"')
+    expect(sidebarSource).toContain('? "bg-green-500"')
+    expect(sidebarSource).toContain(': "bg-muted-foreground"')
+  })
+
+  it("uses gray for completed past sessions", () => {
+    expect(sidebarSource).toContain('session.status === "error"')
+    expect(sidebarSource).toContain(': "bg-muted-foreground"')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -818,7 +818,7 @@ export function ActiveAgentsSidebar({
                       "h-1.5 w-1.5 shrink-0 rounded-full",
                       session.status === "error"
                         ? "bg-red-500"
-                        : "bg-green-500",
+                        : "bg-muted-foreground",
                     )}
                   />
                   {renderEditableTitle(session, "flex-1")}
@@ -862,16 +862,14 @@ export function ActiveAgentsSidebar({
             }
 
             // Active session row
-            // Status colors: amber for pending approval, blue for active, gray for snoozed
+            // Status colors: amber for pending approval, green for active, gray for idle/snoozed
             const statusDotColor = hasPendingApproval
               ? "bg-amber-500"
               : conversationState === "blocked"
                 ? "bg-red-500"
-                : conversationState === "complete"
+                : conversationState === "running"
                   ? "bg-green-500"
-                  : isSnoozed
-                    ? "bg-muted-foreground"
-                    : "bg-blue-500"
+                  : "bg-muted-foreground"
 
             // Get agent/profile name from progress data
             const agentName = sessionProgress?.profileName


### PR DESCRIPTION
### Motivation
- Active agents in the sidebar were rendered with the wrong color (grey) while idle/completed agents were green, which inverts the intended visual state mapping.

### Description
- Replace the past/completed session dot color from green to gray by using `bg-muted-foreground` for non-error past rows in `ActiveAgentsSidebar` (`apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx`).
- Remap active/running sessions to use `bg-green-500` and make the default/idle state use `bg-muted-foreground`, and update the related comment to reflect the new mapping in the same file.
- Add a small regression test `apps/desktop/src/renderer/src/components/active-agents-sidebar.status-colors.test.ts` that asserts the source contains the expected `running` → green and idle/completed → muted rules.

### Testing
- Ran the new unit test with `pnpm --filter @dotagents/desktop test -- --run src/renderer/src/components/active-agents-sidebar.status-colors.test.ts`, which passed (2 tests).
- Running the broader desktop test `pnpm --filter @dotagents/desktop test -- --run src/renderer/src/pages/sessions.in-app-actions.test.ts` surfaced an unrelated existing assertion failure in `sessions.tsx` (this failure is not caused by the status-dot changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c436bc6f1083309c6c3944c8035375)