### PR TITLE
Add Edge TTS provider (web Edge cloud) with UI and backend support

### DIFF
--- a/apps/desktop/src/main/agent-profile-service.ts
+++ b/apps/desktop/src/main/agent-profile-service.ts
@@ -62,7 +62,7 @@ const legacyPersonasPath = path.join(app.getPath("userData"), "personas.json")
 const RESERVED_SERVER_NAMES = [...RESERVED_RUNTIME_TOOL_SERVER_NAMES]
 const VALID_PROVIDER_IDS = ["openai", "groq", "gemini", "chatgpt-web"]
 const VALID_STT_PROVIDER_IDS = ["openai", "groq", "parakeet"]
-const VALID_TTS_PROVIDER_IDS = ["openai", "groq", "gemini", "kitten", "supertonic"]
+const VALID_TTS_PROVIDER_IDS = ["openai", "groq", "gemini", "edge", "kitten", "supertonic"]
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((item) => typeof item === "string")

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -1342,6 +1342,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         groqTtsVoice: cfg.groqTtsVoice || "autumn",
         geminiTtsModel: cfg.geminiTtsModel || "gemini-2.5-flash-preview-tts",
         geminiTtsVoice: cfg.geminiTtsVoice || "Kore",
+        edgeTtsModel: cfg.edgeTtsModel || "edge-tts",
+        edgeTtsVoice: cfg.edgeTtsVoice || "en-US-AriaNeural",
+        edgeTtsRate: cfg.edgeTtsRate ?? 1.0,
         // acpx Agent list for agent selection
         acpxAgents: agentProfileService.getAll()
           .filter(p => p.connection.type === 'acpx' && p.enabled !== false)
@@ -1522,9 +1525,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         updates.groqSttModel = body.groqSttModel
       }
       // TTS Provider
-      const validTtsProviders = ["openai", "groq", "gemini", "kitten", "supertonic"]
+      const validTtsProviders = ["openai", "groq", "gemini", "edge", "kitten", "supertonic"]
       if (typeof body.ttsProviderId === "string" && validTtsProviders.includes(body.ttsProviderId)) {
-        updates.ttsProviderId = body.ttsProviderId as "openai" | "groq" | "gemini" | "kitten" | "supertonic"
+        updates.ttsProviderId = body.ttsProviderId as "openai" | "groq" | "gemini" | "edge" | "kitten" | "supertonic"
       }
       // Transcript Post-Processing Provider
       const validPostProcessingProviders = ["openai", "groq", "gemini", "chatgpt-web"]
@@ -1572,6 +1575,16 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       }
       if (typeof body.geminiTtsVoice === "string") {
         updates.geminiTtsVoice = body.geminiTtsVoice
+      }
+      // Edge TTS settings
+      if (typeof body.edgeTtsModel === "string") {
+        updates.edgeTtsModel = body.edgeTtsModel as "edge-tts"
+      }
+      if (typeof body.edgeTtsVoice === "string") {
+        updates.edgeTtsVoice = body.edgeTtsVoice
+      }
+      if (typeof body.edgeTtsRate === "number" && body.edgeTtsRate >= 0.5 && body.edgeTtsRate <= 2.0) {
+        updates.edgeTtsRate = body.edgeTtsRate
       }
 
       // Session History (pinned/archived conversation IDs)

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1,4 +1,5 @@
 import fs from "fs"
+import { randomUUID } from "crypto"
 import { logApp, logLLM, getDebugFlags } from "./debug"
 import { getErrorMessage } from "./error-utils"
 import { getRendererHandlers, tipc } from "@egoist/tipc/main"
