### PR TITLE
Dev self-recovery: support git worktrees, stale-lock reclamation, symlink-safe backups, and sherpa env fixes

### DIFF
--- a/apps/desktop/scripts/dev-with-sherpa.ts
+++ b/apps/desktop/scripts/dev-with-sherpa.ts
@@ -17,9 +17,15 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 import { fileURLToPath } from "url"
+import {
+  createGitDevSelfRecovery,
+  pathListHasEntry,
+  shouldRecoverFromChildClose,
+} from "../src/main/dev-self-recovery/git-recovery"
 
 const FORCE_KILL_TIMEOUT_MS = 5000
 const WORKSPACE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..")
+const DEBUG_FLAGS = ["-d", "--debug", "--debug-all", "-da", "-dl", "--debug-llm", "-dt", "--debug-tools", "-dui", "--debug-ui", "-dapp", "--debug-app", "-dk", "--debug-keybinds", "-dmcp", "--debug-mcp", "-dacp", "--debug-acp"]
 
 type WindowsProcessTreeTerminator = (pid: number) => {
   status: number | null
@@ -52,6 +58,58 @@ export function getSharedWatchCommand(): {
     command: process.platform === "win32" ? "pnpm.cmd" : "pnpm",
     args: ["--filter", "@dotagents/shared", "dev"],
     cwd: WORKSPACE_ROOT,
+  }
+}
+
+export function buildDevEnvironment(
+  baseEnv: Partial<NodeJS.ProcessEnv> = process.env,
+  userArgs: string[] = [],
+): NodeJS.ProcessEnv {
+  const env = { ...baseEnv } as NodeJS.ProcessEnv
+  env.DOTAGENTS_DEV_SELF_RECOVERY = "1"
+  env.DOTAGENTS_DEV_SELF_RECOVERY_REPO_ROOT = WORKSPACE_ROOT
+
+  const hasDebugFlag = userArgs.some((arg) => DEBUG_FLAGS.includes(arg))
+  if (hasDebugFlag) {
+    if (!env.REMOTE_DEBUGGING_PORT) {
+      env.REMOTE_DEBUGGING_PORT = "9333"
+    }
+    if (!env.ELECTRON_EXTRA_LAUNCH_ARGS?.includes("--inspect")) {
+      const existing = env.ELECTRON_EXTRA_LAUNCH_ARGS || ""
+      env.ELECTRON_EXTRA_LAUNCH_ARGS = existing ? `${existing} --inspect=9339` : "--inspect=9339"
+    }
+  }
+
+  return env
+}
+
+function applySherpaLibraryEnvironment(env: NodeJS.ProcessEnv, sherpaPath: string | null): void {
+  if (!sherpaPath) return
+
+  if (os.platform() === "darwin") {
+    const current = env.DYLD_LIBRARY_PATH || ""
+    if (!pathListHasEntry(current, sherpaPath)) {
+      env.DYLD_LIBRARY_PATH = sherpaPath + (current ? `:${current}` : "")
+    }
+    console.log(`[dev-with-sherpa] DYLD_LIBRARY_PATH=${env.DYLD_LIBRARY_PATH}`)
+  } else if (os.platform() === "linux") {
+    const current = env.LD_LIBRARY_PATH || ""
+    if (!pathListHasEntry(current, sherpaPath)) {
+      env.LD_LIBRARY_PATH = sherpaPath + (current ? `:${current}` : "")
+    }
+    console.log(`[dev-with-sherpa] LD_LIBRARY_PATH=${env.LD_LIBRARY_PATH}`)
+  }
+}
+
+function logDebugEnvironmentChanges(baseEnv: NodeJS.ProcessEnv, env: NodeJS.ProcessEnv, userArgs: string[]): void {
+  const hasDebugFlag = userArgs.some((arg) => DEBUG_FLAGS.includes(arg))
+  if (!hasDebugFlag) return
+
+  if (!baseEnv.REMOTE_DEBUGGING_PORT && env.REMOTE_DEBUGGING_PORT === "9333") {
+    console.log("[dev-with-sherpa] Debug mode: auto-setting REMOTE_DEBUGGING_PORT=9333")
+  }
+  if (!baseEnv.ELECTRON_EXTRA_LAUNCH_ARGS?.includes("--inspect") && env.ELECTRON_EXTRA_LAUNCH_ARGS?.includes("--inspect=9339")) {
+    console.log("[dev-with-sherpa] Debug mode: auto-setting --inspect=9339")
   }
 }
 
@@ -183,52 +241,47 @@ function findSherpaLibraryPath(): string | null {
   return null
 }
 
