### PR TITLE
[codex] Remove mobile generic OpenAI-compatible mode

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -38,14 +38,13 @@ function parseDeepLink(url: string | null) {
   if (!url) return null;
   try {
     const parsed = Linking.parse(url);
-    // Handle dotagents://config?baseUrl=...&apiKey=...&model=...
+    // Handle dotagents://config?baseUrl=...&apiKey=...
     if (parsed.path === 'config' || parsed.hostname === 'config') {
-      const { baseUrl, apiKey, model } = parsed.queryParams || {};
-      if (baseUrl || apiKey || model) {
+      const { baseUrl, apiKey } = parsed.queryParams || {};
+      if (baseUrl || apiKey) {
         return {
           baseUrl: typeof baseUrl === 'string' ? baseUrl : undefined,
           apiKey: typeof apiKey === 'string' ? apiKey : undefined,
-          model: typeof model === 'string' ? model : undefined,
         };
       }
     }
@@ -65,6 +64,7 @@ function Navigation() {
 
   // Initialize tunnel connection manager for persistence and auto-reconnection
   const tunnelConnection = useTunnelConnectionProvider();
+  const isDotAgentsConnected = tunnelConnection.connectionInfo.state === 'connected';
 
   // Initialize push notifications
   const pushNotifications = usePushNotifications();
@@ -86,7 +86,10 @@ function Navigation() {
   const connectionManager = useConnectionManagerProvider(clientConfig);
 
   // Initialize profile provider to track current profile from server
-  const profileProvider = useProfileProvider(cfg.config.baseUrl, cfg.config.apiKey);
+  const profileProvider = useProfileProvider(
+    isDotAgentsConnected ? cfg.config.baseUrl : '',
+    isDotAgentsConnected ? cfg.config.apiKey : ''
+  );
 
   // Create navigation theme that matches our theme
   const navTheme = {
@@ -112,10 +115,14 @@ function Navigation() {
           ...cfg.config,
           ...(params.baseUrl && { baseUrl: params.baseUrl }),
           ...(params.apiKey && { apiKey: params.apiKey }),
-          ...(params.model && { model: params.model }),
         };
         cfg.setConfig(newConfig);
         await saveConfig(newConfig);
+        if (newConfig.baseUrl && newConfig.apiKey) {
+          void tunnelConnection.connect(newConfig.baseUrl, newConfig.apiKey);
+        } else {
+          void tunnelConnection.disconnect();
+        }
       }
     };
 
@@ -128,7 +135,7 @@ function Navigation() {
     });
 
     return () => subscription.remove();
-  }, [cfg.ready]);
+  }, [cfg.ready, cfg.config, cfg.setConfig, tunnelConnection]);
 
   // On Expo web in Chrome, default to the built-in free Google voice when available.
   useEffect(() => {
@@ -237,7 +244,7 @@ function Navigation() {
         // Clear badge when user opens the app or brings it to foreground
         clearNotifications();
         // Also clear badge count on server if connected
-        if (cfg.config.baseUrl && cfg.config.apiKey) {
+        if (isDotAgentsConnected) {
           clearServerBadge(cfg.config.baseUrl, cfg.config.apiKey).catch((err) => {
             console.warn('[App] Failed to clear server badge count:', err);
           });
@@ -248,7 +255,7 @@ function Navigation() {
     // Also clear immediately if app is already active and config is ready
     if (cfg.ready) {
       clearNotifications();
-      if (cfg.config.baseUrl && cfg.config.apiKey) {
+      if (isDotAgentsConnected) {
         clearServerBadge(cfg.config.baseUrl, cfg.config.apiKey).catch((err) => {
           console.warn('[App] Failed to clear server badge count:', err);
         });
@@ -257,12 +264,12 @@ function Navigation() {
 
     const subscription = AppState.addEventListener('change', handleAppStateChange);
     return () => subscription.remove();
-  }, [cfg.ready, cfg.config.baseUrl, cfg.config.apiKey]);
+  }, [cfg.ready, cfg.config.baseUrl, cfg.config.apiKey, isDotAgentsConnected]);
 
   // Auto-sync sessions with desktop server
   useEffect(() => {
     if (!cfg.ready || !sessionStore.ready) return;
-    if (!cfg.config.baseUrl || !cfg.config.apiKey) return;
+    if (!isDotAgentsConnected) return;
 
     const client = new SettingsApiClient(cfg.config.baseUrl, cfg.config.apiKey);
     let appState: AppStateStatus = AppState.currentState;
@@ -327,7 +334,7 @@ function Navigation() {
       stopPolling();
       subscription.remove();
     };
-  }, [cfg.ready, cfg.config.baseUrl, cfg.config.apiKey, sessionStore.ready, sessionStore.syncWithServer]);
+  }, [cfg.ready, cfg.config.baseUrl, cfg.config.apiKey, isDotAgentsConnected, sessionStore.ready, sessionStore.syncWithServer]);
 
   if (!cfg.ready || !sessionStore.ready) {
     return (

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,133 +1,101 @@
-# OpenAI Chat Mobile
+# DotAgents Mobile
 
-A React Native (Expo) mobile interface with voice interaction for OpenAI-compatible APIs — chat with AI models wherever you are, even hands‑free in the car. Quickly configure your API endpoint and model, then chat by text or voice with real‑time transcription and optional text‑to‑speech playback.
+A React Native (Expo) companion app for DotAgents. Pair it with a DotAgents desktop app or another DotAgents server, then continue chats on mobile with voice input, hands-free mode, text-to-speech, and synced conversation history.
 
 ## Features
 
-- Chat with any Inkeep Agent from your tenant
-- Voice input two ways:
-  - Press‑and‑hold mic for real‑time transcription; release to send (or release in edit mode to keep the text in the input)
-  - Hands‑free mode (VAD-backed) to toggle listening without holding the button
-- Assistant responses can be spoken aloud using text‑to‑speech (expo-speech)
-- Local vs Cloud environment toggle with separate Manage API and Run API base URLs
-- Persisted settings (API key, IDs, URLs, voice prefs) via AsyncStorage
-- Clean, readable UI with safe area support and basic theming
-- Web fallback for speech recognition when available (Chrome/Edge over HTTPS)
+- Pair with DotAgents by scanning a QR code from the desktop app
+- Manual fallback for direct DotAgents server URL + API key entry
+- Chat with your current DotAgents profile and synced conversations
+- Voice input:
+  - Press-and-hold mic for live transcription
+  - Hands-free mode for foreground chat sessions
+- Spoken assistant replies with text-to-speech
+- Push notifications and conversation sync when connected to DotAgents
 
 ## Architecture
 
 - Expo SDK 54, React Native 0.81, React 19
-- Navigation: @react-navigation/native + native-stack
-- Speech recognition: expo-speech-recognition (native); Web Speech API fallback in browsers
-- Speech synthesis: expo-speech
+- Navigation: `@react-navigation/native` + native stack
+- Speech recognition: `expo-speech-recognition` on native, Web Speech API fallback on web
+- Speech synthesis: `expo-speech`
 - Persistent config: AsyncStorage
-- OpenAI-compatible API integration
-  - Chat completions endpoint with optional streaming token updates
+- DotAgents remote server integration:
+  - connection handshake via `GET /v1/settings`
+  - chat via `/v1/chat/completions`
+  - conversation/profile/settings sync via existing DotAgents mobile endpoints
 
 Key files:
-- App.tsx: Navigation and providers
-- src/store/config.ts: Config shape, persistence
-- src/lib/openaiClient.ts: OpenAI-compatible API client with streaming parsing
-- src/screens/SettingsScreen.tsx: Configure API key, base URL, model, hands‑free toggle
-- src/screens/ChatScreen.tsx: Chat UI, voice UX, TTS
+- `App.tsx`: app providers, deep links, tunnel lifecycle, session sync
+- `src/store/config.ts`: persisted mobile config
+- `src/lib/openaiClient.ts`: DotAgents chat transport and streaming parser
+- `src/screens/ConnectionSettingsScreen.tsx`: QR pairing and manual DotAgents server connection
+- `src/screens/SettingsScreen.tsx`: local mobile settings plus connected DotAgents settings
+- `src/screens/ChatScreen.tsx`: chat UI, voice UX, TTS
 
-## Getting started
+## Getting Started
 
 Prerequisites:
 - Node 18+
-- Expo CLI (optional): `npm i -g expo` (you can also use `npx expo`)
 
 Install dependencies:
 
 ```bash
-npm install
+pnpm install
 ```
 
 Run the app:
 
 ```bash
-# Start Metro bundler (choose a platform in the UI)
-npm run start
+pnpm --filter @dotagents/mobile start
 
 # Or run directly on a device/simulator
-npm run ios
-npm run android
+pnpm --filter @dotagents/mobile ios
+pnpm --filter @dotagents/mobile android
 ```
 
-Open the app and configure Settings:
-- API Key: Your Inkeep API key (Bearer)
-- Tenant ID: Your tenant
-- Project ID: Your project under the tenant
-- Graph ID: Associated graph (if required by your setup)
-- Model: Model identifier used by Run API (default: gpt-4.1-mini)
-- Environment: Toggle Local vs Cloud
-  - Run API Base URL (Local/Cloud)
-  - Manage API Base URL (Local/Cloud)
-
-After saving, you’ll be taken to the Agents list. Pick an agent to start chatting.
+Connect the app:
+- Recommended: open DotAgents desktop remote server settings and scan the QR code
+- Fallback: open mobile connection settings and enter a DotAgents server URL plus API key
 
 ## Voice UX
 
-- Press‑and‑hold mic (when hands‑free is off):
-  - Hold to record with live transcription overlay
-  - Release to send; or release while in "edit" state to place the transcript into the text box for editing
-- Hands‑free mode:
-  - Toggle from the Chat screen header (microphone icon)
-  - App will listen without needing to hold the button and send on final speech segments
-- Assistant replies can be read aloud via text‑to‑speech
-
-Notes:
-- On native devices, the app uses expo-speech-recognition; on web, it falls back to the browser’s Web Speech API when available
-- Permissions for microphone and speech recognition are requested at runtime (see app.json for iOS `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`; Android uses `RECORD_AUDIO`)
-
-## OpenAI API compatibility
-
-The app works with any OpenAI-compatible API endpoint:
-- Chat completions endpoint at `/v1/chat/completions` supporting streaming (SSE or textual chunking)
-- The client falls back gracefully when streaming readers aren’t available in React Native
-- Compatible with OpenAI, Azure OpenAI, local models (Ollama, LM Studio), and other OpenAI-compatible services
-
-The API key is sent as `Authorization: Bearer <API_KEY>`.
+- Press-and-hold mic:
+  - Hold to record with live transcription
+  - Release to send, or release in edit mode to keep the text in the composer
+- Hands-free mode:
+  - Toggle from chat
+  - Mobile v1 only works while the app stays open on the Chat screen in the foreground
+- Assistant replies can be read aloud with text-to-speech
 
 ## Important: Development Build Required
 
-This app uses `expo-speech-recognition`, which is a native module **not included in Expo Go**. You must use a **development build** to run the app on Android or iOS devices.
+This app uses `expo-speech-recognition`, which is a native module and is not included in Expo Go. Use a development build on Android or iOS devices.
 
-If you see the error:
-```
+If you see:
+
+```text
 Error: Cannot find native module 'ExpoSpeechRecognition'
 ```
 
-You need to build and run the native app:
+build and run the native app:
 
 ```bash
-# For Android
-npx expo run:android
-
-# For iOS
-npx expo run:ios
-
-# If you have existing native folders and need a clean rebuild
-cd android && ./gradlew clean && cd ..
-npx expo run:android
+pnpm --filter @dotagents/mobile exec expo run:android
+pnpm --filter @dotagents/mobile exec expo run:ios
 ```
-
-This will compile the native code with all required modules and install the app on your device/emulator.
 
 ## Troubleshooting
 
-- Speech recognition not starting on native / `Cannot find native module 'ExpoSpeechRecognition'`:
-  - **You must use a development build** — Expo Go does not support native modules like `expo-speech-recognition`
-  - Run `npx expo run:android` or `npx expo run:ios` to build and install the development app
-  - See the "Important: Development Build Required" section above
-  - Verify microphone/speech permissions are granted
-- Web speech not working:
-  - Use Chrome or Edge over HTTPS; some browsers or insecure origins disable Web Speech API
-- Cannot list agents:
-  - Confirm Manage API base URL is reachable and `/health` returns OK
-  - Verify tenant/project IDs and API key
-- No assistant response:
-  - Check Run API base URL and logs; the client supports SSE and non‑SSE responses
+- Speech recognition not starting on native:
+  - use a development build, not Expo Go
+  - verify microphone and speech permissions
+- Mobile stays disconnected:
+  - rescan the desktop QR code or re-enter the DotAgents server URL and API key
+  - confirm the server exposes `GET /v1/settings`
+- Chats or settings do not sync:
+  - confirm the desktop remote server is running and reachable from the device
+  - reconnect from mobile connection settings if the saved server is stale
 
 ## License
 

--- a/apps/mobile/src/lib/connectionRecovery.ts
+++ b/apps/mobile/src/lib/connectionRecovery.ts
@@ -14,6 +14,7 @@ export {
   delay,
   formatConnectionStatus,
   checkServerConnection,
+  checkDotAgentsServerConnection,
   DEFAULT_RECOVERY_CONFIG,
 } from '@dotagents/shared';
 
@@ -268,4 +269,3 @@ export class ConnectionRecoveryManager {
     return this.state.conversationId;
   }
 }
-

--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -15,6 +15,7 @@ import {
   ConnectionStatus,
   RecoveryState,
   StreamingCheckpoint,
+  checkDotAgentsServerConnection,
   isRetryableError,
   delay,
   DEFAULT_RECOVERY_CONFIG,
@@ -22,7 +23,7 @@ import {
 } from './connectionRecovery';
 
 export type OpenAIConfig = {
-  baseUrl: string;    // OpenAI-compatible API base URL e.g., https://api.openai.com/v1
+  baseUrl: string;    // DotAgents API base URL e.g., https://example.com/v1
   apiKey: string;
   model?: string;
   recoveryConfig?: Partial<ConnectionRecoveryConfig>;
@@ -132,14 +133,12 @@ export class OpenAIClient {
   }
 
   async health(): Promise<boolean> {
-    const url = this.getUrl('/models');
-    try {
-      const res = await fetch(url, { headers: this.authHeaders() });
-      return res.ok;
-    } catch (error) {
-      console.error('[OpenAIClient] Health check error:', error);
+    const result = await checkDotAgentsServerConnection(this.baseUrl, this.cfg.apiKey);
+    if (!result.success) {
+      console.error('[OpenAIClient] Health check error:', result.error);
       return false;
     }
+    return true;
   }
 
   async chat(

--- a/apps/mobile/src/screens/AgentEditScreen.tsx
+++ b/apps/mobile/src/screens/AgentEditScreen.tsx
@@ -7,6 +7,7 @@ import { ExtendedSettingsApiClient, AgentProfileFull, AgentProfileCreateRequest,
 import { createButtonAccessibilityLabel, createMinimumTouchTargetStyle } from '../lib/accessibility';
 import { applyConnectionTypeChange, buildAgentConnectionRequestFields, type AgentConnectionFormFields, type ConnectionType } from './agent-edit-connection-utils';
 import { useConfigContext } from '../store/config';
+import { useTunnelConnection } from '../store/tunnelConnection';
 
 const CONNECTION_TYPES = [
   {
@@ -58,6 +59,8 @@ export default function AgentEditScreen({ navigation, route }: any) {
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
   const { config } = useConfigContext();
+  const { connectionInfo } = useTunnelConnection();
+  const isDotAgentsConnected = connectionInfo.state === 'connected';
   const agentId = route.params?.agentId as string | undefined;
   const isEditing = !!agentId;
 
@@ -70,11 +73,11 @@ export default function AgentEditScreen({ navigation, route }: any) {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const settingsClient = useMemo(() => {
-    if (config.baseUrl && config.apiKey) {
+    if (isDotAgentsConnected && config.baseUrl && config.apiKey) {
       return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
     }
     return null;
-  }, [config.baseUrl, config.apiKey]);
+  }, [config.baseUrl, config.apiKey, isDotAgentsConnected]);
 
   // Fetch existing profile if editing
   useEffect(() => {
@@ -113,6 +116,12 @@ export default function AgentEditScreen({ navigation, route }: any) {
       title: isEditing ? 'Edit Agent' : 'Create Agent',
     });
   }, [navigation, isEditing]);
+
+  useEffect(() => {
+    if (!settingsClient) {
+      setError((prev) => prev || 'Connect to a DotAgents server in Settings to edit agents');
+    }
+  }, [settingsClient]);
 
   const handleSave = useCallback(async () => {
     if (!settingsClient) return;
@@ -367,10 +376,14 @@ export default function AgentEditScreen({ navigation, route }: any) {
         />
       </View>
 
+      {!settingsClient && (
+        <Text style={styles.switchHelperText}>Connect to a DotAgents server in Settings before saving agent changes.</Text>
+      )}
+
       <TouchableOpacity
-        style={[styles.saveButton, isSaving && styles.saveButtonDisabled]}
+        style={[styles.saveButton, (isSaving || !settingsClient) && styles.saveButtonDisabled]}
         onPress={handleSave}
-        disabled={isSaving}
+        disabled={isSaving || !settingsClient}
       >
         {isSaving ? (
           <ActivityIndicator color={theme.colors.primaryForeground} size="small" />

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -492,17 +492,18 @@ export default function ChatScreen({ route, navigation }: any) {
   const messageQueue = useMessageQueueContext();
   const connectionManager = useConnectionManager();
   const { connectionInfo } = useTunnelConnection();
+  const isDotAgentsConnected = connectionInfo.state === 'connected';
   const { currentProfile } = useProfile();
   const currentAgentLabel = currentProfile?.name || 'Default Agent';
   const currentSession = sessionStore.getCurrentSession();
   const isCurrentSessionPinned = !!currentSession?.isPinned;
   const handsFree = !!config.handsFree;
   const settingsClient = useMemo(() => {
-    if (!config.baseUrl || !config.apiKey) {
+    if (!isDotAgentsConnected || !config.baseUrl || !config.apiKey) {
       return null;
     }
     return new SettingsApiClient(config.baseUrl, config.apiKey);
-  }, [config.apiKey, config.baseUrl]);
+  }, [config.apiKey, config.baseUrl, isDotAgentsConnected]);
   const [predefinedPrompts, setPredefinedPrompts] = useState<PredefinedPromptSummary[]>([]);
   const [isLoadingQuickStartPrompts, setIsLoadingQuickStartPrompts] = useState(false);
   const [addPromptModalVisible, setAddPromptModalVisible] = useState(false);
@@ -576,11 +577,15 @@ export default function ChatScreen({ route, navigation }: any) {
       console.warn('[ChatScreen] No current session ID, cannot get client');
       return null;
     }
+    if (!isDotAgentsConnected) {
+      console.warn('[ChatScreen] DotAgents connection is not ready');
+      return null;
+    }
     const connection = connectionManager.getOrCreateConnection(currentSessionId);
     // Note: Connection status callback is set up via subscribeToConnectionStatus in useEffect below
     // This avoids overwriting the SessionConnectionManager's internal callback (PR review fix)
     return connection.client;
-  }, [connectionManager, sessionStore.currentSessionId]);
+  }, [connectionManager, isDotAgentsConnected, sessionStore.currentSessionId]);
 
   // Subscribe to connection status changes for the current session
   // Uses subscribeToConnectionStatus to avoid overwriting the internal callback in SessionConnectionManager
@@ -1420,7 +1425,7 @@ export default function ChatScreen({ route, navigation }: any) {
   // Load messages when currentSession changes (fixes #470)
   useEffect(() => {
     const currentSessionId = sessionStore.currentSessionId;
-    const hasServerAuth = !!config.baseUrl && !!config.apiKey;
+    const hasServerAuth = isDotAgentsConnected && !!config.baseUrl && !!config.apiKey;
     let currentSession = sessionStore.getCurrentSession();
     const shouldAttemptStubLoad = !!(
       currentSession &&
@@ -1558,7 +1563,7 @@ export default function ChatScreen({ route, navigation }: any) {
       setMessages([]);
 	      replaceResponseHistory([]);
     }
-	  }, [sessionStore.currentSessionId, sessionStore, sessionStore.deletingSessionIds.size, config.baseUrl, config.apiKey, settingsClient, replaceResponseHistory]);
+	  }, [sessionStore.currentSessionId, sessionStore, sessionStore.deletingSessionIds.size, config.baseUrl, config.apiKey, isDotAgentsConnected, settingsClient, replaceResponseHistory]);
 
   // Auto-send initialMessage from route params (e.g. from rapid fire mode in SessionListScreen)
   const initialMessageRef = useRef<string | null>(route?.params?.initialMessage ?? null);
@@ -1936,7 +1941,13 @@ export default function ChatScreen({ route, navigation }: any) {
     const client = getSessionClient();
     if (!client) {
       console.error('[ChatScreen] No client available for send');
-      setDebugInfo('Error: No session available');
+      const errorText = isDotAgentsConnected
+        ? 'Error: No session available'
+        : 'Connect to a DotAgents server before sending messages.';
+      setDebugInfo(errorText);
+      if (!isDotAgentsConnected) {
+        Alert.alert('Connection Required', 'Connect to a DotAgents server before sending messages.');
+      }
       return;
     }
 
@@ -2954,38 +2965,44 @@ export default function ChatScreen({ route, navigation }: any) {
           )}
           {!sessionStore.isLoadingMessages && messages.length === 0 && (
             <View style={styles.chatHomeCard}>
-              {quickStartSections.map((section) => (
-                <View key={section.id} style={styles.chatHomeSection}>
-                  <Text style={styles.chatHomeSectionTitle}>{section.title}</Text>
-                  <View style={styles.chatHomeShortcutGrid}>
-                    {section.items.map((item) => (
-                      <Pressable
-                        key={item.id}
-                        style={({ pressed }) => [
-                          styles.chatHomeShortcutCard,
-                          item.action === 'add-prompt' && styles.chatHomeShortcutCardAdd,
-                          pressed && styles.chatHomeShortcutCardPressed,
-                        ]}
-                        onPress={() => {
-                          if (item.action === 'add-prompt') {
-                            setAddPromptModalVisible(true);
-                          } else {
-                            handleInsertQuickStartPrompt(item.content);
-                          }
-                        }}
-                        accessibilityRole="button"
-                        accessibilityLabel={createButtonAccessibilityLabel(item.action === 'add-prompt' ? 'Add new prompt' : `${section.title}: ${item.title}`)}
-                        accessibilityHint={item.action === 'add-prompt' ? 'Create a new saved prompt.' : 'Inserts this launcher text into the composer.'}
-                      >
-                        <Text style={[
-                          styles.chatHomeShortcutTitle,
-                          item.action === 'add-prompt' && styles.chatHomeShortcutTitleAdd,
-                        ]} numberOfLines={2}>{item.title}</Text>
-                      </Pressable>
-                    ))}
+              <Text style={styles.chatHomeEyebrow}>Quick start</Text>
+              <Text style={styles.chatHomeDescription}>
+                Custom commands, saved prompts, and starter packs
+              </Text>
+              <View style={styles.quickStartCategoryPills}>
+                {quickStartSections.map((section) => (
+                  <View key={section.id} style={styles.chatHomeSection}>
+                    <Text style={styles.chatHomeSectionTitle}>{section.title}</Text>
+                    <View style={styles.chatHomeShortcutGrid}>
+                      {section.items.map((item) => (
+                        <Pressable
+                          key={item.id}
+                          style={({ pressed }) => [
+                            styles.chatHomeShortcutCard,
+                            item.action === 'add-prompt' && styles.chatHomeShortcutCardAdd,
+                            pressed && styles.chatHomeShortcutCardPressed,
+                          ]}
+                          onPress={() => {
+                            if (item.action === 'add-prompt') {
+                              setAddPromptModalVisible(true);
+                            } else {
+                              handleInsertQuickStartPrompt(item.content);
+                            }
+                          }}
+                          accessibilityRole="button"
+                          accessibilityLabel={createButtonAccessibilityLabel(item.action === 'add-prompt' ? 'Add new prompt' : `${section.title}: ${item.title}`)}
+                          accessibilityHint={item.action === 'add-prompt' ? 'Create a new saved prompt.' : 'Inserts this launcher text into the composer.'}
+                        >
+                          <Text style={[
+                            styles.chatHomeShortcutTitle,
+                            item.action === 'add-prompt' && styles.chatHomeShortcutTitleAdd,
+                          ]} numberOfLines={2}>{item.title}</Text>
+                        </Pressable>
+                      ))}
+                    </View>
                   </View>
-                </View>
-              ))}
+                ))}
+              </View>
             </View>
           )}
           {canLoadOlderMessages && (
@@ -4205,6 +4222,21 @@ function createStyles(theme: Theme, screenHeight: number) {
       borderWidth: 1,
       borderColor: theme.colors.border,
       backgroundColor: theme.colors.card,
+      gap: spacing.sm,
+    },
+    chatHomeEyebrow: {
+      ...theme.typography.caption,
+      color: theme.colors.primary,
+      fontWeight: '700',
+      textTransform: 'uppercase',
+      letterSpacing: 0.6,
+    },
+    chatHomeDescription: {
+      ...theme.typography.body,
+      color: theme.colors.mutedForeground,
+      lineHeight: 20,
+    },
+    quickStartCategoryPills: {
       gap: spacing.sm,
     },
     chatHomeSection: {

--- a/apps/mobile/src/screens/ConnectionSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ConnectionSettingsScreen.tsx
@@ -6,7 +6,7 @@ import { useTheme } from '../ui/ThemeProvider';
 import { spacing, radius } from '../ui/theme';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import * as Linking from 'expo-linking';
-import { checkServerConnection } from '../lib/connectionRecovery';
+import { checkDotAgentsServerConnection } from '../lib/connectionRecovery';
 import { useTunnelConnection } from '../store/tunnelConnection';
 import {
   createButtonAccessibilityLabel,
@@ -15,19 +15,16 @@ import {
 } from '../lib/accessibility';
 import { resolveQrScannerActivation } from './connection-settings-qr';
 
-const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-
-function parseQRCode(data: string): { baseUrl?: string; apiKey?: string; model?: string } | null {
+function parseQRCode(data: string): { baseUrl?: string; apiKey?: string } | null {
   try {
     const parsed = Linking.parse(data);
-    // Handle dotagents://config?baseUrl=...&apiKey=...&model=...
+    // Handle dotagents://config?baseUrl=...&apiKey=...
     if (parsed.scheme === 'dotagents' && (parsed.path === 'config' || parsed.hostname === 'config')) {
-      const { baseUrl, apiKey, model } = parsed.queryParams || {};
-      if (baseUrl || apiKey || model) {
+      const { baseUrl, apiKey } = parsed.queryParams || {};
+      if (baseUrl || apiKey) {
         return {
           baseUrl: typeof baseUrl === 'string' ? baseUrl : undefined,
           apiKey: typeof apiKey === 'string' ? apiKey : undefined,
-          model: typeof model === 'string' ? model : undefined,
         };
       }
     }
@@ -48,7 +45,7 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
   const [isCheckingConnection, setIsCheckingConnection] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [showApiKey, setShowApiKey] = useState(false);
-  const { connect: tunnelConnect, disconnect: tunnelDisconnect } = useTunnelConnection();
+  const { connect: tunnelConnect, disconnect: tunnelDisconnect, connectionInfo } = useTunnelConnection();
   const autoOpenScannerHandledRef = useRef(false);
 
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -74,66 +71,42 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
     // Clear any previous error
     setConnectionError(null);
 
-    // Default to OpenAI URL if baseUrl is empty
-    if (!normalizedDraft.baseUrl) {
-      normalizedDraft.baseUrl = DEFAULT_OPENAI_BASE_URL;
-    }
-
-    const hasCustomUrl = normalizedDraft.baseUrl && normalizedDraft.baseUrl.replace(/\/+$/, '') !== DEFAULT_OPENAI_BASE_URL;
-    const hasApiKey = normalizedDraft.apiKey && normalizedDraft.apiKey.length > 0;
-
-    // On first-time setup, do not silently save a disconnected default config.
-    if (!isConnected && !hasApiKey) {
-      setConnectionError('Enter an API key or scan a DotAgents QR code before saving');
+    if (!normalizedDraft.baseUrl || !normalizedDraft.apiKey) {
+      setConnectionError('Scan a DotAgents QR code or enter both a DotAgents server URL and API key before saving.');
       return;
     }
 
-    // Require API key when using a custom server URL
-    if (hasCustomUrl && !hasApiKey) {
-      setConnectionError('API Key is required when using a custom server URL');
-      return;
-    }
+    setIsCheckingConnection(true);
 
-    // Validate: if API key is set, base URL must also be set
-    if (hasApiKey && !normalizedDraft.baseUrl) {
-      setConnectionError('Base URL is required when an API key is provided');
-      return;
-    }
+    try {
+      const result = await checkDotAgentsServerConnection(
+        normalizedDraft.baseUrl,
+        normalizedDraft.apiKey,
+        10000
+      );
 
-    // Only check connection if we have both a custom URL and API key
-    if (hasApiKey && normalizedDraft.baseUrl) {
-      setIsCheckingConnection(true);
-
-      try {
-        const result = await checkServerConnection(
-          normalizedDraft.baseUrl,
-          normalizedDraft.apiKey,
-          10000
-        );
-
-        if (!result.success) {
-          setConnectionError(result.error || 'Connection failed');
-          setIsCheckingConnection(false);
-          return;
-        }
-
-        if (result.normalizedUrl) {
-          normalizedDraft = {
-            ...normalizedDraft,
-            baseUrl: result.normalizedUrl,
-          };
-        }
-
-        console.log('[ConnectionSettings] Connection check successful:', result);
-      } catch (error: any) {
-        console.error('[ConnectionSettings] Connection check error:', error);
-        setConnectionError(error.message || 'Connection check failed');
+      if (!result.success) {
+        setConnectionError(result.error || 'Connection failed');
         setIsCheckingConnection(false);
         return;
       }
 
+      if (result.normalizedUrl) {
+        normalizedDraft = {
+          ...normalizedDraft,
+          baseUrl: result.normalizedUrl,
+        };
+      }
+
+      console.log('[ConnectionSettings] Connection check successful:', result);
+    } catch (error: any) {
+      console.error('[ConnectionSettings] Connection check error:', error);
+      setConnectionError(error.message || 'Connection check failed');
       setIsCheckingConnection(false);
+      return;
     }
+
+    setIsCheckingConnection(false);
 
     // Connection successful, proceed
     setConfig(normalizedDraft);
@@ -196,7 +169,6 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
         ...prev,
         ...(params.baseUrl && { baseUrl: params.baseUrl }),
         ...(params.apiKey && { apiKey: params.apiKey }),
-        ...(params.model && { model: params.model }),
       }));
       setShowScanner(false);
     } else {
@@ -205,12 +177,15 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
     }
   };
 
-  const resetBaseUrl = () => {
-    setDraft(prev => ({ ...prev, baseUrl: DEFAULT_OPENAI_BASE_URL }));
-  };
-
-  // Connection status indicator
-  const isConnected = Boolean(config.baseUrl && config.apiKey);
+  const isConnected = connectionInfo.state === 'connected';
+  const statusTitle = connectionInfo.state === 'connecting' || connectionInfo.state === 'reconnecting'
+    ? 'Connecting to DotAgents'
+    : connectionInfo.state === 'failed'
+      ? 'Connection failed'
+      : isConnected
+        ? 'Connected to DotAgents'
+        : 'Not connected';
+  const statusUrl = connectionInfo.baseUrl || config.baseUrl;
 
   if (!ready) return null;
 
@@ -231,12 +206,12 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
           <View style={styles.statusRow}>
             <View style={[styles.statusDot, isConnected ? styles.statusConnected : styles.statusDisconnected]} />
             <Text style={styles.statusText}>
-              {isConnected ? 'Connected' : 'Not connected'}
+              {statusTitle}
             </Text>
           </View>
-          {isConnected && (
+          {!!statusUrl && (
             <Text style={styles.statusUrl} numberOfLines={1}>
-              {config.baseUrl}
+              {statusUrl}
             </Text>
           )}
         </View>
@@ -251,7 +226,7 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
           <Text style={styles.scanButtonText}>Scan QR Code</Text>
         </TouchableOpacity>
         <Text style={styles.helperText}>
-          Scan the QR code from your DotAgents desktop app to connect
+          Scan the QR code from your DotAgents desktop app to pair this device.
         </Text>
 
         <View style={styles.labelRow}>
@@ -273,45 +248,37 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
           placeholder="sk-..."
           placeholderTextColor={theme.colors.mutedForeground}
           accessibilityLabel={createTextInputAccessibilityLabel('API key')}
-          accessibilityHint="Enter your API key used to connect to your model provider"
+          accessibilityHint="Enter the API key for your DotAgents server"
           autoCapitalize='none'
           secureTextEntry={!showApiKey}
         />
 
-        <View style={styles.labelRow}>
-          <Text style={styles.label}>Base URL</Text>
-          <TouchableOpacity
-            onPress={resetBaseUrl}
-            style={styles.inlineActionButton}
-            accessibilityRole="button"
-            accessibilityLabel={createButtonAccessibilityLabel('Reset base URL to default')}
-            accessibilityHint="Restores the default OpenAI-compatible base URL"
-          >
-            <Text style={styles.resetText}>Reset to default</Text>
-          </TouchableOpacity>
-        </View>
+        <Text style={styles.label}>DotAgents Server URL</Text>
         <TextInput
           style={styles.input}
           value={draft.baseUrl}
           onChangeText={(t) => setDraft({ ...draft, baseUrl: t })}
-          placeholder='https://api.openai.com/v1'
+          placeholder='https://your-server.example.com/v1'
           placeholderTextColor={theme.colors.mutedForeground}
-          accessibilityLabel={createTextInputAccessibilityLabel('Base URL')}
-          accessibilityHint="Enter the base URL for your OpenAI-compatible server"
+          accessibilityLabel={createTextInputAccessibilityLabel('DotAgents server URL')}
+          accessibilityHint="Enter the base URL for your DotAgents server"
           autoCapitalize='none'
         />
+        <Text style={styles.helperText}>
+          Use this if you are connecting to a DotAgents server directly instead of scanning a QR code.
+        </Text>
 
         <TouchableOpacity
           style={[styles.primaryButton, isCheckingConnection && styles.primaryButtonDisabled]}
           onPress={onSave}
           disabled={isCheckingConnection}
           accessibilityRole="button"
-          accessibilityLabel={isCheckingConnection ? 'Testing connection' : 'Test & Save'}
+          accessibilityLabel={isCheckingConnection ? 'Testing DotAgents connection' : 'Test and save DotAgents connection'}
         >
           {isCheckingConnection ? (
             <View style={styles.loadingContainer}>
               <ActivityIndicator color={theme.colors.primaryForeground} size="small" />
-              <Text style={styles.primaryButtonText}>  Testing connection...</Text>
+              <Text style={styles.primaryButtonText}>  Testing DotAgents connection...</Text>
             </View>
           ) : (
             <Text style={styles.primaryButtonText}>Test & Save</Text>
@@ -510,4 +477,3 @@ function createStyles(theme: ReturnType<typeof useTheme>['theme']) {
     },
   });
 }
-

--- a/apps/mobile/src/screens/KnowledgeNoteEditScreen.tsx
+++ b/apps/mobile/src/screens/KnowledgeNoteEditScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from '../lib/settingsApi';
 import { createButtonAccessibilityLabel, createMinimumTouchTargetStyle } from '../lib/accessibility';
 import { useConfigContext } from '../store/config';
+import { useTunnelConnection } from '../store/tunnelConnection';
 
 const CONTEXT_OPTIONS: { label: string; value: KnowledgeNoteContext; description: string }[] = [
   { label: 'Search only', value: 'search-only', description: 'Keep this note available for search and explicit retrieval.' },
@@ -56,6 +57,8 @@ export default function KnowledgeNoteEditScreen({ navigation, route }: any) {
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
   const { config } = useConfigContext();
+  const { connectionInfo } = useTunnelConnection();
+  const isDotAgentsConnected = connectionInfo.state === 'connected';
 
   const noteFromRoute = route.params?.note as KnowledgeNote | undefined;
   const noteId = route.params?.noteId as string | undefined;
@@ -72,11 +75,11 @@ export default function KnowledgeNoteEditScreen({ navigation, route }: any) {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const settingsClient = useMemo(() => {
-    if (config.baseUrl && config.apiKey) {
+    if (isDotAgentsConnected && config.baseUrl && config.apiKey) {
       return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
     }
     return null;
-  }, [config.baseUrl, config.apiKey]);
+  }, [config.baseUrl, config.apiKey, isDotAgentsConnected]);
 
   useEffect(() => {
     navigation.setOptions({ title: isEditing ? 'Edit Note' : 'Create Note' });
@@ -85,7 +88,7 @@ export default function KnowledgeNoteEditScreen({ navigation, route }: any) {
   useEffect(() => {
     if (isEditing && !noteFromRoute && !settingsClient) {
       setIsLoading(false);
-      setError('Configure Base URL and API key to load and save notes');
+      setError('Connect to a DotAgents server in Settings to load and save notes');
     }
   }, [isEditing, noteFromRoute, settingsClient]);
 
@@ -121,7 +124,7 @@ export default function KnowledgeNoteEditScreen({ navigation, route }: any) {
 
   const handleSave = useCallback(async () => {
     if (!settingsClient) {
-      setError('Configure Base URL and API key in Settings before saving this note');
+      setError('Connect to a DotAgents server in Settings before saving this note');
       return;
     }
 
@@ -197,7 +200,7 @@ export default function KnowledgeNoteEditScreen({ navigation, route }: any) {
       >
         {error && <Text style={styles.errorText}>{error}</Text>}
         {!settingsClient && (
-          <Text style={styles.helperText}>Configure Base URL and API key in Settings to save note changes.</Text>
+          <Text style={styles.helperText}>Connect to a DotAgents server in Settings to save note changes.</Text>
         )}
 
         <Text style={styles.label}>Note ID</Text>

--- a/apps/mobile/src/screens/LoopEditScreen.tsx
+++ b/apps/mobile/src/screens/LoopEditScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from '../lib/settingsApi';
 import { createButtonAccessibilityLabel, createMinimumTouchTargetStyle } from '../lib/accessibility';
 import { useConfigContext } from '../store/config';
+import { useTunnelConnection } from '../store/tunnelConnection';
 
 type LoopFormData = {
   name: string;
@@ -44,6 +45,8 @@ export default function LoopEditScreen({ navigation, route }: any) {
   const insets = useSafeAreaInsets();
   const { theme } = useTheme();
   const { config } = useConfigContext();
+  const { connectionInfo } = useTunnelConnection();
+  const isDotAgentsConnected = connectionInfo.state === 'connected';
 
   const loopFromRoute = route.params?.loop as Loop | undefined;
   const loopId = route.params?.loopId as string | undefined;
@@ -70,11 +73,11 @@ export default function LoopEditScreen({ navigation, route }: any) {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const settingsClient = useMemo(() => {
-    if (config.baseUrl && config.apiKey) {
+    if (isDotAgentsConnected && config.baseUrl && config.apiKey) {
       return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
     }
     return null;
-  }, [config.baseUrl, config.apiKey]);
+  }, [config.baseUrl, config.apiKey, isDotAgentsConnected]);
 
   useEffect(() => {
     navigation.setOptions({ title: isEditing ? 'Edit Loop' : 'Create Loop' });
@@ -83,7 +86,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
   useEffect(() => {
     if (isEditing && !loopFromRoute && !settingsClient) {
       setIsLoading(false);
-      setError('Configure Base URL and API key to load and save loops');
+      setError('Connect to a DotAgents server in Settings to load and save loops');
     }
   }, [isEditing, loopFromRoute, settingsClient]);
 
@@ -150,7 +153,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
 
   const handleSave = useCallback(async () => {
     if (!settingsClient) {
-      setError('Configure Base URL and API key in Settings before saving');
+      setError('Connect to a DotAgents server in Settings before saving');
       return;
     }
 
@@ -220,7 +223,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
         keyboardShouldPersistTaps="handled"
       >
       {error && <Text style={styles.errorText}>{error}</Text>}
-      {!settingsClient && <Text style={styles.helperText}>Configure Base URL and API key in Settings to save changes.</Text>}
+      {!settingsClient && <Text style={styles.helperText}>Connect to a DotAgents server in Settings to save changes.</Text>}
 
       <Text style={styles.label}>Name *</Text>
       <TextInput

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -756,11 +756,11 @@ export default function SessionListScreen({ navigation }: Props) {
 
   // Create a settings client for syncing pin/archive state to server
   const settingsClient = useMemo(() => {
-    if (config.baseUrl && config.apiKey) {
+    if (isConnected && config.baseUrl && config.apiKey) {
       return new SettingsApiClient(config.baseUrl, config.apiKey);
     }
     return undefined;
-  }, [config.baseUrl, config.apiKey]);
+  }, [config.baseUrl, config.apiKey, isConnected]);
 
   const handleToggleSessionPinned = useCallback(async (sessionId: string) => {
     await sessionStore.toggleSessionPinned(sessionId, settingsClient);
@@ -822,10 +822,10 @@ export default function SessionListScreen({ navigation }: Props) {
   const disconnectedSubtitle = connectionInfo.state === 'connecting' || connectionInfo.state === 'reconnecting'
     ? 'We are pairing with your desktop. Your conversation history will appear here as soon as the connection is ready.'
     : connectionInfo.state === 'failed'
-      ? 'Open connection settings or scan a fresh QR code to restore syncing and get back into your conversations.'
+      ? `Open connection settings or scan a fresh QR code to restore syncing and get back into your conversations.${connectionInfo.errorMessage ? ` ${connectionInfo.errorMessage}` : ''}`
       : hasConfiguredConnection
         ? 'Your mobile app is set up, but it is not currently connected. Reconnect to load your recent conversations.'
-        : 'Scan the QR code from the desktop app to pair this device and bring your conversations into mobile.';
+        : 'Scan the QR code from the desktop app to pair this device, or open connection settings to enter a DotAgents server URL and API key.';
 
   // Build a set of stub session IDs for display purposes
   const stubSessionIds = useMemo(() => {

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from '../store/config';
 import { useSessionContext } from '../store/sessions';
 import { useConnectionManager } from '../store/connectionManager';
+import { useTunnelConnection } from '../store/tunnelConnection';
 import { useTheme, ThemeMode } from '../ui/ThemeProvider';
 import { spacing, radius } from '../ui/theme';
 import { useProfile } from '../store/profile';
@@ -181,6 +182,9 @@ export default function SettingsScreen({ navigation }: any) {
   const { setCurrentProfile: setProfileContext } = useProfile();
   const sessionStore = useSessionContext();
   const connectionManager = useConnectionManager();
+  const { connectionInfo } = useTunnelConnection();
+  const isDotAgentsConnected = connectionInfo.state === 'connected';
+  const hasSavedConnection = Boolean(config.baseUrl && config.apiKey);
 
   // Push notification state
   const {
@@ -343,11 +347,11 @@ export default function SettingsScreen({ navigation }: any) {
 
   // Create settings API client when we have valid credentials
   const settingsClient = useMemo(() => {
-    if (config.baseUrl && config.apiKey) {
+    if (isDotAgentsConnected && config.baseUrl && config.apiKey) {
       return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
     }
     return null;
-  }, [config.baseUrl, config.apiKey]);
+  }, [config.baseUrl, config.apiKey, isDotAgentsConnected]);
 
   // Clear pending model update timeout when settingsClient changes
   // to prevent sending updates to the previous server
@@ -373,7 +377,6 @@ export default function SettingsScreen({ navigation }: any) {
 
     try {
       const errors: string[] = [];
-      let successCount = 0;
 
       const [profilesRes, serversRes, settingsRes] = await Promise.all([
         settingsClient.getProfiles().catch((e) => { errors.push('profiles'); return null; }),
@@ -384,11 +387,9 @@ export default function SettingsScreen({ navigation }: any) {
       if (profilesRes) {
         setProfiles(profilesRes.profiles);
         setCurrentProfileId(profilesRes.currentProfileId);
-        successCount++;
       }
       if (serversRes) {
         setMcpServers(serversRes.servers);
-        successCount++;
       }
       if (settingsRes) {
         setRemoteSettings(settingsRes);
@@ -403,18 +404,17 @@ export default function SettingsScreen({ navigation }: any) {
           langfuseSecretKey: settingsRes.langfuseSecretKey === '••••••••' ? '' : (settingsRes.langfuseSecretKey || ''),
           langfuseBaseUrl: settingsRes.langfuseBaseUrl || '',
         });
-        successCount++;
+      } else {
+        setRemoteSettings(null);
       }
 
-      // Consider it a DotAgents server if at least one endpoint succeeded
-      // This gates the Desktop Settings section for non-DotAgents endpoints (e.g., OpenAI)
-      setIsDotAgentsServer(successCount > 0);
+      // The mobile app only considers a server valid when the DotAgents settings API responds.
+      setIsDotAgentsServer(!!settingsRes);
 
-      // Show error if any endpoint failed but at least one succeeded
-      if (errors.length > 0 && successCount > 0) {
+      // Show error if any secondary endpoint failed while settings succeeded.
+      if (errors.length > 0 && settingsRes) {
         setRemoteError(`Failed to load: ${errors.join(', ')}`);
-      } else if (successCount === 0) {
-        // All endpoints failed - not a DotAgents server
+      } else if (!settingsRes) {
         setIsDotAgentsServer(false);
       }
     } catch (error: any) {
@@ -836,8 +836,8 @@ export default function SettingsScreen({ navigation }: any) {
 
   // Handle push notification toggle
   const handleNotificationToggle = async (enabled: boolean) => {
-    if (!config.baseUrl || !config.apiKey) {
-      Alert.alert('Configuration Required', 'Please configure your server connection first.');
+    if (!isDotAgentsConnected || !config.baseUrl || !config.apiKey) {
+      Alert.alert('Connection Required', 'Connect to a DotAgents server before changing push notification settings.');
       return;
     }
 
@@ -907,7 +907,7 @@ export default function SettingsScreen({ navigation }: any) {
     }
   };
 
-  // Handle preset change (OpenAI compatible providers)
+  // Handle preset change for DotAgents-managed model presets
   const handlePresetChange = async (presetId: string) => {
     if (!settingsClient || !remoteSettings || remoteSettings.currentModelPresetId === presetId) return;
 
@@ -936,9 +936,9 @@ export default function SettingsScreen({ navigation }: any) {
 
   // Get current preset display name
   const getCurrentPresetName = () => {
-    if (!remoteSettings?.availablePresets || !remoteSettings.currentModelPresetId) return 'OpenAI';
+    if (!remoteSettings?.availablePresets || !remoteSettings.currentModelPresetId) return 'Preset';
     const preset = remoteSettings.availablePresets.find(p => p.id === remoteSettings.currentModelPresetId);
-    return preset?.name || 'OpenAI';
+    return preset?.name || 'Preset';
   };
 
   // Handle model name change with debouncing to avoid request storms per keystroke
@@ -1218,12 +1218,12 @@ export default function SettingsScreen({ navigation }: any) {
                 <View style={[
                   styles.statusDot,
                   { width: 10, height: 10, borderRadius: 5 },
-                  config.baseUrl && config.apiKey
+                  isDotAgentsConnected
                     ? styles.statusConnected
                     : { backgroundColor: '#ef4444' }
                 ]} />
                 <Text style={styles.connectionCardTitle}>
-                  {config.baseUrl && config.apiKey ? 'Connected' : 'Not connected'}
+                  {isDotAgentsConnected ? 'Connected to DotAgents' : hasSavedConnection ? 'Reconnect to DotAgents' : 'Not connected'}
                 </Text>
               </View>
               {config.baseUrl && (
@@ -1238,7 +1238,7 @@ export default function SettingsScreen({ navigation }: any) {
 
         {/* Go to Chats button */}
         <TouchableOpacity
-          style={[styles.primaryButton, !(config.baseUrl && config.apiKey) && styles.primaryButtonDisabled]}
+          style={[styles.primaryButton, !isDotAgentsConnected && styles.primaryButtonDisabled]}
           onPress={() => {
             if (navigation.canGoBack?.()) {
               navigation.goBack();
@@ -1247,7 +1247,7 @@ export default function SettingsScreen({ navigation }: any) {
 
             navigation.navigate('Sessions');
           }}
-          disabled={!(config.baseUrl && config.apiKey)}
+          disabled={!isDotAgentsConnected}
           accessibilityRole="button"
           accessibilityLabel="Go to Chats"
         >
@@ -1639,7 +1639,7 @@ export default function SettingsScreen({ navigation }: any) {
 
                 {remoteSettings.mcpToolsProviderId === 'openai' && remoteSettings.availablePresets && remoteSettings.availablePresets.length > 0 && (
                   <>
-                    <Text style={styles.label}>OpenAI Compatible Endpoint</Text>
+                    <Text style={styles.label}>Model Preset</Text>
                     <TouchableOpacity
                       style={styles.modelSelector}
                       onPress={() => setShowPresetPicker(true)}

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -4,7 +4,7 @@ import { normalizeApiBaseUrl } from '@dotagents/shared';
 
 export type AppConfig = {
   apiKey: string;
-  baseUrl: string; // OpenAI-compatible API base URL e.g., https://api.openai.com/v1
+  baseUrl: string; // DotAgents API base URL e.g., https://example.com/v1
   model: string; // model name required by /v1/chat/completions
   handsFree?: boolean; // hands-free voice mode toggle (optional for backward compatibility)
   handsFreeMessageDebounceMs?: number; // silence window before auto-sending a hands-free message
@@ -41,7 +41,7 @@ function normalizeHandsFreeMessageDebounceMs(value?: number) {
 
 export const DEFAULT_APP_CONFIG: AppConfig = {
   apiKey: '',
-  baseUrl: 'https://api.openai.com/v1',
+  baseUrl: '',
   model: 'gpt-4.1-mini',
   handsFree: false,
   handsFreeMessageDebounceMs: DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS,
@@ -107,4 +107,3 @@ export function useConfigContext() {
   if (!ctx) throw new Error('ConfigContext missing');
   return ctx;
 }
-

--- a/apps/mobile/src/ui/AgentSelectorSheet.tsx
+++ b/apps/mobile/src/ui/AgentSelectorSheet.tsx
@@ -21,6 +21,7 @@ import { useConfigContext } from '../store/config';
 import { ExtendedSettingsApiClient, SettingsApiClient } from '../lib/settingsApi';
 import { useProfile } from '../store/profile';
 import { SelectableProfile, buildSelectorProfiles } from './agentSelectorOptions';
+import { useTunnelConnection } from '../store/tunnelConnection';
 
 interface AgentSelectorSheetProps {
   visible: boolean;
@@ -31,10 +32,11 @@ export function AgentSelectorSheet({ visible, onClose }: AgentSelectorSheetProps
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
   const { config } = useConfigContext();
+  const { connectionInfo } = useTunnelConnection();
   const { currentProfile, setCurrentProfile } = useProfile();
   const styles = React.useMemo(() => createStyles(theme), [theme]);
-  const hasApiConfig = Boolean(config.baseUrl && config.apiKey);
-  const missingConfigError = 'Configure server URL and API key to switch agents';
+  const hasApiConfig = connectionInfo.state === 'connected' && Boolean(config.baseUrl && config.apiKey);
+  const missingConfigError = 'Connect to a DotAgents server to switch agents';
 
   const [profiles, setProfiles] = useState<SelectableProfile[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/apps/mobile/tests/chat-screen-density.test.js
+++ b/apps/mobile/tests/chat-screen-density.test.js
@@ -71,11 +71,12 @@ test('bases assistant collapse decisions on visible content instead of raw tool 
 
 test('derives tool execution card status from displayed non-meta tool entries', () => {
   assert.match(screenSource, /const displayToolEntries = toolCalls\.reduce\(/);
-  assert.match(screenSource, /const allSuccess =\s+hasToolResults && displayToolEntries\.every\(entry => entry\.result\?\.success === true\);/);
-  assert.match(screenSource, /const hasErrors = displayToolEntries\.some\(entry => entry\.result\?\.success === false\);/);
-  assert.match(screenSource, /const isPending =\s+displayToolEntries\.some\(entry => !entry\.result && entry\.origIdx >= toolResultCount\);/);
-  assert.match(screenSource, /\{displayToolEntries\.map\(\(\{ toolCall, origIdx, result: tcResult \}, tcIdx\) => \{/);
-  assert.match(screenSource, /\{displayToolEntries\.map\(\(\{ toolCall, origIdx, result \}, idx\) => \{/);
+  assert.match(screenSource, /const renderedToolEntries = fallbackToolEntries\.length > 0\s+\? fallbackToolEntries\s+\: displayToolEntries;/);
+  assert.match(screenSource, /const allSuccess =\s+hasToolResults && renderedToolEntries\.every\(entry => entry\.result\?\.success === true\);/);
+  assert.match(screenSource, /const hasErrors = renderedToolEntries\.some\(entry => entry\.result\?\.success === false\);/);
+  assert.match(screenSource, /const isPending =\s+renderedToolEntries\.some\(entry => !entry\.result && entry\.origIdx >= toolResultCount\);/);
+  assert.match(screenSource, /\{renderedToolEntries\.map\(\(\{ toolCall, origIdx, result: tcResult \}, tcIdx\) => \{/);
+  assert.match(screenSource, /\{renderedToolEntries\.map\(\(\{ toolCall, origIdx, result \}, idx\) => \{/);
   assert.doesNotMatch(screenSource, /const allSuccess = hasToolResults && m\.toolResults!\.every\(r => r\.success\);/);
   assert.doesNotMatch(screenSource, /const hasErrors = hasToolResults && m\.toolResults!\.some\(r => !r\.success\);/);
 });

--- a/apps/mobile/tests/connection-settings-density.test.js
+++ b/apps/mobile/tests/connection-settings-density.test.js
@@ -17,5 +17,5 @@ test('avoids decorative emoji chrome in the mobile connection settings screen', 
 test('keeps QR actions explicitly labeled after removing decorative glyphs', () => {
   assert.match(screenSource, /accessibilityLabel="Scan QR Code"/);
   assert.match(screenSource, /accessibilityLabel="Close QR scanner"/);
-  assert.match(screenSource, /Scan the QR code from your DotAgents desktop app to connect/);
+  assert.match(screenSource, /Scan the QR code from your DotAgents desktop app to pair this device\./);
 });

--- a/apps/mobile/tests/connection-settings-validation.test.js
+++ b/apps/mobile/tests/connection-settings-validation.test.js
@@ -8,16 +8,13 @@ const screenSource = fs.readFileSync(
   'utf8'
 );
 
-test('blocks first-time save when no API key is provided', () => {
-  assert.match(screenSource, /if \(!isConnected && !hasApiKey\) \{/);
-  assert.match(screenSource, /Enter an API key or scan a DotAgents QR code before saving/);
+test('requires both a DotAgents server URL and API key before saving', () => {
+  assert.match(screenSource, /if \(!normalizedDraft\.baseUrl \|\| !normalizedDraft\.apiKey\) \{/);
+  assert.match(screenSource, /Scan a DotAgents QR code or enter both a DotAgents server URL and API key before saving\./);
 });
 
-test('keeps the custom URL validation after the no-key guard', () => {
-  assert.match(
-    screenSource,
-    /if \(!isConnected && !hasApiKey\) \{[\s\S]*?return;[\s\S]*?if \(hasCustomUrl && !hasApiKey\) \{/
-  );
+test('validates the DotAgents handshake through the settings API', () => {
+  assert.match(screenSource, /checkDotAgentsServerConnection\(/);
 });
 
 test('exposes the API key visibility toggle as a button with a larger touch target', () => {
@@ -25,15 +22,22 @@ test('exposes the API key visibility toggle as a button with a larger touch targ
   assert.match(screenSource, /inlineActionButton:\s*\{[\s\S]*?createMinimumTouchTargetStyle\([\s\S]*?minSize:\s*44,/);
 });
 
-test('exposes the reset action as an accessible button with a descriptive label', () => {
-  assert.match(screenSource, /createButtonAccessibilityLabel\('Reset base URL to default'\)/);
-  assert.match(screenSource, /Restores the default OpenAI-compatible base URL/);
+test('removes the generic base URL reset affordance', () => {
+  assert.doesNotMatch(screenSource, /Reset base URL to default/);
+  assert.doesNotMatch(screenSource, /Restores the default OpenAI-compatible base URL/);
 });
 
 test('surfaces a clear error when QR scanning cannot get camera permission', () => {
   assert.match(screenSource, /\{connectionError && \(/);
   assert.match(screenSource, /<Text style=\{styles\.errorText\}>\{connectionError\}<\/Text>/);
   assert.match(screenSource, /accessibilityLabel="Scan QR Code"/);
+});
+
+test('uses DotAgents-specific copy for manual connection fallback', () => {
+  assert.match(screenSource, />DotAgents Server URL</);
+  assert.match(screenSource, /placeholder='https:\/\/your-server\.example\.com\/v1'/);
+  assert.match(screenSource, /Enter the API key for your DotAgents server/);
+  assert.match(screenSource, /Enter the base URL for your DotAgents server/);
 });
 
 test('supports opening the QR scanner immediately from navigation params', () => {

--- a/apps/mobile/tests/loop-edit-density.test.js
+++ b/apps/mobile/tests/loop-edit-density.test.js
@@ -16,6 +16,6 @@ test('keeps mobile loop edit errors text-first without decorative warning emoji'
 test('preserves the inline settings helper when loop editing is unavailable', () => {
   assert.match(
     screenSource,
-    /Configure Base URL and API key in Settings to save changes\./
+    /Connect to a DotAgents server in Settings to save changes\./
   );
 });

--- a/packages/shared/src/connection-recovery.test.ts
+++ b/packages/shared/src/connection-recovery.test.ts
@@ -7,6 +7,7 @@ import {
   formatConnectionStatus,
   DEFAULT_RECOVERY_CONFIG,
   checkServerConnection,
+  checkDotAgentsServerConnection,
 } from './connection-recovery'
 import type { RecoveryState, ConnectionStatus } from './connection-recovery'
 
@@ -184,6 +185,42 @@ describe('checkServerConnection', () => {
     const result = await checkServerConnection('https://api.openai.com/v1', '   ')
     expect(result.success).toBe(false)
     expect(result.error).toContain('API Key is required')
+  })
+})
+
+// ── checkDotAgentsServerConnection ──────────────────────────────────────────
+
+describe('checkDotAgentsServerConnection', () => {
+  it('returns error for empty base URL', async () => {
+    const result = await checkDotAgentsServerConnection('', 'key')
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('Base URL is required')
+  })
+
+  it('returns error for empty API key', async () => {
+    const result = await checkDotAgentsServerConnection('https://example.com/v1', '')
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('API Key is required')
+  })
+
+  it('reports a missing DotAgents settings API as an invalid backend', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: vi.fn().mockResolvedValue({ error: 'Not found' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await checkDotAgentsServerConnection('https://example.com/v1', 'test-key')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://example.com/v1/settings',
+      expect.objectContaining({ method: 'GET' })
+    )
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('/v1/settings')
+
+    vi.unstubAllGlobals()
   })
 })
 

--- a/packages/shared/src/connection-recovery.ts
+++ b/packages/shared/src/connection-recovery.ts
@@ -140,6 +140,25 @@ export type ConnectionCheckResult = {
   normalizedUrl?: string;
 };
 
+async function parseConnectionErrorResponse(response: Response, fallbackMessage: string) {
+  try {
+    const errorBody = await response.json();
+    if (errorBody?.error?.message) {
+      return errorBody.error.message as string;
+    }
+    if (typeof errorBody?.error === 'string') {
+      return errorBody.error;
+    }
+    if (typeof errorBody?.message === 'string') {
+      return errorBody.message;
+    }
+  } catch {
+    // Ignore JSON parsing errors and fall back to the provided message.
+  }
+
+  return fallbackMessage;
+}
+
 export function formatConnectionStatus(state: RecoveryState): string {
   switch (state.status) {
     case 'connected':
@@ -154,6 +173,152 @@ export function formatConnectionStatus(state: RecoveryState): string {
       return `Connection failed: ${state.lastError || 'Unknown error'}`;
     default:
       return 'Unknown';
+  }
+}
+
+/**
+ * Check connectivity to a DotAgents server by verifying the mobile settings API.
+ *
+ * @param baseUrl - The API base URL to check (e.g., https://example.com/v1)
+ * @param apiKey - The API key to use for authentication
+ * @param timeoutMs - Timeout in milliseconds (default: 10000)
+ * @returns ConnectionCheckResult with success status and optional error
+ */
+export async function checkDotAgentsServerConnection(
+  baseUrl: string,
+  apiKey: string,
+  timeoutMs: number = 10000
+): Promise<ConnectionCheckResult> {
+  const startTime = Date.now();
+
+  if (!baseUrl || !baseUrl.trim()) {
+    return { success: false, error: 'Base URL is required' };
+  }
+
+  if (!apiKey || !apiKey.trim()) {
+    return { success: false, error: 'API Key is required' };
+  }
+
+  const trimmedApiKey = apiKey.trim();
+  const normalizedUrl = normalizeApiBaseUrl(baseUrl);
+  const settingsUrl = `${normalizedUrl}/settings`;
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(settingsUrl, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${trimmedApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+    const responseTime = Date.now() - startTime;
+
+    if (response.ok) {
+      return {
+        success: true,
+        statusCode: response.status,
+        responseTime,
+        normalizedUrl,
+      };
+    }
+
+    if (response.status === 401) {
+      return {
+        success: false,
+        error: 'Invalid API key. Please check your DotAgents server credentials.',
+        statusCode: response.status,
+        responseTime,
+      };
+    }
+
+    if (response.status === 403) {
+      return {
+        success: false,
+        error: 'Access forbidden. Your DotAgents API key may not have the required permissions.',
+        statusCode: response.status,
+        responseTime,
+      };
+    }
+
+    if (response.status === 404) {
+      return {
+        success: false,
+        error: 'This server does not expose the DotAgents mobile settings API at /v1/settings.',
+        statusCode: response.status,
+        responseTime,
+      };
+    }
+
+    if (response.status >= 500) {
+      return {
+        success: false,
+        error: `DotAgents server error (${response.status}). The server may be temporarily unavailable.`,
+        statusCode: response.status,
+        responseTime,
+      };
+    }
+
+    const errorMessage = await parseConnectionErrorResponse(
+      response,
+      `DotAgents server returned status ${response.status}`
+    );
+
+    return {
+      success: false,
+      error: errorMessage,
+      statusCode: response.status,
+      responseTime,
+    };
+  } catch (error: unknown) {
+    clearTimeout(timeoutId);
+    const responseTime = Date.now() - startTime;
+    const err = error as Error & { name?: string };
+
+    if (err.name === 'AbortError') {
+      return {
+        success: false,
+        error: 'Connection timed out. Please check your network and DotAgents server URL.',
+        responseTime,
+      };
+    }
+
+    const errorMessage = err.message?.toLowerCase() || '';
+
+    if (errorMessage.includes('network') || errorMessage.includes('failed to fetch')) {
+      return {
+        success: false,
+        error: 'Network error. Please check your internet connection.',
+        responseTime,
+      };
+    }
+
+    if (errorMessage.includes('unable to resolve host') || errorMessage.includes('dns')) {
+      return {
+        success: false,
+        error: 'Could not resolve server address. Please check the URL.',
+        responseTime,
+      };
+    }
+
+    if (errorMessage.includes('connection refused') || errorMessage.includes('econnrefused')) {
+      return {
+        success: false,
+        error: 'Connection refused. Is the DotAgents server running?',
+        responseTime,
+      };
+    }
+
+    return {
+      success: false,
+      error: err.message || 'Unknown connection error',
+      responseTime,
+    };
   }
 }
 
@@ -253,16 +418,10 @@ export async function checkServerConnection(
       };
     }
 
-    // Try to get error message from response body
-    let errorMessage = `Server returned status ${response.status}`;
-    try {
-      const errorBody = await response.json();
-      if (errorBody?.error?.message) {
-        errorMessage = errorBody.error.message;
-      }
-    } catch {
-      // Ignore JSON parsing errors
-    }
+    const errorMessage = await parseConnectionErrorResponse(
+      response,
+      `Server returned status ${response.status}`
+    );
 
     return {
       success: false,
@@ -317,4 +476,3 @@ export async function checkServerConnection(
     };
   }
 }
-

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -103,6 +103,7 @@ export type HandsFreeDebugEventType =
   | 'permission-denied'
   | 'recognizer-start'
   | 'recognizer-stop'
+  | 'mic-device-fallback'
   | 'wake-phrase-matched'
   | 'sleep-phrase-matched'
   | 'auto-send'
@@ -114,4 +115,3 @@ export type HandsFreeDebugEventType =
   | 'state-transition'
   | 'session-timeout'
   | 'no-speech-timeout';
-


### PR DESCRIPTION
## Summary
- remove the mobile app's generic OpenAI-compatible connection mode and make mobile a DotAgents-only companion surface
- require a DotAgents handshake through `GET /v1/settings` for manual connection validation, tunnel health, and connected-state gating
- rewrite mobile connection/settings/docs/tests around DotAgents pairing and direct DotAgents server access

## Why
The mobile app still treated arbitrary OpenAI-compatible endpoints as valid backends, which let stale or non-DotAgents servers appear partially configured even though the richer mobile flows depend on DotAgents-specific APIs.

## What Changed
- added `checkDotAgentsServerConnection` in shared connection recovery utilities and reused it from mobile
- removed the default OpenAI base URL/reset path from mobile config and connection settings
- gated chat, session sync, settings, agent switching, notes, loops, and agent editing on a validated DotAgents connection instead of raw saved credentials
- stopped consuming the QR/deep-link `model` field on mobile
- refreshed ChatScreen empty-state/test expectations and added the missing `mic-device-fallback` voice debug event type needed for typecheck

## Impact
- mobile now only accepts DotAgents servers
- previously saved generic OpenAI-compatible endpoints remain persisted but stay disconnected until repaired
- QR pairing remains the primary flow, with manual DotAgents server URL + API key entry as the fallback

## Validation
- `pnpm build:shared`
- `pnpm --filter @dotagents/shared test`
- `pnpm --filter @dotagents/mobile test`
- `pnpm --filter @dotagents/mobile exec tsc --noEmit`
