### PR TITLE
[codex] fix desktop React test mocks to preserve export surface

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -237,7 +237,24 @@ async function loadAgentProgress(
     useIsQueuePaused: () => false,
   }
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("../../../shared/runtime-tool-names", () => ({

--- a/apps/desktop/src/renderer/src/components/mcp-config-manager.hydration.test.tsx
+++ b/apps/desktop/src/renderer/src/components/mcp-config-manager.hydration.test.tsx
@@ -120,7 +120,24 @@ async function loadMCPConfigManager(runtime: ReturnType<typeof createHookRuntime
 
   const Null = () => null
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
 
   // Use relative specifiers so the mock key matches the resolved file path even when the

--- a/apps/desktop/src/renderer/src/components/model-selector.custom-input.test.tsx
+++ b/apps/desktop/src/renderer/src/components/model-selector.custom-input.test.tsx
@@ -57,7 +57,24 @@ async function loadModelSelector(runtime: ReturnType<typeof createHookRuntime>, 
     useConfigQuery: () => ({ data: { currentModelPresetId: "default" } }),
   }
   const debugMock = { logUI: vi.fn(), logFocus: vi.fn(), logStateChange: vi.fn(), logRender: vi.fn() }
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("@renderer/components/ui/select", () => selectMock)

--- a/apps/desktop/src/renderer/src/components/session-action-dialog.voice.test.tsx
+++ b/apps/desktop/src/renderer/src/components/session-action-dialog.voice.test.tsx
@@ -45,7 +45,24 @@ async function loadSessionActionDialog(runtime: ReturnType<typeof createHookRunt
   const queryClientMock = { queryClient: { invalidateQueries: vi.fn(async () => undefined) } }
   const storeMock = { useAgentStore: { getState: () => ({ appendUserMessageToSession: vi.fn() }) } }
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("lucide-react", () => ({ Bot: Null, Loader2: Null, Mic: Null, Send: Null }))

--- a/apps/desktop/src/renderer/src/components/text-input-panel.submit.test.tsx
+++ b/apps/desktop/src/renderer/src/components/text-input-panel.submit.test.tsx
@@ -105,7 +105,24 @@ async function loadTextInputPanel(runtime: ReturnType<typeof createHookRuntime>)
     },
   })
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("@renderer/components/ui/textarea", () => ({ Textarea: (props: any) => ({ type: "Textarea", props }) }))

--- a/apps/desktop/src/renderer/src/components/ui/control.test.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/control.test.tsx
@@ -1,7 +1,21 @@
 import React from "react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { Control, ControlLabel } from "./control"
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>()
+  const useContext = () => ""
+  const merged = {
+    ...actual,
+    useContext,
+  } as any
+  merged.default = {
+    ...(actual as any).default,
+    ...merged,
+  }
+  return merged
+})
 
 function renderFunctionComponent<Props>(element: React.ReactElement<Props>) {
   if (typeof element.type !== "function") {

--- a/apps/desktop/src/renderer/src/hooks/use-resizable.persistence.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-resizable.persistence.test.ts
@@ -88,7 +88,24 @@ function createLocalStorage(seed: Record<string, string> = {}) {
 
 async function loadUseResizable(runtime: ReturnType<typeof createHookRuntime>) {
   await vi.resetModules()
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   return import("./use-resizable")
 }
 

--- a/apps/desktop/src/renderer/src/pages/settings-agents.install-handoff.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.install-handoff.test.tsx
@@ -46,7 +46,24 @@ async function loadSettingsAgents(runtime: ReturnType<typeof createHookRuntime>,
     return ""
   }
   runtime.reactMock.default = runtime.reactMock
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react-router-dom", () => ({ useNavigate: () => vi.fn(), useSearchParams: () => [currentSearchParams, setSearchParams] }))

--- a/apps/desktop/src/renderer/src/pages/settings-discord.review-comments.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-discord.review-comments.test.tsx
@@ -161,7 +161,24 @@ async function loadSettingsDiscord(runtime: ReturnType<typeof createHookRuntime>
     discordDefaultProfileId: undefined,
   }
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("@renderer/components/ui/control", () => ({

--- a/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
@@ -159,6 +159,7 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
     Control: (props: any) => ({ type: "Control", props }),
     ControlGroup: (props: any) => props.children,
     ControlLabel: (props: any) => props.label,
+    SettingsSearchContext: { Provider: PassThrough },
   }
   const inputMock = { Input: (props: any) => ({ type: "Input", props }) }
   const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
@@ -169,7 +170,24 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   const ttsManagerMock = { ttsManager: { stopAll: vi.fn() } }
   const tipcClientMock = { tipcClient: { getAgentsFolders: vi.fn(async () => ({})), getExternalAgents: vi.fn(async () => []) } }
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react-router-dom", () => ({ useNavigate: () => vi.fn() }))
@@ -195,7 +213,7 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   vi.doMock("@renderer/lib/tipc-client", () => tipcClientMock)
   vi.doMock("../lib/tipc-client", () => tipcClientMock)
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null }))
+  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null, Search: Null }))
   vi.doMock("@dotagents/shared", () => ({ __esModule: true, STT_PROVIDER_ID: {}, SUPPORTED_LANGUAGES: [] }))
   vi.doMock("@shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))
   vi.doMock("../shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))

--- a/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
@@ -13,12 +13,15 @@ function createHookRuntime() {
       states[idx] = typeof update === "function" ? (update as (prev: T) => T)(states[idx]) : update
     }) as StateSetter<T>] as const
   }