+export function spawnDesktopDevChild(env: NodeJS.ProcessEnv, userArgs: string[]): ChildProcess {
+  const { command, args } = getDevCommand(userArgs)
+  console.log(`[dev-with-sherpa] Running: ${command} ${args.join(" ")}`)
+
+  return spawn(command, args, {
+    env,
+    stdio: "inherit",
+    detached: process.platform !== "win32",
+    shell: process.platform === "win32",
+  })
+}
+
 function main(): void {
+  const userArgs = process.argv.slice(2)
   const sherpaPath = findSherpaLibraryPath()
 
   // Set up environment
-  const env = { ...process.env }
+  const env = buildDevEnvironment(process.env, userArgs)
+  console.log(`[dev-with-sherpa] Dev self-recovery enabled for repo: ${env.DOTAGENTS_DEV_SELF_RECOVERY_REPO_ROOT}`)
 
   if (sherpaPath) {
     console.log(`[dev-with-sherpa] Found sherpa-onnx libraries: ${sherpaPath}`)
-
-    if (os.platform() === "darwin") {
-      const current = env.DYLD_LIBRARY_PATH || ""
-      if (!current.includes(sherpaPath)) {
-        env.DYLD_LIBRARY_PATH = sherpaPath + (current ? `:${current}` : "")
-      }
-      console.log(`[dev-with-sherpa] DYLD_LIBRARY_PATH=${env.DYLD_LIBRARY_PATH}`)
-    } else if (os.platform() === "linux") {
-      const current = env.LD_LIBRARY_PATH || ""
-      if (!current.includes(sherpaPath)) {
-        env.LD_LIBRARY_PATH = sherpaPath + (current ? `:${current}` : "")
-      }
-      console.log(`[dev-with-sherpa] LD_LIBRARY_PATH=${env.LD_LIBRARY_PATH}`)
-    }
+    applySherpaLibraryEnvironment(env, sherpaPath)
   } else {
     console.warn("[dev-with-sherpa] Could not find sherpa-onnx libraries.")
     console.warn("[dev-with-sherpa] Parakeet local STT may not work correctly.")
   }
 
   // Auto-enable CDP debug ports when any debug flag is passed
-  const userArgs = process.argv.slice(2)
-  const debugFlags = ["-d", "--debug", "--debug-all", "-da", "-dl", "--debug-llm", "-dt", "--debug-tools", "-dui", "--debug-ui", "-dapp", "--debug-app", "-dk", "--debug-keybinds", "-dmcp", "--debug-mcp", "-dacp", "--debug-acp"]
-  const hasDebugFlag = userArgs.some(arg => debugFlags.includes(arg))
+  logDebugEnvironmentChanges(process.env, env, userArgs)
 
-  if (hasDebugFlag) {
-    if (!env.REMOTE_DEBUGGING_PORT) {
-      env.REMOTE_DEBUGGING_PORT = "9333"
-      console.log("[dev-with-sherpa] Debug mode: auto-setting REMOTE_DEBUGGING_PORT=9333")
-    }
-    if (!env.ELECTRON_EXTRA_LAUNCH_ARGS?.includes("--inspect")) {
-      const existing = env.ELECTRON_EXTRA_LAUNCH_ARGS || ""
-      env.ELECTRON_EXTRA_LAUNCH_ARGS = existing ? `${existing} --inspect=9339` : "--inspect=9339"
-      console.log("[dev-with-sherpa] Debug mode: auto-setting --inspect=9339")
-    }
-  }
-
-  const { command, args } = getDevCommand(userArgs)
   const sharedWatch = getSharedWatchCommand()
+  const devSelfRecovery = createGitDevSelfRecovery({
+    repoRoot: WORKSPACE_ROOT,
+    logger: {
+      info: (...args) => console.log("[dev-self-recovery]", ...args),
+      warn: (...args) => console.warn("[dev-self-recovery]", ...args),
+      error: (...args) => console.error("[dev-self-recovery]", ...args),
+    },
+  })
+  devSelfRecovery.startCleanBaselinePolling()
 
   console.log(`[dev-with-sherpa] Running shared watch: ${sharedWatch.command} ${sharedWatch.args.join(" ")}`)
   const sharedChild = spawn(sharedWatch.command, sharedWatch.args, {
@@ -239,17 +292,87 @@ function main(): void {
     shell: process.platform === "win32",
   })
 
-  console.log(`[dev-with-sherpa] Running: ${command} ${args.join(" ")}`)
-
-  const child = spawn(command, args, {
-    env,
-    stdio: "inherit",
-    detached: process.platform !== "win32",
-    shell: process.platform === "win32",
-  })
+  let child = spawnDesktopDevChild(env, userArgs)
+  let restartedAfterRecovery = false
 
   let shutdownSignal: NodeJS.Signals | null = null
   let forceKillTimer: ReturnType<typeof setTimeout> | undefined
+
+  const stopRecoveryPolling = () => {
+    devSelfRecovery.stopCleanBaselinePolling()
+  }
+
+  const exitAfterDesktopChildClose = (code: number | null, signal: NodeJS.Signals | null) => {
+    if (!shutdownSignal) {
+      terminateChildProcessTree(sharedChild, "SIGTERM")
+    }
+
+    stopRecoveryPolling()
+
+    if (code !== null) {
+      process.exit(code)
+    }
+
+    if (signal) {
+      process.exit(getSignalExitCode(signal))
+    }
+
+    if (shutdownSignal) {
+      process.exit(getSignalExitCode(shutdownSignal))
+    }
+
+    process.exit(0)
+  }
+
+  const restartDesktopChildAfterRecovery = () => {
+    restartedAfterRecovery = true
+    child = spawnDesktopDevChild(env, userArgs)
+    attachDesktopChildHandlers(child)
+  }
+
+  const maybeRecoverAndRestart = (trigger: { kind: string; [key: string]: unknown }): boolean => {
+    if (restartedAfterRecovery) return false
+
+    const result = devSelfRecovery.maybeRecover(trigger)
+    if (!result.recovered) {
+      console.warn(`[dev-with-sherpa] Dev self-recovery skipped: ${result.reason}`)
+      return false
+    }
+
+    console.warn(`[dev-with-sherpa] Dev self-recovery completed; backup saved to ${result.backupDir}`)
+    console.warn("[dev-with-sherpa] Restarting desktop dev child once after recovery...")
+    restartDesktopChildAfterRecovery()
+    return true
+  }
+
+  function attachDesktopChildHandlers(desktopChild: ChildProcess) {
+    desktopChild.on("close", (code, signal) => {
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer)
+      }
+
+      if (shouldRecoverFromChildClose({ code, signal, shutdownSignal })) {
+        if (maybeRecoverAndRestart({ kind: "electron-vite-exit", code, signal })) {
+          return
+        }
+      }
+
+      exitAfterDesktopChildClose(code, signal)
+    })
+
+    desktopChild.on("error", (err) => {
+      if (!shutdownSignal && !restartedAfterRecovery && devSelfRecovery.hasRecoverableChanges()) {
+        if (maybeRecoverAndRestart({ kind: "electron-vite-error", message: err.message })) {
+          return
+        }
+      }
+
+      console.error("[dev-with-sherpa] Failed to start:", err)
+      terminateChildProcessTree(sharedChild, "SIGTERM")
+      stopRecoveryPolling()
+      process.exit(1)
+    })
+  }
 
   const shutdown = (signal: NodeJS.Signals) => {
     if (shutdownSignal) return
@@ -274,39 +397,12 @@ function main(): void {
     process.once(signal, () => shutdown(signal))
   }
 
-  child.on("close", (code, signal) => {
-    if (forceKillTimer) {
-      clearTimeout(forceKillTimer)
-    }
-
-    if (!shutdownSignal) {
-      terminateChildProcessTree(sharedChild, "SIGTERM")
-    }
-
-    if (code !== null) {
-      process.exit(code)
-    }
-
-    if (signal) {
-      process.exit(getSignalExitCode(signal))
-    }
-
-    if (shutdownSignal) {
-      process.exit(getSignalExitCode(shutdownSignal))
-    }
-
-    process.exit(0)
-  })
-
-  child.on("error", (err) => {
-    console.error("[dev-with-sherpa] Failed to start:", err)
-    terminateChildProcessTree(sharedChild, "SIGTERM")
-    process.exit(1)
-  })
+  attachDesktopChildHandlers(child)
 
   sharedChild.on("error", (err) => {
     console.error("[dev-with-sherpa] Failed to start shared watch:", err)
     terminateChildProcessTree(child, "SIGTERM")
+    stopRecoveryPolling()
     process.exit(1)
   })
 }

