### PR TITLE
fix(desktop): sidebar title overlap & move model picker to top (#273, #274)

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -874,10 +874,10 @@ export function ActiveAgentsSidebar({
                       pastStatusRailColor,
                     )}
                   />
-                  <div className="min-w-0 flex-1 transition-[padding-right] duration-200 group-hover:pr-20">
+                  <div className="min-w-0 flex-1 overflow-hidden transition-[padding-right] duration-200 group-hover:pr-20">
                     {renderEditableTitle(
                       session,
-                      cn("flex-1", isCurrentView && "text-foreground"),
+                      cn("block flex-1", isCurrentView && "text-foreground"),
                     )}
                   </div>
                   {lastMessageMinutesAgo && (

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -178,6 +178,46 @@ export function Component() {
           </p>
         </div>
 
+        <ControlGroup title="Agent Models">
+          <div className="mx-3 my-2 rounded-md border border-muted bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            Choose which model powers the main agent. OpenAI-compatible presets can carry both an agent model and a transcript processing model.
+          </div>
+
+          {usesOpenAiCompatiblePreset && (
+            <div className="px-3 py-2 border-b">
+              <div className="pb-3">
+                <span className="text-sm font-medium">OpenAI-Compatible Preset</span>
+                <p className="text-xs text-muted-foreground">
+                  Use this when Agent/MCP Tools or Transcript Processing is set to OpenAI-compatible.
+                </p>
+              </div>
+              <ModelPresetManager
+                showAgentModel={agentProviderId === "openai"}
+                showTranscriptCleanupModel={transcriptProcessingEnabled && transcriptProcessingProviderId === "openai"}
+              />
+            </div>
+          )}
+
+          {(agentProviderId === "groq" || agentProviderId === "gemini") && (
+            <div className="px-3 py-2">
+              <ProviderModelSelector
+                providerId={agentProviderId}
+                mcpModel={agentProviderId === "groq" ? config.mcpToolsGroqModel : config.mcpToolsGeminiModel}
+                onMcpModelChange={(value) => saveConfig(agentProviderId === "groq" ? { mcpToolsGroqModel: value } : { mcpToolsGeminiModel: value })}
+                showMcpModel={true}
+                showTranscriptModel={false}
+              />
+            </div>
+          )}
+
+          {!usesOpenAiCompatiblePreset && agentProviderId === "openai" && (
+            <p className="px-3 py-2 text-sm text-muted-foreground">
+              OpenAI-compatible preset controls appear here when Agent/MCP Tools or Transcript Processing uses that provider.
+            </p>
+          )}
+        </ControlGroup>
+
+
         <ControlGroup title="Choose a Provider for Each Job" collapsible>
           <RoleProviderSelector
             label="Speech-to-Text"
@@ -473,45 +513,6 @@ export function Component() {
               </>
             )}
           </div>
-        </ControlGroup>
-
-        <ControlGroup title="Agent Models" collapsible>
-          <div className="mx-3 my-2 rounded-md border border-muted bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-            Keep agent model choices here. OpenAI-compatible presets can carry both an agent model and a transcript processing model.
-          </div>
-
-          {usesOpenAiCompatiblePreset && (
-            <div className="px-3 py-2 border-b">
-              <div className="pb-3">
-                <span className="text-sm font-medium">OpenAI-Compatible Preset</span>
-                <p className="text-xs text-muted-foreground">
-                  Use this when Agent/MCP Tools or Transcript Processing is set to OpenAI-compatible.
-                </p>
-              </div>
-              <ModelPresetManager
-                showAgentModel={agentProviderId === "openai"}
-                showTranscriptCleanupModel={transcriptProcessingEnabled && transcriptProcessingProviderId === "openai"}
-              />
-            </div>
-          )}
-
-          {(agentProviderId === "groq" || agentProviderId === "gemini") && (
-            <div className="px-3 py-2">
-              <ProviderModelSelector
-                providerId={agentProviderId}
-                mcpModel={agentProviderId === "groq" ? config.mcpToolsGroqModel : config.mcpToolsGeminiModel}
-                onMcpModelChange={(value) => saveConfig(agentProviderId === "groq" ? { mcpToolsGroqModel: value } : { mcpToolsGeminiModel: value })}
-                showMcpModel={true}
-                showTranscriptModel={false}
-              />
-            </div>
-          )}
-
-          {!usesOpenAiCompatiblePreset && agentProviderId === "openai" && (
-            <p className="px-3 py-2 text-sm text-muted-foreground">
-              OpenAI-compatible preset controls appear here when Agent/MCP Tools or Transcript Processing uses that provider.
-            </p>
-          )}
         </ControlGroup>
 
         <ControlGroup title="Advanced Agent Models" collapsible>


### PR DESCRIPTION
## Summary

This PR addresses two recent issues in a single changeset:

### Fix #274: Sidebar session title overlapping timestamp

Long session titles in the sidebar were overlapping the "time since last updated" indicator for past sessions. Fixed by:
- Adding `overflow-hidden` to the past session title wrapper div
- Adding `block` display to the title span so `truncate` (text-overflow: ellipsis) works correctly

Titles now truncate cleanly with an ellipsis instead of overlapping the timestamp.

### Fix #273: Move model picker to top of Models page

The Agent Models section was buried below Speech & Voice Models, requiring users to scroll to find the primary model selector. Fixed by:
- Moving the entire Agent Models section to the top of the page (right after the intro banner)
- Making it non-collapsible so the model picker is always visible and immediately accessible on page load
- Updated the description text to be more user-friendly

The page order is now:
1. **Intro banner**
2. **Agent Models** ← moved here (always visible)
3. Choose a Provider for Each Job
4. Transcript Processing
5. Speech & Voice Models
6. Advanced Agent Models

## Files Changed

- `apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx` — sidebar title overflow fix
- `apps/desktop/src/renderer/src/pages/settings-models.tsx` — model picker repositioning

Closes #273
Closes #274

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://app.staging.augmentcode.com/app/session?agentId=01KMZXCF1X2091W910XS6BWY1W&panel=chat)