+  const forwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
 
   const reactMock: any = {
     __esModule: true,
     default: {} as any,
     useState,
     useCallback: (fn: any) => fn,
+    forwardRef,
+    useEffect: () => undefined,
   }
   reactMock.default = reactMock
 
@@ -93,20 +96,34 @@ async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) 
   vi.doMock("react", () => runtime.reactMock)
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
-  vi.doMock("@renderer/components/ui/button", () => ({ Button: (props: any) => ({ type: "Button", props }) }))
-  vi.doMock("@renderer/components/ui/input", () => ({ Input: (props: any) => ({ type: "Input", props }) }))
-  vi.doMock("@renderer/components/ui/label", () => ({ Label: (props: any) => ({ type: "Label", props }) }))
-  vi.doMock("@renderer/components/ui/switch", () => ({ Switch: (props: any) => ({ type: "Switch", props }) }))
-  vi.doMock("@renderer/components/ui/textarea", () => ({ Textarea: (props: any) => ({ type: "Textarea", props }) }))
-  vi.doMock("@renderer/components/ui/card", () => ({
+  const buttonMock = { Button: (props: any) => ({ type: "Button", props }) }
+  const inputMock = { Input: (props: any) => ({ type: "Input", props }) }
+  const labelMock = { Label: (props: any) => ({ type: "Label", props }) }
+  const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
+  const textareaMock = { Textarea: (props: any) => ({ type: "Textarea", props }) }
+  const cardMock = {
     Card: (props: any) => ({ type: "Card", props }),
     CardContent: (props: any) => ({ type: "CardContent", props }),
     CardDescription: (props: any) => ({ type: "CardDescription", props }),
     CardHeader: (props: any) => ({ type: "CardHeader", props }),
     CardTitle: (props: any) => ({ type: "CardTitle", props }),
-  }))
-  vi.doMock("@renderer/components/ui/badge", () => ({ Badge: (props: any) => ({ type: "Badge", props }) }))
-  vi.doMock("@renderer/lib/tipc-client", () => ({
+  }
+  const badgeMock = { Badge: (props: any) => ({ type: "Badge", props }) }
+  vi.doMock("@renderer/components/ui/button", () => buttonMock)
+  vi.doMock("../components/ui/button", () => buttonMock)
+  vi.doMock("@renderer/components/ui/input", () => inputMock)
+  vi.doMock("../components/ui/input", () => inputMock)
+  vi.doMock("@renderer/components/ui/label", () => labelMock)
+  vi.doMock("../components/ui/label", () => labelMock)
+  vi.doMock("@renderer/components/ui/switch", () => switchMock)
+  vi.doMock("../components/ui/switch", () => switchMock)
+  vi.doMock("@renderer/components/ui/textarea", () => textareaMock)
+  vi.doMock("../components/ui/textarea", () => textareaMock)
+  vi.doMock("@renderer/components/ui/card", () => cardMock)
+  vi.doMock("../components/ui/card", () => cardMock)
+  vi.doMock("@renderer/components/ui/badge", () => badgeMock)
+  vi.doMock("../components/ui/badge", () => badgeMock)
+  const tipcClientModule = {
     tipcClient: {
       getLoops: vi.fn(async () => []),
       getLoopStatuses: vi.fn(async () => []),
@@ -117,12 +134,16 @@ async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) 
       triggerLoop: vi.fn(async () => ({ success: true })),
       openLoopTaskFile: vi.fn(async () => ({ success: true })),
     },
-  }))
+  }
+  vi.doMock("@renderer/lib/tipc-client", () => tipcClientModule)
+  vi.doMock("../lib/tipc-client", () => tipcClientModule)
   vi.doMock("@tanstack/react-query", () => ({
     useQuery: ({ queryKey }: any) => ({ data: queryKey?.[0] === "loops" ? [] : [] }),
     useQueryClient: () => ({ invalidateQueries }),
   }))
