### PR TITLE
feat: improve prompt caching across providers

### DIFF
--- a/apps/desktop/src/main/ai-sdk-provider.test.ts
+++ b/apps/desktop/src/main/ai-sdk-provider.test.ts
@@ -105,4 +105,59 @@ describe("ai-sdk-provider chat model sanitization", () => {
       strategy: "gemini-stable-prefix",
     })
   })
+
+  it("enables anthropic cache control when model name contains 'claude'", async () => {
+    const { mod } = await loadModule({
+      mcpToolsOpenaiModel: "claude-sonnet-4-5",
+    })
+
+    expect(mod.getPromptCachingConfig("openai")).toEqual({
+      strategy: "anthropic-cache-control",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+        },
+      },
+    })
+  })
+
+  it("enables anthropic cache control when base URL contains 'openrouter'", async () => {
+    const { mod } = await loadModule({
+      openaiBaseUrl: "https://openrouter.ai/api/v1",
+      mcpToolsOpenaiModel: "some-model",
+    })
+
+    expect(mod.getPromptCachingConfig("openai")).toEqual({
+      strategy: "anthropic-cache-control",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+        },
+      },
+    })
+  })
+
+  it("enables anthropic cache control when model name contains 'anthropic'", async () => {
+    const { mod } = await loadModule({
+      mcpToolsOpenaiModel: "anthropic/claude-3.5-sonnet",
+    })
+
+    expect(mod.getPromptCachingConfig("openai")).toEqual({
+      strategy: "anthropic-cache-control",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+        },
+      },
+    })
+  })
+
+  it("returns undefined for unknown proxy without anthropic model", async () => {
+    const { mod } = await loadModule({
+      openaiBaseUrl: "https://my-custom-proxy.example.com/v1",
+      mcpToolsOpenaiModel: "gpt-4.1-mini",
+    })
+
+    expect(mod.getPromptCachingConfig("openai")).toBeUndefined()
+  })
 })

--- a/apps/desktop/src/main/ai-sdk-provider.ts
+++ b/apps/desktop/src/main/ai-sdk-provider.ts
@@ -208,6 +208,24 @@ export function getCurrentModelName(
   return getProviderConfig(effectiveProviderId, modelContext).model
 }
 
+/**
+ * Check if the model name indicates an Anthropic/Claude model.
+ * Common patterns: "claude-3.5-sonnet", "anthropic/claude-sonnet-4-5", etc.
+ */
+function isAnthropicModel(model: string): boolean {
+  const normalized = model.trim().toLowerCase()
+  return normalized.includes("claude") || normalized.includes("anthropic")
+}
+
+/**
+ * Check if the base URL points to a known proxy that routes to Anthropic.
+ * OpenRouter, LiteLLM, and similar OpenAI-compatible gateways are common proxies.
+ */
+function isAnthropicProxy(baseURL: string): boolean {
+  const normalized = baseURL.trim().toLowerCase()
+  return normalized.includes("openrouter.ai") || normalized.includes("anthropic")
+}
+
 export function getPromptCachingConfig(
   providerId?: ProviderType,
   modelContext: "mcp" | "transcript" = "mcp",
@@ -218,6 +236,7 @@ export function getPromptCachingConfig(
   const providerConfig = getProviderConfig(effectiveProviderId, modelContext)
   const normalizedBaseURL = (providerConfig.baseURL || "").trim().toLowerCase()
 
+  // Vercel AI Gateway handles caching automatically for all providers
   if (normalizedBaseURL.includes("ai-gateway.vercel.sh")) {
     return {
       strategy: "gateway-auto",
@@ -229,12 +248,29 @@ export function getPromptCachingConfig(
     }
   }
 
+  // Anthropic/Claude via OpenAI-compatible proxy (e.g., OpenRouter, LiteLLM).
+  // Anthropic requires explicit cache_control markers — unlike OpenAI/Gemini which cache implicitly.
+  // The AI SDK translates message-level providerOptions.anthropic.cacheControl into
+  // block-level cache_control on the last content block of each message.
+  if (isAnthropicModel(providerConfig.model) || isAnthropicProxy(normalizedBaseURL)) {
+    return {
+      strategy: "anthropic-cache-control",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+        },
+      },
+    }
+  }
+
+  // Direct OpenAI — automatic prefix caching, no API changes needed (≥1,024 tokens)
   if (effectiveProviderId === "openai" && (!normalizedBaseURL || normalizedBaseURL.includes("api.openai.com"))) {
     return {
       strategy: "openai-implicit-prefix",
     }
   }
 
+  // Gemini — automatic caching for prompts ≥32,768 tokens
   if (effectiveProviderId === "gemini") {
     return {
       strategy: "gemini-stable-prefix",

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -112,6 +112,70 @@ describe('LLM Fetch with AI SDK', () => {
     }))
   })
 
