### PR TITLE
Fix compact session expand click propagation and stale expanded state cleanup

### DIFF
--- a/apps/desktop/src/renderer/src/components/session-compact-card.test.tsx
+++ b/apps/desktop/src/renderer/src/components/session-compact-card.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { AgentProgressUpdate } from "@shared/types"
+
+const createProgress = (): AgentProgressUpdate => ({
+  sessionId: "session-1",
+  conversationId: "conversation-1",
+  currentIteration: 1,
+  maxIterations: 1,
+  isComplete: false,
+  steps: [],
+  conversationHistory: [],
+})
+
+function createHookRuntime() {
+  const reactMock: any = {
+    __esModule: true,
+    memo: (component: any) => ({ type: component }),
+    useMemo: (factory: () => unknown) => factory(),
+    useCallback: <T extends (...args: any[]) => any>(callback: T) => callback,
+    Children: {
+      toArray: (children: any) => Array.isArray(children) ? children : children == null ? [] : [children],
+    },
+  }
+  reactMock.default = reactMock
+
+  const Fragment = Symbol.for("react.fragment")
+  const invoke = (type: any, props: any) => {
+    if (type === Fragment) return props?.children ?? null
+    return typeof type === "function" ? type(props ?? {}) : { type, props: props ?? {} }
+  }
+
+  return {
+    reactMock,
+    jsxRuntimeMock: { __esModule: true, Fragment, jsx: invoke, jsxs: invoke, jsxDEV: invoke },
+  }
+}
+
+function findNode(node: any, predicate: (node: any) => boolean): any {
+  if (node == null) return null
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const match = findNode(child, predicate)
+      if (match) return match
+    }
+    return null
+  }
+  if (typeof node === "object") {
+    if (predicate(node)) return node
+    return findNode(node.props?.children, predicate)
+  }
+  return null
+}
+
+async function loadSessionCompactCard() {
+  const runtime = createHookRuntime()
+
+  vi.resetModules()
+  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("@renderer/lib/utils", () => ({ cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" ") }))
+  vi.doMock("./ui/loading-spinner", () => ({ LoadingSpinner: () => ({ type: "LoadingSpinner", props: {} }) }))
+  vi.doMock("lucide-react", () => {
+    const Icon = (props: any) => ({ type: "Icon", props })
+    return { Shield: Icon, Check: Icon, XCircle: Icon, Moon: Icon, Square: Icon, Maximize2: Icon }
+  })
+  vi.doMock("@dotagents/shared", () => ({ normalizeAgentConversationState: () => "running" }))
+  vi.doMock("dayjs", () => ({ default: () => ({ diff: () => 0, format: () => "now" }) }))
+
+  return import("./session-compact-card")
+}
+
+describe("SessionCompactCard", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it("stops propagation when clicking the nested expand button", async () => {
+    const { SessionCompactCard } = await loadSessionCompactCard()
+    const onClick = vi.fn()
+    const stopPropagation = vi.fn()
+    const element = (SessionCompactCard as unknown as { type: (props: any) => any }).type({
+      progress: createProgress(),
+      sessionId: "session-1",
+      onClick,
+    })
+
+    const expandButton = findNode(element, (node) => node?.type === "button" && node?.props?.title === "Expand")
+    expect(expandButton).toBeTruthy()
+
+    expandButton?.props.onClick({ stopPropagation })
+
+    expect(stopPropagation).toHaveBeenCalledOnce()
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/desktop/src/renderer/src/components/session-compact-card.tsx
+++ b/apps/desktop/src/renderer/src/components/session-compact-card.tsx
@@ -122,6 +122,11 @@ export const SessionCompactCard = React.memo(function SessionCompactCard({
     onStop?.()
   }, [onStop])
 
+  const handleExpand = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    onClick()
+  }, [onClick])
+
   return (
     <div
       role="button"
@@ -159,7 +164,7 @@ export const SessionCompactCard = React.memo(function SessionCompactCard({
         )}
         {/* Hover actions */}
         <div className="hidden items-center gap-0.5 group-hover/card:flex">
-          <button type="button" onClick={onClick} className="rounded p-0.5 hover:bg-muted" title="Expand">
+          <button type="button" onClick={handleExpand} className="rounded p-0.5 hover:bg-muted" title="Expand">
             <Maximize2 className="h-3 w-3 text-muted-foreground" />
           </button>
           {!isComplete && onStop && (
@@ -172,4 +177,3 @@ export const SessionCompactCard = React.memo(function SessionCompactCard({
     </div>
   )
 })
-

--- a/apps/desktop/src/renderer/src/stores/agent-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.test.ts
@@ -115,5 +115,45 @@ describe('agent-store delegation merge', () => {
     expect(useAgentStore.getState().focusedSessionId).toBe('session-2')
     expect(useAgentStore.getState().agentProgressById.get('session-1')?.isSnoozed).toBe(true)
   })
-})
 
+  it('clears expanded session when removing that session directly', () => {
+    useAgentStore.setState({
+      agentProgressById: new Map([
+        ['session-1', createBaseUpdate()],
+      ]),
+      expandedSessionId: 'session-1',
+    })
+
+    useAgentStore.getState().clearSessionProgress('session-1')
+
+    expect(useAgentStore.getState().expandedSessionId).toBeNull()
+  })
+
+  it('clears expanded session when clearing inactive sessions removes it', () => {
+    useAgentStore.setState({
+      agentProgressById: new Map([
+        ['session-1', { ...createBaseUpdate(), isComplete: true }],
+        ['session-2', { ...createBaseUpdate(), sessionId: 'session-2', conversationId: 'conversation-2' }],
+      ]),
+      expandedSessionId: 'session-1',
+    })
+
+    useAgentStore.getState().clearInactiveSessions()
+
+    expect(useAgentStore.getState().agentProgressById.has('session-1')).toBe(false)
+    expect(useAgentStore.getState().expandedSessionId).toBeNull()
+  })
+
+  it('clears expanded session when clearing all progress', () => {
+    useAgentStore.setState({
+      agentProgressById: new Map([
+        ['session-1', createBaseUpdate()],
+      ]),
+      expandedSessionId: 'session-1',
+    })
+
+    useAgentStore.getState().clearAllProgress()
+
+    expect(useAgentStore.getState().expandedSessionId).toBeNull()
+  })
+})

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -283,6 +283,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     set({
       agentProgressById: new Map(),
       focusedSessionId: null,
+      expandedSessionId: null,
     })
   },
 
@@ -310,6 +311,8 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       return {
         agentProgressById: newMap,
         focusedSessionId: newFocusedSessionId,
+        expandedSessionId:
+          state.expandedSessionId === sessionId ? null : state.expandedSessionId,
       }
     })
   },