-  vi.doMock("@renderer/lib/utils", () => ({ cn: (...values: Array<string | undefined | false | null>) => values.filter(Boolean).join(" ") }))
+  const utilsMock = { cn: (...values: Array<string | undefined | false | null>) => values.filter(Boolean).join(" ") }
+  vi.doMock("@renderer/lib/utils", () => utilsMock)
+  vi.doMock("../lib/utils", () => utilsMock)
   vi.doMock("lucide-react", () => ({ Trash2: Null, Plus: Null, Edit2: Null, Save: Null, X: Null, Play: Null, Clock: Null, FileText: Null }))
   vi.doMock("sonner", () => ({ toast: { success, error } }))
 
@@ -168,7 +189,9 @@ describe("desktop repeat-task interval editing", () => {
 
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
     findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "" } })
 
     tree = runtime.render(Component, {} as any)
@@ -187,7 +210,9 @@ describe("desktop repeat-task interval editing", () => {
 
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
     findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "60" } })
 
     tree = runtime.render(Component, {} as any)

--- a/apps/desktop/src/renderer/src/pages/settings-whatsapp.allowlist.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-whatsapp.allowlist.test.tsx
@@ -150,7 +150,24 @@ async function loadSettingsWhatsApp(runtime: ReturnType<typeof createHookRuntime
     streamerModeEnabled: false,
   }
 
-  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("react")>()
+    const fallbackForwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
+    const fallbackUseContext = (context: { _currentValue?: unknown; _currentValue2?: unknown }) =>
+      context?._currentValue ?? context?._currentValue2 ?? null
+    const fallbackUseMemo = <T,>(factory: () => T) => factory()
+    const fallbackUseCallback = <T extends (...args: any[]) => any>(callback: T) => callback
+    const merged = {
+      ...actual,
+      ...runtime.reactMock,
+      forwardRef: runtime.reactMock.forwardRef ?? fallbackForwardRef,
+      useContext: runtime.reactMock.useContext ?? fallbackUseContext,
+      useMemo: runtime.reactMock.useMemo ?? fallbackUseMemo,
+      useCallback: runtime.reactMock.useCallback ?? fallbackUseCallback,
+    } as any
+    merged.default = merged
+    return merged
+  })
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("@renderer/components/ui/control", () => ({


### PR DESCRIPTION
## Summary
- fix desktop renderer tests that mocked `react` with partial surfaces by merging each local runtime mock with `importOriginal("react")`
- add safe fallback shims for `forwardRef`, `useContext`, `useMemo`, and `useCallback` in those merged mocks so custom hook runtimes keep working
- update `control.test.tsx` to mock `useContext` in direct function-invocation assertions and keep the suite aligned with `SettingsSearchContext`
- update `settings-loops.interval-draft.test.tsx` to include required mock exports (`forwardRef`, `useEffect`) and resolve alias/relative mock paths; adjust event sequencing to reflect render cycles

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/agent-progress.response-history.test.ts src/renderer/src/components/mcp-config-manager.hydration.test.tsx src/renderer/src/components/model-selector.custom-input.test.tsx src/renderer/src/components/session-action-dialog.voice.test.tsx src/renderer/src/components/text-input-panel.submit.test.tsx src/renderer/src/components/ui/control.test.tsx src/renderer/src/hooks/use-resizable.persistence.test.ts src/renderer/src/pages/settings-agents.install-handoff.test.tsx src/renderer/src/pages/settings-discord.review-comments.test.tsx src/renderer/src/pages/settings-general.langfuse-draft.test.tsx src/renderer/src/pages/settings-loops.interval-draft.test.tsx src/renderer/src/pages/settings-whatsapp.allowlist.test.tsx`
- `pnpm --filter @dotagents/desktop test:run` (full suite still has unrelated baseline failures, but `forwardRef/useContext` React-mock signature failures are gone and total failures dropped from 49 to 46 in this workspace run)

Closes #315
