### PR TITLE
[codex] Fix microphone setting persistence across restarts

### DIFF
--- a/apps/desktop/src/renderer/src/hooks/audio-input-device-utils.ts
+++ b/apps/desktop/src/renderer/src/hooks/audio-input-device-utils.ts
@@ -1,9 +1,36 @@
 import type { AudioDeviceInfo } from "./use-audio-devices"
 
-export function getValidatedAudioInputDeviceId(savedDeviceId: string | undefined, inputDevices: AudioDeviceInfo[]) {
+export function hasResolvedAudioInputDeviceLabel(label: string | undefined): boolean {
+  const trimmedLabel = label?.trim() ?? ""
+  if (!trimmedLabel) return false
+  return !(trimmedLabel.startsWith("Microphone (") && trimmedLabel.endsWith(")"))
+}
+
+function normalizeAudioInputDeviceLabel(label: string | undefined): string | undefined {
+  if (!hasResolvedAudioInputDeviceLabel(label)) return undefined
+  return label.trim().toLowerCase()
+}
+
+export function getValidatedAudioInputDeviceId(
+  savedDeviceId: string | undefined,
+  inputDevices: AudioDeviceInfo[],
+  savedDeviceLabel?: string,
+) {
   if (!savedDeviceId || inputDevices.length === 0) {
     return savedDeviceId
   }
 
-  return inputDevices.some((device) => device.deviceId === savedDeviceId) ? savedDeviceId : undefined
+  if (inputDevices.some((device) => device.deviceId === savedDeviceId)) {
+    return savedDeviceId
+  }
+
+  const normalizedSavedLabel = normalizeAudioInputDeviceLabel(savedDeviceLabel)
+  if (!normalizedSavedLabel) return undefined
+
+  const matchingDevices = inputDevices.filter(
+    (device) => normalizeAudioInputDeviceLabel(device.label) === normalizedSavedLabel,
+  )
+  if (matchingDevices.length !== 1) return undefined
+
+  return matchingDevices[0].deviceId
 }

--- a/apps/desktop/src/renderer/src/hooks/use-audio-input-device-fallback.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-audio-input-device-fallback.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { getValidatedAudioInputDeviceId } from "./audio-input-device-utils"
+import {
+  getValidatedAudioInputDeviceId,
+  hasResolvedAudioInputDeviceLabel,
+} from "./audio-input-device-utils"
 
 describe("getValidatedAudioInputDeviceId", () => {
   it("clears an invalid saved microphone when at least one valid input exists", () => {
@@ -21,5 +24,41 @@ describe("getValidatedAudioInputDeviceId", () => {
 
   it("keeps the saved microphone when there are no inputs to validate against", () => {
     expect(getValidatedAudioInputDeviceId("saved-mic", [])).toBe("saved-mic")
+  })
+
+  it("remaps to a matching label when the saved device id rotated", () => {
+    expect(
+      getValidatedAudioInputDeviceId(
+        "old-mic-id",
+        [
+          { deviceId: "new-mic-id", label: "Built-in Microphone", kind: "audioinput" },
+          { deviceId: "usb-mic", label: "USB Mic", kind: "audioinput" },
+        ],
+        "Built-in Microphone",
+      ),
+    ).toBe("new-mic-id")
+  })
+
+  it("does not remap when the saved label is ambiguous", () => {
+    expect(
+      getValidatedAudioInputDeviceId(
+        "old-mic-id",
+        [
+          { deviceId: "mic-a", label: "USB Mic", kind: "audioinput" },
+          { deviceId: "mic-b", label: "USB Mic", kind: "audioinput" },
+        ],
+        "USB Mic",
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe("hasResolvedAudioInputDeviceLabel", () => {
+  it("treats synthetic labels as unresolved", () => {
+    expect(hasResolvedAudioInputDeviceLabel("Microphone (abcd1234)")).toBe(false)
+  })
+
+  it("treats real labels as resolved", () => {
+    expect(hasResolvedAudioInputDeviceLabel("Built-in Microphone")).toBe(true)
   })
 })

--- a/apps/desktop/src/renderer/src/hooks/use-audio-input-device-fallback.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-audio-input-device-fallback.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef } from "react"
 import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/queries"
 import { enumerateAudioDevices, type AudioDeviceInfo } from "./use-audio-devices"
-import { getValidatedAudioInputDeviceId } from "./audio-input-device-utils"
+import {
+  getValidatedAudioInputDeviceId,
+  hasResolvedAudioInputDeviceLabel,
+} from "./audio-input-device-utils"
 
 /**
  * The enumeration is only authoritative once the browser has resolved
@@ -11,15 +14,7 @@ import { getValidatedAudioInputDeviceId } from "./audio-input-device-utils"
  * and overwrite the persisted selection. See issue #303.
  */
 function hasResolvedLabels(devices: AudioDeviceInfo[]): boolean {
-  return devices.some((device) => {
-    const label = device.label?.trim() ?? ""
-    if (!label) return false
-    // `useAudioDevices` synthesizes placeholder labels like
-    // "Microphone (abcd1234)" when the real label is empty — those must
-    // not count as resolved.
-    if (label.startsWith("Microphone (") && label.endsWith(")")) return false
-    return true
-  })
+  return devices.some((device) => hasResolvedAudioInputDeviceLabel(device.label))
 }
 
 export function useAudioInputDeviceFallback() {
@@ -30,6 +25,7 @@ export function useAudioInputDeviceFallback() {
   useEffect(() => {
     const config = configQuery.data
     const savedDeviceId = config?.audioInputDeviceId
+    const savedDeviceLabel = config?.audioInputDeviceLabel
 
     if (!config || !savedDeviceId) {
       lastRepairedDeviceIdRef.current = null
@@ -49,8 +45,21 @@ export function useAudioInputDeviceFallback() {
         const { inputDevices } = await enumerateAudioDevices({ requestLabels: false })
         if (cancelled || inputDevices.length === 0) return
 
-        const validatedDeviceId = getValidatedAudioInputDeviceId(savedDeviceId, inputDevices)
+        const validatedDeviceId = getValidatedAudioInputDeviceId(savedDeviceId, inputDevices, savedDeviceLabel)
         if (validatedDeviceId) {
+          if (validatedDeviceId !== savedDeviceId) {
+            const matchedDevice = inputDevices.find((device) => device.deviceId === validatedDeviceId)
+            lastRepairedDeviceIdRef.current = savedDeviceId
+            saveConfigMutation.mutate({
+              config: {
+                ...config,
+                audioInputDeviceId: validatedDeviceId,
+                audioInputDeviceLabel: matchedDevice?.label,
+              },
+            })
+            return
+          }
+
           lastRepairedDeviceIdRef.current = null
           return
         }
@@ -63,11 +72,19 @@ export function useAudioInputDeviceFallback() {
           return
         }
 
+        // Legacy configs may only have device IDs. Those IDs can rotate between
+        // restarts on some systems, so avoid clearing to default when we have no
+        // stable label to confidently remap against.
+        if (!hasResolvedAudioInputDeviceLabel(savedDeviceLabel)) {
+          return
+        }
+
         lastRepairedDeviceIdRef.current = savedDeviceId
         saveConfigMutation.mutate({
           config: {
             ...config,
             audioInputDeviceId: undefined,
+            audioInputDeviceLabel: undefined,
           },
         })
       } catch {

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -31,6 +31,7 @@ import {
 } from "@shared/key-utils"
 import { RemoteServerSettingsGroups } from "./settings-remote-server"
 import { useAudioDevices } from "@renderer/hooks/use-audio-devices"
+import { hasResolvedAudioInputDeviceLabel } from "@renderer/hooks/audio-input-device-utils"
 
 const SETTINGS_TEXT_SAVE_DEBOUNCE_MS = 400
 const MCP_MAX_ITERATIONS_MIN = 1
@@ -924,8 +925,14 @@ export function Component() {
             <Select
               value={configQuery.data.audioInputDeviceId || "default"}
               onValueChange={(value) => {
+                const selectedInputDevice = audioInputDevices.find((device) => device.deviceId === value)
+                const selectedInputDeviceLabel = hasResolvedAudioInputDeviceLabel(selectedInputDevice?.label)
+                  ? selectedInputDevice?.label
+                  : undefined
+
                 saveConfig({
                   audioInputDeviceId: value === "default" ? undefined : value,
+                  audioInputDeviceLabel: value === "default" ? undefined : selectedInputDeviceLabel,
                 })
               }}
             >

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1093,6 +1093,7 @@ export type Config = {
 
   // Audio Device Selection
   audioInputDeviceId?: string   // Microphone device ID (from enumerateDevices)
+  audioInputDeviceLabel?: string // Last resolved microphone label (used to remap rotated IDs)
   audioOutputDeviceId?: string  // Speaker device ID (from enumerateDevices / setSinkId)
 
   // Text Input Configuration


### PR DESCRIPTION
## Summary
- persist both the selected microphone ID and last resolved label when users choose a microphone in Settings
- remap saved microphone settings by label when `enumerateDevices()` returns a rotated device ID after restart
- only clear saved microphone selection when labels are fully resolved and the saved label can no longer be matched
- add fallback utility tests covering ID match, rotated ID remap, ambiguous labels, and synthetic unresolved labels

## Root Cause
Some environments rotate `mediaDevices` audio input `deviceId` values between app restarts. The startup fallback logic only matched by saved `deviceId`, then cleared config to default when it no longer matched. That made microphone selection appear to reset after every restart.

## Validation
- `pnpm --filter @dotagents/desktop test -- src/renderer/src/hooks/use-audio-input-device-fallback.test.ts --run`
- `pnpm --filter @dotagents/desktop typecheck` *(fails in this branch due pre-existing unrelated `agent-progress.tsx` type errors)*

Fixes #317