@@ -3279,6 +3280,8 @@ export const router = {
           ttsResult = await generateGroqTTS(processedText, input, config)
         } else if (providerId === "gemini") {
           ttsResult = await generateGeminiTTS(processedText, input, config)
+        } else if (providerId === "edge") {
+          ttsResult = await generateEdgeTTS(processedText, input, config)
         } else if (providerId === "kitten") {
           const { synthesize } = await import('./kitten-tts')
           const voiceId = config.kittenVoiceId ?? 0 // Default to Voice 2 - Male
@@ -3782,7 +3785,7 @@ export const router = {
       transcriptPostProcessingGeminiModel?: string
       transcriptPostProcessingChatgptWebModel?: string
       // TTS Provider settings
-      ttsProviderId?: "openai" | "groq" | "gemini" | "kitten" | "supertonic"
+      ttsProviderId?: "openai" | "groq" | "gemini" | "edge" | "kitten" | "supertonic"
     }>()
     .action(async ({ input }) => {
         return agentProfileService.updateProfileModelConfig(input.profileId, {
@@ -5334,6 +5337,155 @@ async function generateGeminiTTS(
     audio: bytes.buffer,
     mimeType: inlineAudioData?.mimeType || "audio/L16",
   }
+}
+
+async function generateEdgeTTS(
+  text: string,
+  input: { voice?: string; model?: string; speed?: number },
+  config: Config
+): Promise<TTSGenerationResult> {
+  // Model is kept for consistency with other providers/settings UI.
+  // The underlying edge-tts package currently uses one cloud backend.
+  const _model = input.model || config.edgeTtsModel || "edge-tts"
+  const voice = input.voice || config.edgeTtsVoice || "en-US-AriaNeural"
+  const speed = input.speed || config.edgeTtsRate || 1.0
+  const clampedSpeed = Math.min(2.0, Math.max(0.5, speed))
+  const ratePercent = Math.round((clampedSpeed - 1) * 100)
+  const rate = `${ratePercent >= 0 ? "+" : ""}${ratePercent}%`
+  const trustedClientToken = "6A5AA1D4EAFF4E9FB37E23D68491D6F4"
+  const connectionId = randomUUID().replace(/-/g, "")
+  const requestId = randomUUID().replace(/-/g, "")
+  const timestamp = new Date().toISOString()
+  const wsUrl = `wss://speech.platform.bing.com/consumer/speech/synthesize/readaloud/edge/v1?TrustedClientToken=${trustedClientToken}&ConnectionId=${connectionId}`
+
+  const audioChunks: Uint8Array[] = []
+
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(wsUrl)
+
+    const cleanup = () => {
+      ws.onopen = null
+      ws.onmessage = null
+      ws.onerror = null
+      ws.onclose = null
+    }
+
+    ws.onopen = () => {
+      const speechConfig = [
+        `X-Timestamp:${timestamp}`,
+        "Content-Type:application/json; charset=utf-8",
+        "Path:speech.config",
+        "",
+        JSON.stringify({
+          context: {
+            synthesis: {
+              audio: {
+                metadataoptions: {
+                  sentenceBoundaryEnabled: "false",
+                  wordBoundaryEnabled: "false",
+                },
+                outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+              },
+            },
+          },
+        }),
+      ].join("\r\n")
+
+      const ssml = [
+        `<speak version='1.0' xml:lang='en-US'>`,
+        `<voice name='${escapeXml(voice)}'>`,
+        `<prosody rate='${escapeXml(rate)}'>${escapeXml(text)}</prosody>`,
+        "</voice>",
+        "</speak>",
+      ].join("")
+
+      const ssmlRequest = [
+        `X-RequestId:${requestId}`,
+        "Content-Type:application/ssml+xml",
+        `X-Timestamp:${timestamp}`,
+        "Path:ssml",
+        "",
+        ssml,
+      ].join("\r\n")
+
+      ws.send(speechConfig)
+      ws.send(ssmlRequest)
+    }
+
+    ws.onmessage = async (event) => {
+      try {
+        const data = typeof event.data === "string" ? event.data : new Uint8Array(await (event.data as Blob).arrayBuffer())
+        if (typeof data === "string") {
+          if (data.includes("Path:turn.end")) {
+            cleanup()
+            try { ws.close() } catch { /* noop */ }
+            resolve()
+          }
+          return
+        }
+
+        const headerEndIndex = findHeaderBoundary(data)
+        if (headerEndIndex < 0) return
+
+        const headerText = new TextDecoder().decode(data.subarray(0, headerEndIndex))
+        if (!headerText.includes("Path:audio")) return
+
+        const audioData = data.subarray(headerEndIndex + 4)
+        if (audioData.length > 0) {
+          audioChunks.push(audioData)
+        }
+      } catch (error) {
+        cleanup()
+        try { ws.close() } catch { /* noop */ }
+        reject(error)
+      }
+    }
+
+    ws.onerror = () => {
+      cleanup()
+      reject(new Error("Edge TTS websocket connection failed"))
+    }
+
+    ws.onclose = () => {
+      // Some runs close right after turn.end; resolve happens in onmessage.
+      // If close arrives first, reject so callers can surface a clear error.
+      if (audioChunks.length === 0) {
+        cleanup()
+        reject(new Error("Edge TTS connection closed before audio was received"))
+      }
+    }
+  })
+
+  const totalLength = audioChunks.reduce((sum, chunk) => sum + chunk.length, 0)
+  const merged = new Uint8Array(totalLength)
+  let offset = 0
+  for (const chunk of audioChunks) {
+    merged.set(chunk, offset)
+    offset += chunk.length
+  }
+
+  return {
+    audio: merged.buffer,
+    mimeType: "audio/mpeg",
+  }
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}
+
+function findHeaderBoundary(buffer: Uint8Array): number {
+  for (let i = 0; i < buffer.length - 3; i++) {
+    if (buffer[i] === 13 && buffer[i + 1] === 10 && buffer[i + 2] === 13 && buffer[i + 3] === 10) {
+      return i
+    }
+  }
+  return -1
 }
 
 export type Router = typeof router

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -29,6 +29,8 @@ import {
   GROQ_TTS_VOICES_ENGLISH,
   GEMINI_TTS_MODELS,
   GEMINI_TTS_VOICES,
+  EDGE_TTS_MODELS,
+  EDGE_TTS_VOICES,
   KITTEN_TTS_VOICES,
   SUPERTONIC_TTS_LANGUAGES,
   SUPERTONIC_TTS_VOICES,
@@ -457,6 +459,46 @@ export function Component() {
                     </SelectContent>
                   </Select>
                 </Control>
+              </>
+            )}
+
+            {ttsProviderId === "edge" && (
+              <>
+                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Edge TTS model to use." />}>
+                  <Select value={config.edgeTtsModel || "edge-tts"} onValueChange={(value) => saveConfig({ edgeTtsModel: value as "edge-tts" })}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {EDGE_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </Control>
+
+                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Edge TTS." />}>
+                  <Select value={config.edgeTtsVoice || "en-US-AriaNeural"} onValueChange={(value) => saveConfig({ edgeTtsVoice: value })}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      {EDGE_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </Control>
+
+                <Control label={<ControlLabel label="Text-to-Speech speed" tooltip="Speech speed between 0.5 and 2.0." />}>
+                  <Input
+                    type="number"
+                    min="0.5"
+                    max="2.0"
+                    step="0.1"
+                    defaultValue={config.edgeTtsRate?.toString()}
+                    placeholder="1.0"
+                    onChange={(e) => {
+                      const speed = parseFloat(e.currentTarget.value)
+                      if (!isNaN(speed) && speed >= 0.5 && speed <= 2.0) {
+                        saveConfig({ edgeTtsRate: speed })
+                      }
+                    }}
+                  />
+                </Control>
+                <p className="pb-2 text-xs text-muted-foreground">Edge TTS is cloud-based and does not require an API key.</p>
               </>
             )}
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -260,7 +260,7 @@ export type ProfileModelConfig = {
   transcriptPostProcessingGeminiModel?: string
   transcriptPostProcessingChatgptWebModel?: string
   // TTS Provider settings
-  ttsProviderId?: "openai" | "groq" | "gemini" | "kitten" | "supertonic"
+  ttsProviderId?: "openai" | "groq" | "gemini" | "edge" | "kitten" | "supertonic"
 }
 
 // Per-profile skills configuration
@@ -1037,6 +1037,11 @@ export type Config = {
   geminiTtsModel?: "gemini-2.5-flash-preview-tts" | "gemini-2.5-pro-preview-tts"
   geminiTtsVoice?: string
   geminiTtsLanguage?: string
+
+  // Edge TTS Configuration
+  edgeTtsModel?: "edge-tts"
+  edgeTtsVoice?: string
+  edgeTtsRate?: number // 0.5 to 2.0
 
   // Kitten (Local) TTS Configuration
   kittenModelDownloaded?: boolean // Whether model has been downloaded

--- a/apps/mobile/src/lib/edgeTts.ts
+++ b/apps/mobile/src/lib/edgeTts.ts
@@ -1,0 +1,161 @@
+import { Platform } from 'react-native';
+
+type EdgeSpeakOptions = {
+  voice?: string;
+  rate?: number;
+  onDone?: () => void;
+  onError?: () => void;
+  onStopped?: () => void;
+};
+
+let currentAudio: HTMLAudioElement | null = null;
+
+export async function speakEdgeTts(text: string, options: EdgeSpeakOptions = {}): Promise<boolean> {
+  if (Platform.OS !== 'web') return false;
+  if (!text.trim()) return false;
+
+  try {
+    const audioBuffer = await synthesizeEdgeTts(text, options.voice ?? 'en-US-AriaNeural', options.rate ?? 1.0);
+    stopEdgeTts();
+
+    const blob = new Blob([audioBuffer], { type: 'audio/mpeg' });
+    const url = URL.createObjectURL(blob);
+    const audio = new Audio(url);
+    currentAudio = audio;
+
+    const cleanup = () => {
+      URL.revokeObjectURL(url);
+      if (currentAudio === audio) {
+        currentAudio = null;
+      }
+    };
+
+    audio.onended = () => {
+      cleanup();
+      options.onDone?.();
+    };
+    audio.onerror = () => {
+      cleanup();
+      options.onError?.();
+    };
+    audio.onpause = () => {
+      if (!audio.ended) options.onStopped?.();
+    };
+
+    await audio.play();
+    return true;
+  } catch {
+    options.onError?.();
+    return false;
+  }
+}
+
+export function stopEdgeTts(): void {
+  if (!currentAudio) return;
+  currentAudio.pause();
+  currentAudio.currentTime = 0;
+  currentAudio = null;
+}
+
+async function synthesizeEdgeTts(text: string, voice: string, speed: number): Promise<ArrayBuffer> {
+  const clampedSpeed = Math.min(2.0, Math.max(0.5, speed));
+  const ratePercent = Math.round((clampedSpeed - 1) * 100);
+  const rate = `${ratePercent >= 0 ? '+' : ''}${ratePercent}%`;
+
+  const trustedClientToken = '6A5AA1D4EAFF4E9FB37E23D68491D6F4';
+  const connectionId = globalThis.crypto.randomUUID().replace(/-/g, '');
+  const requestId = globalThis.crypto.randomUUID().replace(/-/g, '');
+  const timestamp = new Date().toISOString();
+  const wsUrl = `wss://speech.platform.bing.com/consumer/speech/synthesize/readaloud/edge/v1?TrustedClientToken=${trustedClientToken}&ConnectionId=${connectionId}`;
+
+  const audioChunks: Uint8Array[] = [];
+
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      const speechConfig = [
+        `X-Timestamp:${timestamp}`,
+        'Content-Type:application/json; charset=utf-8',
+        'Path:speech.config',
+        '',
+        JSON.stringify({
+          context: {
+            synthesis: {
+              audio: {
+                metadataoptions: {
+                  sentenceBoundaryEnabled: 'false',
+                  wordBoundaryEnabled: 'false',
+                },
+                outputFormat: 'audio-24khz-48kbitrate-mono-mp3',
+              },
+            },
+          },
+        }),
+      ].join('\r\n');
+
+      const ssml = `<speak version='1.0' xml:lang='en-US'><voice name='${escapeXml(voice)}'><prosody rate='${escapeXml(rate)}'>${escapeXml(text)}</prosody></voice></speak>`;
+      const ssmlRequest = [
+        `X-RequestId:${requestId}`,
+        'Content-Type:application/ssml+xml',
+        `X-Timestamp:${timestamp}`,
+        'Path:ssml',
+        '',
+        ssml,
+      ].join('\r\n');
+
+      ws.send(speechConfig);
+      ws.send(ssmlRequest);
+    };
+
+    ws.onmessage = async (event) => {
+      const data = typeof event.data === 'string' ? event.data : new Uint8Array(await (event.data as Blob).arrayBuffer());
+      if (typeof data === 'string') {
+        if (data.includes('Path:turn.end')) {
+          ws.close();
+          resolve();
+        }
+        return;
+      }
+
+      const headerEndIndex = findHeaderBoundary(data);
+      if (headerEndIndex < 0) return;
+      const headerText = new TextDecoder().decode(data.subarray(0, headerEndIndex));
+      if (!headerText.includes('Path:audio')) return;
+      const audioData = data.subarray(headerEndIndex + 4);
+      if (audioData.length > 0) audioChunks.push(audioData);
+    };
+
+    ws.onerror = () => reject(new Error('Edge TTS websocket failed'));
+    ws.onclose = () => {
+      if (audioChunks.length === 0) reject(new Error('No Edge TTS audio received'));
+    };
+  });
+
+  const totalLength = audioChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of audioChunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged.buffer;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function findHeaderBoundary(buffer: Uint8Array): number {
+  for (let i = 0; i < buffer.length - 3; i++) {
+    if (buffer[i] === 13 && buffer[i + 1] === 10 && buffer[i + 2] === 13 && buffer[i + 3] === 10) {
+      return i;
+    }
+  }
+  return -1;
+}

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -33,6 +33,7 @@ import { useSessionContext } from '../store/sessions';
 import { useMessageQueueContext } from '../store/message-queue';
 import { MessageQueuePanel } from '../ui/MessageQueuePanel';
 import { ResponseHistoryPanel } from '../ui/ResponseHistoryPanel';
+import { speakEdgeTts, stopEdgeTts } from '../lib/edgeTts';
 import { useConnectionManager } from '../store/connectionManager';
 import { useTunnelConnection } from '../store/tunnelConnection';
 import { useProfile } from '../store/profile';
@@ -505,6 +506,9 @@ export default function ChatScreen({ route, navigation }: any) {
   }, [config.apiKey, config.baseUrl]);
   const [predefinedPrompts, setPredefinedPrompts] = useState<PredefinedPromptSummary[]>([]);
   const [isLoadingQuickStartPrompts, setIsLoadingQuickStartPrompts] = useState(false);
+  const [remoteTtsProvider, setRemoteTtsProvider] = useState<'native' | 'edge'>('native');
+  const [remoteEdgeTtsVoice, setRemoteEdgeTtsVoice] = useState('en-US-AriaNeural');
+  const [remoteEdgeTtsRate, setRemoteEdgeTtsRate] = useState(1.0);
   const [addPromptModalVisible, setAddPromptModalVisible] = useState(false);
   const [newPromptName, setNewPromptName] = useState('');
   const [newPromptContent, setNewPromptContent] = useState('');
@@ -532,6 +536,7 @@ export default function ChatScreen({ route, navigation }: any) {
 	      handsFreeController.reset();
       void stopRecognitionOnly?.();
       Speech.stop();
+      stopEdgeTts();
       setDebugInfo('Handsfree mode turned off.');
     } else {
       setDebugInfo('Handsfree mode turned on. Say the wake phrase to begin.');
@@ -1044,6 +1049,17 @@ export default function ChatScreen({ route, navigation }: any) {
 			voiceLog('tts-started', `Assistant speech started (${reason}).`);
 		}
 
+		if (remoteTtsProvider === 'edge' && Platform.OS === 'web') {
+			void speakEdgeTts(processedText, {
+				voice: remoteEdgeTtsVoice,
+				rate: remoteEdgeTtsRate,
+				onDone: settle,
+				onError: settle,
+				onStopped: settle,
+			});
+			return true;
+		}
+
 		const speechOptions: Speech.SpeechOptions = {
 			language: 'en-US',
 			rate: config.ttsRate ?? 1.0,
@@ -1057,7 +1073,7 @@ export default function ChatScreen({ route, navigation }: any) {
 		}
 		Speech.speak(processedText, speechOptions);
 		return true;
-		  }, [config.ttsPitch, config.ttsRate, config.ttsVoiceId, handsFree, handsFreeController, voiceLog]);
+		  }, [config.ttsPitch, config.ttsRate, config.ttsVoiceId, handsFree, handsFreeController, remoteEdgeTtsRate, remoteEdgeTtsVoice, remoteTtsProvider, voiceLog]);
 
 	  const syncResponseHistoryRefs = useCallback((events: AgentUserResponseEvent[]) => {
 	    respondToUserHistoryRef.current = events;
@@ -1170,6 +1186,7 @@ export default function ChatScreen({ route, navigation }: any) {
     // Stop any current speech first
     intendedSpeakingIndexRef.current = index;
     Speech.stop();
+    stopEdgeTts();
     const processedText = preprocessTextForTTS(content);
     if (!processedText) {
       intendedSpeakingIndexRef.current = null;
@@ -1180,6 +1197,39 @@ export default function ChatScreen({ route, navigation }: any) {
 	      voiceLog('tts-started', 'Assistant speech started from message playback.');
 	    }
     setSpeakingMessageIndex(index);
+    if (remoteTtsProvider === 'edge' && Platform.OS === 'web') {
+      void speakEdgeTts(processedText, {
+        voice: remoteEdgeTtsVoice,
+        rate: remoteEdgeTtsRate,
+        onDone: () => {
+          intendedSpeakingIndexRef.current = null;
+          if (handsFree) {
+            handsFreeController.onSpeechFinished();
+            voiceLog('tts-stopped', 'Assistant speech finished from message playback.');
+          }
+          setSpeakingMessageIndex(null);
+        },
+        onError: () => {
+          intendedSpeakingIndexRef.current = null;
+          if (handsFree) {
+            handsFreeController.onSpeechFinished();
+            voiceLog('tts-stopped', 'Assistant speech errored during message playback.');
+          }
+          setSpeakingMessageIndex(null);
+        },
+        onStopped: () => {
+          if (intendedSpeakingIndexRef.current === null) {
+            if (handsFree) {
+              handsFreeController.onSpeechFinished();
+              voiceLog('tts-stopped', 'Assistant speech stopped during message playback.');
+            }
+            setSpeakingMessageIndex(null);
+          }
+        },
+      });
+      return;
+    }
+
     const speechOptions: Speech.SpeechOptions = {
       language: 'en-US',
       rate: config.ttsRate ?? 1.0,
@@ -1221,6 +1271,9 @@ export default function ChatScreen({ route, navigation }: any) {
 		config.ttsRate,
 		config.ttsPitch,
 		config.ttsVoiceId,
+		remoteEdgeTtsRate,
+		remoteEdgeTtsVoice,
+		remoteTtsProvider,
 		handsFree,
 		handsFreeController,
 		voiceLog,
@@ -1242,6 +1295,7 @@ export default function ChatScreen({ route, navigation }: any) {
   useEffect(() => {
     return () => {
       Speech.stop();
+      stopEdgeTts();
     };
   }, []);
 
@@ -1357,6 +1411,9 @@ export default function ChatScreen({ route, navigation }: any) {
         if (cancelled) return;
         const nextPrompts = [...(settings.predefinedPrompts || [])].sort((a, b) => b.updatedAt - a.updatedAt);
         setPredefinedPrompts(nextPrompts);
+        setRemoteTtsProvider(settings.ttsProviderId === 'edge' ? 'edge' : 'native');
+        setRemoteEdgeTtsVoice(settings.edgeTtsVoice || 'en-US-AriaNeural');
+        setRemoteEdgeTtsRate(settings.edgeTtsRate ?? 1.0);
       })
       .catch(() => {
         if (cancelled) return;
@@ -3475,6 +3532,8 @@ export default function ChatScreen({ route, navigation }: any) {
         {respondToUserHistory.length > 0 && (
           <ResponseHistoryPanel
             responses={respondToUserHistory}
+            ttsProvider={remoteTtsProvider}
+            edgeTtsVoice={remoteEdgeTtsVoice}
             ttsRate={config.ttsRate ?? 1.0}
             ttsPitch={config.ttsPitch ?? 1.0}
             ttsVoiceId={config.ttsVoiceId}

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -44,6 +44,7 @@ const TTS_PROVIDERS = [
   { label: 'OpenAI', value: 'openai' },
   { label: 'Groq', value: 'groq' },
   { label: 'Gemini', value: 'gemini' },
+  { label: 'Edge TTS (Free)', value: 'edge' },
   { label: 'Kitten', value: 'kitten' },
   { label: 'Supertonic', value: 'supertonic' },
 ] as const;
@@ -126,6 +127,19 @@ const GEMINI_TTS_MODELS = [
   { label: 'Gemini 2.5 Pro TTS', value: 'gemini-2.5-pro-preview-tts' },
 ] as const;
 
+const EDGE_TTS_VOICES = [
+  { label: 'Aria (US, Female)', value: 'en-US-AriaNeural' },
+  { label: 'Guy (US, Male)', value: 'en-US-GuyNeural' },
+  { label: 'Jenny (US, Female)', value: 'en-US-JennyNeural' },
+  { label: 'Davis (US, Male)', value: 'en-US-DavisNeural' },
+  { label: 'Sonia (UK, Female)', value: 'en-GB-SoniaNeural' },
+  { label: 'Ryan (UK, Male)', value: 'en-GB-RyanNeural' },
+] as const;
+
+const EDGE_TTS_MODELS = [
+  { label: 'Edge Neural (Free)', value: 'edge-tts' },
+] as const;
+
 // Helper to get TTS voices for a provider
 const getTtsVoicesForProvider = (providerId: string, ttsModel?: string): readonly { label: string; value: string }[] => {
   switch (providerId) {
@@ -136,6 +150,8 @@ const getTtsVoicesForProvider = (providerId: string, ttsModel?: string): readonl
       return ttsModel === 'canopylabs/orpheus-arabic-saudi' ? GROQ_TTS_VOICES_ARABIC : GROQ_TTS_VOICES_ENGLISH;
     case 'gemini':
       return GEMINI_TTS_VOICES;
+    case 'edge':
+      return EDGE_TTS_VOICES;
     default:
       return [];
   }
@@ -150,8 +166,40 @@ const getTtsModelsForProvider = (providerId: string): readonly { label: string; 
       return GROQ_TTS_MODELS;
     case 'gemini':
       return GEMINI_TTS_MODELS;
+    case 'edge':
+      return EDGE_TTS_MODELS;
     default:
       return [];
+  }
+};
+
+const getTtsModelSettingKey = (providerId?: string): keyof SettingsUpdate => {
+  switch (providerId) {
+    case 'openai':
+      return 'openaiTtsModel';
+    case 'groq':
+      return 'groqTtsModel';
+    case 'gemini':
+      return 'geminiTtsModel';
+    case 'edge':
+      return 'edgeTtsModel';
+    default:
+      return 'openaiTtsModel';
+  }
+};
+
+const getTtsVoiceSettingKey = (providerId?: string): keyof SettingsUpdate => {
+  switch (providerId) {
+    case 'openai':
+      return 'openaiTtsVoice';
+    case 'groq':
+      return 'groqTtsVoice';
+    case 'gemini':
+      return 'geminiTtsVoice';
+    case 'edge':
+      return 'edgeTtsVoice';
+    default:
+      return 'openaiTtsVoice';
   }
 };
 
@@ -248,7 +296,7 @@ export default function SettingsScreen({ navigation }: any) {
     mcpServers: true,    // Keep MCP servers expanded by default since it was already visible
     streamerMode: false,
     speechToText: false,
-    textToSpeech: false,
+    textToSpeech: true,
     agentSettings: false,
     summarization: false,
     toolExecution: false,
@@ -1414,14 +1462,19 @@ export default function SettingsScreen({ navigation }: any) {
 
         {/* TTS Voice Settings - shown when TTS is enabled */}
         {draft.ttsEnabled !== false && (
-          <TTSSettings
-            voiceId={draft.ttsVoiceId}
-            rate={draft.ttsRate ?? 1.0}
-            pitch={draft.ttsPitch ?? 1.0}
-            onVoiceChange={(v) => updateLocalConfig({ ttsVoiceId: v })}
-            onRateChange={(r) => updateLocalConfig({ ttsRate: r })}
-            onPitchChange={(p) => updateLocalConfig({ ttsPitch: p })}
-          />
+          <>
+            <TTSSettings
+              voiceId={draft.ttsVoiceId}
+              rate={draft.ttsRate ?? 1.0}
+              pitch={draft.ttsPitch ?? 1.0}
+              onVoiceChange={(v) => updateLocalConfig({ ttsVoiceId: v })}
+              onRateChange={(r) => updateLocalConfig({ ttsRate: r })}
+              onPitchChange={(p) => updateLocalConfig({ ttsPitch: p })}
+            />
+            <Text style={styles.helperText}>
+              Cloud voices/models (OpenAI, Groq, Gemini, Edge) are under the desktop-connected Text-to-Speech section below.
+            </Text>
+          </>
         )}
 
         <View style={styles.row}>
@@ -1871,7 +1924,7 @@ export default function SettingsScreen({ navigation }: any) {
                     </ScrollView>
 
                     {/* Per-provider Voice/Model Settings */}
-                    {(remoteSettings.ttsProviderId === 'openai' || remoteSettings.ttsProviderId === 'groq' || remoteSettings.ttsProviderId === 'gemini') && (
+                    {(remoteSettings.ttsProviderId === 'openai' || remoteSettings.ttsProviderId === 'groq' || remoteSettings.ttsProviderId === 'gemini' || remoteSettings.ttsProviderId === 'edge') && (
                       <>
                         {/* TTS Model Selector */}
                         <Text style={[styles.label, { marginTop: spacing.sm }]}>Model</Text>
@@ -1885,7 +1938,8 @@ export default function SettingsScreen({ navigation }: any) {
                                 const models = getTtsModelsForProvider(remoteSettings.ttsProviderId || 'openai');
                                 const modelValue = remoteSettings.ttsProviderId === 'openai' ? remoteSettings.openaiTtsModel
                                   : remoteSettings.ttsProviderId === 'groq' ? remoteSettings.groqTtsModel
-                                  : remoteSettings.geminiTtsModel;
+                                  : remoteSettings.ttsProviderId === 'gemini' ? remoteSettings.geminiTtsModel
+                                  : remoteSettings.edgeTtsModel;
                                 const model = models.find(m => m.value === modelValue);
                                 return model?.label || modelValue || 'Select model';
                               })()}
@@ -1907,7 +1961,8 @@ export default function SettingsScreen({ navigation }: any) {
                                 const voices = getTtsVoicesForProvider(remoteSettings.ttsProviderId || 'openai', ttsModel);
                                 const voiceValue = remoteSettings.ttsProviderId === 'openai' ? remoteSettings.openaiTtsVoice
                                   : remoteSettings.ttsProviderId === 'groq' ? remoteSettings.groqTtsVoice
-                                  : remoteSettings.geminiTtsVoice;
+                                  : remoteSettings.ttsProviderId === 'gemini' ? remoteSettings.geminiTtsVoice
+                                  : remoteSettings.edgeTtsVoice;
                                 const voice = voices.find(v => v.value === voiceValue);
                                 return voice?.label || voiceValue || 'Select voice';
                               })()}
@@ -1932,6 +1987,28 @@ export default function SettingsScreen({ navigation }: any) {
                               step={0.25}
                               value={remoteSettings.openaiTtsSpeed ?? 1.0}
                               onSlidingComplete={(v) => handleRemoteSettingUpdate('openaiTtsSpeed', v)}
+                              minimumTrackTintColor={theme.colors.primary}
+                              maximumTrackTintColor={theme.colors.muted}
+                              thumbTintColor={theme.colors.primary}
+                            />
+                          </View>
+                        )}
+
+                        {remoteSettings.ttsProviderId === 'edge' && (
+                          <View style={{ marginTop: spacing.sm }}>
+                            <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+                              <Text style={styles.label}>Speed</Text>
+                              <Text style={[styles.helperText, { marginTop: 0 }]}>
+                                {(remoteSettings.edgeTtsRate ?? 1.0).toFixed(1)}x
+                              </Text>
+                            </View>
+                            <Slider
+                              style={{ width: '100%', height: 40 }}
+                              minimumValue={0.5}
+                              maximumValue={2.0}
+                              step={0.1}
+                              value={remoteSettings.edgeTtsRate ?? 1.0}
+                              onSlidingComplete={(v) => handleRemoteSettingUpdate('edgeTtsRate', v)}
                               minimumTrackTintColor={theme.colors.primary}
                               maximumTrackTintColor={theme.colors.muted}
                               thumbTintColor={theme.colors.primary}
@@ -2822,7 +2899,8 @@ export default function SettingsScreen({ navigation }: any) {
               {getTtsModelsForProvider(remoteSettings?.ttsProviderId || 'openai').map((model) => {
                 const currentValue = remoteSettings?.ttsProviderId === 'openai' ? remoteSettings.openaiTtsModel
                   : remoteSettings?.ttsProviderId === 'groq' ? remoteSettings.groqTtsModel
-                  : remoteSettings?.geminiTtsModel;
+                  : remoteSettings?.ttsProviderId === 'gemini' ? remoteSettings.geminiTtsModel
+                  : remoteSettings?.edgeTtsModel;
                 const isSelected = currentValue === model.value;
                 return (
                   <TouchableOpacity
@@ -2832,9 +2910,7 @@ export default function SettingsScreen({ navigation }: any) {
                       isSelected && styles.modelItemActive,
                     ]}
                     onPress={() => {
-                      const key = remoteSettings?.ttsProviderId === 'openai' ? 'openaiTtsModel'
-                        : remoteSettings?.ttsProviderId === 'groq' ? 'groqTtsModel'
-                        : 'geminiTtsModel';
+                      const key = getTtsModelSettingKey(remoteSettings?.ttsProviderId);
                       handleRemoteSettingUpdate(key, model.value);
                       setShowTtsModelPicker(false);
                     }}
@@ -2893,7 +2969,8 @@ export default function SettingsScreen({ navigation }: any) {
                 return voices.map((voice) => {
                   const currentValue = remoteSettings?.ttsProviderId === 'openai' ? remoteSettings.openaiTtsVoice
                     : remoteSettings?.ttsProviderId === 'groq' ? remoteSettings.groqTtsVoice
-                    : remoteSettings?.geminiTtsVoice;
+                    : remoteSettings?.ttsProviderId === 'gemini' ? remoteSettings.geminiTtsVoice
+                    : remoteSettings?.edgeTtsVoice;
                   const isSelected = currentValue === voice.value;
                   return (
                     <TouchableOpacity
@@ -2903,9 +2980,7 @@ export default function SettingsScreen({ navigation }: any) {
                         isSelected && styles.modelItemActive,
                       ]}
                       onPress={() => {
-                        const key = remoteSettings?.ttsProviderId === 'openai' ? 'openaiTtsVoice'
-                          : remoteSettings?.ttsProviderId === 'groq' ? 'groqTtsVoice'
-                          : 'geminiTtsVoice';
+                        const key = getTtsVoiceSettingKey(remoteSettings?.ttsProviderId);
                         handleRemoteSettingUpdate(key, voice.value);
                         setShowTtsVoicePicker(false);
                       }}

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -13,11 +13,13 @@ export type AppConfig = {
   handsFreeDebug?: boolean; // show structured handsfree debug state/events in chat
   handsFreeForegroundOnly?: boolean; // v1 safeguard: only run while chat is foregrounded
   ttsEnabled?: boolean; // text-to-speech toggle (optional for backward compatibility)
+  ttsProvider?: 'native' | 'edge';
   messageQueueEnabled?: boolean; // message queue toggle (allows queuing messages while agent is busy)
   // TTS voice settings
   ttsVoiceId?: string; // Voice identifier (e.g., "Google US English" or native voice URI)
   ttsRate?: number; // Speech rate (0.1 to 10, default 1.0)
   ttsPitch?: number; // Voice pitch (0 to 2, default 1.0)
+  edgeTtsVoice?: string; // Edge voice id (web playback)
   // Audio input device settings
   // On web (Expo Web), this deviceId is passed to getUserMedia before starting the
   // Web Speech API recognizer so the browser routes audio from the selected mic.
@@ -50,10 +52,12 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   handsFreeDebug: false,
   handsFreeForegroundOnly: true,
   ttsEnabled: true,
+  ttsProvider: 'native',
   messageQueueEnabled: true,
   ttsVoiceId: undefined, // Use system default
   ttsRate: 1.0,
   ttsPitch: 1.0,
+  edgeTtsVoice: 'en-US-AriaNeural',
   audioInputDeviceId: undefined, // Use system default microphone
 };
 
@@ -107,4 +111,3 @@ export function useConfigContext() {
   if (!ctx) throw new Error('ConfigContext missing');
   return ctx;
 }
-

--- a/apps/mobile/src/ui/ResponseHistoryPanel.tsx
+++ b/apps/mobile/src/ui/ResponseHistoryPanel.tsx
@@ -11,6 +11,7 @@ import {
   TouchableOpacity,
   ScrollView,
   Animated,
+  Platform,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import * as Speech from 'expo-speech';
@@ -18,6 +19,7 @@ import { preprocessTextForTTS } from '@dotagents/shared';
 import { useTheme } from './ThemeProvider';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { spacing, radius } from './theme';
+import { speakEdgeTts, stopEdgeTts } from '../lib/edgeTts';
 
 export interface ResponseHistoryEntry {
   id?: string;
@@ -27,6 +29,8 @@ export interface ResponseHistoryEntry {
 
 interface ResponseHistoryPanelProps {
   responses: ResponseHistoryEntry[];
+  ttsProvider?: 'native' | 'edge';
+  edgeTtsVoice?: string;
   ttsRate?: number;
   ttsPitch?: number;
   ttsVoiceId?: string;
@@ -63,6 +67,8 @@ function AnimatedResponseItem({
 
 export function ResponseHistoryPanel({
   responses,
+  ttsProvider = 'native',
+  edgeTtsVoice = 'en-US-AriaNeural',
   ttsRate = 1.0,
   ttsPitch = 1.0,
   ttsVoiceId,
@@ -90,6 +96,7 @@ export function ResponseHistoryPanel({
       isMountedRef.current = false;
       nextSpeechRequestId();
       Speech.stop();
+      stopEdgeTts();
     };
   }, [nextSpeechRequestId]);
 
@@ -97,6 +104,7 @@ export function ResponseHistoryPanel({
     if (isCollapsed && speakingIndex !== null) {
       nextSpeechRequestId();
       Speech.stop();
+      stopEdgeTts();
       safeSetSpeakingIndex(null);
     }
   }, [isCollapsed, speakingIndex, safeSetSpeakingIndex, nextSpeechRequestId]);
@@ -110,6 +118,7 @@ export function ResponseHistoryPanel({
     if (speakingIndex === index) {
       nextSpeechRequestId();
       Speech.stop();
+      stopEdgeTts();
       safeSetSpeakingIndex(null);
       return;
     }
@@ -117,6 +126,7 @@ export function ResponseHistoryPanel({
     // Stop any current speech
     const requestId = nextSpeechRequestId();
     Speech.stop();
+    stopEdgeTts();
 
     const processedText = preprocessTextForTTS(text);
     if (!processedText) {
@@ -130,6 +140,18 @@ export function ResponseHistoryPanel({
       }
     };
 
+    safeSetSpeakingIndex(index);
+    if (ttsProvider === 'edge' && Platform.OS === 'web') {
+      void speakEdgeTts(processedText, {
+        voice: edgeTtsVoice,
+        rate: ttsRate,
+        onDone: clearIfCurrentRequest,
+        onStopped: clearIfCurrentRequest,
+        onError: clearIfCurrentRequest,
+      });
+      return;
+    }
+
     const speechOptions: Speech.SpeechOptions = {
       language: 'en-US',
       rate: ttsRate,
@@ -141,8 +163,6 @@ export function ResponseHistoryPanel({
     if (ttsVoiceId) {
       speechOptions.voice = ttsVoiceId;
     }
-
-    safeSetSpeakingIndex(index);
     Speech.speak(processedText, speechOptions);
   };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,7 +93,7 @@ export type ProfileModelConfig = {
   transcriptPostProcessingGroqModel?: string
   transcriptPostProcessingGeminiModel?: string
   transcriptPostProcessingChatgptWebModel?: string
-  ttsProviderId?: "openai" | "groq" | "gemini" | "kitten" | "supertonic"
+  ttsProviderId?: "openai" | "groq" | "gemini" | "edge" | "kitten" | "supertonic"
 }
 
 export type ProfileSkillsConfig = {

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -95,7 +95,7 @@ export interface Settings {
   // Text-to-Speech Configuration
   ttsEnabled?: boolean;
   ttsAutoPlay?: boolean;
-  ttsProviderId?: 'openai' | 'groq' | 'gemini' | 'kitten' | 'supertonic';
+  ttsProviderId?: 'openai' | 'groq' | 'gemini' | 'edge' | 'kitten' | 'supertonic';
   ttsPreprocessingEnabled?: boolean;
   ttsRemoveCodeBlocks?: boolean;
   ttsRemoveUrls?: boolean;
@@ -110,6 +110,9 @@ export interface Settings {
   groqTtsVoice?: string;
   geminiTtsModel?: string;
   geminiTtsVoice?: string;
+  edgeTtsModel?: string;
+  edgeTtsVoice?: string;
+  edgeTtsRate?: number;
 
   // WhatsApp Integration
   whatsappEnabled?: boolean;
@@ -178,7 +181,7 @@ export interface SettingsUpdate {
   // Text-to-Speech Configuration
   ttsEnabled?: boolean;
   ttsAutoPlay?: boolean;
-  ttsProviderId?: 'openai' | 'groq' | 'gemini' | 'kitten' | 'supertonic';
+  ttsProviderId?: 'openai' | 'groq' | 'gemini' | 'edge' | 'kitten' | 'supertonic';
   ttsPreprocessingEnabled?: boolean;
   ttsRemoveCodeBlocks?: boolean;
   ttsRemoveUrls?: boolean;
@@ -193,6 +196,9 @@ export interface SettingsUpdate {
   groqTtsVoice?: string;
   geminiTtsModel?: string;
   geminiTtsVoice?: string;
+  edgeTtsModel?: string;
+  edgeTtsVoice?: string;
+  edgeTtsRate?: number;
 
   // WhatsApp Integration
   whatsappEnabled?: boolean;

--- a/packages/shared/src/providers.test.ts
+++ b/packages/shared/src/providers.test.ts
@@ -10,6 +10,8 @@ import {
   GROQ_TTS_MODELS,
   GEMINI_TTS_VOICES,
   GEMINI_TTS_MODELS,
+  EDGE_TTS_VOICES,
+  EDGE_TTS_MODELS,
   KITTEN_TTS_VOICES,
   SUPERTONIC_TTS_VOICES,
   SUPERTONIC_TTS_LANGUAGES,
@@ -54,6 +56,7 @@ describe('TTS_PROVIDERS', () => {
     expect(values).toContain('openai')
     expect(values).toContain('groq')
     expect(values).toContain('gemini')
+    expect(values).toContain('edge')
     expect(values).toContain('kitten')
     expect(values).toContain('supertonic')
   })
@@ -81,6 +84,11 @@ describe('Voice lists', () => {
 
   it('KITTEN_TTS_VOICES has 8 voices', () => {
     expect(KITTEN_TTS_VOICES).toHaveLength(8)
+  })
+
+  it('EDGE_TTS_VOICES has at least 4 voices', () => {
+    expect(EDGE_TTS_VOICES.length).toBeGreaterThanOrEqual(4)
+    expect(EDGE_TTS_VOICES.map(v => v.value)).toContain('en-US-AriaNeural')
   })
 
   it('SUPERTONIC_TTS_VOICES has 10 voices (5 male + 5 female)', () => {
@@ -113,6 +121,11 @@ describe('TTS Models', () => {
 
   it('GEMINI_TTS_MODELS has 2 models', () => {
     expect(GEMINI_TTS_MODELS).toHaveLength(2)
+  })
+
+  it('EDGE_TTS_MODELS has 1 model', () => {
+    expect(EDGE_TTS_MODELS).toHaveLength(1)
+    expect(EDGE_TTS_MODELS[0].value).toBe('edge-tts')
   })
 })
 

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -38,6 +38,7 @@ export const TTS_PROVIDERS = [
   { label: "OpenAI", value: "openai" },
   { label: "Groq", value: "groq" },
   { label: "Gemini", value: "gemini" },
+  { label: "Edge TTS (Free)", value: "edge" },
   { label: "Kitten (Local)", value: "kitten" },
   { label: "Supertonic (Local)", value: "supertonic" },
 ] as const;
@@ -120,6 +121,20 @@ export const GEMINI_TTS_VOICES = [
 export const GEMINI_TTS_MODELS = [
   { label: "Gemini 2.5 Flash TTS", value: "gemini-2.5-flash-preview-tts" },
   { label: "Gemini 2.5 Pro TTS", value: "gemini-2.5-pro-preview-tts" },
+] as const;
+
+// Edge TTS (Microsoft Edge cloud TTS) options
+export const EDGE_TTS_MODELS = [
+  { label: "Edge Neural (Free)", value: "edge-tts" },
+] as const;
+
+export const EDGE_TTS_VOICES = [
+  { label: "Aria (US, Female)", value: "en-US-AriaNeural" },
+  { label: "Guy (US, Male)", value: "en-US-GuyNeural" },
+  { label: "Jenny (US, Female)", value: "en-US-JennyNeural" },
+  { label: "Davis (US, Male)", value: "en-US-DavisNeural" },
+  { label: "Sonia (UK, Female)", value: "en-GB-SoniaNeural" },
+  { label: "Ryan (UK, Male)", value: "en-GB-RyanNeural" },
 ] as const;
 
 // Kitten TTS Voice Options (8 voices, sid 0-7)


### PR DESCRIPTION
### Motivation

- Provide an additional cloud-based, free TTS option using the Edge/Bing speech service so web users can play higher-quality voices without an API key. 
- Surface the provider across desktop/server, mobile UI, shared types and provider lists so settings and profiles can select Edge TTS consistently. 

### Description

- Added `edge` to TTS provider enums and types in `packages/*`, `apps/*` and shared API types, and added `EDGE_TTS_MODELS`/`EDGE_TTS_VOICES` provider lists in `packages/shared` and tests. 
- Implemented Edge TTS synthesis for the desktop backend in `apps/desktop/src/main/tipc.ts` via `generateEdgeTTS` that streams audio over a Bing Edge websocket and returns `audio/mpeg`. 
- Exposed Edge TTS config and controls in settings and profile flows: desktop remote-server settings (`edgeTtsModel`, `edgeTtsVoice`, `edgeTtsRate`), renderer settings UI (`settings-models.tsx`), and mobile settings (`SettingsScreen.tsx`, `ChatScreen.tsx`, `ResponseHistoryPanel.tsx`). 
- Added web playback helpers in the mobile app (`apps/mobile/src/lib/edgeTts.ts`) and wired playback controls to use Edge TTS on web when `edge` is selected, including start/stop handling and speed clamping. 
- Updated profile/config shapes (`shared/types.ts`, `core/types.ts`, API types) and the RPC/router input types to accept `edge` as a valid `ttsProviderId` and included new config fields. 

### Testing

- Ran the shared provider unit tests (`vitest` in `packages/shared` which includes `providers.test.ts`) and they passed after adding `EDGE_TTS_MODELS`/`EDGE_TTS_VOICES`. 
- Performed TypeScript type-check / build for affected packages to ensure new fields integrate with existing types and the changes compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d33eb03be883309e45a30b7743095d)