### PR TITLE
fix(desktop): prevent tile metadata clicks from opening hover panel

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -4863,10 +4863,13 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
 
             {/* Footer with status info — only show when active, omit when complete to save space */}
             {!isComplete && (
-              <div className={cn(
-                "border-t bg-muted/20 text-muted-foreground flex-shrink-0",
-                "px-3 py-1.5 text-xs",
-              )}>
+              <div
+                className={cn(
+                  "border-t bg-muted/20 text-muted-foreground flex-shrink-0",
+                  "px-3 py-1.5 text-xs",
+                )}
+                onClick={(e) => e.stopPropagation()}
+              >
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex min-w-0 flex-1 items-center gap-x-2">
                     {profileName && (


### PR DESCRIPTION
## Summary
- Stop click propagation on the session tile's footer so clicks on the agent name, model name, and iteration count no longer bubble to the parent `onClick={onFocus}` handler and open the hover panel.

## Root cause
In `apps/desktop/src/renderer/src/components/agent-progress.tsx`, the tile variant wraps the entire tile in a `<div onClick={onFocus}>` (to focus the session / open the panel). The footer rendering the metadata (profile name, model, Step X/Y) had no click handler, so clicks on those labels bubbled up and triggered `onFocus`.

## Fix
Added `onClick={(e) => e.stopPropagation()}` on the footer container. This matches the pattern already used elsewhere in the tile (tab toggle row, chat area, summary area, message queue panel) and keeps the rest of the tile-click-to-open behavior unchanged.

## Test plan
- [ ] Start an active agent session tile.
- [ ] Click the agent name, model name, and iteration count in the footer — hover panel should NOT open.
- [ ] Click elsewhere on the tile background — hover panel opens as before.
- [ ] Header buttons (pin, stop, dismiss) continue to work without opening the panel.

Closes #328