### PR TITLE
fix: run aggressive tool payload truncation before target limit check

### DIFF
--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -47,7 +47,14 @@ vi.mock('@dotagents/shared', () => ({
   sanitizeMessageContentForDisplay: (content: string) => content,
 }))
 
-import { clearArchiveFrontier, clearContextRefs, readMoreContext, shrinkMessagesForLLM } from './context-budget'
+import {
+  clearActualTokenUsage,
+  clearArchiveFrontier,
+  clearContextRefs,
+  readMoreContext,
+  recordActualTokenUsage,
+  shrinkMessagesForLLM,
+} from './context-budget'
 
 describe('shrinkMessagesForLLM replacement policy', () => {
   beforeEach(() => {
@@ -57,11 +64,22 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearArchiveFrontier('session-archive')
     clearArchiveFrontier('session-live-tail')
     clearArchiveFrontier('session-protected-tail')
+    clearArchiveFrontier('session-actual-scale')
+    clearArchiveFrontier('session-bracket-log')
     clearContextRefs('session-truncate')
     clearContextRefs('session-batch')
     clearContextRefs('session-archive')
     clearContextRefs('session-live-tail')
     clearContextRefs('session-protected-tail')
+    clearContextRefs('session-actual-scale')
+    clearContextRefs('session-bracket-log')
+    clearActualTokenUsage('session-truncate')
+    clearActualTokenUsage('session-batch')
+    clearActualTokenUsage('session-archive')
+    clearActualTokenUsage('session-live-tail')
+    clearActualTokenUsage('session-protected-tail')
+    clearActualTokenUsage('session-actual-scale')
+    clearActualTokenUsage('session-bracket-log')
     Object.assign(mockConfig, {
       mcpContextReductionEnabled: true,
       mcpContextTargetRatio: 0.5,
@@ -114,6 +132,47 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(result.appliedStrategies).toContain('minimal_system_prompt')
     expect(result.estTokensBefore).toBe(2000)
     expect(result.estTokensAfter).toBeGreaterThan(600)
+  })
+
+  it('preserves the initial token baseline when actual usage comes from session state', async () => {
+    const toolPayload = `[server:search] ${'x'.repeat(3500)}`
+    recordActualTokenUsage('session-actual-scale', 2100, 120)
+
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-actual-scale',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'inspect this result' },
+        { role: 'user', content: toolPayload },
+      ],
+    })
+
+    expect(result.appliedStrategies).toContain('aggressive_truncate')
+    expect(result.estTokensBefore).toBe(2100)
+    expect(result.estTokensAfter).toBeGreaterThan(600)
+  })
+
+  it('does not treat bracketed user logs as mapped tool results or JSON payloads', async () => {
+    Object.assign(mockConfig, {
+      mcpContextTargetRatio: 0.95,
+      mcpMaxContextTokensOverride: 10000,
+    })
+
+    const bracketedLog = `[INFO] ${'x'.repeat(5500)}`
+
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-bracket-log',
+      lastNMessages: 1,
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'keep this log verbatim' },
+        { role: 'assistant', content: 'acknowledged' },
+        { role: 'user', content: bracketedLog },
+      ],
+    })
+
+    expect(result.appliedStrategies).not.toContain('aggressive_truncate')
+    expect(result.messages[result.messages.length - 1]?.content).toBe(bracketedLog)
   })
 
   it('batch-summarizes contiguous oversized conversational messages in one call', async () => {

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -854,20 +854,36 @@ const ARCHIVE_FRONTIER_KEEP_LIVE_MESSAGES = 20
 const ARCHIVE_FRONTIER_TRIGGER_MESSAGE_COUNT = 40
 const ARCHIVE_FRONTIER_TRIGGER_TOKEN_RATIO = 0.9
 const ARCHIVE_FRONTIER_MIN_ARCHIVE_BATCH = 8
+const MAPPED_TOOL_RESULT_PREFIX_RE = /^\[((?=[^\]]*[a-z])[A-Za-z0-9._:/-]+)\]\s(?:ERROR:\s*)?/
 
-function hasBracketedToolPrefix(content: string): boolean {
-  return /^\[[^\]]+\]/.test(content.trim())
+function parseMappedToolResultContent(content: string): { toolName: string; resultContent: string } | null {
+  const trimmed = content.trimStart()
+  const match = trimmed.match(MAPPED_TOOL_RESULT_PREFIX_RE)
+  if (!match) return null
+
+  return {
+    toolName: match[1],
+    resultContent: trimmed.slice(match[0].length),
+  }
+}
+
+function hasMappedToolResultPrefix(content: string): boolean {
+  return parseMappedToolResultContent(content) !== null
+}
+
+function startsWithJsonLikeArray(content: string): boolean {
+  return /^\[\s*(?:\{|\[|"|-?\d|true\b|false\b|null\b)/.test(content.trim())
 }
 
 function isLikelyPayloadLikeMessage(message: LLMMessage): boolean {
   const content = message.content || ""
   return message.role === "tool"
-    || hasBracketedToolPrefix(content) // Tool results mapped to user role
+    || hasMappedToolResultPrefix(content) // Tool results mapped to user role
     || content.includes('"url":')
     || content.includes('"id":')
     || content.includes("```json")
     || content.trim().startsWith("{")
-    || content.trim().startsWith("[")
+    || startsWithJsonLikeArray(content)
 }
 
 function truncateWithMarker(content: string, keepChars: number, marker: string): string {
@@ -1180,15 +1196,12 @@ function buildContextFromSummaries(sessionId: string): string | null {
 }
 
 /**
- * Parse tool name from content that uses format: [toolName] content...
- * Returns { toolName, content } where content is the part after the tool name prefix
+ * Parse tool name from llm.ts mapped tool-result content:
+ * [toolName] content... or [toolName] ERROR: content...
  */
 function parseToolNameFromContent(content: string): { toolName: string; resultContent: string } {
-  // Match format: [toolName] content... or [toolName] ERROR: content...
-  const match = content.match(/^\[([^\]]+)\]\s*(?:ERROR:\s*)?(.*)$/s)
-  if (match) {
-    return { toolName: match[1], resultContent: match[2] }
-  }
+  const parsed = parseMappedToolResultContent(content)
+  if (parsed) return parsed
   return { toolName: 'unknown', resultContent: content }
 }
 
@@ -1369,8 +1382,8 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
 
     const isPayloadLike = isLikelyPayloadLikeMessage(msg)
 
-    // NOTE: tool messages are mapped to 'user' role by llm.ts but have a '[toolName] ' prefix
-    const isToolResultLike = msg.role === "tool" || (msg.role === "user" && hasBracketedToolPrefix(msg.content))
+    // NOTE: tool messages are mapped to 'user' role by llm.ts with a '[toolName] ' prefix.
+    const isToolResultLike = msg.role === "tool" || (msg.role === "user" && hasMappedToolResultPrefix(msg.content))
 
     const shouldTruncateToolResult = isToolResultLike && msg.content.length > TOOL_RESULT_TRUNCATE_THRESHOLD
     const shouldAggressivelyTruncatePayload = isPayloadLike && msg.content.length > AGGRESSIVE_TRUNCATE_THRESHOLD


### PR DESCRIPTION
### What changed
1. Moved Tier 0b aggressive context truncation *before* the early return check in `context-budget.ts`. Previously, large tool payloads (e.g. from `execute_command`) were bypassing truncation entirely if the total token count was still below the 80k threshold, leading to context bloat.
2. Updated the `isToolResultLike` and `isLikelyPayloadLikeMessage` checks to recognize the `[toolName]` prefix that `llm.ts` applies to tool results mapped to the user role. This ensures tool payloads are actually caught and truncated correctly.