### PR TITLE
fix: skip native module rebuild on Windows

### DIFF
--- a/apps/desktop/electron-builder.config.cjs
+++ b/apps/desktop/electron-builder.config.cjs
@@ -363,6 +363,7 @@ module.exports = {
     artifactName: "${productName}-${version}-${arch}.${ext}",
   },
   npmRebuild: false,
+  nodeGypRebuild: false,
   // After packing, clean up unnecessary files
   afterPack: async (context) => {
     const path = require('path');

--- a/apps/desktop/scripts/postinstall.cjs
+++ b/apps/desktop/scripts/postinstall.cjs
@@ -60,6 +60,15 @@ function execCommand(command, args) {
 }
 
 async function main() {
+  // On Windows, skip native module rebuild entirely
+  // - electron-panel-window is Mac-only (no Windows sources)
+  // - nodeGypRebuild: false in electron-builder.config.cjs disables it during packaging
+  if (isWindows) {
+    console.log('[postinstall] Windows detected, skipping native module rebuild');
+    console.log('[postinstall] Note: electron-panel-window (floating panel) requires macOS');
+    process.exit(0);
+  }
+
   try {
     // Use npx on all platforms to find electron-builder from node_modules
     // On Windows, this also avoids the issue where electron-builder tries
@@ -68,9 +77,6 @@ async function main() {
     // The --no flag prevents npx from prompting to install if electron-builder
     // is not found locally, avoiding interactive prompts or non-deterministic
     // installs in CI/production environments
-    if (isWindows) {
-      console.log('[postinstall] Windows detected, using npx with shell...');
-    }
     await execCommand('npx', ['--no', 'electron-builder', 'install-app-deps']);
 
     console.log('[postinstall] Native dependencies installed successfully!');

--- a/apps/desktop/src/main/acp-service.ts
+++ b/apps/desktop/src/main/acp-service.ts
@@ -22,6 +22,7 @@ import { agentProfileService } from "./agent-profile-service"
 import { emitAgentProgress } from "./emit-agent-progress"
 import { logACP, logApp } from "./debug"
 import { RUNTIME_TOOLS_SERVER_NAME } from "../shared/runtime-tool-names"
+import { mcpService } from "./mcp-service"
 import {
   clearAcpClientSessionTokenMapping,
   getAppRunIdForAcpSession,
@@ -829,9 +830,10 @@ class ACPService extends EventEmitter {
       // Merge environment variables
       const processEnv = { ...process.env, ...env }
       const agentCwd = targetWorkingDirectory
+      const resolvedCommand = await mcpService.resolveCommandPath(command)
 
       // Spawn the process with optional working directory
-      const proc = spawn(command, args, {
+      const proc = spawn(resolvedCommand, args, {
         env: processEnv,
         stdio: ["pipe", "pipe", "pipe"],
         shell: process.platform === "win32",

--- a/apps/desktop/src/main/command-verification-service.ts
+++ b/apps/desktop/src/main/command-verification-service.ts
@@ -8,6 +8,7 @@ export interface ExternalAgentCommandVerificationInput {
   command: string
   args?: string[]
   cwd?: string
+  env?: Record<string, string>
   probeArgs?: string[]
 }
 
@@ -53,13 +54,14 @@ async function runProbe(
   resolvedCommand: string,
   probeArgs: string[],
   cwd?: string,
+  env?: Record<string, string>,
 ): Promise<ExternalAgentCommandVerificationResult> {
   const probePreview = buildCommandPreview(resolvedCommand, probeArgs)
 
   return await new Promise((resolve) => {
     const child = spawn(resolvedCommand, probeArgs, {
       cwd: cwd || process.cwd(),
-      env: process.env,
+      env: { ...process.env, ...(env || {}) },
       stdio: ["ignore", "pipe", "pipe"],
       shell: process.platform === "win32",
     })
@@ -144,7 +146,7 @@ export async function verifyExternalAgentCommand(
       }
     }
 
-    return await runProbe(resolvedCommand, [...args, ...probeArgs], cwd)
+    return await runProbe(resolvedCommand, [...args, ...probeArgs], cwd, input.env)
   } catch (error) {
     return {
       ok: false,

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -2858,9 +2858,29 @@ export class MCPService {
 
     // Split PATH and search for the command
     const pathDirs = systemPath.split(pathSeparator)
+    const appPath = app.getAppPath()
+    const resourcesPath = process.resourcesPath || appPath
+    const userDataPath = app.getPath("userData")
+    const opencodeResourceSuffix =
+      process.platform === "darwin"
+        ? `darwin-${process.arch}`
+        : process.platform === "win32"
+          ? `windows-${process.arch}`
+          : `${process.platform}-${process.arch}`
 
-    // Add common Node.js paths that might be missing in Electron
+    // Add common Node.js, repo-local, and packaged-app binary locations that might be missing in Electron.
     const additionalPaths = [
+      path.join(userDataPath, "external-tools", "opencode", "current"),
+      path.join(resourcesPath, "opencode", opencodeResourceSuffix),
+      path.join(appPath, "resources", "opencode", opencodeResourceSuffix),
+      path.join(resourcesPath, "bin"),
+      path.join(appPath, "resources", "bin"),
+      path.join(appPath, "node_modules", ".bin"),
+      path.join(appPath, "..", "node_modules", ".bin"),
+      path.join(appPath, "..", "..", "node_modules", ".bin"),
+      path.join(process.cwd(), "node_modules", ".bin"),
+      path.join(process.cwd(), "..", "node_modules", ".bin"),
+      path.join(process.cwd(), "..", "..", "node_modules", ".bin"),
       "/usr/local/bin",
       "/opt/homebrew/bin",
       path.join(os.homedir(), ".npm-global", "bin"),

--- a/apps/desktop/src/main/opencode-installer.ts
+++ b/apps/desktop/src/main/opencode-installer.ts
@@ -1,0 +1,252 @@
+import { app } from "electron"
+import fs from "fs"
+import https from "https"
+import os from "os"
+import path from "path"
+import { spawn } from "child_process"
+
+type OpenCodeInstallStatus = {
+  installed: boolean
+  installing: boolean
+  binaryPath: string
+  version?: string
+  error?: string
+}
+
+const RELEASE_BASE_URL = "https://github.com/anomalyco/opencode/releases/latest/download"
+
+const installState: OpenCodeInstallStatus = {
+  installed: false,
+  installing: false,
+  binaryPath: "",
+}
+
+function getBinaryName(): string {
+  return process.platform === "win32" ? "opencode.exe" : "opencode"
+}
+
+function getManagedInstallRoot(): string {
+  return path.join(app.getPath("userData"), "external-tools", "opencode")
+}
+
+export function getManagedOpencodeBinaryPath(): string {
+  return path.join(getManagedInstallRoot(), "current", getBinaryName())
+}
+
+function getArchiveExtension(): ".zip" | ".tar.gz" {
+  if (process.platform === "linux") return ".tar.gz"
+  return ".zip"
+}
+
+function getReleaseAssetFileName(): string {
+  const ext = getArchiveExtension()
+  if (process.platform === "darwin") {
+    if (process.arch === "arm64") return `opencode-darwin-arm64${ext}`
+    if (process.arch === "x64") return `opencode-darwin-x64-baseline${ext}`
+  }
+
+  if (process.platform === "linux") {
+    if (process.arch === "arm64") return "opencode-linux-arm64.tar.gz"
+    if (process.arch === "x64") return "opencode-linux-x64.tar.gz"
+  }
+
+  if (process.platform === "win32" && process.arch === "x64") {
+    return "opencode-windows-x64-baseline.zip"
+  }
+
+  throw new Error(`Unsupported platform for managed OpenCode install: ${process.platform}/${process.arch}`)
+}
+
+function getReleaseDownloadUrl(): string {
+  return `${RELEASE_BASE_URL}/${getReleaseAssetFileName()}`
+}
+
+function updateInstallState(partial: Partial<OpenCodeInstallStatus>): OpenCodeInstallStatus {
+  Object.assign(installState, partial)
+  installState.binaryPath = getManagedOpencodeBinaryPath()
+  installState.installed = fs.existsSync(installState.binaryPath)
+  return { ...installState }
+}
+
+function downloadFile(url: string, destination: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fs.mkdirSync(path.dirname(destination), { recursive: true })
+    const file = fs.createWriteStream(destination)
+
+    const cleanupAndReject = (error: Error) => {
+      file.destroy()
+      fs.unlink(destination, () => {})
+      reject(error)
+    }
+
+    const request = (currentUrl: string) => {
+      https
+        .get(currentUrl, (response) => {
+          if (
+            response.statusCode
+            && response.statusCode >= 300
+            && response.statusCode < 400
+            && response.headers.location
+          ) {
+            response.resume()
+            request(new URL(response.headers.location, currentUrl).toString())
+            return
+          }
+
+          if (response.statusCode !== 200) {
+            cleanupAndReject(new Error(`OpenCode download failed with HTTP ${response.statusCode}: ${response.statusMessage}`))
+            return
+          }
+
+          response.pipe(file)
+          file.on("finish", () => {
+            file.close()
+            resolve()
+          })
+        })
+        .on("error", cleanupAndReject)
+    }
+
+    request(url)
+  })
+}
+
+async function extractTarArchive(archivePath: string, destination: string): Promise<void> {
+  try {
+    const tar = await import("tar")
+    await tar.x({ file: archivePath, cwd: destination })
+    return
+  } catch {
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("tar", ["-xzf", archivePath, "-C", destination], {
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+      let stderr = ""
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString()
+      })
+      child.on("error", reject)
+      child.on("close", (code) => {
+        if (code === 0) resolve()
+        else reject(new Error(stderr || `tar extraction failed with exit code ${code}`))
+      })
+    })
+  }
+}
+
+async function extractZipArchive(archivePath: string, destination: string): Promise<void> {
+  if (process.platform === "win32") {
+    await new Promise<void>((resolve, reject) => {
+      const command = `Expand-Archive -LiteralPath '${archivePath.replace(/'/g, "''")}' -DestinationPath '${destination.replace(/'/g, "''")}' -Force`
+      const child = spawn("powershell.exe", ["-NoProfile", "-NonInteractive", "-Command", command], {
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+      let stderr = ""
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString()
+      })
+      child.on("error", reject)
+      child.on("close", (code) => {
+        if (code === 0) resolve()
+        else reject(new Error(stderr || `Expand-Archive failed with exit code ${code}`))
+      })
+    })
+    return
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("unzip", ["-q", archivePath, "-d", destination], {
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    let stderr = ""
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString()
+    })
+    child.on("error", reject)
+    child.on("close", (code) => {
+      if (code === 0) resolve()
+      else reject(new Error(stderr || `unzip failed with exit code ${code}`))
+    })
+  })
+}
+
+async function extractArchive(archivePath: string, destination: string): Promise<void> {
+  fs.mkdirSync(destination, { recursive: true })
+  if (archivePath.endsWith(".tar.gz")) {
+    await extractTarArchive(archivePath, destination)
+    return
+  }
+  await extractZipArchive(archivePath, destination)
+}
+
+function findExtractedBinary(root: string): string {
+  const directPath = path.join(root, getBinaryName())
+  if (fs.existsSync(directPath)) return directPath
+
+  const nestedPath = path.join(root, "opencode", getBinaryName())
+  if (fs.existsSync(nestedPath)) return nestedPath
+
+  throw new Error(`Could not find extracted OpenCode binary in ${root}`)
+}
+
+async function readInstalledVersion(binaryPath: string): Promise<string | undefined> {
+  return await new Promise((resolve) => {
+    const child = spawn(binaryPath, ["--version"], { stdio: ["ignore", "pipe", "pipe"] })
+    let stdout = ""
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString()
+    })
+    child.on("error", () => resolve(undefined))
+    child.on("close", (code) => {
+      if (code === 0) resolve(stdout.trim() || undefined)
+      else resolve(undefined)
+    })
+  })
+}
+
+export async function getOpencodeInstallStatus(): Promise<OpenCodeInstallStatus> {
+  const binaryPath = getManagedOpencodeBinaryPath()
+  const version = fs.existsSync(binaryPath)
+    ? await readInstalledVersion(binaryPath)
+    : undefined
+  return updateInstallState({ binaryPath, version })
+}
+
+export async function installManagedOpencode(): Promise<OpenCodeInstallStatus> {
+  if (installState.installing) {
+    throw new Error("OpenCode install already in progress")
+  }
+
+  updateInstallState({ installing: true, error: undefined })
+
+  const installRoot = getManagedInstallRoot()
+  const currentDir = path.join(installRoot, "current")
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-opencode-install-"))
+  const archivePath = path.join(tempDir, getReleaseAssetFileName())
+  const extractDir = path.join(tempDir, "extract")
+
+  try {
+    await downloadFile(getReleaseDownloadUrl(), archivePath)
+    await extractArchive(archivePath, extractDir)
+
+    const extractedBinaryPath = findExtractedBinary(extractDir)
+    fs.rmSync(currentDir, { recursive: true, force: true })
+    fs.mkdirSync(currentDir, { recursive: true })
+
+    const installedBinaryPath = path.join(currentDir, getBinaryName())
+    fs.copyFileSync(extractedBinaryPath, installedBinaryPath)
+    if (process.platform !== "win32") {
+      fs.chmodSync(installedBinaryPath, 0o755)
+    }
+
+    const version = await readInstalledVersion(installedBinaryPath)
+    return updateInstallState({ installing: false, error: undefined, version })
+  } catch (error) {
+    return updateInstallState({
+      installing: false,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+}

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -4155,11 +4155,21 @@ export const router = {
   }),
 
   verifyExternalAgentCommand: t.procedure
-    .input<{ command: string; args?: string[]; cwd?: string; probeArgs?: string[] }>()
+    .input<{ command: string; args?: string[]; cwd?: string; env?: Record<string, string>; probeArgs?: string[] }>()
     .action(async ({ input }) => {
       const { verifyExternalAgentCommand } = await import("./command-verification-service")
       return verifyExternalAgentCommand(input)
     }),
+
+  getOpencodeInstallStatus: t.procedure.action(async () => {
+    const { getOpencodeInstallStatus } = await import("./opencode-installer")
+    return getOpencodeInstallStatus()
+  }),
+
+  installManagedOpencode: t.procedure.action(async () => {
+    const { installManagedOpencode } = await import("./opencode-installer")
+    return installManagedOpencode()
+  }),
 
   spawnAcpAgent: t.procedure
     .input<{ agentName: string; workingDirectory?: string }>()

--- a/apps/desktop/src/renderer/src/lib/onboarding-main-agent.test.ts
+++ b/apps/desktop/src/renderer/src/lib/onboarding-main-agent.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ONBOARDING_MAIN_AGENT_OPTIONS,
+  buildAcpOnboardingConfigUpdate,
+  buildByokConfigUpdate,
+  buildExternalAgentProfileInput,
+  buildOpenCodeManagedEnv,
+  findExistingExternalAgentProfile,
+} from "./onboarding-main-agent"
+
+describe("onboarding-main-agent", () => {
+  it("surfaces the requested onboarding choices", () => {
+    expect(ONBOARDING_MAIN_AGENT_OPTIONS.map((option) => option.id)).toEqual([
+      "opencode",
+      "auggie",
+      "claude-code",
+      "codex",
+      "byok",
+    ])
+  })
+
+  it("builds BYOK config updates with provider defaults and local voice fallbacks", () => {
+    expect(
+      buildByokConfigUpdate("groq", "gsk_test", {
+        kittenModelDownloaded: true,
+      } as any)
+    ).toMatchObject({
+      mainAgentMode: "api",
+      groqApiKey: "gsk_test",
+      mcpToolsProviderId: "groq",
+      transcriptPostProcessingProviderId: "groq",
+      sttProviderId: "groq",
+      ttsProviderId: "kitten",
+      mcpToolsGroqModel: "openai/gpt-oss-120b",
+    })
+
+    expect(
+      buildByokConfigUpdate("gemini", "gm_test", {
+        parakeetModelDownloaded: true,
+      } as any)
+    ).toMatchObject({
+      geminiApiKey: "gm_test",
+      sttProviderId: "parakeet",
+      ttsProviderId: "gemini",
+      mcpToolsGeminiModel: "gemini-2.5-flash",
+    })
+  })
+
+  it("builds external ACP profiles and reuses matching existing ones", () => {
+    const draft = buildExternalAgentProfileInput("opencode", { cwd: "/repo" })
+    expect(draft).toMatchObject({
+      displayName: "OpenCode",
+      connection: { type: "acp", command: "opencode", args: ["acp"], cwd: "/repo" },
+      enabled: true,
+    })
+
+    const existing = findExistingExternalAgentProfile(
+      [
+        {
+          id: "1",
+          name: "OpenCode",
+          displayName: "OpenCode",
+          enabled: true,
+          connection: { type: "acp", command: "opencode", args: ["acp"] },
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        } as any,
+      ],
+      "opencode"
+    )
+
+    expect(existing?.displayName).toBe("OpenCode")
+  })
+
+  it("builds ACP config updates that preserve local voice defaults when available", () => {
+    expect(
+      buildAcpOnboardingConfigUpdate("OpenCode", {
+        parakeetModelDownloaded: true,
+        supertonicModelDownloaded: true,
+      } as any)
+    ).toEqual({
+      mainAgentMode: "acp",
+      mainAgentName: "OpenCode",
+      acpInjectRuntimeTools: true,
+      sttProviderId: "parakeet",
+      ttsProviderId: "supertonic",
+    })
+  })
+
+  it("builds managed OpenCode env injection from a provider api key", () => {
+    const env = buildOpenCodeManagedEnv("groq", "gsk_test")
+    expect(env.GROQ_API_KEY).toBe("gsk_test")
+    expect(env.DOTAGENTS_OPENCODE_PROVIDER_API_KEY).toBe("gsk_test")
+
+    const parsed = JSON.parse(env.OPENCODE_CONFIG_CONTENT)
+    expect(parsed).toMatchObject({
+      autoupdate: false,
+      model: "groq/openai/gpt-oss-120b",
+      provider: {
+        groq: {
+          options: {
+            apiKey: "{env:DOTAGENTS_OPENCODE_PROVIDER_API_KEY}",
+          },
+        },
+      },
+      disabled_providers: ["openai", "google"],
+    })
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/onboarding-main-agent.ts
+++ b/apps/desktop/src/renderer/src/lib/onboarding-main-agent.ts
@@ -1,0 +1,233 @@
+import type { AgentProfile, Config } from "@shared/types"
+import {
+  EXTERNAL_AGENT_PRESETS,
+  detectExternalAgentPresetKey,
+  type ExternalAgentPresetKey,
+} from "@shared/external-agent-presets"
+
+export type ByokProviderId = "openai" | "groq" | "gemini"
+
+export type OnboardingMainAgentChoiceId = "byok" | ExternalAgentPresetKey
+
+export type OnboardingMainAgentOption = {
+  id: OnboardingMainAgentChoiceId
+  displayName: string
+  description: string
+  setupSummary: string
+  mode: "api" | "acp"
+  isRecommended?: boolean
+}
+
+export type CreateAgentProfileInput = {
+  displayName: string
+  description?: string
+  connection: {
+    type: "acp" | "stdio"
+    command: string
+    args?: string[]
+    env?: Record<string, string>
+    cwd?: string
+  }
+  enabled: boolean
+  isUserProfile: boolean
+  isAgentTarget: boolean
+  autoSpawn?: boolean
+}
+
+const DEFAULT_CHAT_MODELS = {
+  openai: "gpt-4.1-mini",
+  groq: "openai/gpt-oss-120b",
+  gemini: "gemini-2.5-flash",
+} as const
+
+export const ONBOARDING_MAIN_AGENT_OPTIONS: OnboardingMainAgentOption[] = [
+  {
+    id: "opencode",
+    displayName: EXTERNAL_AGENT_PRESETS.opencode.displayName,
+    description: EXTERNAL_AGENT_PRESETS.opencode.description,
+    setupSummary: "Provision an ACP profile now, then verify or finish external auth as needed.",
+    mode: "acp",
+    isRecommended: true,
+  },
+  {
+    id: "auggie",
+    displayName: EXTERNAL_AGENT_PRESETS.auggie.displayName,
+    description: EXTERNAL_AGENT_PRESETS.auggie.description,
+    setupSummary: "Connect your existing Auggie install over ACP.",
+    mode: "acp",
+  },
+  {
+    id: "claude-code",
+    displayName: EXTERNAL_AGENT_PRESETS["claude-code"].displayName,
+    description: EXTERNAL_AGENT_PRESETS["claude-code"].description,
+    setupSummary: "Connect your existing Claude Code ACP adapter.",
+    mode: "acp",
+  },
+  {
+    id: "codex",
+    displayName: EXTERNAL_AGENT_PRESETS.codex.displayName,
+    description: EXTERNAL_AGENT_PRESETS.codex.description,
+    setupSummary: "Connect your existing Codex ACP adapter.",
+    mode: "acp",
+  },
+  {
+    id: "byok",
+    displayName: "Bring Your Own Key (BYOK)",
+    description: "Use DotAgents' built-in main agent with your own provider key.",
+    setupSummary: "Enter one API key for OpenAI, Groq, or Gemini.",
+    mode: "api",
+  },
+]
+
+function pickSttProvider(preferredProviderId: ByokProviderId, currentConfig?: Config): Config["sttProviderId"] | undefined {
+  if (currentConfig?.parakeetModelDownloaded) return "parakeet"
+  if (preferredProviderId === "openai" || preferredProviderId === "groq") return preferredProviderId
+  if (currentConfig?.groqApiKey) return "groq"
+  if (currentConfig?.openaiApiKey) return "openai"
+  return currentConfig?.sttProviderId
+}
+
+function pickTtsProvider(preferredProviderId: ByokProviderId, currentConfig?: Config): Config["ttsProviderId"] | undefined {
+  if (currentConfig?.kittenModelDownloaded) return "kitten"
+  if (currentConfig?.supertonicModelDownloaded) return "supertonic"
+  return preferredProviderId
+}
+
+export function buildByokConfigUpdate(
+  providerId: ByokProviderId,
+  apiKey: string,
+  currentConfig?: Config,
+): Partial<Config> {
+  const trimmedApiKey = apiKey.trim()
+  const sttProviderId = pickSttProvider(providerId, currentConfig)
+  const ttsProviderId = pickTtsProvider(providerId, currentConfig)
+  const update: Partial<Config> = {
+    mainAgentMode: "api",
+    mainAgentName: "",
+    mcpToolsProviderId: providerId,
+    transcriptPostProcessingProviderId: providerId,
+  }
+
+  if (sttProviderId) update.sttProviderId = sttProviderId
+  if (ttsProviderId) update.ttsProviderId = ttsProviderId
+
+  if (providerId === "openai") {
+    update.openaiApiKey = trimmedApiKey
+    update.mcpToolsOpenaiModel = currentConfig?.mcpToolsOpenaiModel || DEFAULT_CHAT_MODELS.openai
+    update.transcriptPostProcessingOpenaiModel =
+      currentConfig?.transcriptPostProcessingOpenaiModel || DEFAULT_CHAT_MODELS.openai
+  } else if (providerId === "groq") {
+    update.groqApiKey = trimmedApiKey
+    update.mcpToolsGroqModel = currentConfig?.mcpToolsGroqModel || DEFAULT_CHAT_MODELS.groq
+    update.transcriptPostProcessingGroqModel =
+      currentConfig?.transcriptPostProcessingGroqModel || DEFAULT_CHAT_MODELS.groq
+  } else {
+    update.geminiApiKey = trimmedApiKey
+    update.mcpToolsGeminiModel = currentConfig?.mcpToolsGeminiModel || DEFAULT_CHAT_MODELS.gemini
+    update.transcriptPostProcessingGeminiModel =
+      currentConfig?.transcriptPostProcessingGeminiModel || DEFAULT_CHAT_MODELS.gemini
+  }
+
+  return update
+}
+
+export function buildExternalAgentProfileInput(
+  presetKey: ExternalAgentPresetKey,
+  options?: {
+    cwd?: string
+    env?: Record<string, string>
+  },
+): CreateAgentProfileInput {
+  const preset = EXTERNAL_AGENT_PRESETS[presetKey]
+  return {
+    displayName: preset.displayName,
+    description: preset.description,
+    connection: {
+      type: preset.connectionType,
+      command: preset.connectionCommand,
+      args: preset.connectionArgs ? preset.connectionArgs.split(" ").filter(Boolean) : undefined,
+      env: options?.env,
+      cwd: options?.cwd?.trim() || undefined,
+    },
+    enabled: true,
+    isUserProfile: false,
+    isAgentTarget: true,
+    autoSpawn: false,
+  }
+}
+
+const OPENCODE_MANAGED_PROVIDER_ENV_KEY = "DOTAGENTS_OPENCODE_PROVIDER_API_KEY"
+
+const OPENCODE_PROVIDER_ENV_BY_PROVIDER: Record<ByokProviderId, string> = {
+  openai: "OPENAI_API_KEY",
+  groq: "GROQ_API_KEY",
+  gemini: "GEMINI_API_KEY",
+}
+
+const OPENCODE_PROVIDER_NAME_BY_PROVIDER: Record<ByokProviderId, string> = {
+  openai: "openai",
+  groq: "groq",
+  gemini: "google",
+}
+
+const OPENCODE_DEFAULT_MODEL_BY_PROVIDER: Record<ByokProviderId, string> = {
+  openai: "openai/gpt-4.1-mini",
+  groq: "groq/openai/gpt-oss-120b",
+  gemini: "google/gemini-2.5-flash",
+}
+
+export function buildOpenCodeManagedEnv(providerId: ByokProviderId, apiKey: string): Record<string, string> {
+  const trimmedApiKey = apiKey.trim()
+  const providerEnvKey = OPENCODE_PROVIDER_ENV_BY_PROVIDER[providerId]
+  const providerName = OPENCODE_PROVIDER_NAME_BY_PROVIDER[providerId]
+  const config = {
+    $schema: "https://opencode.ai/config.json",
+    autoupdate: false,
+    model: OPENCODE_DEFAULT_MODEL_BY_PROVIDER[providerId],
+    provider: {
+      [providerName]: {
+        options: {
+          apiKey: `{env:${OPENCODE_MANAGED_PROVIDER_ENV_KEY}}`,
+        },
+      },
+    },
+    disabled_providers: ["openai", "groq", "google"].filter((candidate) => candidate !== providerName),
+  }
+
+  return {
+    OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+    [OPENCODE_MANAGED_PROVIDER_ENV_KEY]: trimmedApiKey,
+    [providerEnvKey]: trimmedApiKey,
+    OPENCODE_DISABLE_UPDATE_CHECK: "1",
+  }
+}
+
+export function findExistingExternalAgentProfile(
+  profiles: AgentProfile[],
+  presetKey: ExternalAgentPresetKey,
+): AgentProfile | undefined {
+  return profiles.find((profile) =>
+    detectExternalAgentPresetKey({
+      connectionType: profile.connection.type,
+      connectionCommand: profile.connection.command,
+      connectionArgs: profile.connection.args,
+    }) === presetKey
+  )
+}
+
+export function buildAcpOnboardingConfigUpdate(
+  profileName: string,
+  currentConfig?: Config,
+): Partial<Config> {
+  return {
+    mainAgentMode: "acp",
+    mainAgentName: profileName,
+    acpInjectRuntimeTools: currentConfig?.acpInjectRuntimeTools ?? true,
+    ...(currentConfig?.parakeetModelDownloaded ? { sttProviderId: "parakeet" as const } : {}),
+    ...(currentConfig?.kittenModelDownloaded
+      ? { ttsProviderId: "kitten" as const }
+      : currentConfig?.supertonicModelDownloaded
+        ? { ttsProviderId: "supertonic" as const }
+        : {}),
+  }
+}

--- a/apps/desktop/src/renderer/src/pages/onboarding.tsx
+++ b/apps/desktop/src/renderer/src/pages/onboarding.tsx
@@ -11,19 +11,99 @@ import {
 } from "@renderer/components/ui/select"
 import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
 import { decodeBlobToPcm } from "@renderer/lib/audio-utils"
-import { Config } from "@shared/types"
+import type { AgentProfile, Config } from "@shared/types"
 import { useNavigate } from "react-router-dom"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { Recorder } from "@renderer/lib/recorder"
 import { useMutation } from "@tanstack/react-query"
 import { KeyRecorder } from "@renderer/components/key-recorder"
 import { getMcpToolsShortcutDisplay } from "@shared/key-utils"
+import {
+  EXTERNAL_AGENT_PRESETS,
+  type ExternalAgentPresetKey,
+} from "@shared/external-agent-presets"
+import {
+  ONBOARDING_MAIN_AGENT_OPTIONS,
+  buildAcpOnboardingConfigUpdate,
+  buildByokConfigUpdate,
+  buildExternalAgentProfileInput,
+  buildOpenCodeManagedEnv,
+  findExistingExternalAgentProfile,
+  type ByokProviderId,
+  type OnboardingMainAgentChoiceId,
+} from "@renderer/lib/onboarding-main-agent"
 
-type OnboardingStep = "welcome" | "api-key" | "dictation" | "agent" | "complete"
+type OnboardingStep = "welcome" | "main-agent" | "setup" | "voice" | "finish"
+
+type ExternalAgentCommandVerificationResult = {
+  ok: boolean
+  resolvedCommand?: string
+  details?: string
+  error?: string
+  warnings?: string[]
+}
+
+type OpenCodeInstallStatus = {
+  installed: boolean
+  installing: boolean
+  binaryPath: string
+  version?: string
+  error?: string
+}
+
+const BYOK_PROVIDER_DETAILS: Record<ByokProviderId, { label: string; placeholder: string; url: string }> = {
+  openai: {
+    label: "OpenAI",
+    placeholder: "sk-...",
+    url: "https://platform.openai.com/api-keys",
+  },
+  groq: {
+    label: "Groq",
+    placeholder: "gsk_...",
+    url: "https://console.groq.com/keys",
+  },
+  gemini: {
+    label: "Gemini",
+    placeholder: "AIza...",
+    url: "https://aistudio.google.com/app/apikey",
+  },
+}
+
+function getProviderLabel(providerId?: string): string {
+  switch (providerId) {
+    case "openai":
+      return "OpenAI"
+    case "groq":
+      return "Groq"
+    case "gemini":
+      return "Gemini"
+    case "parakeet":
+      return "Parakeet"
+    case "kitten":
+      return "Kitten"
+    case "supertonic":
+      return "Supertonic"
+    default:
+      return "Not configured"
+  }
+}
 
 export function Component() {
   const [step, setStep] = useState<OnboardingStep>("welcome")
+  const [selectedChoiceId, setSelectedChoiceId] = useState<OnboardingMainAgentChoiceId>("opencode")
+  const [byokProviderId, setByokProviderId] = useState<ByokProviderId>("groq")
   const [apiKey, setApiKey] = useState("")
+  const [isApplyingSetup, setIsApplyingSetup] = useState(false)
+  const [commandVerification, setCommandVerification] =
+    useState<ExternalAgentCommandVerificationResult | null>(null)
+  const [isVerifyingCommand, setIsVerifyingCommand] = useState(false)
+  const [setupError, setSetupError] = useState<string | null>(null)
+  const [provisionedAgentName, setProvisionedAgentName] = useState<string | null>(null)
+  const [openCodeSetupMode, setOpenCodeSetupMode] = useState<"existing-auth" | "managed-api-key">("managed-api-key")
+  const [openCodeProviderId, setOpenCodeProviderId] = useState<ByokProviderId>("groq")
+  const [openCodeApiKey, setOpenCodeApiKey] = useState("")
+  const [openCodeInstallStatus, setOpenCodeInstallStatus] = useState<OpenCodeInstallStatus | null>(null)
+  const [isInstallingOpenCode, setIsInstallingOpenCode] = useState(false)
   const [isRecording, setIsRecording] = useState(false)
   const [isTranscribing, setIsTranscribing] = useState(false)
   const [dictationResult, setDictationResult] = useState<string | null>(null)
@@ -33,6 +113,12 @@ export function Component() {
   const configQuery = useConfigQuery()
   const saveConfigMutation = useSaveConfigMutation()
   const recorderRef = useRef<Recorder | null>(null)
+
+  const selectedOption =
+    ONBOARDING_MAIN_AGENT_OPTIONS.find((option) => option.id === selectedChoiceId)
+    || ONBOARDING_MAIN_AGENT_OPTIONS[0]
+  const selectedExternalPreset =
+    selectedChoiceId === "byok" ? undefined : EXTERNAL_AGENT_PRESETS[selectedChoiceId]
 
   const saveConfig = useCallback(
     (config: Partial<Config>) => {
@@ -49,10 +135,10 @@ export function Component() {
 
   const saveConfigAsync = useCallback(
     async (config: Partial<Config>) => {
-      if (!configQuery.data) return
+      const currentConfig = configQuery.data || (await tipcClient.getConfig())
       await saveConfigMutation.mutateAsync({
         config: {
-          ...configQuery.data,
+          ...currentConfig,
           ...config,
         },
       })
@@ -60,21 +146,47 @@ export function Component() {
     [saveConfigMutation, configQuery.data]
   )
 
-  // Transcription mutation
+  useEffect(() => {
+    setCommandVerification(null)
+    setSetupError(null)
+    setProvisionedAgentName(null)
+  }, [selectedChoiceId])
+
+  useEffect(() => {
+    if (selectedChoiceId !== "opencode") return
+
+    const config = configQuery.data
+    if (!config) return
+
+    if (!openCodeApiKey.trim()) {
+      if (openCodeProviderId === "groq" && config.groqApiKey) {
+        setOpenCodeApiKey(config.groqApiKey)
+      } else if (openCodeProviderId === "openai" && config.openaiApiKey) {
+        setOpenCodeApiKey(config.openaiApiKey)
+      } else if (openCodeProviderId === "gemini" && config.geminiApiKey) {
+        setOpenCodeApiKey(config.geminiApiKey)
+      }
+    }
+  }, [configQuery.data, openCodeApiKey, openCodeProviderId, selectedChoiceId])
+
+  useEffect(() => {
+    if (selectedChoiceId !== "opencode") return
+    void tipcClient.getOpencodeInstallStatus().then(setOpenCodeInstallStatus).catch(() => {
+      setOpenCodeInstallStatus(null)
+    })
+  }, [selectedChoiceId])
+
   const transcribeMutation = useMutation({
     mutationFn: async ({ blob, duration }: { blob: Blob; duration: number }) => {
       setIsTranscribing(true)
-      // Fetch config synchronously to avoid race condition where configQuery.data
-      // is undefined on early interactions (augment review feedback)
       const config = await tipcClient.getConfig()
       const isParakeet = config?.sttProviderId === "parakeet"
       const pcmRecording = isParakeet ? await decodeBlobToPcm(blob) : undefined
-      const result = await tipcClient.createRecording({
+      return tipcClient.createRecording({
         recording: await blob.arrayBuffer(),
         pcmRecording,
         duration,
       })
-      return result
     },
     onSuccess: (result) => {
       setIsTranscribing(false)
@@ -84,19 +196,25 @@ export function Component() {
     },
     onError: (error: any) => {
       setIsTranscribing(false)
-      console.error("Transcription failed:", error)
       const errorMessage = error?.message || String(error)
-      if (errorMessage.includes("API key") || errorMessage.includes("401") || errorMessage.includes("403")) {
-        setTranscriptionError("API key is missing or invalid. Please go back and enter a valid Groq API key.")
+      if (
+        errorMessage.includes("API key")
+        || errorMessage.includes("401")
+        || errorMessage.includes("403")
+      ) {
+        setTranscriptionError(
+          "Speech-to-text is not ready yet. Add the required API key or switch to a local provider later in Settings → Providers."
+        )
       } else if (errorMessage.includes("model")) {
-        setTranscriptionError("Model configuration error. Please check your settings.")
+        setTranscriptionError(
+          "Speech-to-text model configuration needs attention. You can finish onboarding and adjust it later in Settings."
+        )
       } else {
         setTranscriptionError(`Transcription failed: ${errorMessage}`)
       }
     },
   })
 
-  // Initialize recorder
   useEffect(() => {
     if (recorderRef.current) return undefined
 
@@ -116,29 +234,7 @@ export function Component() {
     return () => {
       recorder.stopRecording()
     }
-  }, [])
-
-  const handleSaveApiKey = useCallback(async () => {
-    if (!apiKey.trim()) return
-
-    // Save Groq API key and set Groq as the default provider for STT, chat, and TTS
-    // Wait for config to save before advancing to ensure transcription uses the new provider
-    // Set recommended models: gpt-oss-120b for agent tasks
-    await saveConfigAsync({
-      groqApiKey: apiKey.trim(),
-      sttProviderId: "groq",
-      transcriptPostProcessingProviderId: "groq",
-      mcpToolsProviderId: "groq",
-      mcpToolsGroqModel: "openai/gpt-oss-120b",
-      ttsProviderId: "groq",
-    })
-
-    setStep("dictation")
-  }, [apiKey, saveConfigAsync])
-
-  const handleSkipApiKey = useCallback(() => {
-    setStep("dictation")
-  }, [])
+  }, [transcribeMutation])
 
   const handleStartRecording = useCallback(async () => {
     setDictationResult(null)
@@ -148,10 +244,11 @@ export function Component() {
       const config = await tipcClient.getConfig()
       await recorderRef.current?.startRecording(config?.audioInputDeviceId)
     } catch (error: any) {
-      console.error("Failed to start recording:", error)
       const errorMessage = error?.message || String(error)
       if (errorMessage.includes("Permission denied") || errorMessage.includes("NotAllowedError")) {
-        setMicError("Microphone access was denied. Please allow microphone access in your system settings and try again.")
+        setMicError(
+          "Microphone access was denied. Please allow microphone access in your system settings and try again."
+        )
       } else if (errorMessage.includes("NotFoundError") || errorMessage.includes("no audio input")) {
         setMicError("No microphone found. Please connect a microphone and try again.")
       } else {
@@ -174,6 +271,163 @@ export function Component() {
     navigate("/")
   }, [saveConfigAsync, navigate])
 
+  const ensureExternalAgentProfile = useCallback(async (
+    presetKey: ExternalAgentPresetKey,
+    options?: { env?: Record<string, string> },
+  ) => {
+    const profiles = ((await tipcClient.getAgentProfiles()) || []) as AgentProfile[]
+    const existing = findExistingExternalAgentProfile(profiles, presetKey)
+    const profileDraft = buildExternalAgentProfileInput(presetKey, { env: options?.env })
+    if (existing) {
+      const nextEnv = options?.env ? { ...(existing.connection.env || {}), ...options.env } : existing.connection.env
+      const shouldUpdateEnv = Boolean(options?.env)
+      if (existing.enabled === false) {
+        await tipcClient.updateAgentProfile({
+          id: existing.id,
+          updates: {
+            enabled: true,
+            ...(shouldUpdateEnv
+              ? {
+                  connection: {
+                    ...existing.connection,
+                    env: nextEnv,
+                  },
+                }
+              : {}),
+          },
+        })
+      } else if (shouldUpdateEnv) {
+        await tipcClient.updateAgentProfile({
+          id: existing.id,
+          updates: {
+            connection: {
+              ...existing.connection,
+              env: nextEnv,
+            },
+          },
+        })
+      }
+      return existing.name || existing.displayName
+    }
+
+    const created = await tipcClient.createAgentProfile({
+      profile: {
+        name: profileDraft.displayName,
+        ...profileDraft,
+      },
+    })
+
+    return created?.name || created?.displayName || profileDraft.displayName
+  }, [])
+
+  const handleVerifyExternalAgent = useCallback(async () => {
+    if (!selectedExternalPreset || selectedChoiceId === "byok") return
+
+    setIsVerifyingCommand(true)
+    setSetupError(null)
+
+    try {
+      const profiles = ((await tipcClient.getAgentProfiles()) || []) as AgentProfile[]
+      const existing = findExistingExternalAgentProfile(profiles, selectedChoiceId)
+      const managedEnv =
+        selectedChoiceId === "opencode" && openCodeSetupMode === "managed-api-key" && openCodeApiKey.trim()
+          ? buildOpenCodeManagedEnv(openCodeProviderId, openCodeApiKey)
+          : undefined
+      const draft = buildExternalAgentProfileInput(selectedChoiceId, { env: managedEnv })
+      const result = await tipcClient.verifyExternalAgentCommand({
+        command: existing?.connection.command || draft.connection.command,
+        args: existing?.connection.args || draft.connection.args,
+        cwd: existing?.connection.cwd || draft.connection.cwd,
+        env: managedEnv,
+        probeArgs: selectedExternalPreset.verifyArgs,
+      })
+      setCommandVerification(result)
+      if (!result?.ok && result?.error) {
+        setSetupError(result.error)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      setCommandVerification({ ok: false, error: message })
+      setSetupError(message)
+    } finally {
+      setIsVerifyingCommand(false)
+    }
+  }, [selectedExternalPreset, selectedChoiceId])
+
+  const handleContinueFromSetup = useCallback(async () => {
+    setSetupError(null)
+    setIsApplyingSetup(true)
+
+    try {
+      const currentConfig = configQuery.data || (await tipcClient.getConfig())
+
+      if (selectedChoiceId === "byok") {
+        if (!apiKey.trim()) {
+          setSetupError("Enter an API key before continuing.")
+          return
+        }
+
+        await saveConfigAsync(buildByokConfigUpdate(byokProviderId, apiKey, currentConfig))
+        await configQuery.refetch()
+        setStep("voice")
+        return
+      }
+
+      if (!commandVerification?.ok) {
+        setSetupError("Verify the external agent command before continuing.")
+        return
+      }
+
+      const openCodeManagedEnv =
+        selectedChoiceId === "opencode" && openCodeSetupMode === "managed-api-key"
+          ? (() => {
+              if (!openCodeApiKey.trim()) {
+                throw new Error("Enter an API key so DotAgents can configure OpenCode automatically.")
+              }
+              return buildOpenCodeManagedEnv(openCodeProviderId, openCodeApiKey)
+            })()
+          : undefined
+
+      const agentName = await ensureExternalAgentProfile(selectedChoiceId, { env: openCodeManagedEnv })
+      setProvisionedAgentName(agentName)
+      await saveConfigAsync(buildAcpOnboardingConfigUpdate(agentName, currentConfig))
+      await configQuery.refetch()
+      setStep("voice")
+    } catch (error) {
+      setSetupError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setIsApplyingSetup(false)
+    }
+  }, [
+    apiKey,
+    byokProviderId,
+    commandVerification?.ok,
+    configQuery,
+    ensureExternalAgentProfile,
+    openCodeApiKey,
+    openCodeProviderId,
+    openCodeSetupMode,
+    saveConfigAsync,
+    selectedChoiceId,
+  ])
+
+  const handleInstallOpenCode = useCallback(async () => {
+    setIsInstallingOpenCode(true)
+    setSetupError(null)
+    try {
+      const status = await tipcClient.installManagedOpencode()
+      setOpenCodeInstallStatus(status)
+      if (!status.installed) {
+        throw new Error(status.error || "OpenCode install did not complete successfully.")
+      }
+      await handleVerifyExternalAgent()
+    } catch (error) {
+      setSetupError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setIsInstallingOpenCode(false)
+    }
+  }, [handleVerifyExternalAgent])
+
   const shellClassName =
     step === "welcome"
       ? "w-full max-w-2xl mx-auto my-auto px-6 py-10"
@@ -183,40 +437,76 @@ export function Component() {
     <div className="app-drag-region flex h-dvh overflow-y-auto">
       <div className={shellClassName}>
         {step === "welcome" && (
-          <WelcomeStep onNext={() => setStep("api-key")} onSkip={handleSkipOnboarding} />
+          <WelcomeStep onNext={() => setStep("main-agent")} onSkip={handleSkipOnboarding} />
         )}
-        {step === "api-key" && (
-          <ApiKeyStep
-            apiKey={apiKey}
-            onApiKeyChange={setApiKey}
-            onNext={handleSaveApiKey}
-            onSkip={handleSkipApiKey}
+        {step === "main-agent" && (
+          <MainAgentChoiceStep
+            selectedChoiceId={selectedChoiceId}
+            onSelect={setSelectedChoiceId}
+            onNext={() => setStep("setup")}
             onBack={() => setStep("welcome")}
           />
         )}
-        {step === "dictation" && (
-          <DictationStep
+        {step === "setup" && selectedChoiceId === "byok" && (
+          <ByokSetupStep
+            providerId={byokProviderId}
+            onProviderChange={setByokProviderId}
+            apiKey={apiKey}
+            onApiKeyChange={setApiKey}
+            onBack={() => setStep("main-agent")}
+            onContinue={handleContinueFromSetup}
+            isSubmitting={isApplyingSetup}
+            error={setupError}
+          />
+        )}
+        {step === "setup" && selectedChoiceId !== "byok" && selectedExternalPreset && (
+          <ExternalAgentSetupStep
+            presetKey={selectedChoiceId}
+            openCodeInstallStatus={openCodeInstallStatus}
+            onInstallOpenCode={handleInstallOpenCode}
+            isInstallingOpenCode={isInstallingOpenCode}
+            openCodeSetupMode={openCodeSetupMode}
+            onOpenCodeSetupModeChange={setOpenCodeSetupMode}
+            openCodeProviderId={openCodeProviderId}
+            onOpenCodeProviderChange={setOpenCodeProviderId}
+            openCodeApiKey={openCodeApiKey}
+            onOpenCodeApiKeyChange={setOpenCodeApiKey}
+            onBack={() => setStep("main-agent")}
+            onContinue={handleContinueFromSetup}
+            onVerify={handleVerifyExternalAgent}
+            isVerifyingCommand={isVerifyingCommand}
+            isSubmitting={isApplyingSetup}
+            commandVerification={commandVerification}
+            error={setupError}
+          />
+        )}
+        {step === "voice" && (
+          <VoiceStep
             isRecording={isRecording}
             isTranscribing={isTranscribing}
             dictationResult={dictationResult}
             onDictationResultChange={setDictationResult}
             onStartRecording={handleStartRecording}
             onStopRecording={handleStopRecording}
-            onNext={() => setStep("agent")}
-            onBack={() => setStep("api-key")}
+            onNext={() => setStep("finish")}
+            onBack={() => setStep("setup")}
             config={configQuery.data}
             onSaveConfig={saveConfig}
             transcriptionError={transcriptionError}
             micError={micError}
           />
         )}
-        {step === "agent" && (
-          <AgentStep
+        {step === "finish" && (
+          <FinishStep
+            selectedChoiceId={selectedChoiceId}
+            byokProviderId={byokProviderId}
+            provisionedAgentName={provisionedAgentName}
+            selectedOptionDescription={selectedOption.description}
+            selectedOptionMode={selectedOption.mode}
+            onBack={() => setStep("voice")}
             onComplete={handleCompleteOnboarding}
-            onBack={() => setStep("dictation")}
             config={configQuery.data}
             onSaveConfig={saveConfig}
-            onSaveConfigAsync={saveConfigAsync}
           />
         )}
       </div>
@@ -235,7 +525,7 @@ function WelcomeStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
         Welcome to {process.env.PRODUCT_NAME}!
       </h1>
       <p className="mx-auto mb-6 max-w-xl text-base text-muted-foreground sm:text-lg">
-        Let's get you set up with voice dictation and AI-powered tools in just a few steps.
+        Choose how you want DotAgents to think, then optionally try voice dictation and set your hotkeys.
       </p>
       <div className="flex flex-col items-center gap-2.5">
         <Button size="lg" onClick={onNext} className="w-full max-w-56">
@@ -249,71 +539,405 @@ function WelcomeStep({ onNext, onSkip }: { onNext: () => void; onSkip: () => voi
   )
 }
 
-// API Key Step
-function ApiKeyStep({
-  apiKey,
-  onApiKeyChange,
+function MainAgentChoiceStep({
+  selectedChoiceId,
+  onSelect,
   onNext,
-  onSkip,
   onBack,
 }: {
-  apiKey: string
-  onApiKeyChange: (value: string) => void
+  selectedChoiceId: OnboardingMainAgentChoiceId
+  onSelect: (value: OnboardingMainAgentChoiceId) => void
   onNext: () => void
-  onSkip: () => void
   onBack: () => void
 }) {
   return (
     <div>
-      <StepIndicator current={1} total={3} />
-      <h2 className="text-2xl font-bold mb-2 text-center">Set Up Your API Key</h2>
-      <p className="text-muted-foreground mb-6 text-center">
-        Enter your Groq API key to enable voice transcription and AI features.
-        You can also configure other providers later in Settings.
+      <StepIndicator current={1} total={4} />
+      <h2 className="mb-2 text-center text-2xl font-bold">Choose your main agent</h2>
+      <p className="mb-6 text-center text-muted-foreground">
+        Pick the brain DotAgents should use by default. You can change this later in Settings.
       </p>
-      <div className="space-y-4 mb-8">
-        <div>
-          <label className="block text-sm font-medium mb-2">Groq API Key</label>
-          <Input
-            type="password"
-            placeholder="gsk_..."
-            value={apiKey}
-            onChange={(e) => onApiKeyChange(e.target.value)}
-            className="w-full"
-          />
-          <p className="text-xs text-muted-foreground mt-2">
-            Get your <span className="font-medium text-green-600 dark:text-green-400">free</span> API key from{" "}
-            <a
-              href="https://console.groq.com/keys"
-              target="_blank"
-              rel="noreferrer"
-              className="text-primary underline"
+
+      <div className="mb-8 space-y-3">
+        {ONBOARDING_MAIN_AGENT_OPTIONS.map((option) => {
+          const selected = option.id === selectedChoiceId
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => onSelect(option.id)}
+              className={`w-full rounded-xl border p-4 text-left transition ${
+                selected
+                  ? "border-primary bg-primary/5 shadow-sm"
+                  : "border-border bg-background hover:border-primary/40 hover:bg-muted/30"
+              }`}
             >
-              console.groq.com/keys
-            </a>
-          </p>
-        </div>
+              <div className="mb-2 flex items-start justify-between gap-3">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="font-semibold">{option.displayName}</h3>
+                    {option.isRecommended && (
+                      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+                        Recommended
+                      </span>
+                    )}
+                    <span className="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+                      {option.mode}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">{option.description}</p>
+                </div>
+                <span
+                  className={`mt-0.5 h-4 w-4 rounded-full border ${
+                    selected ? "border-primary bg-primary" : "border-muted-foreground/40"
+                  }`}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">{option.setupSummary}</p>
+            </button>
+          )
+        })}
       </div>
+
       <div className="flex justify-between">
         <Button variant="outline" onClick={onBack}>
           Back
         </Button>
-        <div className="flex gap-2">
-          <Button variant="ghost" onClick={onSkip}>
-            Skip for Now
-          </Button>
-          <Button onClick={onNext} disabled={!apiKey.trim()}>
-            Continue
-          </Button>
-        </div>
+        <Button onClick={onNext}>Continue</Button>
       </div>
     </div>
   )
 }
 
+function ByokSetupStep({
+  providerId,
+  onProviderChange,
+  apiKey,
+  onApiKeyChange,
+  onBack,
+  onContinue,
+  isSubmitting,
+  error,
+}: {
+  providerId: ByokProviderId
+  onProviderChange: (value: ByokProviderId) => void
+  apiKey: string
+  onApiKeyChange: (value: string) => void
+  onBack: () => void
+  onContinue: () => void
+  isSubmitting: boolean
+  error: string | null
+}) {
+  const provider = BYOK_PROVIDER_DETAILS[providerId]
 
-// Dictation Step
-function DictationStep({
+  return (
+    <div>
+      <StepIndicator current={2} total={4} />
+      <h2 className="mb-2 text-center text-2xl font-bold">Connect your provider</h2>
+      <p className="mb-6 text-center text-muted-foreground">
+        DotAgents will use its built-in main agent and your provider key for chat and model-backed features.
+      </p>
+
+      <div className="mb-6 space-y-4 rounded-xl border bg-muted/20 p-4">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Provider</label>
+          <Select value={providerId} onValueChange={(value) => onProviderChange(value as ByokProviderId)}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="openai">OpenAI</SelectItem>
+              <SelectItem value="groq">Groq</SelectItem>
+              <SelectItem value="gemini">Gemini</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">{provider.label} API key</label>
+          <Input
+            type="password"
+            placeholder={provider.placeholder}
+            value={apiKey}
+            onChange={(event) => onApiKeyChange(event.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Get a key from{" "}
+            <a href={provider.url} target="_blank" rel="noreferrer" className="text-primary underline">
+              {provider.url.replace(/^https?:\/\//, "")}
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">
+          <span className="i-mingcute-warning-fill mr-2"></span>
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={onContinue} disabled={isSubmitting || !apiKey.trim()}>
+          {isSubmitting ? "Saving..." : "Continue"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function ExternalAgentSetupStep({
+  presetKey,
+  openCodeInstallStatus,
+  onInstallOpenCode,
+  isInstallingOpenCode,
+  openCodeSetupMode,
+  onOpenCodeSetupModeChange,
+  openCodeProviderId,
+  onOpenCodeProviderChange,
+  openCodeApiKey,
+  onOpenCodeApiKeyChange,
+  onBack,
+  onContinue,
+  onVerify,
+  isVerifyingCommand,
+  isSubmitting,
+  commandVerification,
+  error,
+}: {
+  presetKey: ExternalAgentPresetKey
+  openCodeInstallStatus: OpenCodeInstallStatus | null
+  onInstallOpenCode: () => void
+  isInstallingOpenCode: boolean
+  openCodeSetupMode: "existing-auth" | "managed-api-key"
+  onOpenCodeSetupModeChange: (value: "existing-auth" | "managed-api-key") => void
+  openCodeProviderId: ByokProviderId
+  onOpenCodeProviderChange: (value: ByokProviderId) => void
+  openCodeApiKey: string
+  onOpenCodeApiKeyChange: (value: string) => void
+  onBack: () => void
+  onContinue: () => void
+  onVerify: () => void
+  isVerifyingCommand: boolean
+  isSubmitting: boolean
+  commandVerification: ExternalAgentCommandVerificationResult | null
+  error: string | null
+}) {
+  const preset = EXTERNAL_AGENT_PRESETS[presetKey]
+  const commandPreview = [preset.connectionCommand, preset.connectionArgs].filter(Boolean).join(" ")
+  const isOpenCode = presetKey === "opencode"
+  const openCodeProvider = BYOK_PROVIDER_DETAILS[openCodeProviderId]
+  const requiresManagedOpenCodeKey = isOpenCode && openCodeSetupMode === "managed-api-key" && !openCodeApiKey.trim()
+
+  return (
+    <div>
+      <StepIndicator current={2} total={4} />
+      <h2 className="mb-2 text-center text-2xl font-bold">Connect {preset.displayName}</h2>
+      <p className="mb-6 text-center text-muted-foreground">
+        DotAgents will use this ACP agent as the main brain after the command is verified.
+      </p>
+
+      <div className="mb-6 space-y-3 rounded-xl border bg-muted/20 p-4">
+        <div>
+          <div className="mb-1 flex flex-wrap items-center gap-2">
+            <h3 className="font-semibold">{preset.displayName}</h3>
+            <span className="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+              {preset.setupMode === "managed" ? "recommended ACP" : "existing install"}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">{preset.description}</p>
+          <p className="mt-2 text-xs text-muted-foreground">{preset.onboardingNote}</p>
+        </div>
+
+        {(preset.installCommand || preset.authHint || preset.cwdHint) && (
+          <div className="grid gap-2 sm:grid-cols-3">
+            {preset.installCommand && (
+              <div className="space-y-1 rounded-md border bg-background/80 px-2.5 py-2">
+                <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Install</p>
+                <p className="font-mono text-[11px] leading-relaxed">{preset.installCommand}</p>
+              </div>
+            )}
+            {preset.authHint && (
+              <div className="space-y-1 rounded-md border bg-background/80 px-2.5 py-2">
+                <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Auth</p>
+                <p className="text-[11px] leading-relaxed text-muted-foreground">{preset.authHint}</p>
+              </div>
+            )}
+            {preset.cwdHint && (
+              <div className="space-y-1 rounded-md border bg-background/80 px-2.5 py-2">
+                <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Working directory</p>
+                <p className="text-[11px] leading-relaxed text-muted-foreground">{preset.cwdHint}</p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {isOpenCode && (
+          <div className="space-y-3 rounded-md border bg-background/80 px-3 py-3">
+            <div>
+              <p className="text-sm font-medium">OpenCode setup</p>
+              <p className="text-xs text-muted-foreground">
+                Choose whether to use your existing OpenCode auth or let DotAgents inject a provider key directly.
+              </p>
+            </div>
+
+            <div className="rounded-md border bg-muted/20 px-3 py-2 text-[11px] text-muted-foreground">
+              {openCodeInstallStatus?.installed ? (
+                <>
+                  <p className="font-medium text-foreground">Managed OpenCode runtime ready</p>
+                  <p>{openCodeInstallStatus.version || openCodeInstallStatus.binaryPath}</p>
+                </>
+              ) : (
+                <>
+                  <p className="font-medium text-foreground">Need OpenCode installed?</p>
+                  <p>Download it into DotAgents on request. This avoids requiring the user to preinstall OpenCode globally.</p>
+                </>
+              )}
+              {openCodeInstallStatus?.error && (
+                <p className="mt-1 text-red-600 dark:text-red-400">Last install error: {openCodeInstallStatus.error}</p>
+              )}
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 px-2.5 text-xs"
+                disabled={isInstallingOpenCode}
+                onClick={onInstallOpenCode}
+              >
+                <span className={`i-mingcute-download-2-line ${isInstallingOpenCode ? "animate-pulse" : ""}`}></span>
+                {openCodeInstallStatus?.installed ? "Reinstall OpenCode" : "Install OpenCode"}
+              </Button>
+              <span className="text-[11px] text-muted-foreground">Downloads the official OpenCode release into an app-managed folder.</span>
+            </div>
+
+            <div className="space-y-2">
+              <label className="block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Setup mode
+              </label>
+              <Select value={openCodeSetupMode} onValueChange={(value) => onOpenCodeSetupModeChange(value as "existing-auth" | "managed-api-key")}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="managed-api-key">Configure OpenCode now with an API key</SelectItem>
+                  <SelectItem value="existing-auth">Use my existing OpenCode auth</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {openCodeSetupMode === "managed-api-key" && (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Provider
+                  </label>
+                  <Select value={openCodeProviderId} onValueChange={(value) => onOpenCodeProviderChange(value as ByokProviderId)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="openai">OpenAI</SelectItem>
+                      <SelectItem value="groq">Groq</SelectItem>
+                      <SelectItem value="gemini">Gemini</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <label className="block text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {openCodeProvider.label} API key
+                  </label>
+                  <Input
+                    type="password"
+                    placeholder={openCodeProvider.placeholder}
+                    value={openCodeApiKey}
+                    onChange={(event) => onOpenCodeApiKeyChange(event.target.value)}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="rounded-md border bg-background/80 px-3 py-2 text-[11px] text-muted-foreground">
+          Verification runs <span className="font-mono text-foreground">{commandPreview}</span>
+          {preset.verifyArgs?.length ? ` ${preset.verifyArgs.join(" ")}` : ""} to confirm the command is runnable.
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5 px-2.5 text-xs"
+            disabled={isVerifyingCommand}
+            onClick={onVerify}
+          >
+            <span className={`i-mingcute-refresh-3-line ${isVerifyingCommand ? "animate-spin" : ""}`}></span>
+            Verify Setup
+          </Button>
+          {preset.docsUrl && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2.5 text-xs"
+              onClick={() => window.open(preset.docsUrl, "_blank")}
+            >
+              Open docs
+            </Button>
+          )}
+        </div>
+
+        {commandVerification && (
+          <div
+            className={`space-y-1 rounded-md border px-2.5 py-2 text-[11px] ${
+              commandVerification.ok
+                ? "border-emerald-500/40 bg-emerald-500/5"
+                : "border-amber-500/40 bg-amber-500/5"
+            }`}
+          >
+            <p className="font-medium">
+              {commandVerification.ok ? "Verification passed" : "Verification needs attention"}
+            </p>
+            <p className="text-muted-foreground">
+              {commandVerification.details || commandVerification.error}
+            </p>
+            {commandVerification.resolvedCommand && (
+              <p className="font-mono text-[10px] text-muted-foreground">
+                Resolved command: {commandVerification.resolvedCommand}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+
+      {error && !commandVerification?.error && (
+        <div className="mb-6 rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">
+          <span className="i-mingcute-warning-fill mr-2"></span>
+          {error}
+        </div>
+      )}
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={onBack}>
+          Back
+        </Button>
+        <Button onClick={onContinue} disabled={isSubmitting || !commandVerification?.ok || requiresManagedOpenCodeKey}>
+          {isSubmitting ? "Saving..." : "Continue"}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function VoiceStep({
   isRecording,
   isTranscribing,
   dictationResult,
@@ -343,11 +967,9 @@ function DictationStep({
   const shortcut = config?.shortcut || "hold-ctrl"
 
   const getShortcutDisplay = () => {
-    if (shortcut === "hold-ctrl") {
-      return "Hold Ctrl"
-    } else if (shortcut === "ctrl-slash") {
-      return "Press Ctrl+/"
-    } else if (shortcut === "custom" && config?.customShortcut) {
+    if (shortcut === "hold-ctrl") return "Hold Ctrl"
+    if (shortcut === "ctrl-slash") return "Press Ctrl+/"
+    if (shortcut === "custom" && config?.customShortcut) {
       const mode = config.customShortcutMode || "hold"
       return mode === "hold" ? `Hold ${config.customShortcut}` : `Press ${config.customShortcut}`
     }
@@ -355,12 +977,8 @@ function DictationStep({
   }
 
   const getButtonContent = () => {
-    if (isTranscribing) {
-      return { icon: "i-mingcute-loading-fill animate-spin", text: "Transcribing..." }
-    }
-    if (isRecording) {
-      return { icon: "i-mingcute-stop-fill", text: "Stop" }
-    }
+    if (isTranscribing) return { icon: "i-mingcute-loading-fill animate-spin", text: "Transcribing..." }
+    if (isRecording) return { icon: "i-mingcute-stop-fill", text: "Stop" }
     return { icon: "i-mingcute-mic-fill", text: "Record" }
   }
 
@@ -368,26 +986,27 @@ function DictationStep({
 
   return (
     <div>
-      <StepIndicator current={2} total={3} />
-      <h2 className="text-2xl font-bold mb-2 text-center">Try Voice Dictation</h2>
-      <p className="text-muted-foreground mb-4 text-center">
-        Click the button or use your hotkey to record. Your speech will be transcribed below.
+      <StepIndicator current={3} total={4} />
+      <h2 className="mb-2 text-center text-2xl font-bold">Try voice dictation</h2>
+      <p className="mb-4 text-center text-muted-foreground">
+        This step is optional. If speech-to-text is not ready yet, you can skip the demo and finish onboarding.
       </p>
 
-      {/* Hotkey Configuration */}
-      <div className="mb-6 p-4 rounded-lg border bg-muted/30">
-        <div className="flex items-center gap-2 mb-3">
+      <div className="mb-4 rounded-lg border bg-primary/5 p-3 text-sm text-muted-foreground">
+        Current voice stack: STT <strong className="text-foreground">{getProviderLabel(config?.sttProviderId)}</strong>
+        {" · "}
+        TTS <strong className="text-foreground">{getProviderLabel(config?.ttsProviderId)}</strong>
+      </div>
+
+      <div className="mb-6 rounded-lg border bg-muted/30 p-4">
+        <div className="mb-3 flex items-center gap-2">
           <span className="i-mingcute-keyboard-fill text-lg text-primary"></span>
-          <label className="text-sm font-medium">Recording Hotkey</label>
+          <label className="text-sm font-medium">Recording hotkey</label>
         </div>
         <div className="space-y-3">
           <Select
             value={shortcut}
-            onValueChange={(value) => {
-              onSaveConfig({
-                shortcut: value as Config["shortcut"],
-              })
-            }}
+            onValueChange={(value) => onSaveConfig({ shortcut: value as Config["shortcut"] })}
           >
             <SelectTrigger>
               <SelectValue />
@@ -406,9 +1025,7 @@ function DictationStep({
                 <Select
                   value={config?.customShortcutMode || "hold"}
                   onValueChange={(value: "hold" | "toggle") => {
-                    onSaveConfig({
-                      customShortcutMode: value,
-                    })
+                    onSaveConfig({ customShortcutMode: value })
                   }}
                 >
                   <SelectTrigger>
@@ -422,11 +1039,7 @@ function DictationStep({
               </div>
               <KeyRecorder
                 value={config?.customShortcut || ""}
-                onChange={(keyCombo) => {
-                  onSaveConfig({
-                    customShortcut: keyCombo,
-                  })
-                }}
+                onChange={(keyCombo) => onSaveConfig({ customShortcut: keyCombo })}
                 placeholder="Click to record custom shortcut"
               />
             </>
@@ -434,8 +1047,7 @@ function DictationStep({
         </div>
       </div>
 
-      {/* Recording Button and Result */}
-      <div className="flex flex-col items-center gap-4 mb-6">
+      <div className="mb-6 flex flex-col items-center gap-4">
         <div className="flex items-center gap-4">
           <div className="relative">
             <Button
@@ -443,43 +1055,47 @@ function DictationStep({
               variant={isRecording ? "destructive" : "default"}
               onClick={isRecording ? onStopRecording : onStartRecording}
               disabled={isTranscribing}
-              className="w-20 h-20 rounded-full flex flex-col items-center justify-center gap-1"
+              className="flex h-20 w-20 flex-col items-center justify-center gap-1 rounded-full"
             >
               <span className={`text-2xl ${buttonContent.icon}`}></span>
               <span className="text-xs">{buttonContent.text}</span>
             </Button>
             {isRecording && (
-              <div className="absolute inset-0 rounded-full border-4 border-red-500 animate-ping pointer-events-none"></div>
+              <div className="pointer-events-none absolute inset-0 animate-ping rounded-full border-4 border-red-500"></div>
             )}
           </div>
           <div className="text-sm text-muted-foreground">
             <p className="font-medium">Or use your hotkey:</p>
-            <p className="text-primary font-semibold">{getShortcutDisplay()}</p>
+            <p className="font-semibold text-primary">{getShortcutDisplay()}</p>
           </div>
         </div>
 
-        {/* Transcription Result Textarea */}
         <div className="w-full">
-          <label className="block text-sm font-medium mb-2">Transcription Result</label>
+          <label className="mb-2 block text-sm font-medium">Transcription result</label>
           <Textarea
             value={dictationResult || ""}
-            onChange={(e) => onDictationResultChange(e.target.value || null)}
-            placeholder={isRecording ? "Listening..." : isTranscribing ? "Transcribing..." : "Your transcribed text will appear here..."}
+            onChange={(event) => onDictationResultChange(event.target.value || null)}
+            placeholder={
+              isRecording
+                ? "Listening..."
+                : isTranscribing
+                  ? "Transcribing..."
+                  : "Your transcribed text will appear here..."
+            }
             className="min-h-[100px] resize-none"
             readOnly={isRecording || isTranscribing}
           />
         </div>
 
-        {/* Error Messages */}
         {micError && (
-          <div className="w-full p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-600 dark:text-red-400">
+          <div className="w-full rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">
             <span className="i-mingcute-warning-fill mr-2"></span>
             {micError}
           </div>
         )}
 
         {transcriptionError && (
-          <div className="w-full p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-600 dark:text-red-400">
+          <div className="w-full rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-600 dark:text-red-400">
             <span className="i-mingcute-warning-fill mr-2"></span>
             {transcriptionError}
           </div>
@@ -491,142 +1107,69 @@ function DictationStep({
           Back
         </Button>
         <Button onClick={onNext} disabled={isRecording || isTranscribing}>
-          {dictationResult ? "Continue" : "Skip Demo"}
+          Continue
         </Button>
       </div>
     </div>
   )
 }
 
-// Agent Step
-function AgentStep({
-  onComplete,
+function FinishStep({
+  selectedChoiceId,
+  byokProviderId,
+  provisionedAgentName,
+  selectedOptionDescription,
+  selectedOptionMode,
   onBack,
+  onComplete,
   config,
   onSaveConfig,
-  onSaveConfigAsync,
 }: {
-  onComplete: () => void
+  selectedChoiceId: OnboardingMainAgentChoiceId
+  byokProviderId: ByokProviderId
+  provisionedAgentName: string | null
+  selectedOptionDescription: string
+  selectedOptionMode: "api" | "acp"
   onBack: () => void
+  onComplete: () => void
   config: Config | undefined
   onSaveConfig: (config: Partial<Config>) => void
-  onSaveConfigAsync: (config: Partial<Config>) => Promise<void>
 }) {
-  const [isInstallingExa, setIsInstallingExa] = useState(false)
-  const [exaInstalled, setExaInstalled] = useState(false)
-  const [agentPrompt, setAgentPrompt] = useState("")
-  const [isAgentRunning, setIsAgentRunning] = useState(false)
-  const [agentResponse, setAgentResponse] = useState<string | null>(null)
-  const [agentError, setAgentError] = useState<string | null>(null)
-
-  // Check if Exa is already installed
-  useEffect(() => {
-    const mcpServers = config?.mcpConfig?.mcpServers || {}
-    setExaInstalled("exa" in mcpServers)
-  }, [config?.mcpConfig?.mcpServers])
-
   const mcpToolsShortcut = config?.mcpToolsShortcut || "hold-ctrl-alt"
-
-  const handleInstallExa = async () => {
-    setIsInstallingExa(true)
-    try {
-      // Add Exa MCP server to config
-      const currentMcpConfig = config?.mcpConfig || { mcpServers: {} }
-      const newMcpConfig = {
-        ...currentMcpConfig,
-        mcpServers: {
-          ...currentMcpConfig.mcpServers,
-          exa: {
-            transport: "streamableHttp" as const,
-            url: "https://mcp.exa.ai/mcp",
-          },
-        },
-      }
-
-      // Wait for config to save, then start the server
-      await onSaveConfigAsync({ mcpConfig: newMcpConfig })
-
-      // Enable and start the server
-      await tipcClient.setMcpServerRuntimeEnabled({
-        serverName: "exa",
-        enabled: true,
-      })
-      await tipcClient.restartMcpServer({ serverName: "exa" })
-
-      setExaInstalled(true)
-    } catch (error) {
-      console.error("Failed to install Exa:", error)
-    } finally {
-      setIsInstallingExa(false)
-    }
-  }
-
-  const handleTestAgent = async () => {
-    if (!agentPrompt.trim()) return
-
-    // Check if API key is configured for the selected provider
-    const providerId = config?.mcpToolsProviderId || "openai"
-    const hasApiKey = providerId === "groq"
-      ? !!config?.groqApiKey
-      : providerId === "gemini"
-      ? !!config?.geminiApiKey
-      : !!config?.openaiApiKey
-
-    if (!hasApiKey) {
-      setAgentError(`No API key configured. Please go back and enter your ${providerId === "groq" ? "Groq" : providerId === "gemini" ? "Gemini" : "OpenAI"} API key, or configure it in Settings.`)
-      return
-    }
-
-    setIsAgentRunning(true)
-    setAgentResponse(null)
-    setAgentError(null)
-
-    try {
-      // Start agent session - this will run in the background
-      // and show in the floating panel
-      await tipcClient.createMcpTextInput({
-        text: agentPrompt.trim(),
-      })
-
-      // Clear the prompt after sending
-      setAgentPrompt("")
-      setAgentResponse("Agent started! Check the floating panel to see the progress.")
-    } catch (error: any) {
-      console.error("Failed to start agent:", error)
-      const errorMessage = error?.message || String(error)
-      if (errorMessage.includes("API key")) {
-        setAgentError("API key is missing or invalid. Please check your settings.")
-      } else if (errorMessage.includes("model")) {
-        setAgentError("Model configuration error. Please check your model settings.")
-      } else {
-        setAgentError(`Failed to start agent: ${errorMessage}`)
-      }
-    } finally {
-      setIsAgentRunning(false)
-    }
-  }
+  const mainAgentSummary =
+    selectedChoiceId === "byok"
+      ? `DotAgents built-in agent (${BYOK_PROVIDER_DETAILS[byokProviderId].label})`
+      : provisionedAgentName || EXTERNAL_AGENT_PRESETS[selectedChoiceId].displayName
 
   return (
     <div>
-      <StepIndicator current={3} total={3} />
-      <h2 className="text-2xl font-bold mb-2 text-center">Meet Your AI Agent</h2>
-      <p className="text-muted-foreground mb-4 text-center">
-        Your AI agent can use MCP tools to search the web, run code, and more.
+      <StepIndicator current={4} total={4} />
+      <h2 className="mb-2 text-center text-2xl font-bold">You’re ready to go</h2>
+      <p className="mb-6 text-center text-muted-foreground">
+        Review your default agent setup and pick the hotkey you want for agent mode.
       </p>
 
-      {/* Agent Mode Hotkey Configuration */}
-      <div className="mb-4 p-4 rounded-lg border bg-muted/30">
-        <div className="flex items-center gap-2 mb-3">
+      <div className="mb-4 rounded-lg border bg-muted/30 p-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <h3 className="font-semibold">Main agent</h3>
+          <span className="rounded-full border px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            {selectedOptionMode}
+          </span>
+        </div>
+        <p className="text-sm text-foreground">{mainAgentSummary}</p>
+        <p className="mt-1 text-xs text-muted-foreground">{selectedOptionDescription}</p>
+      </div>
+
+      <div className="mb-6 rounded-lg border bg-muted/30 p-4">
+        <div className="mb-3 flex items-center gap-2">
           <span className="i-mingcute-keyboard-fill text-lg text-primary"></span>
-          <label className="text-sm font-medium">Agent Mode Hotkey</label>
+          <label className="text-sm font-medium">Agent mode hotkey</label>
         </div>
         <div className="space-y-3">
           <Select
             value={mcpToolsShortcut}
             onValueChange={(value) => {
-              onSaveConfig({
-                mcpToolsShortcut: value as Config["mcpToolsShortcut"],
-              })
+              onSaveConfig({ mcpToolsShortcut: value as Config["mcpToolsShortcut"] })
             }}
           >
             <SelectTrigger>
@@ -643,123 +1186,13 @@ function AgentStep({
           {mcpToolsShortcut === "custom" && (
             <KeyRecorder
               value={config?.customMcpToolsShortcut || ""}
-              onChange={(keyCombo) => {
-                onSaveConfig({
-                  customMcpToolsShortcut: keyCombo,
-                })
-              }}
+              onChange={(keyCombo) => onSaveConfig({ customMcpToolsShortcut: keyCombo })}
               placeholder="Click to record custom agent mode shortcut"
             />
           )}
         </div>
-      </div>
-
-      {/* Install Exa MCP Server */}
-      <div className="mb-4 p-4 rounded-lg border bg-muted/30">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="i-mingcute-search-fill text-2xl text-primary"></span>
-            <div>
-              <h3 className="font-semibold">Exa Web Search</h3>
-              <p className="text-sm text-muted-foreground">
-                Give your agent the power to search the web
-              </p>
-            </div>
-          </div>
-          <Button
-            onClick={handleInstallExa}
-            disabled={isInstallingExa || exaInstalled}
-            variant={exaInstalled ? "outline" : "default"}
-            size="sm"
-          >
-            {isInstallingExa ? (
-              <>
-                <span className="i-mingcute-loading-fill animate-spin mr-2"></span>
-                Installing...
-              </>
-            ) : exaInstalled ? (
-              <>
-                <span className="i-mingcute-check-fill mr-2 text-green-500"></span>
-                Installed
-              </>
-            ) : (
-              <>
-                <span className="i-mingcute-add-fill mr-2"></span>
-                Install
-              </>
-            )}
-          </Button>
-        </div>
-        <p className="text-xs text-muted-foreground mt-2">
-          Get your Exa API key at{" "}
-          <a
-            href="https://dashboard.exa.ai/api-keys"
-            target="_blank"
-            rel="noreferrer"
-            className="text-primary underline"
-          >
-            dashboard.exa.ai/api-keys
-          </a>
-          . Add more MCP tools in Settings → MCP Tools.
-        </p>
-      </div>
-
-      {/* Try Your Agent */}
-      <div className="mb-4 p-4 rounded-lg border bg-muted/30">
-        <div className="flex items-center gap-2 mb-3">
-          <span className="i-mingcute-robot-fill text-lg text-primary"></span>
-          <label className="text-sm font-medium">Try Your Agent</label>
-        </div>
-
-        {/* Hotkey hint */}
-        <div className="flex items-center gap-2 mb-3 p-2 rounded bg-primary/10 border border-primary/20">
-          <span className="i-mingcute-keyboard-fill text-primary"></span>
-          <span className="text-sm">
-            <strong>{getMcpToolsShortcutDisplay(mcpToolsShortcut, config?.customMcpToolsShortcut)}</strong> to speak to your agent from anywhere
-          </span>
-        </div>
-
-        <div className="flex gap-2">
-          <Input
-            value={agentPrompt}
-            onChange={(e) => setAgentPrompt(e.target.value)}
-            placeholder={exaInstalled ? "Try: What's the latest news about AI?" : "Ask your agent anything..."}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault()
-                handleTestAgent()
-              }
-            }}
-            disabled={isAgentRunning}
-          />
-          <Button
-            onClick={handleTestAgent}
-            disabled={isAgentRunning || !agentPrompt.trim()}
-          >
-            {isAgentRunning ? (
-              <span className="i-mingcute-loading-fill animate-spin"></span>
-            ) : (
-              <span className="i-mingcute-send-fill"></span>
-            )}
-          </Button>
-        </div>
-
-        {agentResponse && (
-          <div className="mt-3 p-2 rounded bg-green-500/10 border border-green-500/20 text-sm text-green-600 dark:text-green-400">
-            <span className="i-mingcute-check-circle-fill mr-2"></span>
-            {agentResponse}
-          </div>
-        )}
-
-        {agentError && (
-          <div className="mt-3 p-2 rounded bg-red-500/10 border border-red-500/20 text-sm text-red-600 dark:text-red-400">
-            <span className="i-mingcute-warning-fill mr-2"></span>
-            {agentError}
-          </div>
-        )}
-
-        <p className="text-xs text-muted-foreground mt-2">
-          Or use your hotkey to speak to the agent. Results will appear in the floating panel.
+        <p className="mt-3 text-xs text-muted-foreground">
+          Current shortcut: {getMcpToolsShortcutDisplay(mcpToolsShortcut, config?.customMcpToolsShortcut)}
         </p>
       </div>
 
@@ -775,7 +1208,6 @@ function AgentStep({
   )
 }
 
-// Step Indicator
 function StepIndicator({ current, total }: { current: number; total: number }) {
   return (
     <div className="mb-6 flex justify-center gap-2">
@@ -790,27 +1222,3 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
     </div>
   )
 }
-
-// Feature Card
-function FeatureCard({
-  icon,
-  title,
-  description,
-}: {
-  icon: string
-  title: string
-  description: string
-}) {
-  return (
-    <div className="flex gap-4 p-4 rounded-lg border bg-muted/30">
-      <div className="flex-shrink-0">
-        <span className={`${icon} text-2xl text-primary`}></span>
-      </div>
-      <div>
-        <h3 className="font-semibold mb-1">{title}</h3>
-        <p className="text-sm text-muted-foreground">{description}</p>
-      </div>
-    </div>
-  )
-}
-

--- a/apps/desktop/src/renderer/src/pages/settings-agents.install-handoff.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.install-handoff.test.tsx
@@ -13,6 +13,7 @@ function createHookRuntime() {
     if (states[idx] === undefined) states[idx] = typeof initial === "function" ? (initial as () => T)() : initial
     return [states[idx] as T, (update: T | ((prev: T) => T)) => { states[idx] = typeof update === "function" ? (update as (prev: T) => T)(states[idx]) : update }] as const
   }
+  const useMemo = <T,>(factory: () => T) => factory()
   const forwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
   const useRef = <T,>(initial: T) => (refs[refIndex] ??= { current: initial }) as { current: T }
   const useEffect = (callback: EffectRecord["callback"], deps?: any[]) => { effects[effectIndex] = { ...(effects[effectIndex] ?? { hasRun: false }), callback, nextDeps: deps }; effectIndex += 1 }
@@ -22,7 +23,7 @@ function createHookRuntime() {
   return {
     render,
     commitEffects,
-    reactMock: { __esModule: true, default: {} as any, useState, useRef: <T,>(initial: T) => { const ref = useRef(initial); refIndex += 1; return ref }, useEffect, forwardRef },
+    reactMock: { __esModule: true, default: {} as any, useState, useMemo, useRef: <T,>(initial: T) => { const ref = useRef(initial); refIndex += 1; return ref }, useEffect, forwardRef },
     jsxRuntimeMock: { __esModule: true, jsx: invoke, jsxs: invoke, jsxDEV: invoke, Fragment: Symbol.for("react.fragment") },
   }
 }

--- a/apps/desktop/src/renderer/src/pages/settings-agents.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.tsx
@@ -34,6 +34,12 @@ import { BundleExportDialog } from "@renderer/components/bundle-export-dialog"
 import { BundlePublishDialog } from "@renderer/components/bundle-publish-dialog"
 import { SandboxSlotSwitcher } from "@renderer/components/sandbox-slot-switcher"
 import {
+  EXTERNAL_AGENT_PRESETS,
+  detectExternalAgentPresetKey,
+  type ExternalAgentPresetDefinition,
+  type ExternalAgentPresetKey,
+} from "@shared/external-agent-presets"
+import {
   AgentProfile, AgentProfileConnectionType, AgentProfileConnection,
   ProfileModelConfig, AgentProfileToolConfig, ProfileSkillsConfig, AgentSkill, DetailedToolInfo,
 } from "../../../shared/types"
@@ -61,17 +67,9 @@ interface EditingAgent {
   avatarDataUrl?: string | null
 }
 
-type AgentPresetKey = "auggie" | "claude-code" | "codex" | "opencode"
+type AgentPresetKey = ExternalAgentPresetKey
 
-interface AgentPresetDefinition extends Partial<EditingAgent> {
-  displayName: string
-  description: string
-  docsUrl?: string
-  installCommand?: string
-  authHint?: string
-  cwdHint?: string
-  verifyArgs?: string[]
-}
+type AgentPresetDefinition = ExternalAgentPresetDefinition & Partial<EditingAgent>
 
 interface ExternalAgentCommandVerificationResult {
   ok: boolean
@@ -83,57 +81,21 @@ interface ExternalAgentCommandVerificationResult {
 
 type ServerInfo = { connected: boolean; toolCount: number; runtimeEnabled?: boolean; configDisabled?: boolean }
 
-const AGENT_PRESETS: Record<AgentPresetKey, AgentPresetDefinition> = {
-  auggie: {
-    displayName: "Auggie (Augment Code)",
-    description: "Augment Code's AI coding assistant with native ACP support",
-    connectionType: "acp", connectionCommand: "auggie", connectionArgs: "--acp", enabled: true,
-    docsUrl: "https://www.augmentcode.com/",
-    cwdHint: "Point the working directory at the repo you want Auggie to operate in.",
-    verifyArgs: ["--help"],
-  },
-  "claude-code": {
-    displayName: "Claude Code",
-    description: "Anthropic's Claude for coding tasks via ACP adapter",
-    connectionType: "acp", connectionCommand: "claude-code-acp", connectionArgs: "", enabled: true,
-    docsUrl: "https://github.com/zed-industries/claude-code-acp",
-    installCommand: "npm install -g @zed-industries/claude-code-acp",
-    authHint: "Sign in to Claude Code in your terminal before verifying if this is your first run.",
-    cwdHint: "Use your repo root so Claude Code inherits the right project context.",
-    verifyArgs: ["--help"],
-  },
-  codex: {
-    displayName: "Codex",
-    description: "OpenAI Codex via the official ACP adapter",
-    connectionType: "acp", connectionCommand: "codex-acp", connectionArgs: "", enabled: true,
-    docsUrl: "https://github.com/zed-industries/codex-acp",
-    installCommand: "npm install -g @zed-industries/codex-acp",
-    authHint: "Run codex login first, or set CODEX_API_KEY / OPENAI_API_KEY before verifying.",
-    cwdHint: "Set the working directory to the project Codex should inspect and edit.",
-    verifyArgs: ["--help"],
-  },
-  opencode: {
-    displayName: "OpenCode",
-    description: "OpenCode's native ACP server for terminal-first agent workflows",
-    connectionType: "acp", connectionCommand: "opencode", connectionArgs: "acp", enabled: true,
-    docsUrl: "https://opencode.ai/docs/acp/",
-    installCommand: "npm install -g opencode-ai",
-    authHint: "OpenCode stores provider auth after you run opencode and complete /connect in the TUI.",
-    cwdHint: "Use your workspace root so opencode acp can load the right project and config.",
-    verifyArgs: ["--help"],
-  },
-}
+const AGENT_PRESETS: Record<AgentPresetKey, AgentPresetDefinition> = Object.fromEntries(
+  Object.entries(EXTERNAL_AGENT_PRESETS).map(([key, preset]) => [
+    key,
+    {
+      ...preset,
+      connectionType: preset.connectionType,
+      connectionCommand: preset.connectionCommand,
+      connectionArgs: preset.connectionArgs,
+      enabled: true,
+    },
+  ])
+) as Record<AgentPresetKey, AgentPresetDefinition>
 
 function detectPresetKey(agent?: Partial<EditingAgent> | null): AgentPresetKey | undefined {
-  if (!agent) return undefined
-  const args = (agent.connectionArgs || "").trim()
-
-  if (agent.connectionType === "acp" && agent.connectionCommand === "auggie" && args === "--acp") return "auggie"
-  if (agent.connectionType === "acp" && agent.connectionCommand === "claude-code-acp") return "claude-code"
-  if (agent.connectionType === "acp" && agent.connectionCommand === "codex-acp") return "codex"
-  if (agent.connectionType === "acp" && agent.connectionCommand === "opencode" && args === "acp") return "opencode"
-
-  return undefined
+  return detectExternalAgentPresetKey(agent)
 }
 
 function buildCommandPreview(command?: string, args?: string): string {

--- a/apps/desktop/src/shared/external-agent-presets.test.ts
+++ b/apps/desktop/src/shared/external-agent-presets.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  EXTERNAL_AGENT_PRESETS,
+  detectExternalAgentPresetKey,
+} from "./external-agent-presets"
+
+describe("external-agent-presets", () => {
+  it("keeps all curated ACP onboarding options available", () => {
+    expect(Object.keys(EXTERNAL_AGENT_PRESETS)).toEqual([
+      "auggie",
+      "claude-code",
+      "codex",
+      "opencode",
+    ])
+    expect(EXTERNAL_AGENT_PRESETS.opencode.setupMode).toBe("managed")
+  })
+
+  it("detects presets from stored connection details", () => {
+    expect(
+      detectExternalAgentPresetKey({
+        connectionType: "acp",
+        connectionCommand: "opencode",
+        connectionArgs: ["acp"],
+      })
+    ).toBe("opencode")
+
+    expect(
+      detectExternalAgentPresetKey({
+        connectionType: "acp",
+        connectionCommand: "claude-code-acp",
+        connectionArgs: "",
+      })
+    ).toBe("claude-code")
+  })
+
+  it("returns undefined for unrelated agents", () => {
+    expect(
+      detectExternalAgentPresetKey({
+        connectionType: "remote",
+        connectionCommand: "https://example.com",
+      })
+    ).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/shared/external-agent-presets.ts
+++ b/apps/desktop/src/shared/external-agent-presets.ts
@@ -1,0 +1,110 @@
+import type { AgentProfileConnectionType } from "./types"
+
+export type ExternalAgentPresetKey = "auggie" | "claude-code" | "codex" | "opencode"
+
+export type ExternalAgentSetupMode = "connect-existing" | "managed"
+
+export type ExternalAgentPresetDefinition = {
+  displayName: string
+  description: string
+  connectionType: Extract<AgentProfileConnectionType, "acp" | "stdio">
+  connectionCommand: string
+  connectionArgs?: string
+  docsUrl?: string
+  installCommand?: string
+  authHint?: string
+  cwdHint?: string
+  verifyArgs?: string[]
+  setupMode: ExternalAgentSetupMode
+  onboardingNote: string
+}
+
+export const EXTERNAL_AGENT_PRESETS: Record<ExternalAgentPresetKey, ExternalAgentPresetDefinition> = {
+  auggie: {
+    displayName: "Auggie (Augment Code)",
+    description: "Augment Code's AI coding assistant with native ACP support",
+    connectionType: "acp",
+    connectionCommand: "auggie",
+    connectionArgs: "--acp",
+    docsUrl: "https://www.augmentcode.com/",
+    cwdHint: "Point the working directory at the repo you want Auggie to operate in.",
+    verifyArgs: ["--help"],
+    setupMode: "connect-existing",
+    onboardingNote: "Best for users who already have Auggie installed and authenticated.",
+  },
+  "claude-code": {
+    displayName: "Claude Code",
+    description: "Anthropic's Claude for coding tasks via ACP adapter",
+    connectionType: "acp",
+    connectionCommand: "claude-code-acp",
+    connectionArgs: "",
+    docsUrl: "https://github.com/zed-industries/claude-code-acp",
+    installCommand: "npm install -g @zed-industries/claude-code-acp",
+    authHint: "Sign in to Claude Code in your terminal before verifying if this is your first run.",
+    cwdHint: "Use your repo root so Claude Code inherits the right project context.",
+    verifyArgs: ["--help"],
+    setupMode: "connect-existing",
+    onboardingNote: "Connect an existing Claude Code install and verify it before continuing.",
+  },
+  codex: {
+    displayName: "Codex",
+    description: "OpenAI Codex via the official ACP adapter",
+    connectionType: "acp",
+    connectionCommand: "codex-acp",
+    connectionArgs: "",
+    docsUrl: "https://github.com/zed-industries/codex-acp",
+    installCommand: "npm install -g @zed-industries/codex-acp",
+    authHint: "Run codex login first, or set CODEX_API_KEY / OPENAI_API_KEY before verifying.",
+    cwdHint: "Set the working directory to the project Codex should inspect and edit.",
+    verifyArgs: ["--help"],
+    setupMode: "connect-existing",
+    onboardingNote: "Connect an existing Codex ACP adapter and verify the command path.",
+  },
+  opencode: {
+    displayName: "OpenCode",
+    description: "OpenCode's native ACP server for terminal-first agent workflows",
+    connectionType: "acp",
+    connectionCommand: "opencode",
+    connectionArgs: "acp",
+    docsUrl: "https://opencode.ai/docs/acp/",
+    installCommand: "curl -fsSL https://opencode.ai/install | bash",
+    authHint: "You can either reuse existing OpenCode auth or let DotAgents inject a provider API key during onboarding.",
+    cwdHint: "Use your workspace root so opencode acp can load the right project and config.",
+    verifyArgs: ["--help"],
+    setupMode: "managed",
+    onboardingNote: "Recommended ACP option for terminal-first workflows and external tool ownership.",
+  },
+}
+
+function normalizeArgs(args?: string | string[]): string {
+  if (Array.isArray(args)) return args.join(" ").trim()
+  return args?.trim() || ""
+}
+
+export function detectExternalAgentPresetKey(agent?: {
+  connectionType?: AgentProfileConnectionType
+  connectionCommand?: string
+  connectionArgs?: string | string[]
+} | null): ExternalAgentPresetKey | undefined {
+  if (!agent) return undefined
+
+  const args = normalizeArgs(agent.connectionArgs)
+
+  if (agent.connectionType === "acp" && agent.connectionCommand === "auggie" && args === "--acp") {
+    return "auggie"
+  }
+
+  if (agent.connectionType === "acp" && agent.connectionCommand === "claude-code-acp") {
+    return "claude-code"
+  }
+
+  if (agent.connectionType === "acp" && agent.connectionCommand === "codex-acp") {
+    return "codex"
+  }
+
+  if (agent.connectionType === "acp" && agent.connectionCommand === "opencode" && args === "acp") {
+    return "opencode"
+  }
+
+  return undefined
+}

--- a/apps/desktop/tests/onboarding-step-shell-density.test.mjs
+++ b/apps/desktop/tests/onboarding-step-shell-density.test.mjs
@@ -8,6 +8,11 @@ const onboardingSource = fs.readFileSync(
   'utf8',
 )
 
+const onboardingHelperSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/renderer/src/lib/onboarding-main-agent.ts'),
+  'utf8',
+)
+
 test('desktop onboarding keeps only the welcome hero vertically centered', () => {
   assert.match(
     onboardingSource,
@@ -19,4 +24,10 @@ test('desktop onboarding keeps only the welcome hero vertically centered', () =>
 test('desktop onboarding setup steps use a tighter shared step-indicator gap', () => {
   assert.match(onboardingSource, /<div className="mb-6 flex justify-center gap-2">/)
   assert.doesNotMatch(onboardingSource, /<div className="flex justify-center gap-2 mb-8">/)
+})
+
+test('desktop onboarding source includes the requested main-agent choices', () => {
+  assert.match(onboardingHelperSource, /Bring Your Own Key \(BYOK\)/)
+  assert.match(onboardingHelperSource, /id: "opencode"/)
+  assert.match(onboardingSource, /Connect your provider/)
 })

--- a/apps/desktop/tests/onboarding-welcome-density.test.mjs
+++ b/apps/desktop/tests/onboarding-welcome-density.test.mjs
@@ -8,7 +8,7 @@ const onboardingSource = fs.readFileSync(
   'utf8',
 )
 
-const welcomeStepMatch = onboardingSource.match(/function WelcomeStep[\s\S]*?\/\/ API Key Step/)
+const welcomeStepMatch = onboardingSource.match(/function WelcomeStep[\s\S]*?function MainAgentChoiceStep/)
 
 assert.ok(welcomeStepMatch, 'expected to find WelcomeStep in onboarding.tsx')
 

--- a/apps/desktop/tests/opencode-managed-onboarding-source.test.mjs
+++ b/apps/desktop/tests/opencode-managed-onboarding-source.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const onboardingSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/renderer/src/pages/onboarding.tsx'),
+  'utf8',
+)
+
+const onboardingHelperSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/renderer/src/lib/onboarding-main-agent.ts'),
+  'utf8',
+)
+
+const installerSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/main/opencode-installer.ts'),
+  'utf8',
+)
+
+const mcpServiceSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/main/mcp-service.ts'),
+  'utf8',
+)
+
+test('OpenCode onboarding supports managed API-key setup', () => {
+  assert.match(onboardingSource, /Configure OpenCode now with an API key/)
+  assert.match(onboardingHelperSource, /OPENCODE_CONFIG_CONTENT/)
+  assert.match(onboardingHelperSource, /DOTAGENTS_OPENCODE_PROVIDER_API_KEY/)
+})
+
+test('desktop supports managed on-demand OpenCode install and command resolution', () => {
+  assert.match(installerSource, /installManagedOpencode/)
+  assert.match(installerSource, /opencode-darwin-arm64/)
+  assert.match(mcpServiceSource, /opencodeResourceSuffix/)
+  assert.match(mcpServiceSource, /external-tools", "opencode", "current"/)
+  assert.match(mcpServiceSource, /resourcesPath, "opencode"/)
+})

--- a/apps/desktop/tests/settings-agents-acp-setup.test.mjs
+++ b/apps/desktop/tests/settings-agents-acp-setup.test.mjs
@@ -8,6 +8,11 @@ const settingsAgentsSource = fs.readFileSync(
   'utf8',
 )
 
+const presetSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/shared/external-agent-presets.ts'),
+  'utf8',
+)
+
 const tipcSource = fs.readFileSync(
   path.join(process.cwd(), 'apps/desktop/src/main/tipc.ts'),
   'utf8',
@@ -19,13 +24,14 @@ const commandVerificationSource = fs.readFileSync(
 )
 
 test('desktop agent presets include Codex and OpenCode ACP defaults with setup guidance', () => {
-  assert.match(settingsAgentsSource, /codex:\s*\{[\s\S]*displayName: "Codex"/)
-  assert.match(settingsAgentsSource, /codex:[\s\S]*connectionCommand: "codex-acp"/)
-  assert.match(settingsAgentsSource, /codex:[\s\S]*installCommand: "npm install -g @zed-industries\/codex-acp"/)
-  assert.match(settingsAgentsSource, /opencode:\s*\{[\s\S]*displayName: "OpenCode"/)
-  assert.match(settingsAgentsSource, /opencode:[\s\S]*connectionCommand: "opencode"/)
-  assert.match(settingsAgentsSource, /opencode:[\s\S]*connectionArgs: "acp"/)
-  assert.match(settingsAgentsSource, /opencode:[\s\S]*docsUrl: "https:\/\/opencode\.ai\/docs\/acp\/"/)
+  assert.match(presetSource, /codex:\s*\{[\s\S]*displayName: "Codex"/)
+  assert.match(presetSource, /codex:[\s\S]*connectionCommand: "codex-acp"/)
+  assert.match(presetSource, /codex:[\s\S]*installCommand: "npm install -g @zed-industries\/codex-acp"/)
+  assert.match(presetSource, /opencode:\s*\{[\s\S]*displayName: "OpenCode"/)
+  assert.match(presetSource, /opencode:[\s\S]*connectionCommand: "opencode"/)
+  assert.match(presetSource, /opencode:[\s\S]*connectionArgs: "acp"/)
+  assert.match(presetSource, /opencode:[\s\S]*docsUrl: "https:\/\/opencode\.ai\/docs\/acp\/"/)
+  assert.match(presetSource, /setupMode: "managed"/)
 })
 
 test('desktop agent edit form exposes external-agent verification and actionable setup copy', () => {

--- a/docs/desktop-multi-agent-onboarding-spec-2026-04-05.md
+++ b/docs/desktop-multi-agent-onboarding-spec-2026-04-05.md
@@ -1,0 +1,225 @@
+## Desktop multi-agent onboarding spec
+
+### Goal
+
+Replace the current Groq-only onboarding with a provider-agnostic flow that can onboard users into one of five main-agent paths:
+
+1. OpenCode via ACP
+2. Auggie via ACP
+3. Claude Code via ACP
+4. Codex via ACP
+5. BYOK using DotAgents' built-in API mode
+
+### Product requirements
+
+- Fresh onboarding must expose all five options up front.
+- BYOK must be fully completable inside onboarding.
+- ACP options must provision or reuse an agent profile instead of forcing the user into Settings first.
+- OpenCode should be presented as the recommended ACP option.
+- Onboarding must verify external commands before finishing ACP setup.
+- Voice/dictation should remain optional and skippable.
+- The flow must preserve the existing shell density constraints for welcome vs non-welcome steps.
+
+### Explicit scope for this implementation
+
+This implementation ships the new onboarding architecture and verification UX now.
+
+- **Implemented now**
+  - Unified main-agent choice step
+  - BYOK setup path for OpenAI / Groq / Gemini
+  - ACP setup path for OpenCode / Auggie / Claude Code / Codex
+  - External agent profile provisioning / reuse
+  - External command verification from onboarding
+  - OpenCode managed env/config injection from an in-app provider key
+  - OpenCode on-demand install affordance for explicit user-requested setup
+  - Updated onboarding copy, summaries, and finish step
+
+- **Spec'd but not fully automated yet**
+  - Background progress UI for OpenCode download/install
+  - Richer multi-arch install target detection (baseline / musl variants)
+  - Automatic install/auth for Claude Code, Codex, or Auggie
+
+### Non-goals for this patch
+
+- Bundling a new external binary dependency
+- Changing package manifests or lockfiles
+- Reworking the Settings > Providers page
+- Reworking mobile onboarding in this patch
+
+### Architecture
+
+#### Shared preset metadata
+
+Move curated external-agent presets into a shared desktop module so onboarding and Settings use the same source of truth.
+
+The shared preset metadata owns:
+
+- display name
+- description
+- command / args
+- docs URL
+- install command
+- auth hint
+- cwd hint
+- verification args
+- setup mode (`connect-existing` vs `managed`)
+
+#### Pure onboarding helper module
+
+Create a renderer helper module that owns:
+
+- the five onboarding choices
+- BYOK config updates
+- ACP config updates
+- ACP profile draft creation
+- matching/reusing an existing external agent profile
+
+This keeps the branching logic testable without mounting the full onboarding component.
+
+### UX flow
+
+#### Step 1 — Welcome
+
+Keep the centered welcome hero and skip path.
+
+#### Step 2 — Choose main agent
+
+Show five cards:
+
+- OpenCode (recommended)
+- Auggie
+- Claude Code
+- Codex
+- BYOK
+
+Each card shows:
+
+- description
+- setup summary
+- whether it is API mode or ACP mode
+
+#### Step 3 — Setup
+
+Branch by selected choice.
+
+##### BYOK
+
+- choose OpenAI / Groq / Gemini
+- enter API key
+- save config for internal API mode
+
+##### ACP options
+
+- show preset install/auth/cwd guidance
+- run onboarding-time verification through `verifyExternalAgentCommand`
+- provision or reuse an ACP agent profile
+- save `mainAgentMode = "acp"` and `mainAgentName`
+
+##### OpenCode-specific behavior
+
+- allow explicit user-requested runtime install into an app-managed directory
+- allow OpenCode to be configured from onboarding with an OpenAI / Groq / Gemini-compatible API key
+- inject `OPENCODE_CONFIG_CONTENT` and provider env vars on the generated ACP profile
+- prefer the managed app install path when resolving the `opencode` command
+
+Verification is required before enabling the primary continue action for ACP paths.
+
+#### Step 4 — Voice & shortcuts
+
+- keep recording hotkey setup
+- keep optional dictation demo
+- update copy so failure is not framed as only a Groq problem
+- allow users to continue even if dictation is skipped or unavailable
+
+#### Step 5 — Finish
+
+- configure agent hotkey
+- summarize chosen main agent
+- mark onboarding complete
+
+### Data/config behavior
+
+#### BYOK
+
+Save:
+
+- `mainAgentMode = "api"`
+- provider API key
+- `mcpToolsProviderId`
+- transcript post-processing provider/model
+- STT provider where compatible
+- TTS provider, preferring local downloaded TTS when available
+
+#### ACP
+
+Save:
+
+- `mainAgentMode = "acp"`
+- `mainAgentName = <profile display name>`
+- `acpInjectRuntimeTools` left enabled by default
+- local STT/TTS defaults only when already downloaded
+
+Provisioned profiles should:
+
+- be enabled
+- use ACP connection settings from the preset
+- reuse an existing matching preset profile when present
+- avoid destructive overwrites of custom existing profiles
+
+### OpenCode install design
+
+OpenCode should **not** be bundled by default.
+
+Instead:
+
+1. detect whether `opencode` is already available
+2. if the user chose OpenCode and explicitly requests installation, download the official release asset into an app-managed folder
+3. prefer that managed binary path during command resolution
+4. continue to support already-installed global `opencode` binaries through normal PATH lookup
+
+### Verification plan
+
+#### Static / unit verification
+
+Add or update tests for:
+
+- shared external preset definitions
+- preset detection from stored connection config
+- onboarding option availability and order
+- BYOK config update generation
+- ACP config update generation
+- ACP profile draft creation / preset reuse
+
+#### Source-density / structural regression tests
+
+Update node-based source assertions for:
+
+- onboarding welcome shell density
+- onboarding option presence
+- settings agent ACP setup guidance source
+
+#### Type / build validation
+
+Run targeted desktop checks:
+
+- `pnpm --filter @dotagents/desktop exec vitest run src/shared/external-agent-presets.test.ts src/renderer/src/lib/onboarding-main-agent.test.ts src/renderer/src/pages/settings-general-main-agent-options.test.ts`
+- `cd apps/desktop && node --test tests/settings-agents-acp-setup.test.mjs tests/onboarding-step-shell-density.test.mjs tests/onboarding-welcome-density.test.mjs`
+- `pnpm --filter @dotagents/desktop typecheck`
+
+#### Manual behavior validation
+
+Smoke-check the following scenarios after the code lands:
+
+1. BYOK + Groq completes onboarding and lands in the app.
+2. BYOK + Gemini completes without forcing an invalid STT provider.
+3. OpenCode path blocks primary continue until verification succeeds.
+4. Existing OpenCode preset profile is reused instead of duplicated.
+5. Finishing onboarding marks `onboardingCompleted = true`.
+6. Managed OpenCode env/config is accepted by the real CLI.
+7. The official OpenCode release asset for the current platform downloads, extracts, and executes successfully.
+
+### Rollback safety
+
+- The refactor only changes onboarding and shared preset metadata.
+- Settings > Agents continues using the same verification route.
+- Existing saved configs and external profiles remain valid.


### PR DESCRIPTION
## Summary

- Skips native module rebuild during `pnpm install` on Windows since `@egoist/electron-panel-window` is Mac-only (uses NSPanel)
- Adds `nodeGypRebuild: false` to electron-builder config to disable it during packaging

## Problem

- `electron-panel-window` only has macOS native sources (Objective-C++ for NSPanel)
- electron-builder tries to rebuild it on Windows, requiring VS Build Tools
- This fails for developers without VS installed

## Changes

- **postinstall.cjs**: Exit early on Windows before attempting rebuild
- **electron-builder.config.cjs**: Add `nodeGypRebuild: false` to disable rebuild during packaging

Note: The floating panel feature requires macOS.