--- a/apps/desktop/src/main/dev-self-recovery/git-recovery.test.ts
+++ b/apps/desktop/src/main/dev-self-recovery/git-recovery.test.ts
@@ -1,0 +1,168 @@
+import { spawnSync } from "child_process"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createGitDevSelfRecovery } from "./git-recovery"
+
+const hasGit = spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0
+const testIfGit = hasGit ? it : it.skip
+const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+let tempDirs: string[] = []
+
+function git(repo: string, args: string[]): string {
+  const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" })
+  expect(result.status, result.stderr).toBe(0)
+  return result.stdout
+}
+
+function writeFile(repo: string, relativePath: string, content: string): void {
+  const filePath = path.join(repo, relativePath)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content, "utf8")
+}
+
+function createRepo(): string {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-git-recovery-"))
+  tempDirs.push(repo)
+  git(repo, ["init"])
+  git(repo, ["config", "user.email", "test@example.com"])
+  git(repo, ["config", "user.name", "Test User"])
+  writeFile(repo, "tracked.txt", "initial\n")
+  git(repo, ["add", "tracked.txt"])
+  git(repo, ["-c", "commit.gpgSign=false", "commit", "--no-verify", "-m", "initial"])
+  return repo
+}
+
+function status(repo: string): string {
+  return git(repo, ["status", "--porcelain=v1"])
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+describe("git dev self-recovery", () => {
+  testIfGit("arms from a clean repo and recovers dirty tracked changes to HEAD", () => {
+    const repo = createRepo()
+    const controller = createGitDevSelfRecovery({ repoRoot: repo, logger: silentLogger })
+
+    expect(controller.refreshCleanBaseline()).toBe(true)
+    writeFile(repo, "tracked.txt", "dirty\n")
+
+    expect(controller.hasRecoverableChanges()).toBe(true)
+    const result = controller.maybeRecover("tracked-change")
+
+    expect(result.recovered).toBe(true)
+    if (!result.recovered) throw new Error("expected recovery to succeed")
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("initial\n")
+    expect(status(repo)).toBe("")
+    expect(fs.existsSync(path.join(result.backupDir, "tracked-head.patch"))).toBe(true)
+  })
+
+  testIfGit("backs up staged and unstaged tracked changes before resetting", () => {
+    const repo = createRepo()
+    const controller = createGitDevSelfRecovery({ repoRoot: repo, logger: silentLogger })
+
+    expect(controller.refreshCleanBaseline()).toBe(true)
+    writeFile(repo, "tracked.txt", "staged\n")
+    git(repo, ["add", "tracked.txt"])
+    writeFile(repo, "tracked.txt", "unstaged\n")
+
+    const result = controller.maybeRecover("staged-and-unstaged")
+
+    expect(result.recovered).toBe(true)
+    if (!result.recovered) throw new Error("expected recovery to succeed")
+    expect(fs.readFileSync(path.join(result.backupDir, "tracked-index.patch"), "utf8")).toContain("staged")
+    expect(fs.readFileSync(path.join(result.backupDir, "tracked-worktree.patch"), "utf8")).toContain("unstaged")
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("initial\n")
+    expect(status(repo)).toBe("")
+  })
+
+  testIfGit("copies untracked files into the backup and removes them with git clean -fd", () => {
+    const repo = createRepo()
+    const controller = createGitDevSelfRecovery({ repoRoot: repo, logger: silentLogger })
+
+    expect(controller.refreshCleanBaseline()).toBe(true)
+    writeFile(repo, "nested/new.txt", "untracked\n")
+
+    const result = controller.maybeRecover("untracked-file")
+
+    expect(result.recovered).toBe(true)
+    if (!result.recovered) throw new Error("expected recovery to succeed")
+    expect(fs.existsSync(path.join(repo, "nested/new.txt"))).toBe(false)
+    expect(fs.readFileSync(path.join(result.backupDir, "untracked", "nested/new.txt"), "utf8")).toBe("untracked\n")
+    expect(fs.readFileSync(path.join(result.backupDir, "untracked-files.txt"), "utf8")).toContain("nested/new.txt")
+  })
+
+  testIfGit("preserves ignored files because recovery does not use git clean -x", () => {
+    const repo = createRepo()
+    writeFile(repo, ".gitignore", "ignored.tmp\n")
+    git(repo, ["add", ".gitignore"])
+    git(repo, ["-c", "commit.gpgSign=false", "commit", "--no-verify", "-m", "ignore ignored tmp"])
+
+    const controller = createGitDevSelfRecovery({ repoRoot: repo, logger: silentLogger })
+    expect(controller.refreshCleanBaseline()).toBe(true)
+    writeFile(repo, "tracked.txt", "dirty\n")
+    writeFile(repo, "ignored.tmp", "keep me\n")
+
+    const result = controller.maybeRecover("ignored-file")
+
+    expect(result.recovered).toBe(true)
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("initial\n")
+    expect(fs.readFileSync(path.join(repo, "ignored.tmp"), "utf8")).toBe("keep me\n")
+    expect(status(repo)).toBe("")
+  })
+
+  testIfGit("aborts before reset and clean when backup creation fails", () => {
+    const repo = createRepo()
+    const controller = createGitDevSelfRecovery({
+      repoRoot: repo,
+      logger: silentLogger,
+      copyFile: () => {
+        throw new Error("copy failed")
+      },
+    })
+
+    expect(controller.refreshCleanBaseline()).toBe(true)
+    writeFile(repo, "tracked.txt", "dirty\n")
+    writeFile(repo, "new.txt", "untracked\n")
+
+    const result = controller.maybeRecover("backup-failure")
+
+    expect(result).toMatchObject({ recovered: false, reason: "backup-failed" })
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("dirty\n")
+    expect(fs.existsSync(path.join(repo, "new.txt"))).toBe(true)
+  })
+
+  testIfGit("skips recovery when the recovery lock file already exists", () => {
+    const repo = createRepo()
+    const controller = createGitDevSelfRecovery({ repoRoot: repo, logger: silentLogger })
+
+    expect(controller.refreshCleanBaseline()).toBe(true)
+    writeFile(repo, "tracked.txt", "dirty\n")
+    fs.mkdirSync(path.join(repo, ".git", "dotagents-dev-recovery"), { recursive: true })
+    fs.writeFileSync(path.join(repo, ".git", "dotagents-dev-recovery", ".lock"), "locked")
+
+    const result = controller.maybeRecover("locked")
+
+    expect(result).toEqual({ recovered: false, reason: "locked" })
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("dirty\n")
+  })
+
+  testIfGit("does not recover a dirty tree until a clean baseline has been observed", () => {
+    const repo = createRepo()
+    writeFile(repo, "tracked.txt", "dirty-at-start\n")
+    const controller = createGitDevSelfRecovery({ repoRoot: repo, logger: silentLogger })
+
+    expect(controller.refreshCleanBaseline()).toBe(false)
+    expect(controller.hasRecoverableChanges()).toBe(false)
+    expect(controller.maybeRecover("dirty-at-start")).toEqual({ recovered: false, reason: "unarmed" })
+    expect(fs.readFileSync(path.join(repo, "tracked.txt"), "utf8")).toBe("dirty-at-start\n")
+  })
+})

--- a/apps/desktop/src/main/dev-self-recovery/git-recovery.ts
+++ b/apps/desktop/src/main/dev-self-recovery/git-recovery.ts
@@ -1,0 +1,492 @@
+import { spawnSync, type SpawnSyncReturns } from "child_process"
+import fs from "fs"
+import path from "path"
+
+export const RECOVERABLE_RENDERER_GONE_REASONS = new Set([
+  "crashed",
+  "oom",
+  "launch-failed",
+  "integrity-failure",
+])
+
+const DEFAULT_POLL_INTERVAL_MS = 2000
+const RECOVERY_DIR_NAME = "dotagents-dev-recovery"
+const LOCK_FILE_NAME = ".lock"
+const LOCK_STALE_AFTER_MS = 30 * 60 * 1000
+
+export type GitDevSelfRecoveryTrigger =
+  | string
+  | {
+      kind: string
+      [key: string]: unknown
+    }
+
+export type GitCommandResult = Pick<SpawnSyncReturns<Buffer>, "status" | "signal" | "error"> & {
+  stdout: Buffer
+  stderr: Buffer
+}
+
+export type GitRunner = (args: string[], cwd: string) => GitCommandResult
+
+export type GitDevSelfRecoveryLogger = Pick<Console, "info" | "warn" | "error">
+
+export type GitDevSelfRecoveryResult =
+  | {
+      recovered: true
+      backupDir: string
+      statusAfter: string
+      warning?: string
+    }
+  | {
+      recovered: false
+      reason:
+        | "unarmed"
+        | "locked"
+        | "invalid-repo"
+        | "clean"
+        | "backup-failed"
+        | "reset-failed"
+        | "clean-failed"
+        | "post-check-failed"
+      backupDir?: string
+      error?: string
+    }
+
+export interface GitDevSelfRecoveryController {
+  startCleanBaselinePolling(intervalMs?: number): void
+  stopCleanBaselinePolling(): void
+  refreshCleanBaseline(): boolean
+  hasRecoverableChanges(): boolean
+  maybeRecover(trigger: GitDevSelfRecoveryTrigger): GitDevSelfRecoveryResult
+}
+
+interface CleanBaseline {
+  head: string
+  repoRoot: string
+  observedAt: string
+}
+
+interface RecoveryOptions {
+  repoRoot: string
+  runGit?: GitRunner
+  now?: () => Date
+  logger?: GitDevSelfRecoveryLogger
+  copyFile?: (source: string, destination: string) => void
+  mkdir?: (dir: string) => void
+  writeFile?: (file: string, data: string | Buffer) => void
+}
+
+interface RepoSnapshot {
+  repoRoot: string
+  gitDir: string
+  head: string
+  status: Buffer
+}
+
+interface BackupResult {
+  ok: true
+  backupDir: string
+  dryRunDeletePreview: string
+}
+
+type BackupFailure = {
+  ok: false
+  backupDir?: string
+  error: string
+}
+
+export function isRecoverableRendererGoneReason(reason: string): boolean {
+  return RECOVERABLE_RENDERER_GONE_REASONS.has(reason)
+}
+
+export function shouldRecoverFromChildClose({
+  code,
+  signal,
+  shutdownSignal,
+}: {
+  code: number | null
+  signal: NodeJS.Signals | null
+  shutdownSignal: NodeJS.Signals | null
+}): boolean {
+  if (shutdownSignal) return false
+  if (signal) return false
+  return code !== null && code !== 0
+}
+
+function defaultRunGit(args: string[], cwd: string): GitCommandResult {
+  return spawnSync("git", args, {
+    cwd,
+    encoding: "buffer",
+    maxBuffer: 100 * 1024 * 1024,
+    windowsHide: true,
+  }) as GitCommandResult
+}
+
+function normalizeGitOutput(output: Buffer): string {
+  return output.toString("utf8").replace(/\0/g, "\n").trim()
+}
+
+function commandError(command: string[], result: GitCommandResult): string {
+  const stderr = normalizeGitOutput(result.stderr)
+  const suffix = stderr ? `: ${stderr}` : ""
+  const signal = result.signal ? ` signal=${result.signal}` : ""
+  const error = result.error ? ` error=${result.error.message}` : ""
+  return `git ${command.join(" ")} failed with status ${String(result.status)}${signal}${error}${suffix}`
+}
+
+function realpathIfPossible(value: string): string {
+  try {
+    return fs.realpathSync(value)
+  } catch {
+    return path.resolve(value)
+  }
+}
+
+function safeTriggerLabel(trigger: GitDevSelfRecoveryTrigger): string {
+  const label = typeof trigger === "string" ? trigger : trigger.kind
+  return label.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "unknown"
+}
+
+function timestampForPath(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, "-")
+}
+
+function splitNulList(output: Buffer): string[] {
+  return output
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+}
+
+
+function resolveGitDir(repoRoot: string, rawGitDir: string): string {
+  const trimmed = rawGitDir.trim()
+  if (!trimmed) {
+    throw new Error("Unable to resolve git dir")
+  }
+
+  return path.isAbsolute(trimmed)
+    ? realpathIfPossible(trimmed)
+    : realpathIfPossible(path.resolve(repoRoot, trimmed))
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException
+    return err.code === "EPERM"
+  }
+}
+
+export function pathListHasEntry(currentValue: string, entry: string): boolean {
+  if (!currentValue) return false
+  return currentValue.split(path.delimiter).some((part) => part === entry)
+}
+function ensureRelativeGitPath(relativePath: string): void {
+  if (path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing absolute untracked path: ${relativePath}`)
+  }
+
+  const normalized = path.normalize(relativePath)
+  if (normalized === ".." || normalized.startsWith(`..${path.sep}`)) {
+    throw new Error(`Refusing untracked path outside repo: ${relativePath}`)
+  }
+}
+
+export function createGitDevSelfRecovery(options: RecoveryOptions): GitDevSelfRecoveryController {
+  const repoRoot = path.resolve(options.repoRoot)
+  const runGit = options.runGit ?? defaultRunGit
+  const now = options.now ?? (() => new Date())
+  const logger = options.logger ?? console
+  const copyFile = options.copyFile ?? ((source, destination) => fs.copyFileSync(source, destination))
+  const mkdir = options.mkdir ?? ((dir) => fs.mkdirSync(dir, { recursive: true }))
+  const writeFile = options.writeFile ?? ((file, data) => fs.writeFileSync(file, data))
+
+  let baseline: CleanBaseline | null = null
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+
+  const runRequiredGit = (args: string[], cwd = repoRoot): GitCommandResult => {
+    const result = runGit(args, cwd)
+    if (result.status !== 0) {
+      throw new Error(commandError(args, result))
+    }
+    return result
+  }
+
+  const validateRepo = (): RepoSnapshot => {
+    const topLevel = normalizeGitOutput(runRequiredGit(["rev-parse", "--show-toplevel"]).stdout)
+    const expected = realpathIfPossible(repoRoot)
+    const actual = realpathIfPossible(topLevel)
+
+    if (actual !== expected) {
+      throw new Error(`Expected git repo root ${expected}, got ${actual}`)
+    }
+
+    const gitDir = resolveGitDir(
+      actual,
+      normalizeGitOutput(runRequiredGit(["rev-parse", "--git-dir"]).stdout),
+    )
+    const head = normalizeGitOutput(runRequiredGit(["rev-parse", "HEAD"]).stdout)
+    const status = runRequiredGit(["status", "--porcelain=v1", "-z"]).stdout
+
+    return { repoRoot: actual, gitDir, head, status }
+  }
+
+  const recoveryRoot = (gitDir: string) => path.join(gitDir, RECOVERY_DIR_NAME)
+  const lockFile = (gitDir: string) => path.join(recoveryRoot(gitDir), LOCK_FILE_NAME)
+
+  const acquireLock = (gitDir: string): number | null => {
+    mkdir(recoveryRoot(gitDir))
+    const lockPath = lockFile(gitDir)
+
+    const tryAcquire = (): number | null => {
+      try {
+        return fs.openSync(lockPath, "wx")
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException
+        if (err.code === "EEXIST") return null
+        throw error
+      }
+    }
+
+    const fd = tryAcquire()
+    if (fd !== null) return fd
+
+    try {
+      const lockRaw = fs.readFileSync(lockPath, "utf8")
+      const lockData = JSON.parse(lockRaw) as {
+        pid?: unknown
+        createdAt?: unknown
+      }
+
+      const lockPid = typeof lockData.pid === "number" ? lockData.pid : NaN
+      const createdAtMs =
+        typeof lockData.createdAt === "string"
+          ? Date.parse(lockData.createdAt)
+          : NaN
+
+      const isStale =
+        Number.isFinite(createdAtMs)
+        && now().getTime() - createdAtMs > LOCK_STALE_AFTER_MS
+        && !isProcessAlive(lockPid)
+
+      if (isStale) {
+        fs.unlinkSync(lockPath)
+        return tryAcquire()
+      }
+    } catch {
+      // keep existing lock when metadata is unreadable
+    }
+
+    return null
+  }
+
+  const releaseLock = (fd: number, gitDir: string): void => {
+    try {
+      fs.closeSync(fd)
+    } finally {
+      try {
+        fs.unlinkSync(lockFile(gitDir))
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+
+  const runGitToFile = (args: string[], outputPath: string): void => {
+    const result = runRequiredGit(args)
+    writeFile(outputPath, result.stdout)
+  }
+
+  const writeMetadata = (backupDir: string, metadata: Record<string, unknown>): void => {
+    writeFile(path.join(backupDir, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`)
+  }
+
+  const createBackup = (
+    trigger: GitDevSelfRecoveryTrigger,
+    snapshot: RepoSnapshot,
+  ): BackupResult | BackupFailure => {
+    const backupDir = path.join(
+      recoveryRoot(snapshot.gitDir),
+      `${timestampForPath(now())}-${process.pid}-${safeTriggerLabel(trigger)}`,
+    )
+
+    try {
+      mkdir(backupDir)
+      mkdir(path.join(backupDir, "untracked"))
+
+      runGitToFile(["diff", "--binary", "HEAD", "--"], path.join(backupDir, "tracked-head.patch"))
+      runGitToFile(["diff", "--binary", "--"], path.join(backupDir, "tracked-worktree.patch"))
+      runGitToFile(["diff", "--cached", "--binary", "--"], path.join(backupDir, "tracked-index.patch"))
+
+      const untrackedResult = runRequiredGit(["ls-files", "--others", "--exclude-standard", "-z"])
+      const untrackedFiles = splitNulList(untrackedResult.stdout)
+      writeFile(path.join(backupDir, "untracked-files.txt"), `${untrackedFiles.join("\n")}\n`)
+
+      for (const relativePath of untrackedFiles) {
+        ensureRelativeGitPath(relativePath)
+        const source = path.join(repoRoot, relativePath)
+        const destination = path.join(backupDir, "untracked", relativePath)
+        mkdir(path.dirname(destination))
+
+        const stat = fs.lstatSync(source)
+        if (stat.isSymbolicLink()) {
+          const target = fs.readlinkSync(source)
+          fs.symlinkSync(target, destination)
+        } else {
+          copyFile(source, destination)
+        }
+      }
+
+      const dryRunResult = runRequiredGit(["clean", "-fdn", "--", "."])
+      const dryRunDeletePreview = dryRunResult.stdout.toString("utf8")
+
+      writeMetadata(backupDir, {
+        trigger,
+        baseline,
+        backupCreatedAt: now().toISOString(),
+        repoRoot: snapshot.repoRoot,
+        currentHead: snapshot.head,
+        statusBefore: normalizeGitOutput(snapshot.status),
+        untrackedFiles,
+        dryRunDeletePreview,
+      })
+
+      return { ok: true, backupDir, dryRunDeletePreview }
+    } catch (error) {
+      return { ok: false, backupDir, error: error instanceof Error ? error.message : String(error) }
+    }
+  }
+
+  const updateCleanBaseline = (snapshot: RepoSnapshot): void => {
+    baseline = {
+      head: snapshot.head,
+      repoRoot: snapshot.repoRoot,
+      observedAt: now().toISOString(),
+    }
+    logger.info(`[git-recovery] Clean baseline observed at ${baseline.head}`)
+  }
+
+  return {
+    startCleanBaselinePolling(intervalMs = DEFAULT_POLL_INTERVAL_MS): void {
+      this.refreshCleanBaseline()
+      if (pollTimer) return
+
+      pollTimer = setInterval(() => {
+        this.refreshCleanBaseline()
+      }, intervalMs)
+      pollTimer.unref?.()
+    },
+
+    stopCleanBaselinePolling(): void {
+      if (!pollTimer) return
+      clearInterval(pollTimer)
+      pollTimer = null
+    },
+
+    refreshCleanBaseline(): boolean {
+      try {
+        const snapshot = validateRepo()
+        if (snapshot.status.length !== 0) return false
+        updateCleanBaseline(snapshot)
+        return true
+      } catch (error) {
+        logger.warn(`[git-recovery] Skipping clean baseline refresh: ${error instanceof Error ? error.message : String(error)}`)
+        return false
+      }
+    },
+
+    hasRecoverableChanges(): boolean {
+      if (!baseline) return false
+
+      try {
+        const snapshot = validateRepo()
+        return snapshot.status.length !== 0
+      } catch (error) {
+        logger.warn(`[git-recovery] Cannot check recoverable changes: ${error instanceof Error ? error.message : String(error)}`)
+        return false
+      }
+    },
+
+    maybeRecover(trigger: GitDevSelfRecoveryTrigger): GitDevSelfRecoveryResult {
+      if (!baseline) {
+        logger.info("[git-recovery] Recovery skipped: no clean baseline observed yet")
+        return { recovered: false, reason: "unarmed" }
+      }
+
+      let fd: number | null = null
+      let lockGitDir: string | null = null
+      try {
+        const snapshotBeforeLock = validateRepo()
+        lockGitDir = snapshotBeforeLock.gitDir
+        fd = acquireLock(snapshotBeforeLock.gitDir)
+        if (fd === null) {
+          logger.warn("[git-recovery] Recovery skipped: another recovery is already running")
+          return { recovered: false, reason: "locked" }
+        }
+
+        fs.writeFileSync(fd, `${JSON.stringify({ pid: process.pid, createdAt: now().toISOString() })}
+`)
+
+        const snapshot = validateRepo()
+        if (snapshot.status.length === 0) {
+          updateCleanBaseline(snapshot)
+          return { recovered: false, reason: "clean" }
+        }
+
+        const backup = createBackup(trigger, snapshot)
+        if (backup.ok === false) {
+          logger.error(`[git-recovery] Backup failed; aborting recovery: ${backup.error}`)
+          return { recovered: false, reason: "backup-failed", backupDir: backup.backupDir, error: backup.error }
+        }
+
+        const resetResult = runGit(["reset", "--hard", "HEAD"], repoRoot)
+        if (resetResult.status !== 0) {
+          const error = commandError(["reset", "--hard", "HEAD"], resetResult)
+          logger.error(`[git-recovery] ${error}`)
+          return { recovered: false, reason: "reset-failed", backupDir: backup.backupDir, error }
+        }
+
+        const cleanResult = runGit(["clean", "-fd", "--", "."], repoRoot)
+        if (cleanResult.status !== 0) {
+          const error = commandError(["clean", "-fd", "--", "."], cleanResult)
+          logger.error(`[git-recovery] ${error}`)
+          return { recovered: false, reason: "clean-failed", backupDir: backup.backupDir, error }
+        }
+
+        const postCheck = runGit(["status", "--porcelain=v1", "-z"], repoRoot)
+        if (postCheck.status !== 0) {
+          const error = commandError(["status", "--porcelain=v1", "-z"], postCheck)
+          logger.error(`[git-recovery] ${error}`)
+          return { recovered: false, reason: "post-check-failed", backupDir: backup.backupDir, error }
+        }
+
+        const statusAfter = normalizeGitOutput(postCheck.stdout)
+        if (statusAfter) {
+          const warning = "Working tree is still dirty after dev self-recovery"
+          logger.warn(`[git-recovery] ${warning}: ${statusAfter}`)
+          return { recovered: true, backupDir: backup.backupDir, statusAfter, warning }
+        }
+
+        baseline = {
+          head: snapshot.head,
+          repoRoot: snapshot.repoRoot,
+          observedAt: now().toISOString(),
+        }
+
+        logger.warn(`[git-recovery] Recovered dev working tree; backup saved to ${backup.backupDir}`)
+        return { recovered: true, backupDir: backup.backupDir, statusAfter }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error)
+        logger.warn(`[git-recovery] Recovery skipped: ${message}`)
+        return { recovered: false, reason: "invalid-repo", error: message }
+      } finally {
+        if (fd !== null && lockGitDir) releaseLock(fd, lockGitDir)
+      }
+    },
+  }
+}