@@ -348,6 +351,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       return {
         agentProgressById: newMap,
         focusedSessionId: newFocusedSessionId,
+        expandedSessionId:
+          state.expandedSessionId && !newMap.has(state.expandedSessionId)
+            ? null
+            : state.expandedSessionId,
       }
     })
   },


### PR DESCRIPTION
### Motivation
- Prevent the nested Expand button in the compact session card from bubbling its click to the parent card which caused a double-toggle of expansion. 
- Ensure the UI does not point at a nonexistent session by keeping `expandedSessionId` in sync when sessions are removed.
- Add targeted tests to prevent regressions for both the click-propagation behavior and expanded-session cleanup.

### Description
- Stop propagation on the compact card expand button by introducing `handleExpand` that calls `e.stopPropagation()` before invoking the parent `onClick` handler in `apps/desktop/src/renderer/src/components/session-compact-card.tsx`.
- Clear `expandedSessionId` during session removals in `apps/desktop/src/renderer/src/stores/agent-store.ts` by resetting it in `clearAllProgress`, conditionally clearing it in `clearSessionProgress`, and nulling it when `clearInactiveSessions` removes the expanded session.
- Add tests: new `apps/desktop/src/renderer/src/components/session-compact-card.test.tsx` to verify the Expand button stops propagation and new assertions in `apps/desktop/src/renderer/src/stores/agent-store.test.ts` to assert `expandedSessionId` is cleared when sessions are removed by the three cleanup paths.

### Testing
- Ran `pnpm build:shared` successfully to prepare shared package resources.
- Ran component and store tests with `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/stores/agent-store.test.ts src/renderer/src/components/session-compact-card.test.tsx` and all tests passed (8 tests total).
- Built core package with `pnpm build:core` and ran `pnpm --filter @dotagents/desktop typecheck`; typecheck completed successfully.
- Attempted to run the desktop app (`pnpm --filter @dotagents/desktop dev:no-sherpa`) to exercise the full Electron UI, but the Electron binary failed to launch in this cloud environment due to a missing system library (`libatk-1.0.so.0`), so full interactive UI validation could not be completed here. The renderer/preload/main bundles did build successfully prior to the launch failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4404c557c8330a9c6fa94f2a5548d)