### PR TITLE
Prevent TTS autoplay when expanding/collapsing session tiles

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -242,6 +242,11 @@ describe("agent progress tile layout", () => {
     )
   })
 
+  it("does not auto-play TTS for tile expansion/collapse interactions", () => {
+    expect(agentProgressSource).toContain('variant === "overlay" &&')
+    expect(agentProgressSource).toContain('autoPlay={variant === "overlay" && !isSnoozed && (configQuery.data?.ttsAutoPlay ?? true)}')
+  })
+
   it("uses shared conversation-state normalization across agent progress surfaces", () => {
     expect(agentProgressSource).toContain('getAgentConversationStateLabel')
     expect(agentProgressSource).toContain('normalizeAgentConversationState(progress.conversationState, isComplete ? "complete" : "running")')

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -591,7 +591,12 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
                 isGenerating={isGeneratingAudio}
                 error={ttsError}
                 compact={true}
-                autoPlay={(isLast || !!message.responseEvent) ? ((configQuery.data?.ttsAutoPlay ?? true) && !isSnoozed) : false}
+                autoPlay={
+                  variant === "overlay" &&
+                  (isLast || !!message.responseEvent) &&
+                  (configQuery.data?.ttsAutoPlay ?? true) &&
+                  !isSnoozed
+                }
                 onPlayStateChange={setIsTTSPlaying}
                 audioOutputDeviceId={configQuery.data?.audioOutputDeviceId}
               />
@@ -3216,7 +3221,7 @@ const MidTurnUserResponseBubble: React.FC<{
             isGenerating={isGeneratingAudio}
             error={ttsError}
             compact={true}
-            autoPlay={!isSnoozed && (configQuery.data?.ttsAutoPlay ?? true)}
+            autoPlay={variant === "overlay" && !isSnoozed && (configQuery.data?.ttsAutoPlay ?? true)}
             onPlayStateChange={setIsTTSPlaying}
           />
           {isExpanded && ttsError && (


### PR DESCRIPTION
### Motivation
- Expanding or collapsing a session tile could inadvertently start text-to-speech playback because `AudioPlayer` `autoPlay` was enabled for tile-rendered messages when `ttsAutoPlay` was true.
- Tile expand/collapse is a UI interaction and should not trigger audio; autoplay is intended only for overlay views where the agent UI intentionally presents spoken output.

### Description
- Gate `AudioPlayer` `autoPlay` behind `variant === "overlay"` in `AgentProgress` so only overlay variants may auto-play TTS, preventing tile expand/collapse from starting playback; changes applied to both the compact assistant message player and mid-turn response player. (`apps/desktop/src/renderer/src/components/agent-progress.tsx`)
- Add a regression assertion to `agent-progress.tile-layout.test.ts` that verifies the code contains the `variant === "overlay"` autoplay gating so future changes don't reintroduce the regression. (`apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts`)

### Testing
- Ran the desktop unit test for the updated file with `pnpm --filter @dotagents/desktop test -- agent-progress.tile-layout.test.ts`, which builds `@dotagents/shared` as pretest and then ran the test file. The test suite passed: `1 passed (1)`, `17 tests` OK.
- Verified the updated `agent-progress.tsx` contains the new `variant === "overlay"` autoplay checks and that the new test assertion is present and passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c436e194d483308ee361b18b40720f)