--- a/apps/desktop/src/main/dev-self-recovery/renderer-crash-recovery.test.ts
+++ b/apps/desktop/src/main/dev-self-recovery/renderer-crash-recovery.test.ts
@@ -1,0 +1,155 @@
+import { EventEmitter } from "events"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { GitDevSelfRecoveryController } from "./git-recovery"
+import {
+  isRendererCrashRecoveryEnabled,
+  resetRendererCrashRecoveryForTests,
+  setupRendererCrashRecovery,
+} from "./renderer-crash-recovery"
+
+function makeWindow() {
+  const webContents = new EventEmitter()
+  return {
+    win: { webContents } as any,
+    webContents,
+  }
+}
+
+function makeController(overrides: Partial<GitDevSelfRecoveryController> = {}): GitDevSelfRecoveryController {
+  return {
+    startCleanBaselinePolling: vi.fn(),
+    stopCleanBaselinePolling: vi.fn(),
+    refreshCleanBaseline: vi.fn(() => true),
+    hasRecoverableChanges: vi.fn(() => true),
+    maybeRecover: vi.fn(() => ({ recovered: true, backupDir: "/repo/.git/dotagents-dev-recovery/backup", statusAfter: "" })),
+    ...overrides,
+  }
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+afterEach(() => {
+  resetRendererCrashRecoveryForTests()
+  vi.clearAllMocks()
+})
+
+describe("renderer crash recovery", () => {
+  it("attaches render-process-gone listeners when dev self-recovery is enabled", () => {
+    const { win, webContents } = makeWindow()
+    const controller = makeController()
+
+    const enabled = setupRendererCrashRecovery(win, "main", {
+      env: { DOTAGENTS_DEV_SELF_RECOVERY: "1" },
+      isProd: false,
+      repoRoot: "/repo",
+      logger,
+      createController: () => controller,
+    })
+
+    expect(enabled).toBe(true)
+    expect(webContents.listenerCount("render-process-gone")).toBe(1)
+    expect(controller.startCleanBaselinePolling).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(["crashed", "oom", "launch-failed", "integrity-failure"])(
+    "recovers on renderer gone reason %s when recoverable changes exist",
+    (reason) => {
+      const { win, webContents } = makeWindow()
+      const controller = makeController()
+
+      setupRendererCrashRecovery(win, "panel", {
+        env: { DOTAGENTS_DEV_SELF_RECOVERY: "1" },
+        isProd: false,
+        repoRoot: "/repo",
+        logger,
+        createController: () => controller,
+      })
+
+      webContents.emit("render-process-gone", {}, { reason })
+
+      expect(controller.hasRecoverableChanges).toHaveBeenCalledTimes(1)
+      expect(controller.maybeRecover).toHaveBeenCalledWith({
+        kind: "renderer-process-gone",
+        windowId: "panel",
+        reason,
+      })
+    },
+  )
+
+  it.each(["clean-exit", "killed", "abnormal-exit"])("ignores non-recoverable renderer gone reason %s", (reason) => {
+    const { win, webContents } = makeWindow()
+    const controller = makeController()
+
+    setupRendererCrashRecovery(win, "main", {
+      env: { DOTAGENTS_DEV_SELF_RECOVERY: "1" },
+      isProd: false,
+      repoRoot: "/repo",
+      logger,
+      createController: () => controller,
+    })
+
+    webContents.emit("render-process-gone", {}, { reason })
+
+    expect(controller.hasRecoverableChanges).not.toHaveBeenCalled()
+    expect(controller.maybeRecover).not.toHaveBeenCalled()
+  })
+
+  it("skips recovery when recoverable renderer crashes happen without git changes", () => {
+    const { win, webContents } = makeWindow()
+    const controller = makeController({ hasRecoverableChanges: vi.fn(() => false) })
+
+    setupRendererCrashRecovery(win, "main", {
+      env: { ELECTRON_RENDERER_URL: "http://localhost:5173" },
+      isProd: false,
+      repoRoot: "/repo",
+      logger,
+      createController: () => controller,
+    })
+
+    webContents.emit("render-process-gone", {}, { reason: "crashed" })
+
+    expect(controller.hasRecoverableChanges).toHaveBeenCalledTimes(1)
+    expect(controller.maybeRecover).not.toHaveBeenCalled()
+  })
+
+  it("does not attach listeners outside dev/source mode", () => {
+    const { win, webContents } = makeWindow()
+    const controller = makeController()
+
+    const enabled = setupRendererCrashRecovery(win, "main", {
+      env: {},
+      isProd: false,
+      repoRoot: "/repo",
+      logger,
+      createController: () => controller,
+    })
+
+    expect(enabled).toBe(false)
+    expect(webContents.listenerCount("render-process-gone")).toBe(0)
+    expect(controller.startCleanBaselinePolling).not.toHaveBeenCalled()
+  })
+
+  it("does not attach listeners in production mode even when env is set", () => {
+    const { win, webContents } = makeWindow()
+    const controller = makeController()
+
+    const enabled = setupRendererCrashRecovery(win, "main", {
+      env: { DOTAGENTS_DEV_SELF_RECOVERY: "1" },
+      isProd: true,
+      repoRoot: "/repo",
+      logger,
+      createController: () => controller,
+    })
+
+    expect(enabled).toBe(false)
+    expect(webContents.listenerCount("render-process-gone")).toBe(0)
+    expect(controller.startCleanBaselinePolling).not.toHaveBeenCalled()
+  })
+
+  it("enables only for the explicit recovery env flag or Electron renderer dev URL", () => {
+    expect(isRendererCrashRecoveryEnabled({ env: {}, isProd: false })).toBe(false)
+    expect(isRendererCrashRecoveryEnabled({ env: { DOTAGENTS_DEV_SELF_RECOVERY: "1" }, isProd: false })).toBe(true)
+    expect(isRendererCrashRecoveryEnabled({ env: { ELECTRON_RENDERER_URL: "http://localhost:5173" }, isProd: false })).toBe(true)
+    expect(isRendererCrashRecoveryEnabled({ env: { DOTAGENTS_DEV_SELF_RECOVERY: "1" }, isProd: true })).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/dev-self-recovery/renderer-crash-recovery.ts
+++ b/apps/desktop/src/main/dev-self-recovery/renderer-crash-recovery.ts
@@ -1,0 +1,140 @@
+import { spawnSync } from "child_process"
+import path from "path"
+import type { BrowserWindow } from "electron"
+import {
+  createGitDevSelfRecovery,
+  isRecoverableRendererGoneReason,
+  type GitDevSelfRecoveryController,
+  type GitDevSelfRecoveryLogger,
+} from "./git-recovery"
+
+type BrowserWindowLike = Pick<BrowserWindow, "webContents">
+
+interface RendererCrashRecoveryOptions {
+  env?: Partial<NodeJS.ProcessEnv>
+  isProd?: boolean
+  repoRoot?: string | null
+  logger?: GitDevSelfRecoveryLogger
+  createController?: (repoRoot: string, logger: GitDevSelfRecoveryLogger) => GitDevSelfRecoveryController
+}
+
+let singletonController: GitDevSelfRecoveryController | null = null
+let recoveryInProgress = false
+
+function importMetaProd(): boolean {
+  const meta = import.meta as unknown as { env?: { PROD?: boolean } }
+  return Boolean(meta.env?.PROD)
+}
+
+function prefixedLogger(logger: GitDevSelfRecoveryLogger = console): GitDevSelfRecoveryLogger {
+  return {
+    info: (...args: unknown[]) => logger.info("[renderer-crash-recovery]", ...args),
+    warn: (...args: unknown[]) => logger.warn("[renderer-crash-recovery]", ...args),
+    error: (...args: unknown[]) => logger.error("[renderer-crash-recovery]", ...args),
+  }
+}
+
+function resolveRepoRootFromGit(): string | null {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    windowsHide: true,
+  })
+
+  if (result.status !== 0) return null
+  return path.resolve(result.stdout.trim())
+}
+
+export function resetRendererCrashRecoveryForTests(): void {
+  singletonController?.stopCleanBaselinePolling()
+  singletonController = null
+  recoveryInProgress = false
+}
+
+export function getRendererCrashRecoveryRepoRoot(options: RendererCrashRecoveryOptions = {}): string | null {
+  if (options.repoRoot) return path.resolve(options.repoRoot)
+
+  const env = options.env ?? process.env
+  if (env.DOTAGENTS_DEV_SELF_RECOVERY_REPO_ROOT) {
+    return path.resolve(env.DOTAGENTS_DEV_SELF_RECOVERY_REPO_ROOT)
+  }
+
+  return resolveRepoRootFromGit()
+}
+
+export function isRendererCrashRecoveryEnabled(options: RendererCrashRecoveryOptions = {}): boolean {
+  const env = options.env ?? process.env
+  const isProd = options.isProd ?? importMetaProd()
+
+  if (isProd) return false
+  return env.DOTAGENTS_DEV_SELF_RECOVERY === "1" || Boolean(env.ELECTRON_RENDERER_URL)
+}
+
+function getController(options: RendererCrashRecoveryOptions): GitDevSelfRecoveryController | null {
+  if (singletonController) return singletonController
+
+  const logger = prefixedLogger(options.logger)
+  const repoRoot = getRendererCrashRecoveryRepoRoot(options)
+  if (!repoRoot) {
+    logger.warn("Skipping setup: no git repo root could be resolved")
+    return null
+  }
+
+  singletonController = options.createController
+    ? options.createController(repoRoot, logger)
+    : createGitDevSelfRecovery({ repoRoot, logger })
+  singletonController.startCleanBaselinePolling()
+
+  return singletonController
+}
+
+export function setupRendererCrashRecovery(
+  win: BrowserWindowLike,
+  windowId: string,
+  options: RendererCrashRecoveryOptions = {},
+): boolean {
+  const logger = prefixedLogger(options.logger)
+
+  if (!isRendererCrashRecoveryEnabled(options)) {
+    return false
+  }
+
+  const controller = getController(options)
+  if (!controller) return false
+
+  win.webContents.on("render-process-gone", (_event, details) => {
+    const reason = String(details.reason)
+    if (!isRecoverableRendererGoneReason(reason)) {
+      logger.info(`Ignoring renderer exit for ${windowId}: ${reason}`)
+      return
+    }
+
+    if (recoveryInProgress) {
+      logger.warn(`Ignoring renderer crash for ${windowId}: recovery already in progress`)
+      return
+    }
+
+    if (!controller.hasRecoverableChanges()) {
+      logger.info(`Ignoring renderer crash for ${windowId}: no recoverable git changes`)
+      return
+    }
+
+    recoveryInProgress = true
+    try {
+      const result = controller.maybeRecover({
+        kind: "renderer-process-gone",
+        windowId,
+        reason,
+      })
+
+      if (result.recovered === true) {
+        logger.warn(`Recovered after renderer crash in ${windowId}; backup saved to ${result.backupDir}`)
+      } else {
+        logger.warn(`Renderer crash recovery skipped for ${windowId}: ${result.reason}`)
+      }
+    } finally {
+      recoveryInProgress = false
+    }
+  })
+
+  return true
+}

--- a/apps/desktop/src/main/dev-with-sherpa.test.ts
+++ b/apps/desktop/src/main/dev-with-sherpa.test.ts
@@ -3,12 +3,14 @@ import { pathToFileURL } from "url"
 import { describe, expect, it, vi, afterEach } from "vitest"
 
 import {
+  buildDevEnvironment,
   getDevCommand,
   getSharedWatchCommand,
   getSignalExitCode,
   isDirectExecution,
   terminateChildProcessTree,
 } from "../../scripts/dev-with-sherpa"
+import { pathListHasEntry, shouldRecoverFromChildClose } from "./dev-self-recovery/git-recovery"
 
 describe("dev-with-sherpa launcher helpers", () => {
   afterEach(() => {
@@ -35,6 +37,35 @@ describe("dev-with-sherpa launcher helpers", () => {
     expect(result.command === "pnpm" || result.command === "pnpm.cmd").toBe(true)
     expect(result.args).toEqual(["--filter", "@dotagents/shared", "dev"])
     expect(result.cwd).toContain("dotagents-mono")
+  })
+
+  it("builds the always-on dev self-recovery environment", () => {
+    const env = buildDevEnvironment({ PATH: "/usr/bin" }, [])
+
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.DOTAGENTS_DEV_SELF_RECOVERY).toBe("1")
+    expect(env.DOTAGENTS_DEV_SELF_RECOVERY_REPO_ROOT).toContain("dotagents-mono")
+  })
+
+  it("preserves existing env while adding debug launch args", () => {
+    const env = buildDevEnvironment({ ELECTRON_EXTRA_LAUNCH_ARGS: "--foo" }, ["--debug-app"])
+
+    expect(env.REMOTE_DEBUGGING_PORT).toBe("9333")
+    expect(env.ELECTRON_EXTRA_LAUNCH_ARGS).toBe("--foo --inspect=9339")
+  })
+
+  it("matches full path entries in env path lists", () => {
+    const list = ["/foo/bar-baz", "/foo/bar"].join(path.delimiter)
+
+    expect(pathListHasEntry(list, "/foo/bar")).toBe(true)
+    expect(pathListHasEntry(list, "/foo/bar-ba")).toBe(false)
+  })
+
+  it("only recovers from nonzero child exits without shutdown or signal-only exits", () => {
+    expect(shouldRecoverFromChildClose({ code: 1, signal: null, shutdownSignal: null })).toBe(true)
+    expect(shouldRecoverFromChildClose({ code: 0, signal: null, shutdownSignal: null })).toBe(false)
+    expect(shouldRecoverFromChildClose({ code: null, signal: "SIGTERM", shutdownSignal: null })).toBe(false)
+    expect(shouldRecoverFromChildClose({ code: 1, signal: null, shutdownSignal: "SIGINT" })).toBe(false)
   })
 
   it("detects direct execution when argv[1] is a relative script path", () => {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -16,6 +16,7 @@ import { state, agentProcessManager, suppressPanelAutoShow, isHeadlessMode } fro
 import { calculatePanelPosition } from "./panel-position"
 import { setupConsoleLogger } from "./console-logger"
 import { emergencyStopAll } from "./emergency-stop"
+import { setupRendererCrashRecovery } from "./dev-self-recovery/renderer-crash-recovery"
 
 type WINDOW_ID = "main" | "panel" | "setup"
 
@@ -140,6 +141,7 @@ function createBaseWindow({
   WINDOWS.set(id, win)
 
   setupConsoleLogger(win, id)
+  setupRendererCrashRecovery(win, id)
 
   const _label = id.toUpperCase()
   win.on("show", () => logUI(`[WINDOW ${_label}] show`))


### PR DESCRIPTION
### Motivation
- Fix reliability issues in the development self-recovery flow so recovery works in worktree-style repos, avoids deadlock on stale locks, and preserves untracked symlinks during backups.
- Prevent false-positive matches when adding sherpa native library paths to `DYLD_LIBRARY_PATH`/`LD_LIBRARY_PATH` and provide a more robust dev launcher environment.
- Harden tests against developer-local git hooks/GPG signing to reduce CI/test flakiness.

### Description
- Resolve the git metadata directory dynamically with `git rev-parse --git-dir` and thread a `gitDir` through recovery code so the recovery root no longer assumes `repoRoot/.git` (new/updated `apps/desktop/src/main/dev-self-recovery/git-recovery.ts`).
- Add lock metadata (`pid`, `createdAt`), write the metadata to the lockfile, and reclaim stale locks after a TTL when the owning process is dead (30-minute TTL) to avoid permanent lockouts.
- Preserve symlinks when copying untracked files into backups by using `lstat`/`readlink`/`symlink` instead of always following links with `copyFileSync`.
- Add `pathListHasEntry` helper and switch `dev-with-sherpa` path handling to exact path-list entry checks to avoid substring false-positives when appending sherpa library paths, plus other launcher hardening and helper exports (`apps/desktop/scripts/dev-with-sherpa.ts`).
- Add renderer crash recovery wiring and helpers to attach recovery to renderer process exits and to enable/disable the feature via env/URL heuristics (`apps/desktop/src/main/dev-self-recovery/renderer-crash-recovery.ts`) and call setup from window creation (`apps/desktop/src/main/window.ts`).
- Harden tests by disabling user-level commit signing/hooks for test commits (`-c commit.gpgSign=false` and `--no-verify`) and add tests for the new behaviors (`git-recovery.test.ts`, `dev-with-sherpa.test.ts` updates and new renderer crash tests).

### Testing
- Ran the unit test subset with `pnpm --filter @dotagents/desktop exec vitest run src/main/dev-self-recovery/git-recovery.test.ts src/main/dev-with-sherpa.test.ts` and all tests passed (`23 passed`).
- Ran `pnpm --filter @dotagents/desktop typecheck` which failed in this environment due to workspace module-resolution issues for `@dotagents/shared` / `@dotagents/core` that are unrelated to these edits (typecheck failure is environmental, not caused by the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd0f11306c8330867ce28128b17fb8)