### PR TITLE
fix: text input fills parent modal height in SessionActionDialog

### DIFF
--- a/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
@@ -276,7 +276,7 @@ export function SessionActionDialog({
       <DialogContent
         className={cn(
           "flex max-h-[calc(100vh-48px)] flex-col sm:max-w-2xl",
-          mode === "text" && "min-h-[560px]",
+          mode === "text" && "h-[560px]",
           mode === "voice" && "sm:max-w-xl",
         )}
       >


### PR DESCRIPTION
## Summary

- Replaces `min-h-[560px]` with `h-[560px]` on the text-mode `DialogContent` in `SessionActionDialog`
- The textarea in the text input modal now expands to fill the full available height of the modal

## Root Cause

CSS Flexbox `flex-grow` only distributes free space when the **flex container has a definite height**. `min-height` alone does **not** establish a definite height — the flex algorithm sizes children from their intrinsic content height (~200px) first, and then `min-height` visually expands the container to 560px, but the flex items are already laid out in the smaller space. This left ~338px of empty space below the textarea.

Changing to an explicit `h-[560px]` gives the container a definite height so the flex algorithm correctly distributes the remaining space to the `flex-grow: 1` content div, allowing the textarea to fill the full modal height.

## Test plan

- [ ] Open the app on the start screen (Sessions page, no active sessions)
- [ ] Click "Start with Text" — the dialog opens with mode `text`
- [ ] Verify the textarea now fills the available vertical space inside the modal (no large empty gap below it)
- [ ] Confirm Cancel and Send buttons are still visible at the bottom
- [ ] Verify the voice mode dialog is unaffected

Closes #329
Closes #330

https://claude.ai/code/session_01E53nrK9FwbFMx7e2kDPYru