+  it('logs cache metrics when usage includes inputTokenDetails with cache data', async () => {
+    getPromptCachingConfigMock.mockReturnValue({
+      strategy: 'openai-implicit-prefix',
+    })
+
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+    const { diagnosticsService } = await import('./diagnostics')
+    const logInfoMock = vi.mocked(diagnosticsService.logInfo)
+
+    generateTextMock.mockResolvedValue({
+      text: '{"content":"cached response"}',
+      finishReason: 'stop',
+      usage: {
+        promptTokens: 1000,
+        completionTokens: 50,
+        inputTokens: 1000,
+        outputTokens: 50,
+        inputTokenDetails: {
+          cacheReadTokens: 800,
+          cacheWriteTokens: 200,
+          noCacheTokens: 0,
+        },
+      },
+    } as any)
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+    await makeLLMCallWithFetch([{ role: 'user', content: 'test' }], 'openai')
+
+    expect(logInfoMock).toHaveBeenCalledWith(
+      'prompt-cache',
+      expect.stringContaining('80% hit rate'),
+      expect.objectContaining({
+        provider: 'openai',
+        cacheReadTokens: 800,
+        cacheWriteTokens: 200,
+        cacheHitRate: 80,
+      })
+    )
+  })
+
+  it('passes anthropic cache control provider options through to generateText', async () => {
+    getPromptCachingConfigMock.mockReturnValue({
+      strategy: 'anthropic-cache-control',
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+    })
+
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+    generateTextMock.mockResolvedValue({
+      text: '{"content":"anthropic cached"}',
+      finishReason: 'stop',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    } as any)
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    await makeLLMCallWithFetch([{ role: 'user', content: 'test' }], 'openai')
+
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+    }))
+  })
+
   it('should return parsed JSON content from LLM response', async () => {
     const { generateText } = await import('ai')
     const generateTextMock = vi.mocked(generateText)

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -37,10 +37,26 @@ import {
 import { recordActualTokenUsage } from "./context-budget"
 
 /**
+ * Extended usage type that includes cache token details from AI SDK providers.
+ * OpenAI, Anthropic, and Gemini all populate these fields when prompt caching is active.
+ */
+interface ExtendedUsage {
+  inputTokens?: number
+  outputTokens?: number
+  inputTokenDetails?: {
+    cacheReadTokens?: number
+    cacheWriteTokens?: number
+    noCacheTokens?: number
+  }
+  totalTokens?: number
+}
+
+/**
  * Build token usage object for Langfuse, only including it when at least one token field is present.
  * This avoids reporting 0 tokens when the provider doesn't return usage data.
+ * Also extracts prompt caching metrics (cache read/write tokens) when available.
  */
-function buildTokenUsage(usage?: { inputTokens?: number; outputTokens?: number }): {
+function buildTokenUsage(usage?: ExtendedUsage): {
   promptTokens?: number
   completionTokens?: number
   totalTokens?: number
@@ -57,6 +73,48 @@ function buildTokenUsage(usage?: { inputTokens?: number; outputTokens?: number }
     promptTokens: inputTokens,
     completionTokens: outputTokens,
     totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0),
+  }
+}
+
+/**
+ * Log prompt cache hit/miss metrics from AI SDK usage data.
+ * OpenAI, Anthropic, and Gemini populate inputTokenDetails when caching is active.
+ * This helps monitor whether prompt caching is actually saving costs.
+ */
+function logCacheMetrics(
+  usage: ExtendedUsage | undefined,
+  strategy: string | undefined,
+  providerId: string,
+): void {
+  if (!usage?.inputTokenDetails) return
+
+  const { cacheReadTokens, cacheWriteTokens } = usage.inputTokenDetails
+  // Only log when we have actual cache data
+  if (cacheReadTokens === undefined && cacheWriteTokens === undefined) return
+
+  const inputTokens = usage.inputTokens ?? 0
+  const cacheRead = cacheReadTokens ?? 0
+  const cacheWrite = cacheWriteTokens ?? 0
+  const cacheHitRate = inputTokens > 0 ? Math.round((cacheRead / inputTokens) * 100) : 0
+
+  diagnosticsService.logInfo("prompt-cache", `Cache metrics: ${cacheHitRate}% hit rate`, {
+    provider: providerId,
+    strategy,
+    inputTokens,
+    cacheReadTokens: cacheRead,
+    cacheWriteTokens: cacheWrite,
+    cacheHitRate,
+  })
+
+  if (isDebugLLM()) {
+    logLLM("📦 Prompt cache metrics", {
+      provider: providerId,
+      strategy,
+      inputTokens,
+      cacheReadTokens: cacheRead,
+      cacheWriteTokens: cacheWrite,
+      cacheHitRate: `${cacheHitRate}%`,
+    })
   }
 }
 
@@ -752,6 +810,9 @@ export async function makeLLMCallWithFetch(
           throw error
         }
 
+        // Log prompt cache metrics from usage data
+        logCacheMetrics(result.usage as ExtendedUsage, promptCaching?.strategy, effectiveProviderId)
+
         const text = result.text?.trim() || ""
 
         // Check for native AI SDK tool calls first
@@ -991,6 +1052,9 @@ export async function makeLLMCallWithStreamingAndTools(
           }
         }
 
+        // Log prompt cache metrics from streaming usage data
+        logCacheMetrics(finishUsage as ExtendedUsage, promptCaching?.strategy, effectiveProviderId)
+
         if (generationId) {
           endLLMGeneration(generationId, {
             output: collectedToolCalls.length > 0
@@ -1087,6 +1151,9 @@ export async function makeTextCompletionWithFetch(
           abortSignal: abortController.signal,
           providerOptions: promptCaching?.providerOptions as any,
         })
+
+        // Log prompt cache metrics
+        logCacheMetrics(result.usage as ExtendedUsage, promptCaching?.strategy, effectiveProviderId)
 
         const text = result.text?.trim() || ""
 
@@ -1189,6 +1256,9 @@ export async function verifyCompletionWithFetch(
           }
           throw error
         }
+
+        // Log prompt cache metrics
+        logCacheMetrics(result.usage as ExtendedUsage, promptCaching?.strategy, effectiveProviderId)
 
         const text = result.text?.trim() || ""
         const jsonObject = extractJsonObject(text)

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1564,6 +1564,8 @@ export async function processTranscriptWithAgentMode(
   let verificationFailCount = 0 // Count consecutive verification failures to avoid loops
   const toolFailureCount = new Map<string, number>() // Track failures per tool name
   const MAX_TOOL_FAILURES = 3 // Max times a tool can fail before being excluded
+  let lastExcludedToolCount = 0 // Track previous excluded count to avoid unnecessary system prompt rebuilds
+  let cachedSystemPrompt: string | undefined // Cached rebuilt prompt when tools are excluded
 
   while (iteration < maxIterations) {
     iteration++
@@ -1583,22 +1585,28 @@ export async function processTranscriptWithAgentMode(
       logLLM(`ℹ️ ${excludedToolCount} tool(s) excluded due to repeated failures`)
     }
 
-    // Rebuild system prompt if tools were excluded to keep LLM's view of tools in sync
-    // This ensures the system prompt lists only the tools that are actually available
+    // Rebuild system prompt only when the excluded tool count actually changes.
+    // This keeps the system prompt stable across iterations for better prefix caching
+    // (OpenAI, Anthropic, and Gemini all cache based on prefix matching).
     let currentSystemPrompt = systemPrompt
     if (excludedToolCount > 0) {
-      currentSystemPrompt = constructSystemPrompt(
-        activeTools,
-        agentModeGuidelines,
-        true,
-        undefined, // relevantTools removed - let LLM decide tool relevance
-        customSystemPrompt, // custom base system prompt from profile snapshot or global config
-        skillsInstructions, // agent skills instructions
-        agentProperties, // dynamic agent properties
-        workingNotes, // injected working notes
-        excludeAgentId, // exclude this agent from delegation targets
-      )
-      logLLM(`[processTranscriptWithAgentMode] Rebuilt system prompt with ${activeTools.length} active tools (excluded ${excludedToolCount})`)
+      if (excludedToolCount !== lastExcludedToolCount) {
+        // Tool list changed — rebuild and cache the prompt
+        cachedSystemPrompt = constructSystemPrompt(
+          activeTools,
+          agentModeGuidelines,
+          true,
+          undefined, // relevantTools removed - let LLM decide tool relevance
+          customSystemPrompt, // custom base system prompt from profile snapshot or global config
+          skillsInstructions, // agent skills instructions
+          agentProperties, // dynamic agent properties
+          workingNotes, // injected working notes
+          excludeAgentId, // exclude this agent from delegation targets
+        )
+        lastExcludedToolCount = excludedToolCount
+        logLLM(`[processTranscriptWithAgentMode] Rebuilt system prompt with ${activeTools.length} active tools (excluded ${excludedToolCount})`)
+      }
+      currentSystemPrompt = cachedSystemPrompt!
     }
 
     // Check for stop signal (session-specific or global)


### PR DESCRIPTION
## Summary

Three improvements to take better advantage of prompt caching across LLM providers:

### 1. Track cache hit/miss metrics (low effort, high visibility)

Extract `inputTokenDetails.cacheReadTokens` and `cacheWriteTokens` from AI SDK usage data after every `generateText`/`streamText` call. Logs cache hit rates to diagnostics service and debug output so you can monitor whether caching is actually saving costs.

Example log: `Cache metrics: 80% hit rate` with details on read/write/total tokens.

### 2. Stabilize system prompts in agent loops (improves OpenAI cache hits)

Previously, the system prompt was rebuilt on **every iteration** when tools were excluded due to failures. Now it's only rebuilt when the excluded tool count actually **changes**. Since OpenAI's automatic prefix caching matches on identical prefixes, keeping the system prompt stable between iterations improves cache hit rates.

### 3. Detect Anthropic/Claude via OpenAI-compatible proxies

When the model name contains `claude` or `anthropic`, or the base URL points to `openrouter.ai`, automatically add `cache_control: { type: "ephemeral" }` as provider options. Unlike OpenAI and Gemini which cache implicitly, **Anthropic requires explicit cache markers** — this was previously only handled for Vercel AI Gateway users.

## Files Changed

- `ai-sdk-provider.ts` — Added `isAnthropicModel()`, `isAnthropicProxy()` helpers and `anthropic-cache-control` strategy
- `llm-fetch.ts` — Added `ExtendedUsage` type, `logCacheMetrics()` function, called after all 4 LLM call paths
- `llm.ts` — Cache system prompt across iterations when tool exclusion count is unchanged
- `ai-sdk-provider.test.ts` — 4 new tests for Anthropic detection
- `llm-fetch.test.ts` — 2 new tests for cache metrics logging and Anthropic provider options passthrough

## Testing

All 41 tests pass (11 provider + 30 fetch).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author