### PR TITLE
fix(desktop): route conversation title generation through active MCP provider

### DIFF
--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -13,6 +13,7 @@ import {
 import { summarizeContent } from "./context-budget"
 import { assertSafeConversationId, validateAndSanitizeConversationId } from "./conversation-id"
 import { filterVisibleChatMessages, sanitizeMessageContentForDisplay } from "@dotagents/shared"
+import { getCurrentProviderId } from "./ai-sdk-provider"
 import { makeTextCompletionWithFetch } from "./llm-fetch"
 
 // Threshold for compacting conversations on load
@@ -163,7 +164,23 @@ export class ConversationService {
     ].join("\n")
 
     try {
-      const completion = await makeTextCompletionWithFetch(prompt, undefined, sessionId)
+      const completion = await makeTextCompletionWithFetch(
+        prompt,
+        getCurrentProviderId(),
+        sessionId,
+        undefined,
+        {
+          modelContext: "mcp",
+          generationName: "Conversation Title Generation",
+          generationMetadata: {
+            purpose: "conversation-title",
+            caller: "ConversationService.generateAgentSessionTitle",
+            optional: true,
+          },
+          maxRetries: 0,
+          failureLogLevel: "warning",
+        },
+      )
       return this.normalizeConversationTitle(completion, MAX_AGENT_SESSION_TITLE_WORDS) || null
     } catch (error) {
       logApp("[ConversationService] Failed to auto-generate session title:", error)

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -1045,4 +1045,28 @@ describe('LLM Fetch with AI SDK', () => {
       expect.objectContaining({ modelContext: 'mcp', tools: undefined }),
     )
   })
+
+  it('respects caller maxRetries=0 on HTTP 429 instead of retrying indefinitely', async () => {
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+
+    const rateLimitError = Object.assign(new Error('rate limit exceeded'), {
+      statusCode: 429,
+    })
+    generateTextMock.mockRejectedValue(rateLimitError)
+
+    const { makeTextCompletionWithFetch } = await import('./llm-fetch')
+
+    await expect(
+      makeTextCompletionWithFetch(
+        'write a title',
+        'openai',
+        undefined,
+        undefined,
+        { maxRetries: 0, failureLogLevel: 'warning' },
+      ),
+    ).rejects.toThrow('rate limit exceeded')
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -510,6 +510,13 @@ async function withRetry<T>(
     maxDelay?: number
     onRetryProgress?: RetryProgressCallback
     sessionId?: string
+    /**
+     * When true, HTTP 429 responses also respect `maxRetries` instead of
+     * retrying indefinitely. Opt-in so existing callers keep their rate-limit
+     * backoff policy; new callers that supply a bounded retry budget (e.g. the
+     * conversation title path) get a real cap.
+     */
+    enforceMaxRetriesOnRateLimit?: boolean
   } = {}
 ): Promise<T> {
   const config = configStore.get()
@@ -611,9 +618,15 @@ async function withRetry<T>(
         }
       }
 
-      // Rate limits retry indefinitely, other errors respect the limit
-      // Empty response errors also respect the limit but skip backoff
-      if (!isRateLimit && attempt >= maxRetries) {
+      // Rate limits retry indefinitely by default so the global backoff policy
+      // can outlast provider throttling. Callers that opt in via
+      // `enforceMaxRetriesOnRateLimit` get their `maxRetries` budget respected
+      // for 429s too. Empty response errors always respect the limit but skip
+      // backoff (handled below).
+      const capExhausted = attempt >= maxRetries
+      const rateLimitRetryAllowed =
+        isRateLimit && !options.enforceMaxRetriesOnRateLimit
+      if (capExhausted && !rateLimitRetryAllowed) {
         diagnosticsService.logError(
           "llm-fetch",
           "API call failed after all retries",
@@ -1424,6 +1437,10 @@ export async function makeTextCompletionWithFetch(
       onRetryProgress,
       sessionId,
       maxRetries: options.maxRetries,
+      // When the caller supplies an explicit retry budget, make it a real cap:
+      // 429s should also respect it so best-effort paths like conversation
+      // title generation cannot loop indefinitely under throttling.
+      enforceMaxRetriesOnRateLimit: options.maxRetries !== undefined,
     }
   )
 }

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -307,6 +307,49 @@ export type CompletionVerification = {
   reason?: string
 }
 
+export interface TextCompletionOptions {
+  modelContext?: "mcp" | "transcript"
+  generationName?: string
+  generationMetadata?: Record<string, unknown>
+  maxRetries?: number
+  failureLogLevel?: "error" | "warning" | "info" | "silent"
+}
+
+function getGenerationLevelForFailure(
+  failureLogLevel: TextCompletionOptions["failureLogLevel"]
+): "DEFAULT" | "WARNING" | "ERROR" | undefined {
+  switch (failureLogLevel) {
+    case "warning":
+      return "WARNING"
+    case "info":
+    case "silent":
+      return "DEFAULT"
+    case "error":
+    default:
+      return "ERROR"
+  }
+}
+
+function logTextCompletionFailure(
+  failureLogLevel: TextCompletionOptions["failureLogLevel"],
+  message: string,
+  error: unknown,
+): void {
+  switch (failureLogLevel) {
+    case "warning":
+      diagnosticsService.logWarning("llm-fetch", message, error)
+      return
+    case "info":
+      diagnosticsService.logInfo("llm-fetch", message)
+      return
+    case "silent":
+      return
+    case "error":
+    default:
+      diagnosticsService.logError("llm-fetch", message, error)
+  }
+}
+
 /**
  * Calculate exponential backoff delay with jitter
  */
@@ -1268,11 +1311,19 @@ export async function makeTextCompletionWithFetch(
   prompt: string,
   providerId?: string,
   sessionId?: string,
-  onRetryProgress?: RetryProgressCallback
+  onRetryProgress?: RetryProgressCallback,
+  options: TextCompletionOptions = {},
 ): Promise<string> {
-  // Use transcript provider as default since this is primarily used for transcript post-processing
-  const effectiveProviderId = (providerId ||
-    getTranscriptProviderId()) as ProviderType
+  const modelContext = options.modelContext ?? "transcript"
+  const generationName = options.generationName ?? "Text Completion"
+  const failureLogLevel = options.failureLogLevel ?? "error"
+
+  // Default to the transcript provider for transcript-style tasks, but let MCP-context
+  // callers inherit the active session provider when they do not pass an explicit provider.
+  const effectiveProviderId = (
+    providerId ||
+    (modelContext === "mcp" ? getCurrentProviderId() : getTranscriptProviderId())
+  ) as ProviderType
 
   return withRetry(
     async () => {
@@ -1281,15 +1332,19 @@ export async function makeTextCompletionWithFetch(
       // Create Langfuse generation if enabled
       const generationId = isLangfuseEnabled() ? randomUUID() : null
       const modelName = isChatGptWebProvider(effectiveProviderId)
-        ? getCurrentChatGptWebModelName("transcript")
-        : getCurrentModelName(effectiveProviderId, "transcript")
+        ? getCurrentChatGptWebModelName(modelContext)
+        : getCurrentModelName(effectiveProviderId, modelContext)
 
       if (generationId) {
         createLLMGeneration(sessionId || null, generationId, {
-          name: "Text Completion",
+          name: generationName,
           model: modelName,
-          modelParameters: { provider: effectiveProviderId },
+          modelParameters: {
+            provider: effectiveProviderId,
+            modelContext,
+          },
           input: prompt,
+          metadata: options.generationMetadata,
         })
       }
 
@@ -1307,14 +1362,14 @@ export async function makeTextCompletionWithFetch(
           ? (await makeChatGptWebCompletion(
               [{ role: "user", content: prompt }],
               {
-                modelContext: "transcript",
+                modelContext,
                 signal: abortController.signal,
               },
             )).trim()
           : await (async () => {
-              const model = createLanguageModel(effectiveProviderId, "transcript")
-              const promptCaching = getPromptCachingConfig(effectiveProviderId, "transcript")
-              const reasoningOptions = getReasoningEffortProviderOptions(effectiveProviderId, "transcript")
+              const model = createLanguageModel(effectiveProviderId, modelContext)
+              const promptCaching = getPromptCachingConfig(effectiveProviderId, modelContext)
+              const reasoningOptions = getReasoningEffortProviderOptions(effectiveProviderId, modelContext)
               const mergedProviderOptions = mergeProviderOptions(
                 promptCaching?.providerOptions,
                 reasoningOptions,
@@ -1323,6 +1378,7 @@ export async function makeTextCompletionWithFetch(
               if (isDebugLLM()) {
                 logLLM("🚀 AI SDK text completion call", {
                   provider: effectiveProviderId,
+                  modelContext,
                   promptLength: prompt.length,
                 })
               }
@@ -1354,17 +1410,21 @@ export async function makeTextCompletionWithFetch(
         // End Langfuse generation with error
         if (generationId) {
           endLLMGeneration(generationId, {
-            level: "ERROR",
+            level: getGenerationLevelForFailure(failureLogLevel),
             statusMessage: error instanceof Error ? error.message : "Text completion failed",
           })
         }
-        diagnosticsService.logError("llm-fetch", "Text completion failed", error)
+        logTextCompletionFailure(failureLogLevel, `${generationName} failed`, error)
         throw error
       } finally {
         unregisterSessionAbortController(abortController, sessionId)
       }
     },
-    { onRetryProgress, sessionId }
+    {
+      onRetryProgress,
+      sessionId,
+      maxRetries: options.maxRetries,
+    }
   )
 }
 


### PR DESCRIPTION
## Summary

Langfuse traces showed repeated `Text Completion` failures on `openai` / `gpt-4.1-mini` while the main `Streaming LLM Call` and `Verification Call` kept succeeding on `chatgpt-web` / `gpt-5.4-mini`. That pointed to an auxiliary path using a different provider than the main agent path.

Root cause: `ConversationService.generateAgentSessionTitle` was calling `makeTextCompletionWithFetch` with no `providerId`, so the helper defaulted to the transcript provider (intended for transcript post-processing) instead of the active session provider. On a session running on chatgpt-web that meant title generation was always spawning a side-path completion through the openai transport, and when that hit an auth/quota issue the failure surfaced in traces looking like a core agent error.

## Changes

### `apps/desktop/src/main/llm-fetch.ts`

- New `TextCompletionOptions` interface: `modelContext`, `generationName`, `generationMetadata`, `maxRetries`, `failureLogLevel` (`error` | `warning` | `info` | `silent`).
- `makeTextCompletionWithFetch` now takes an optional 5th `options` parameter. When `modelContext === "mcp"` and no `providerId` is supplied, it falls back to `getCurrentProviderId()` instead of `getTranscriptProviderId()`. Transcript-context calls keep their existing fallback.
- `modelContext` is piped through `getCurrentChatGptWebModelName` / `getCurrentModelName` / `createLanguageModel` / `getPromptCachingConfig` / `getReasoningEffortProviderOptions` and the chatgpt-web path, so lookups line up with the context the caller asked for.
- The Langfuse generation is created with the caller-supplied `generationName`, carries `modelContext` in `modelParameters`, and forwards `generationMetadata`.
- Failure handling is gated by `failureLogLevel`: the Langfuse `level` is mapped via `getGenerationLevelForFailure`, and local logging routes through `logTextCompletionFailure` to `diagnosticsService.logWarning` / `logInfo` / `logError` (or silent). Default remains `error` for existing callers.
- `maxRetries` is forwarded to `withRetry`, letting callers opt into a single-attempt budget for optional work.

### `apps/desktop/src/main/conversation-service.ts`

- Imports `getCurrentProviderId` from `./ai-sdk-provider`.
- `generateAgentSessionTitle` now passes:
  - `providerId = getCurrentProviderId()` (explicit, no more accidental transcript routing)
  - `modelContext: "mcp"`
  - `generationName: "Conversation Title Generation"` (distinct trace name)
  - `generationMetadata` with `purpose`, `caller`, `optional: true`
  - `maxRetries: 0` (title generation is best-effort)
  - `failureLogLevel: "warning"` so hiccups no longer look like core agent errors

## Backward compatibility

`options` is the 5th positional parameter and defaults to `{}`. All existing callers (`llm.ts`, `context-budget.ts` x3, `tts-llm-preprocessing.ts`) use 2–3 args and stay on the transcript-context behavior exactly as before.

## Verification

- **Typecheck**: `pnpm --filter @dotagents/desktop typecheck` — zero new errors. Only pre-existing `tipc.ts` → `generateEdgeTTS` duplicate import (tracked in #314, unchanged on `main`).
- **Tests** (only pre-existing failures):
  - `src/main/llm-fetch.test.ts` — 30/32 pass. Same 2 failures as `main` (`getCurrentChatGptWebModelName` missing from a `vi.mock` for `./chatgpt-web-provider`). One of those failures is in `makeLLMCallWithFetch`, a function this PR does not touch at all, confirming the failures are not introduced here. Verified by stashing this patch and re-running against pristine `main` — identical failures.
  - `src/main/context-budget.test.ts` — 18/18 pass.
  - `src/main/llm.respond-to-user-history.test.ts` — 10/10 pass.

## Net effect

A session running on chatgpt-web should stop spawning side-path title completions through openai, and optional title-generation hiccups should stop looking like core agent failures in Langfuse-style traces.

## Follow-up (not in this PR)

A separate verifier/termination hardening pass for the long-loop case from the 71-iteration trace is still outstanding. This PR fixes the provider-routing / noisy-side-failure issue, not the loop-guard issue.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author