### PR TITLE
Improve agent context efficiency in agent runs

### DIFF
--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -9,6 +9,7 @@ const {
   mockConfig: {
     mcpContextReductionEnabled: true,
     mcpContextTargetRatio: 0.5,
+    mcpContextAbsoluteTokenCap: 16000,
     mcpContextLastNMessages: 3,
     mcpContextSummarizeCharThreshold: 2000,
     mcpMaxContextTokensOverride: 1200,
@@ -84,6 +85,8 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearArchiveFrontier('session-actual-scale')
     clearArchiveFrontier('session-bracket-log')
     clearArchiveFrontier('session-no-microcompact')
+    clearArchiveFrontier('session-absolute-cap')
+    clearArchiveFrontier('session-protected-retruncate')
     clearContextRefs('session-truncate')
     clearContextRefs('session-batch')
     clearContextRefs('session-archive')
@@ -92,6 +95,8 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearContextRefs('session-actual-scale')
     clearContextRefs('session-bracket-log')
     clearContextRefs('session-no-microcompact')
+    clearContextRefs('session-absolute-cap')
+    clearContextRefs('session-protected-retruncate')
     clearActualTokenUsage('session-truncate')
     clearActualTokenUsage('session-batch')
     clearActualTokenUsage('session-archive')
@@ -100,6 +105,8 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearActualTokenUsage('session-actual-scale')
     clearActualTokenUsage('session-bracket-log')
     clearActualTokenUsage('session-no-microcompact')
+    clearActualTokenUsage('session-absolute-cap')
+    clearActualTokenUsage('session-protected-retruncate')
     clearIterativeSummary('session-archive')
     clearIterativeSummary('session-live-tail')
     clearIterativeSummary('session-protected-tail')
@@ -107,6 +114,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     Object.assign(mockConfig, {
       mcpContextReductionEnabled: true,
       mcpContextTargetRatio: 0.5,
+      mcpContextAbsoluteTokenCap: 16000,
       mcpContextLastNMessages: 3,
       mcpContextSummarizeCharThreshold: 2000,
       mcpMaxContextTokensOverride: 1200,
@@ -250,6 +258,58 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(result.appliedStrategies).not.toContain('aggressive_truncate')
     expect(result.messages.find((msg) => msg.content.includes('[OUTPUT TRUNCATED:'))?.content).toContain('456-TAIL')
     expect(makeTextCompletionWithFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('re-truncates very large already-truncated runtime tool output', async () => {
+    const runtimeTruncatedHuge = [
+      '[server:shell] {',
+      '  "stdout": "HEAD-' + 'a'.repeat(7000),
+      '... [OUTPUT TRUNCATED: 25000 bytes, ~500 lines total. Showing first 5000 + last 5000 chars.] ...',
+      'TAIL-' + 'b'.repeat(7000) + '",',
+      '  "outputTruncated": true',
+      '}',
+    ].join('\n')
+
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-protected-retruncate',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'inspect this result' },
+        { role: 'user', content: runtimeTruncatedHuge },
+      ],
+    })
+
+    expect(result.appliedStrategies).toContain('aggressive_truncate')
+    const retruncatedMessage = result.messages.find((msg) => msg.content.includes('Large tool result truncated for context management'))
+    expect(retruncatedMessage).toBeTruthy()
+    expect(retruncatedMessage?.content).toContain('HEAD-')
+    expect(retruncatedMessage?.content).toContain('"outputTruncated": true')
+    expect(makeTextCompletionWithFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('honors the absolute context target token cap on large-context models', async () => {
+    makeTextCompletionWithFetchMock.mockResolvedValue('compressed')
+    Object.assign(mockConfig, {
+      mcpContextTargetRatio: 0.9,
+      mcpContextAbsoluteTokenCap: 4000,
+      mcpMaxContextTokensOverride: undefined,
+      mcpToolsProviderId: 'openai',
+      mcpToolsOpenaiModel: 'gpt-5.4',
+    })
+
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-absolute-cap',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'Original task request' },
+        { role: 'assistant', content: 'a'.repeat(12000) },
+        { role: 'assistant', content: 'b'.repeat(12000) },
+        { role: 'user', content: 'latest follow up' },
+      ],
+    })
+
+    expect(result.appliedStrategies.length).toBeGreaterThan(0)
+    expect(result.estTokensAfter).toBeLessThanOrEqual(4000)
   })
 
   it('keeps actual-token scaling after aggressive truncation and preserves the original budget baseline', async () => {

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -931,8 +931,12 @@ interface SummaryBatch {
 const TOOL_TRUNCATE_MARKER = "[Large tool result truncated for context management. If more detail is needed, re-run the tool with narrower input or inspect the source directly.]"
 const PAYLOAD_TRUNCATE_MARKER = "[Large payload truncated for context management. Keep only the most relevant leading content here and fetch narrower details if needed.]"
 const EXTERNAL_TOOL_TRUNCATE_MARKERS = ["[OUTPUT TRUNCATED:", "[truncated]"]
+const DEFAULT_CONTEXT_TARGET_TOKEN_CAP = 16_000
+const MIN_CONTEXT_TARGET_TOKENS = 512
 const AGGRESSIVE_TRUNCATE_THRESHOLD = 5000
 const AGGRESSIVE_TRUNCATE_KEEP_CHARS = 4000
+const PROTECTED_MESSAGE_RETRUNCATE_THRESHOLD = 12_000
+const PROTECTED_MESSAGE_RETRUNCATE_KEEP_CHARS = 3_000
 const TOOL_RESULT_TRUNCATE_THRESHOLD = 4000
 const TOOL_RESULT_KEEP_CHARS = 2400
 const TOOL_RESULT_TRUNCATE_TRIGGER_TOKEN_RATIO = 0.8
@@ -1423,7 +1427,18 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     return { messages: opts.messages, appliedStrategies: [], estTokensBefore: est, estTokensAfter: est, maxTokens }
   }
   const maxTokens = await getMaxContextTokens(providerId, model)
-  const targetTokens = Math.floor(maxTokens * targetRatio)
+  const configuredAbsoluteTargetCap = config.mcpContextAbsoluteTokenCap
+  const absoluteTargetCap = typeof configuredAbsoluteTargetCap === "number" && Number.isFinite(configuredAbsoluteTargetCap) && configuredAbsoluteTargetCap > 0
+    ? Math.floor(configuredAbsoluteTargetCap)
+    : DEFAULT_CONTEXT_TARGET_TOKEN_CAP
+  const ratioTargetTokens = Math.floor(maxTokens * targetRatio)
+  const targetTokens = Math.max(
+    1,
+    Math.min(
+      maxTokens,
+      Math.max(MIN_CONTEXT_TARGET_TOKENS, Math.min(ratioTargetTokens, absoluteTargetCap)),
+    ),
+  )
 
   let messages = [...opts.messages]
   const estimatedTokensBefore = estimateTokensFromMessages(messages)
@@ -1499,7 +1514,10 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i]
     if (msg.role === "system" || !msg.content) continue
-    if (isTruncationProtectedMessage(msg)) continue
+    const isProtected = isTruncationProtectedMessage(msg)
+    const shouldRetruncateProtectedMessage = isProtected
+      && msg.content.length > PROTECTED_MESSAGE_RETRUNCATE_THRESHOLD
+    if (isProtected && !shouldRetruncateProtectedMessage) continue
 
     const isPayloadLike = isLikelyPayloadLikeMessage(msg)
 
@@ -1508,13 +1526,21 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
 
     const shouldTruncateToolResult = isToolResultLike
       && msg.content.length > TOOL_RESULT_TRUNCATE_THRESHOLD
-      && tokens > Math.floor(targetTokens * TOOL_RESULT_TRUNCATE_TRIGGER_TOKEN_RATIO)
+      && (
+        tokens > Math.floor(targetTokens * TOOL_RESULT_TRUNCATE_TRIGGER_TOKEN_RATIO)
+        || shouldRetruncateProtectedMessage
+      )
     const shouldAggressivelyTruncatePayload = isPayloadLike && msg.content.length > AGGRESSIVE_TRUNCATE_THRESHOLD
+    const shouldRetruncateProtectedPayload = shouldRetruncateProtectedMessage && !isToolResultLike
 
-    if (!shouldTruncateToolResult && !shouldAggressivelyTruncatePayload) continue
+    if (!shouldTruncateToolResult && !shouldAggressivelyTruncatePayload && !shouldRetruncateProtectedPayload) continue
 
     const marker = isToolResultLike ? TOOL_TRUNCATE_MARKER : PAYLOAD_TRUNCATE_MARKER
-    const keepChars = isToolResultLike ? TOOL_RESULT_KEEP_CHARS : AGGRESSIVE_TRUNCATE_KEEP_CHARS
+    const keepChars = isToolResultLike
+      ? TOOL_RESULT_KEEP_CHARS
+      : shouldRetruncateProtectedMessage
+        ? PROTECTED_MESSAGE_RETRUNCATE_KEEP_CHARS
+        : AGGRESSIVE_TRUNCATE_KEEP_CHARS
     const { toolName } = parseToolNameFromContent(msg.content)
     const contextRef = registerContextRef(opts.sessionId, {
       kind: isToolResultLike ? "truncated_tool" : "truncated_payload",

--- a/apps/desktop/src/main/convergence-controller.test.ts
+++ b/apps/desktop/src/main/convergence-controller.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { ConvergenceController, assessToolBatch, classifyToolCall } from "./convergence-controller"
+
+describe("convergence-controller", () => {
+  it("classifies read-only execute_command batches as research", () => {
+    expect(classifyToolCall({
+      name: "execute_command",
+      arguments: { command: "cd repo && pwd && find . -maxdepth 2 -type f | sed -n '1,120p'" },
+    } as any)).toBe("research")
+  })
+
+  it("classifies build/test execute_command batches as validation", () => {
+    expect(classifyToolCall({
+      name: "execute_command",
+      arguments: { command: "cd repo && pnpm test" },
+    } as any)).toBe("validation")
+  })
+
+  it("distinguishes communication-only and research-only tool batches", () => {
+    expect(assessToolBatch([
+      { name: "respond_to_user", arguments: { text: "Hello" } },
+    ] as any)).toEqual(expect.objectContaining({
+      communicationOnly: true,
+      researchOnly: false,
+      substantive: false,
+    }))
+
+    expect(assessToolBatch([
+      { name: "load_skill_instructions", arguments: { skillId: "video-editing" } },
+      { name: "read_more_context", arguments: { contextRef: "ctx_abc", mode: "overview" } },
+    ] as any)).toEqual(expect.objectContaining({
+      communicationOnly: false,
+      researchOnly: true,
+      substantive: false,
+    }))
+  })
+
+  it("blocks repeated research-only batches after the configured budget", () => {
+    const controller = new ConvergenceController({
+      maxConsecutiveResearchTurns: 2,
+      maxBlockedResearchBatches: 2,
+    })
+    const researchBatch = [
+      { name: "load_skill_instructions", arguments: { skillId: "video-editing" } },
+    ] as any
+
+    controller.recordSuccessfulToolBatch(researchBatch)
+    controller.recordSuccessfulToolBatch(researchBatch)
+
+    const firstBlock = controller.evaluateResearchBatch(researchBatch)
+    expect(firstBlock).toEqual(expect.objectContaining({
+      allowExecution: false,
+      shouldForceStop: false,
+    }))
+
+    const secondBlock = controller.evaluateResearchBatch(researchBatch)
+    expect(secondBlock).toEqual(expect.objectContaining({
+      allowExecution: false,
+      shouldForceStop: true,
+    }))
+  })
+
+  it("resets the research budget after substantive work", () => {
+    const controller = new ConvergenceController({
+      maxConsecutiveResearchTurns: 1,
+      maxBlockedResearchBatches: 1,
+    })
+    const researchBatch = [
+      { name: "load_skill_instructions", arguments: { skillId: "video-editing" } },
+    ] as any
+
+    controller.recordSuccessfulToolBatch(researchBatch)
+    controller.resetResearchBudget()
+
+    expect(controller.evaluateResearchBatch(researchBatch)).toEqual(expect.objectContaining({
+      allowExecution: true,
+      shouldForceStop: false,
+    }))
+  })
+})
+

--- a/apps/desktop/src/main/convergence-controller.ts
+++ b/apps/desktop/src/main/convergence-controller.ts
@@ -1,0 +1,172 @@
+import type { MCPToolCall } from "./mcp-service"
+
+export type ToolProgressCategory =
+  | "research"
+  | "execution"
+  | "validation"
+  | "communication"
+  | "completion"
+  | "meta"
+
+export interface ToolBatchAssessment {
+  categories: ToolProgressCategory[]
+  communicationOnly: boolean
+  researchOnly: boolean
+  substantive: boolean
+}
+
+export interface ResearchBudgetPolicy {
+  maxConsecutiveResearchTurns: number
+  maxBlockedResearchBatches: number
+}
+
+export interface ResearchBudgetDecision {
+  allowExecution: boolean
+  shouldForceStop: boolean
+  nudge?: string
+}
+
+const DEFAULT_POLICY: ResearchBudgetPolicy = {
+  maxConsecutiveResearchTurns: 6,
+  maxBlockedResearchBatches: 3,
+}
+
+const READ_ONLY_SHELL_COMMAND_RE = /\b(pwd|ls|find|rg|sed|head|tail|cat|wc|jq|git status|git diff|git show|echo|printf)\b/i
+const WRITE_SHELL_INDICATOR_RE = /(^|[;&|]\s*)\s*(mkdir|touch|rm|mv|cp|tee|chmod|chown)\b|(^|[;&|]\s*)\s*git\s+(commit|push|checkout|switch|merge|rebase|apply|stash|tag)\b|(^|[;&|]\s*)\s*(pnpm|npm|yarn|bun)\s+(install|add|remove|update|upgrade|build|test|lint|typecheck)\b|(^|[;&|]\s*)\s*remotion\s+render\b|(^|[;&|]\s*)\s*ffmpeg\b|(^|[;&|]\s*)\s*python\d*\s+[^\n<]|(^|[;&|]\s*)\s*node\s+[^\n<]|(^|[;&|]\s*)\s*perl\s+/i
+const VALIDATION_SHELL_INDICATOR_RE = /(^|[;&|]\s*)\s*(pnpm|npm|yarn|bun)\s+.*\b(test|lint|typecheck|build)\b|(^|[;&|]\s*)\s*(vitest|jest|playwright(?:\s+test)?|cypress|eslint|tsc)\b/i
+
+function getExecuteCommandString(toolCall: MCPToolCall): string | undefined {
+  if (toolCall.name !== "execute_command") return undefined
+  if (!toolCall.arguments || typeof toolCall.arguments !== "object" || Array.isArray(toolCall.arguments)) {
+    return undefined
+  }
+  const command = (toolCall.arguments as Record<string, unknown>).command
+  return typeof command === "string" ? command : undefined
+}
+
+function isReadOnlyExecuteCommand(command: string): boolean {
+  const normalized = command.trim()
+  if (!normalized) return false
+  if (VALIDATION_SHELL_INDICATOR_RE.test(normalized)) return false
+  if (WRITE_SHELL_INDICATOR_RE.test(normalized)) return false
+  return READ_ONLY_SHELL_COMMAND_RE.test(normalized)
+}
+
+export function classifyToolCall(toolCall: MCPToolCall): ToolProgressCategory {
+  switch (toolCall.name) {
+    case "respond_to_user":
+      return "communication"
+    case "mark_work_complete":
+      return "completion"
+    case "load_skill_instructions":
+    case "read_more_context":
+      return "research"
+    case "set_session_title":
+    case "list_running_agents":
+    case "list_server_tools":
+    case "get_tool_schema":
+    case "list_available_agents":
+    case "check_agent_status":
+      return "meta"
+    case "delegate_to_agent":
+    case "spawn_agent":
+    case "send_to_agent":
+      return "execution"
+    case "execute_command": {
+      const command = getExecuteCommandString(toolCall)
+      if (!command) return "execution"
+      if (VALIDATION_SHELL_INDICATOR_RE.test(command)) return "validation"
+      return isReadOnlyExecuteCommand(command) ? "research" : "execution"
+    }
+    default:
+      return "execution"
+  }
+}
+
+export function assessToolBatch(toolCalls: MCPToolCall[]): ToolBatchAssessment {
+  const categories = toolCalls.map(classifyToolCall)
+  const communicationOnly = categories.every((category) => category === "communication")
+  const researchOnly = categories.every((category) => category === "research" || category === "meta")
+  const substantive = categories.some(
+    (category) => category === "execution" || category === "validation" || category === "completion",
+  )
+
+  return {
+    categories,
+    communicationOnly,
+    researchOnly,
+    substantive,
+  }
+}
+
+export class ConvergenceController {
+  private readonly policy: ResearchBudgetPolicy
+  private consecutiveResearchTurns = 0
+  private blockedResearchBatches = 0
+
+  constructor(policy: Partial<ResearchBudgetPolicy> = {}) {
+    this.policy = {
+      ...DEFAULT_POLICY,
+      ...policy,
+    }
+  }
+
+  evaluateResearchBatch(toolCalls: MCPToolCall[]): ResearchBudgetDecision {
+    const assessment = assessToolBatch(toolCalls)
+    if (!assessment.researchOnly) {
+      return { allowExecution: true, shouldForceStop: false }
+    }
+
+    if (this.consecutiveResearchTurns < this.policy.maxConsecutiveResearchTurns) {
+      return { allowExecution: true, shouldForceStop: false }
+    }
+
+    this.blockedResearchBatches += 1
+
+    if (this.blockedResearchBatches >= this.policy.maxBlockedResearchBatches) {
+      return {
+        allowExecution: false,
+        shouldForceStop: true,
+        nudge: "Research budget exhausted. Stop gathering more context and either (1) make the highest-leverage change now, (2) provide the best concrete answer you can from the information already gathered, or (3) explain the remaining blocker. Do not load more skills, inspect more references, or call more read-only tools.",
+      }
+    }
+
+    return {
+      allowExecution: false,
+      shouldForceStop: false,
+      nudge: "You have enough context. Do not call more read-only tools, load more skills, or inspect more references right now. Use the information already gathered to make a concrete change, produce a concrete plan, or deliver the user-facing answer.",
+    }
+  }
+
+  recordSuccessfulToolBatch(toolCalls: MCPToolCall[]): void {
+    const assessment = assessToolBatch(toolCalls)
+    if (assessment.researchOnly) {
+      this.consecutiveResearchTurns += 1
+      return
+    }
+
+    if (assessment.substantive || assessment.communicationOnly) {
+      this.resetResearchBudget()
+    }
+  }
+
+  recordFailedToolBatch(toolCalls: MCPToolCall[]): void {
+    const assessment = assessToolBatch(toolCalls)
+    if (!assessment.researchOnly) {
+      this.resetResearchBudget()
+    }
+  }
+
+  resetResearchBudget(): void {
+    this.consecutiveResearchTurns = 0
+    this.blockedResearchBatches = 0
+  }
+
+  getState() {
+    return {
+      consecutiveResearchTurns: this.consecutiveResearchTurns,
+      blockedResearchBatches: this.blockedResearchBatches,
+    }
+  }
+}
+

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -257,6 +257,51 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
     expect(mocks.makeLLMCallWithFetch).toHaveBeenCalledTimes(1)
   })
 
+  it("stores one tool transcript entry per tool call instead of one giant merged blob", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+
+    mocks.makeLLMCallWithStreamingAndTools
+      .mockResolvedValueOnce({
+        content: "",
+        toolCalls: [
+          { name: "execute_command", arguments: { command: "pwd" } },
+          { name: "execute_command", arguments: { command: "ls" } },
+        ],
+      })
+      .mockResolvedValueOnce({
+        content: "",
+        toolCalls: [{ name: "mark_work_complete", arguments: { summary: "Captured tool output" } }],
+      })
+
+    const result = await processTranscriptWithAgentMode(
+      "Inspect the workspace",
+      availableTools as any,
+      makeExecuteToolCall("session-command", 1, {
+        execute_command: (toolCall: any) => ({
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ success: true, command: toolCall.arguments.command }),
+          }],
+          isError: false,
+        }),
+      }),
+      3,
+      [],
+      "conv-command",
+      "session-command",
+      undefined,
+      undefined,
+      1,
+    )
+
+    const executeToolMessages = result.conversationHistory.filter((message) =>
+      message.role === "tool" && message.content.includes("[execute_command]")
+    )
+    expect(executeToolMessages).toHaveLength(2)
+    expect(executeToolMessages[0]?.content).toContain("\"command\":\"pwd\"")
+    expect(executeToolMessages[1]?.content).toContain("\"command\":\"ls\"")
+  })
+
   it("keeps the internal completion nudge ephemeral across resumed runs", async () => {
     const { processTranscriptWithAgentMode } = await import("./llm")
 

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -548,7 +548,7 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
     const secondPrompt = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[1]?.[0] ?? [])
       .map((message: any) => message.content)
       .join("\n")
-    expect(secondPrompt).toContain("[respond_to_user]")
+    expect(secondPrompt).toContain("Completion criteria not met.")
     expect(secondPrompt.split("First interim answer").length - 1).toBe(0)
   })
 

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -118,6 +118,7 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       "session-resume",
       "session-resume-followup",
       "session-command",
+      "session-printf-failure",
       "session-tool-error",
       "session-blank-response",
       "session-review-loop",
@@ -402,6 +403,68 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
     expect(secondPrompt).toContain("Invalid execute_command.skillId: aj47/dotagents-mono")
     expect(secondPrompt).toContain("Retry the same command without skillId")
     expect(secondPrompt).toContain("Do not use repo names, file paths, URLs, or GitHub slugs as skillId")
+  })
+
+  it("keeps execute_command failure attempts scoped to the command signature", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+
+    mocks.makeLLMCallWithStreamingAndTools
+      .mockResolvedValueOnce({
+        content: "",
+        toolCalls: [
+          { name: "execute_command", arguments: { command: "printf '--- ROOT ---\\n'" } },
+        ],
+      })
+      .mockResolvedValueOnce({
+        content: "",
+        toolCalls: [
+          { name: "execute_command", arguments: { command: "printf '--- PACKAGE ---\\n'" } },
+        ],
+      })
+      .mockResolvedValueOnce({
+        content: "",
+        toolCalls: [
+          { name: "respond_to_user", arguments: { text: "Switched to safer shell labels." } },
+          { name: "mark_work_complete", arguments: { summary: "Recovered from shell label errors" } },
+        ],
+      })
+
+    await processTranscriptWithAgentMode(
+      "Inspect the repo",
+      availableTools as any,
+      makeExecuteToolCall("session-printf-failure", 1, {
+        execute_command: (toolCall: any) => ({
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({
+              success: false,
+              command: toolCall.arguments.command,
+              error: "printf: --: invalid option",
+              retrySuggestion: "Retry with echo '--- LABEL ---', printf -- '--- LABEL ---\\n', or printf '%s\\n' '--- LABEL ---'.",
+            }, null, 2),
+          }],
+          isError: true,
+        }),
+      }),
+      5,
+      [],
+      "conv-printf-failure",
+      "session-printf-failure",
+      undefined,
+      undefined,
+      1,
+    )
+
+    const secondPrompt = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[1]?.[0] ?? [])
+      .map((message: any) => message.content)
+      .join("\n")
+    expect(secondPrompt).toContain("bare printf strings that start with '-'")
+
+    const thirdPrompt = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[2]?.[0] ?? [])
+      .map((message: any) => message.content)
+      .join("\n")
+    expect(thirdPrompt).toContain("TOOL FAILED: execute_command (attempt 1/3)")
+    expect(thirdPrompt).not.toContain("TOOL FAILED: execute_command (attempt 2/3)")
   })
 
   it("routes failed communication-only tool batches through error recovery before retrying", async () => {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -2663,18 +2663,15 @@ export async function processTranscriptWithAgentMode(
         return result
       })
 
-      // Format tool results with tool name prefix for better context preservation
-      // Format: [toolName] content... or [toolName] ERROR: content...
-      const toolResultsText = resultsWithPlaceholders
-        .map((result, i) => {
-          const toolName = toolCallsArray[i]?.name || 'unknown'
-          const content = result.content.map((c) => c.text).join("\n")
-          const prefix = result.isError ? `[${toolName}] ERROR: ` : `[${toolName}] `
-          return `${prefix}${content}`
-        })
-        .join("\n\n")
-
-      addMessage("tool", toolResultsText, undefined, resultsWithPlaceholders)
+      // Preserve one tool result per message so context budgeting can compact each
+      // payload independently (instead of carrying one giant concatenated blob).
+      for (let i = 0; i < resultsWithPlaceholders.length; i++) {
+        const result = resultsWithPlaceholders[i]
+        const toolName = toolCallsArray[i]?.name || "unknown"
+        const content = result.content.map((c) => c.text).join("\n")
+        const prefix = result.isError ? `[${toolName}] ERROR: ` : `[${toolName}] `
+        addMessage("tool", `${prefix}${content}`, undefined, [result])
+      }
     }
 
     latestMaterializedUserResponse = materializePendingUserResponses()

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -223,6 +223,36 @@ function isInvalidExecuteCommandSkillIdFailure(toolName: string | undefined, res
     || (errorText.includes("skill not found") && errorText.includes("omit skillid"))
 }
 
+function isExecuteCommandPrintfOptionFailure(toolName: string | undefined, result: MCPToolResult): boolean {
+  if (toolName !== "execute_command" || !result.isError) return false
+
+  const errorText = result.content
+    .map((content) => content.text)
+    .join(" ")
+    .toLowerCase()
+
+  return errorText.includes("printf: --: invalid option")
+}
+
+function getExecuteCommandFailureSignature(toolCall: MCPToolCall | undefined): string | undefined {
+  if (!toolCall || toolCall.name !== "execute_command") return undefined
+
+  const args = toolCall.arguments
+  if (!args || typeof args !== "object" || Array.isArray(args)) return undefined
+
+  const command = (args as Record<string, unknown>).command
+  if (typeof command !== "string") return undefined
+
+  const normalized = command.trim().replace(/\s+/g, " ")
+  return normalized ? normalized.slice(0, 240) : undefined
+}
+
+function getToolFailureKey(toolCall: MCPToolCall | undefined): string {
+  const toolName = toolCall?.name || "unknown"
+  const executeCommandSignature = getExecuteCommandFailureSignature(toolCall)
+  return executeCommandSignature ? `${toolName}::${executeCommandSignature}` : toolName
+}
+
 export async function postProcessTranscript(transcript: string) {
   const config = configStore.get()
 
@@ -1598,11 +1628,9 @@ export async function processTranscriptWithAgentMode(
   // research run with many legitimate "not done yet" verifier verdicts safe,
   // because every successful tool call breaks the failure streak.
   let verificationFailCount = 0
-  // Track *consecutive* failures per tool name. The counter resets to 0 the
-  // next time that specific tool succeeds, so a tool that fails twice while the
-  // agent iterates on its arguments and then succeeds is fully reinstated. This
-  // is critical for experiment-style flows where the agent legitimately needs
-  // to retry the same tool with progressively refined inputs.
+  // Track *consecutive* failures per tool. For execute_command we scope the
+  // counter to the command signature so unrelated shell mistakes do not all
+  // look like repeated retries of the same failing command.
   const toolFailureCount = new Map<string, number>()
   const MAX_TOOL_FAILURES = 3 // Max consecutive failures of a tool before excluding it
   let lastExcludedToolCount = 0 // Track previous excluded count to avoid unnecessary system prompt rebuilds
@@ -1615,6 +1643,7 @@ export async function processTranscriptWithAgentMode(
     // Filter out tools that have failed too many times - compute at start of iteration
     // so the same filtered list is used consistently throughout (LLM call + heuristics)
     const activeTools = baseAvailableTools.filter((tool) => {
+      if (tool.name === "execute_command") return true
       const failures = toolFailureCount.get(tool.name) || 0
       return failures < MAX_TOOL_FAILURES
     })
@@ -2368,7 +2397,7 @@ export async function processTranscriptWithAgentMode(
 
     // Execute tool calls with enhanced error handling
     const toolResults: MCPToolResult[] = []
-    const failedTools: string[] = []
+    const failedTools: Array<{ toolCall: MCPToolCall; result: MCPToolResult }> = []
 
     // Add assistant response with tool calls to conversation history BEFORE executing tools
     // This ensures the tool call request is visible immediately in the UI
@@ -2495,11 +2524,11 @@ export async function processTranscriptWithAgentMode(
         toolsExecutedInSession = true
         garbledToolCallCount = 0 // Reset on successful tool execution
         if (execResult.result.isError) {
-          failedTools.push(execResult.toolCall.name)
+          failedTools.push({ toolCall: execResult.toolCall, result: execResult.result })
         } else {
           // Reset the consecutive-failure counter for this specific tool on
           // success so the agent gets a fresh budget after recovering.
-          toolFailureCount.delete(execResult.toolCall.name)
+          toolFailureCount.delete(getToolFailureKey(execResult.toolCall))
         }
       }
 
@@ -2597,7 +2626,9 @@ export async function processTranscriptWithAgentMode(
 
         // Track failed tools for better error reporting
         if (execResult.result.isError) {
-          failedTools.push(toolCall.name)
+          failedTools.push({ toolCall, result: execResult.result })
+        } else {
+          toolFailureCount.delete(getToolFailureKey(toolCall))
         }
 
         // Update tool call step with result
@@ -2731,18 +2762,29 @@ export async function processTranscriptWithAgentMode(
           "For execute_command, omit skillId unless you are using an exact skill id from Available Skills. Do not use repo names, file paths, URLs, or GitHub slugs as skillId. Retry the same command without skillId unless you explicitly need a skill directory."
         )
       }
+      const hasExecuteCommandPrintfOptionError = toolResults.some((result, index) =>
+        isExecuteCommandPrintfOptionFailure(toolCallsArray[index]?.name, result)
+      )
+      if (hasExecuteCommandPrintfOptionError) {
+        addEphemeralMessage(
+          "user",
+          "For execute_command under bash, do not use bare printf strings that start with '-'. Use echo '--- LABEL ---', printf -- '--- LABEL ---\\n', or printf '%s\\n' '--- LABEL ---' instead."
+        )
+      }
 
       // Track per-tool failures
       for (let i = 0; i < toolResults.length; i++) {
         const result = toolResults[i]
         if (result.isError) {
           // Get the tool name from toolCallsArray by index
-          const toolName = toolCallsArray[i]?.name || "unknown"
-          const currentCount = toolFailureCount.get(toolName) || 0
-          toolFailureCount.set(toolName, currentCount + 1)
+          const toolCall = toolCallsArray[i]
+          const toolName = toolCall?.name || "unknown"
+          const failureKey = getToolFailureKey(toolCall)
+          const currentCount = toolFailureCount.get(failureKey) || 0
+          toolFailureCount.set(failureKey, currentCount + 1)
 
           if (currentCount + 1 >= MAX_TOOL_FAILURES) {
-            logLLM(`⚠️ Tool "${toolName}" has failed ${MAX_TOOL_FAILURES} times - will be excluded`)
+            logLLM(`⚠️ Tool "${toolName}" has failed ${MAX_TOOL_FAILURES} times for the current failure signature`)
           }
         }
       }
@@ -2782,11 +2824,11 @@ export async function processTranscriptWithAgentMode(
 
       // Add clean error summary to conversation history for LLM context
       const errorSummary = failedTools
-        .map((toolName, idx) => {
-          const failedResult = toolResults.filter((r) => r.isError)[idx]
-          const rawError = failedResult?.content.map((c) => c.text).join(" ") || "Unknown error"
+        .map(({ toolCall, result }) => {
+          const toolName = toolCall.name
+          const rawError = result.content.map((c) => c.text).join(" ") || "Unknown error"
           const cleanedError = cleanErrorMessage(rawError)
-          const failureCount = toolFailureCount.get(toolName) || 1
+          const failureCount = toolFailureCount.get(getToolFailureKey(toolCall)) || 1
           return `TOOL FAILED: ${toolName} (attempt ${failureCount}/${MAX_TOOL_FAILURES})\nError: ${cleanedError}`
         })
         .join("\n\n")

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -67,6 +67,8 @@ import {
 } from "./llm-continuation-guards"
 import { buildVerificationMessagesFromAgentState } from "./llm-verification-replay"
 import { loadWorkingKnowledgeNotesForPrompt } from "./working-notes-runtime"
+import { ConvergenceController, assessToolBatch } from "./convergence-controller"
+import { buildModelReplayMessages } from "./model-replay"
 import {
   normalizeAgentConversationState,
   type AgentConversationState,
@@ -1310,26 +1312,9 @@ export async function processTranscriptWithAgentMode(
   const mapConversationToMessages = (
     addSummaryPrompt: boolean = false
   ): Array<{ role: "user" | "assistant"; content: string }> => {
-    const mapped = conversationHistory
-      .map((entry) => {
-        const rawContent = typeof entry.content === "string" ? entry.content : ""
-        const content = sanitizeMessageContentForDisplay(rawContent).trim()
-        if (!content) return null
-
-        if (entry.role === "tool") {
-          // Tool results already contain tool name prefix (format: [toolName] content...)
-          // Just pass through without adding generic "Tool execution results:" wrapper
-          return { role: "user" as const, content }
-        }
-
-        return { role: entry.role as "user" | "assistant", content }
-      })
-      .filter(Boolean) as Array<{ role: "user" | "assistant"; content: string }>
+    const mapped = buildModelReplayMessages(conversationHistory, { addSummaryPrompt })
 
     // Add summary prompt if last message is from assistant (ensures LLM has something to respond to)
-    if (addSummaryPrompt && mapped.length > 0 && mapped[mapped.length - 1].role === "assistant") {
-      mapped.push({ role: "user", content: "Please provide a brief summary of what was accomplished." })
-    }
     return mapped
   }
 
@@ -1635,6 +1620,7 @@ export async function processTranscriptWithAgentMode(
   const MAX_TOOL_FAILURES = 3 // Max consecutive failures of a tool before excluding it
   let lastExcludedToolCount = 0 // Track previous excluded count to avoid unnecessary system prompt rebuilds
   let cachedSystemPrompt: string | undefined // Cached rebuilt prompt when tools are excluded
+  const convergenceController = new ConvergenceController()
 
   while (iteration < maxIterations) {
     iteration++
@@ -1724,40 +1710,7 @@ export async function processTranscriptWithAgentMode(
     // Build messages for LLM call
     const messages = [
       { role: "system", content: currentSystemPrompt },
-      ...conversationHistory
-        .map((entry) => {
-          const rawContent = typeof entry.content === "string" ? entry.content : ""
-          const sanitizedContent = sanitizeMessageContentForDisplay(rawContent)
-
-          if (entry.role === "tool") {
-            const text = sanitizedContent.trim()
-            if (!text) return null
-            // Tool results already contain tool name prefix (format: [toolName] content...)
-            // Pass through directly without adding redundant wrapper
-            return {
-              role: "user" as const,
-              content: text,
-            }
-          }
-          // Skip empty assistant tool-call placeholders entirely when replaying history.
-          // Re-injecting synthetic text like "[Calling tools: ...]" into the prompt can
-          // cause the model to parrot that placeholder back as garbled tool-call text and
-          // answer our internal recovery nudges instead of the user's actual request.
-          if (entry.role === "assistant" && !sanitizedContent.trim()) {
-            return null
-          }
-
-          if (entry.role === "assistant" && entry.skipModelReplay) {
-            return null
-          }
-
-          const content = sanitizedContent
-          return {
-            role: entry.role as "user" | "assistant",
-            content,
-          }
-        })
-        .filter(Boolean as any),
+      ...buildModelReplayMessages(conversationHistory),
     ]
 
     // Apply context budget management before the agent LLM call
@@ -2040,6 +1993,7 @@ export async function processTranscriptWithAgentMode(
     // Don't treat mark_work_complete as confirmed completion yet.
     // We defer completion until after tool execution confirms the whole batch succeeded.
     const hasToolCalls = toolCallsArray.length > 0
+    const toolBatchAssessment = hasToolCalls ? assessToolBatch(toolCallsArray) : undefined
     let onlyCommunicationTools = false
 
     // Handle no-op iterations (no tool calls).
@@ -2371,21 +2325,53 @@ export async function processTranscriptWithAgentMode(
         break
       }
     } else {
-      // Check if the only tools called are communication-only (respond_to_user).
-      // These don't represent real work progress — they're just the agent talking to the user.
-      // If respond_to_user is called without mark_work_complete, don't reset the completion
-      // counters; otherwise the agent can loop indefinitely: text → nudge → respond_to_user
-      // (resets counters) → text → nudge → respond_to_user → … (#respond-to-user-spam)
-      const COMMUNICATION_ONLY_TOOLS = new Set([RESPOND_TO_USER_TOOL])
-      onlyCommunicationTools = toolCallsArray.every(tc => COMMUNICATION_ONLY_TOOLS.has(tc.name))
+      // Communication-only batches are not substantive task progress.
+      onlyCommunicationTools = toolBatchAssessment?.communicationOnly ?? false
+      const toolCallResponseText = llmResponse.content || ""
+      const trimmedToolCallResponseText = toolCallResponseText.trim()
 
       if (onlyCommunicationTools) {
         // Communication-only batches are explicit user-facing updates, not proof of
         // task completion. Keep the no-op counters moving so the runtime can nudge
         // the model to either continue working or explicitly mark the task complete.
         noOpCount++
+      } else if (toolBatchAssessment?.researchOnly) {
+        const researchDecision = convergenceController.evaluateResearchBatch(toolCallsArray)
+        if (!researchDecision.allowExecution) {
+          if (trimmedToolCallResponseText.length > 0) {
+            addMessage("assistant", toolCallResponseText)
+          }
+          addEphemeralMessage(
+            "user",
+            researchDecision.nudge || "Use the information already gathered to act or answer. Do not gather more context right now.",
+          )
+          noOpCount++
+          if (researchDecision.shouldForceStop) {
+            finalContent = buildIncompleteTaskFallback(toolCallResponseText, {
+              reason: "Research budget exhausted before the agent converged on an implementation or final answer.",
+            })
+            addMessage("assistant", finalContent)
+            emit({
+              currentIteration: iteration,
+              maxIterations,
+              steps: progressSteps.slice(-3),
+              isComplete: true,
+              conversationState: "blocked",
+              finalContent,
+              conversationHistory: formatConversationForProgress(conversationHistory),
+            })
+            break
+          }
+          continue
+        }
+
+        // Limited research batches are allowed, but they should not reset the
+        // stuck/nudge counters — otherwise endless read-only inspection looks
+        // like meaningful progress and the loop never converges.
+        noOpCount++
       } else {
         // Real work tools: full counter reset
+        convergenceController.resetResearchBudget()
         noOpCount = 0
         // Reset nudge count when tools are actually being used - this allows
         // nudging to work per "stuck segment" rather than globally across the run.
@@ -2742,6 +2728,11 @@ export async function processTranscriptWithAgentMode(
     // said "still more work to do" several times before the agent finished.
     if (allToolsSuccessful) {
       verificationFailCount = 0
+      if (toolBatchAssessment) {
+        convergenceController.recordSuccessfulToolBatch(toolCallsArray)
+      }
+    } else if (toolBatchAssessment) {
+      convergenceController.recordFailedToolBatch(toolCallsArray)
     }
 
     // Deferred completion signal: only treat mark_work_complete as a completion signal

--- a/apps/desktop/src/main/model-replay.test.ts
+++ b/apps/desktop/src/main/model-replay.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+
+import { buildModelReplayMessages } from "./model-replay"
+
+describe("model-replay", () => {
+  it("collapses split tool results into a single replay user message", () => {
+    const replay = buildModelReplayMessages([
+      {
+        role: "user",
+        content: "Inspect the repo",
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { name: "respond_to_user", arguments: { text: "Working on it" } },
+          { name: "execute_command", arguments: { command: "pwd" } },
+          { name: "execute_command", arguments: { command: "ls" } },
+        ] as any,
+      },
+      {
+        role: "tool",
+        content: "",
+        toolResults: [
+          { isError: false, content: [{ type: "text", text: "ok" }] },
+        ] as any,
+      },
+      {
+        role: "tool",
+        content: "",
+        toolResults: [
+          { isError: false, content: [{ type: "text", text: JSON.stringify({ success: true, command: "pwd", stdout: "/repo" }) }] },
+        ] as any,
+      },
+      {
+        role: "tool",
+        content: "",
+        toolResults: [
+          { isError: false, content: [{ type: "text", text: JSON.stringify({ success: true, command: "ls", stdout: "file.ts" }) }] },
+        ] as any,
+      },
+    ] as any)
+
+    expect(replay).toHaveLength(2)
+    expect(replay[0]).toEqual({ role: "user", content: "Inspect the repo" })
+    expect(replay[1]?.role).toBe("user")
+    expect(replay[1]?.content).toContain("[execute_command] command: pwd")
+    expect(replay[1]?.content).toContain("[execute_command] command: ls")
+    expect(replay[1]?.content).not.toContain("respond_to_user")
+  })
+
+  it("keeps internal nudges and omits skipModelReplay assistant entries", () => {
+    const replay = buildModelReplayMessages([
+      {
+        role: "user",
+        content: "real user",
+      },
+      {
+        role: "user",
+        content: "Please finish the parent task.",
+      },
+      {
+        role: "assistant",
+        content: "hidden assistant",
+        skipModelReplay: true,
+      },
+      {
+        role: "assistant",
+        content: "visible assistant",
+      },
+    ] as any)
+
+    expect(replay).toEqual([
+      { role: "user", content: "real user" },
+      { role: "user", content: "Please finish the parent task." },
+      { role: "assistant", content: "visible assistant" },
+    ])
+  })
+
+  it("adds the summary prompt on demand after the replay assistant tail", () => {
+    const replay = buildModelReplayMessages([
+      { role: "user", content: "Do the thing" },
+      { role: "assistant", content: "Done." },
+    ] as any, { addSummaryPrompt: true })
+
+    expect(replay[2]).toEqual({
+      role: "user",
+      content: "Please provide a brief summary of what was accomplished.",
+    })
+  })
+})

--- a/apps/desktop/src/main/model-replay.ts
+++ b/apps/desktop/src/main/model-replay.ts
@@ -1,0 +1,257 @@
+import type { MCPToolCall, MCPToolResult } from "./mcp-service"
+import { assessToolBatch } from "./convergence-controller"
+import { sanitizeMessageContentForDisplay } from "@dotagents/shared"
+
+type ConversationEntry = {
+  role: "user" | "assistant" | "tool"
+  content: string
+  toolCalls?: MCPToolCall[]
+  toolResults?: MCPToolResult[]
+  ephemeral?: boolean
+  skipModelReplay?: boolean
+}
+
+type ReplayMessage = {
+  role: "user" | "assistant"
+  content: string
+}
+
+function truncateReplayText(content: string, maxChars: number, preserveTail: boolean = true): string {
+  const trimmed = content.trim()
+  if (trimmed.length <= maxChars) return trimmed
+  if (!preserveTail || maxChars < 160) {
+    return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`
+  }
+
+  const headChars = Math.ceil(maxChars * 0.67)
+  const tailChars = Math.max(80, maxChars - headChars)
+  const head = trimmed.slice(0, headChars).trimEnd()
+  const tail = trimmed.slice(trimmed.length - tailChars).trimStart()
+  return `${head}\n\n[replay truncated]\n\n${tail}`
+}
+
+function extractContextRefs(content: string): string[] {
+  return Array.from(new Set(content.match(/Context ref:\s*ctx_[a-z0-9]+/gi) ?? []))
+}
+
+function tryParseJsonPayload(content: string): Record<string, unknown> | null {
+  const sanitized = content
+    .replace(/\n?Context ref:\s*ctx_[a-z0-9]+\s*$/gi, "")
+    .trim()
+
+  if (!sanitized.startsWith("{") || !sanitized.endsWith("}")) return null
+
+  try {
+    const parsed = JSON.parse(sanitized)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+function compactExecuteCommandResult(content: string): string {
+  const parsed = tryParseJsonPayload(content)
+  if (!parsed) {
+    return truncateReplayText(content, 1200)
+  }
+
+  const lines: string[] = []
+  const command = typeof parsed.command === "string" ? parsed.command : ""
+  if (command) {
+    lines.push(`command: ${truncateReplayText(command, 220, false)}`)
+  }
+
+  const success = parsed.success === true
+  const outputTruncated = parsed.outputTruncated === true
+
+  if (!success) {
+    const errorText = typeof parsed.error === "string"
+      ? parsed.error
+      : typeof parsed.stderr === "string"
+        ? parsed.stderr
+        : content
+    lines.push(`error: ${truncateReplayText(errorText, 900)}`)
+  } else {
+    const stdout = typeof parsed.stdout === "string" ? parsed.stdout : ""
+    const stderr = typeof parsed.stderr === "string" ? parsed.stderr : ""
+    if (stdout.trim()) {
+      lines.push(`stdout: ${truncateReplayText(stdout, 1000)}`)
+    }
+    if (stderr.trim()) {
+      lines.push(`stderr: ${truncateReplayText(stderr, 400)}`)
+    }
+    if (outputTruncated) {
+      lines.push("output: [truncated]")
+    }
+  }
+
+  const retrySuggestion = typeof parsed.retrySuggestion === "string" ? parsed.retrySuggestion : ""
+  if (retrySuggestion.trim()) {
+    lines.push(`retry: ${truncateReplayText(retrySuggestion, 220, false)}`)
+  }
+
+  const hint = typeof parsed.hint === "string" ? parsed.hint : ""
+  if (hint.trim()) {
+    lines.push(`hint: ${truncateReplayText(hint, 220, false)}`)
+  }
+
+  const refs = extractContextRefs(content)
+  if (refs.length > 0) {
+    lines.push(...refs)
+  }
+
+  return lines.join("\n").trim()
+}
+
+function compactReadMoreContextResult(content: string): string {
+  const parsed = tryParseJsonPayload(content)
+  if (!parsed) return truncateReplayText(content, 900)
+
+  const lines: string[] = []
+  if (typeof parsed.mode === "string") lines.push(`mode: ${parsed.mode}`)
+  if (typeof parsed.query === "string" && parsed.query.trim()) lines.push(`query: ${truncateReplayText(parsed.query, 140, false)}`)
+  if (typeof parsed.preview === "string" && parsed.preview.trim()) lines.push(`preview: ${truncateReplayText(parsed.preview, 500)}`)
+  if (typeof parsed.excerpt === "string" && parsed.excerpt.trim()) lines.push(`excerpt: ${truncateReplayText(parsed.excerpt, 700)}`)
+  if (Array.isArray(parsed.matches) && parsed.matches.length > 0) {
+    const first = parsed.matches[0] as Record<string, unknown>
+    if (typeof first.excerpt === "string") {
+      lines.push(`match: ${truncateReplayText(first.excerpt, 700)}`)
+    }
+  }
+  const refs = extractContextRefs(content)
+  if (refs.length > 0) lines.push(...refs)
+  return lines.join("\n").trim()
+}
+
+function compactToolReplayText(toolName: string, result: MCPToolResult | undefined): string {
+  if (!result) return "[pending]"
+
+  const joined = result.content.map((item) => item.text).join("\n").trim()
+  if (!joined) {
+    return result.isError ? "[error]" : "[no output]"
+  }
+
+  let compacted: string
+  if (toolName === "execute_command") {
+    compacted = compactExecuteCommandResult(joined)
+  } else if (toolName === "read_more_context") {
+    compacted = compactReadMoreContextResult(joined)
+  } else if (toolName === "load_skill_instructions") {
+    compacted = truncateReplayText(joined, 1200)
+  } else {
+    compacted = truncateReplayText(joined, 1000)
+  }
+
+  return compacted
+}
+
+function compactToolBatchReplay(
+  toolCalls: MCPToolCall[],
+  toolResults: Array<MCPToolResult | undefined>,
+): string | null {
+  const assessment = assessToolBatch(toolCalls)
+  const lines: string[] = []
+
+  for (let i = 0; i < toolCalls.length; i++) {
+    const toolCall = toolCalls[i]
+    const toolName = toolCall.name
+
+    // Completion-only tools should be represented by their materialized assistant
+    // messages rather than replayed as raw tool control chatter.
+    if (assessment.communicationOnly || toolName === "respond_to_user" || toolName === "mark_work_complete" || toolName === "set_session_title") {
+      continue
+    }
+
+    const replayText = compactToolReplayText(toolName, toolResults[i])
+    if (!replayText) continue
+    lines.push(`[${toolName}] ${replayText}`)
+  }
+
+  return lines.length > 0 ? lines.join("\n\n") : null
+}
+
+export function buildModelReplayMessages(
+  history: ConversationEntry[],
+  options: { addSummaryPrompt?: boolean } = {},
+): ReplayMessage[] {
+  const replayMessages: ReplayMessage[] = []
+
+  for (let i = 0; i < history.length; i++) {
+    const entry = history[i]
+    const rawContent = typeof entry.content === "string" ? entry.content : ""
+    const sanitizedContent = sanitizeMessageContentForDisplay(rawContent).trim()
+
+    if (entry.role === "assistant" && entry.skipModelReplay) continue
+
+    if (entry.role === "assistant" && entry.toolCalls && entry.toolCalls.length > 0) {
+      if (sanitizedContent.length > 0) {
+        replayMessages.push({ role: "assistant", content: sanitizedContent })
+      }
+
+      const collectedResults: Array<MCPToolResult | undefined> = []
+      let consumedToolMessages = 0
+      let resultMessageIndex = i + 1
+
+      while (
+        resultMessageIndex < history.length &&
+        history[resultMessageIndex].role === "tool" &&
+        collectedResults.length < entry.toolCalls.length
+      ) {
+        const toolEntry = history[resultMessageIndex]
+        if (toolEntry.toolResults && toolEntry.toolResults.length > 0) {
+          collectedResults.push(...toolEntry.toolResults)
+        } else {
+          collectedResults.push(undefined)
+        }
+        consumedToolMessages += 1
+        resultMessageIndex += 1
+      }
+
+      while (collectedResults.length < entry.toolCalls.length) {
+        collectedResults.push(undefined)
+      }
+
+      const replayToolBatch = compactToolBatchReplay(entry.toolCalls, collectedResults.slice(0, entry.toolCalls.length))
+      if (replayToolBatch) {
+        replayMessages.push({ role: "user", content: replayToolBatch })
+      }
+
+      if (consumedToolMessages > 0) {
+        i += consumedToolMessages
+      }
+      continue
+    }
+
+    if (entry.role === "tool") {
+      if (entry.toolResults?.length) {
+        const replayToolBatch = compactToolBatchReplay(
+          entry.toolResults.map(() => ({ name: "tool_result_passthrough", arguments: {} })),
+          entry.toolResults,
+        )
+        if (replayToolBatch) {
+          replayMessages.push({ role: "user", content: replayToolBatch })
+        }
+      } else if (sanitizedContent) {
+        replayMessages.push({
+          role: "user",
+          content: truncateReplayText(sanitizedContent, 1200),
+        })
+      }
+      continue
+    }
+
+    if (!sanitizedContent) continue
+    replayMessages.push({
+      role: entry.role,
+      content: sanitizedContent,
+    })
+  }
+
+  if (options.addSummaryPrompt && replayMessages.length > 0 && replayMessages[replayMessages.length - 1].role === "assistant") {
+    replayMessages.push({ role: "user", content: "Please provide a brief summary of what was accomplished." })
+  }
+
+  return replayMessages
+}

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -3025,6 +3025,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         mcpUnlimitedIterations: cfg.mcpUnlimitedIterations ?? true,
         // Tool Execution
         mcpContextReductionEnabled: cfg.mcpContextReductionEnabled ?? true,
+        mcpContextAbsoluteTokenCap: cfg.mcpContextAbsoluteTokenCap ?? 16000,
         mcpToolResponseProcessingEnabled: cfg.mcpToolResponseProcessingEnabled ?? true,
         mcpParallelToolExecution: cfg.mcpParallelToolExecution ?? true,
         // Remote Server
@@ -3248,6 +3249,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       // Tool Execution
       if (typeof body.mcpContextReductionEnabled === "boolean") {
         updates.mcpContextReductionEnabled = body.mcpContextReductionEnabled
+      }
+      if (typeof body.mcpContextAbsoluteTokenCap === "number" && Number.isFinite(body.mcpContextAbsoluteTokenCap) && body.mcpContextAbsoluteTokenCap > 0) {
+        updates.mcpContextAbsoluteTokenCap = Math.floor(body.mcpContextAbsoluteTokenCap)
       }
       if (typeof body.mcpToolResponseProcessingEnabled === "boolean") {
         updates.mcpToolResponseProcessingEnabled = body.mcpToolResponseProcessingEnabled

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -206,6 +206,10 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
           type: "string",
           description: "Exact skill id from the Available Skills list, e.g. \"api-testing\".",
         },
+        forceReload: {
+          type: "boolean",
+          description: "Reload full instructions even if this skill was already loaded in the current session.",
+        },
       },
       required: ["skillId"],
     },

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -210,6 +210,10 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
           type: "boolean",
           description: "Reload full instructions even if this skill was already loaded in the current session.",
         },
+        reason: {
+          type: "string",
+          description: "Short explanation of why a reload is necessary after the skill was already loaded in this session.",
+        },
       },
       required: ["skillId"],
     },

--- a/apps/desktop/src/main/runtime-tools.execute-command.test.ts
+++ b/apps/desktop/src/main/runtime-tools.execute-command.test.ts
@@ -185,5 +185,18 @@ describe("runtime-tools execute_command", () => {
     }))
     expect(payload.error).toContain("planning/context question")
   })
-})
 
+  it("adds a targeted hint for bash printf labels that start with dashes", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool("execute_command", {
+      command: "printf '--- ROOT ---\\n'",
+    })
+
+    expect(result?.isError).toBe(true)
+    const payload = JSON.parse(String(result?.content[0]?.text))
+    expect(payload.error).toContain("printf: --: invalid option")
+    expect(payload.error).toContain("Use echo '--- LABEL ---'")
+    expect(payload.retrySuggestion).toContain("printf -- '--- LABEL ---\\n'")
+    expect(payload.retrySuggestion).toContain("printf '%s\\n' '--- LABEL ---'")
+  })
+})

--- a/apps/desktop/src/main/runtime-tools.execute-command.test.ts
+++ b/apps/desktop/src/main/runtime-tools.execute-command.test.ts
@@ -186,17 +186,27 @@ describe("runtime-tools execute_command", () => {
     expect(payload.error).toContain("planning/context question")
   })
 
-  it("adds a targeted hint for bash printf labels that start with dashes", async () => {
+  it("rewrites bash printf labels that start with dashes into a safe form", async () => {
     const { executeRuntimeTool } = await import("./runtime-tools")
     const result = await executeRuntimeTool("execute_command", {
-      command: "printf '--- ROOT ---\\n'",
+      command: "printf '--- ROOT ---\\n' && printf '\\n--- FILES ---\\n'",
     })
 
-    expect(result?.isError).toBe(true)
+    expect(result?.isError).toBe(false)
     const payload = JSON.parse(String(result?.content[0]?.text))
-    expect(payload.error).toContain("printf: --: invalid option")
-    expect(payload.error).toContain("Use echo '--- LABEL ---'")
-    expect(payload.retrySuggestion).toContain("printf -- '--- LABEL ---\\n'")
-    expect(payload.retrySuggestion).toContain("printf '%s\\n' '--- LABEL ---'")
+    expect(payload.command).toContain("printf '%s\\n' '--- ROOT ---'")
+    expect(payload.command).toContain("printf '\\n%s\\n' '--- FILES ---'")
+    expect(payload.normalizedPrintfLabels).toEqual([
+      {
+        from: "printf '--- ROOT ---\\n'",
+        to: "printf '%s\\n' '--- ROOT ---'",
+      },
+      {
+        from: "printf '\\n--- FILES ---\\n'",
+        to: "printf '\\n%s\\n' '--- FILES ---'",
+      },
+    ])
+    expect(String(payload.stdout)).toContain("--- ROOT ---")
+    expect(String(payload.stdout)).toContain("--- FILES ---")
   })
 })

--- a/apps/desktop/src/main/runtime-tools.load-skill.test.ts
+++ b/apps/desktop/src/main/runtime-tools.load-skill.test.ts
@@ -80,13 +80,27 @@ describe("runtime-tools load_skill_instructions", () => {
     await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-2")
     const reloaded = await executeRuntimeTool(
       "load_skill_instructions",
-      { skillId: "video-editing", forceReload: true },
+      { skillId: "video-editing", forceReload: true, reason: "Need the full rules again after scope changed" },
       "session-2",
     )
 
     expect(reloaded?.isError).toBe(false)
     expect(String(reloaded?.content?.[0]?.text)).toContain("## Video Editing")
     expect(String(reloaded?.content?.[0]?.text)).not.toContain("Skill already loaded in this session")
+  })
+
+  it("requires a reason before force reloading an already loaded skill", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+
+    await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-5")
+    const blockedReload = await executeRuntimeTool(
+      "load_skill_instructions",
+      { skillId: "video-editing", forceReload: true },
+      "session-5",
+    )
+
+    expect(blockedReload?.isError).toBe(false)
+    expect(String(blockedReload?.content?.[0]?.text)).toContain("pass both {\"forceReload\": true} and a short {\"reason\": \"...\"}")
   })
 
   it("keeps skill load state isolated per session", async () => {
@@ -100,4 +114,3 @@ describe("runtime-tools load_skill_instructions", () => {
     expect(String(otherSessionLoad?.content?.[0]?.text)).not.toContain("Skill already loaded in this session")
   })
 })
-

--- a/apps/desktop/src/main/runtime-tools.load-skill.test.ts
+++ b/apps/desktop/src/main/runtime-tools.load-skill.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockGetSkill = vi.fn()
+const mockGetSkills = vi.fn()
+const mockGetAppSessionForAcpSession = vi.fn()
+
+vi.mock("./mcp-service", () => ({
+  mcpService: { getAvailableTools: vi.fn(() => []) },
+}))
+
+vi.mock("./agent-session-tracker", () => ({
+  agentSessionTracker: { getSession: vi.fn(), getActiveSessions: vi.fn(() => []) },
+}))
+
+vi.mock("./state", () => ({
+  agentSessionStateManager: { getSessionRunId: vi.fn(() => 1) },
+  toolApprovalManager: {},
+}))
+
+vi.mock("./emergency-stop", () => ({ emergencyStopAll: vi.fn() }))
+vi.mock("./acp/acp-router-tools", () => ({ executeACPRouterTool: vi.fn(), isACPRouterTool: vi.fn(() => false) }))
+vi.mock("./message-queue-service", () => ({ messageQueueService: {} }))
+vi.mock("./session-user-response-store", () => ({ appendSessionUserResponse: vi.fn() }))
+vi.mock("./conversation-service", () => ({ conversationService: {} }))
+vi.mock("./context-budget", () => ({ readMoreContext: vi.fn() }))
+vi.mock("./acp-session-state", () => ({
+  getAppSessionForAcpSession: mockGetAppSessionForAcpSession,
+  setAcpSessionTitleOverride: vi.fn(),
+}))
+vi.mock("./skills-service", () => ({
+  skillsService: {
+    getSkill: mockGetSkill,
+    getSkills: mockGetSkills,
+    upgradeGitHubSkillToLocal: vi.fn(),
+  },
+}))
+
+describe("runtime-tools load_skill_instructions", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockGetAppSessionForAcpSession.mockImplementation((sessionId: string) => `app-${sessionId}`)
+    mockGetSkill.mockImplementation((skillId: string) => {
+      if (skillId === "video-editing") {
+        return {
+          id: "video-editing",
+          name: "video-editing",
+          description: "Video editing skill",
+          instructions: "## Video Editing\nUse remotion best practices.",
+        }
+      }
+      return undefined
+    })
+    mockGetSkills.mockReturnValue([
+      {
+        id: "video-editing",
+        name: "video-editing",
+        description: "Video editing skill",
+        instructions: "## Video Editing\nUse remotion best practices.",
+      },
+    ])
+  })
+
+  it("returns a compact already-loaded response for repeated loads in the same session", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+
+    const first = await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-1")
+    expect(first?.isError).toBe(false)
+    expect(String(first?.content?.[0]?.text)).toContain("## Video Editing")
+
+    const second = await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-1")
+    expect(second?.isError).toBe(false)
+    expect(String(second?.content?.[0]?.text)).toContain("Skill already loaded in this session")
+    expect(String(second?.content?.[0]?.text)).toContain("\"forceReload\": true")
+  })
+
+  it("reloads full instructions when forceReload is true", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+
+    await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-2")
+    const reloaded = await executeRuntimeTool(
+      "load_skill_instructions",
+      { skillId: "video-editing", forceReload: true },
+      "session-2",
+    )
+
+    expect(reloaded?.isError).toBe(false)
+    expect(String(reloaded?.content?.[0]?.text)).toContain("## Video Editing")
+    expect(String(reloaded?.content?.[0]?.text)).not.toContain("Skill already loaded in this session")
+  })
+
+  it("keeps skill load state isolated per session", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+
+    await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-3")
+    const otherSessionLoad = await executeRuntimeTool("load_skill_instructions", { skillId: "video-editing" }, "session-4")
+
+    expect(otherSessionLoad?.isError).toBe(false)
+    expect(String(otherSessionLoad?.content?.[0]?.text)).toContain("## Video Editing")
+    expect(String(otherSessionLoad?.content?.[0]?.text)).not.toContain("Skill already loaded in this session")
+  })
+})
+

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -342,6 +342,7 @@ const getUtf8ByteLength = (value: string): number =>
 
 interface SessionSkillLoadState {
   loadedSkillIds: Set<string>
+  forceReloadCountBySkillId: Map<string, number>
   lastTouched: number
 }
 
@@ -372,6 +373,7 @@ function getOrCreateLoadedSkillState(sessionId: string): SessionSkillLoadState {
 
   const created: SessionSkillLoadState = {
     loadedSkillIds: new Set<string>(),
+    forceReloadCountBySkillId: new Map<string, number>(),
     lastTouched: now,
   }
   loadedSkillStateBySession.set(sessionId, created)
@@ -1269,6 +1271,7 @@ const toolHandlers: Record<string, ToolHandler> = {
 
     const skillId = args.skillId.trim()
     const forceReload = args.forceReload === true
+    const reloadReason = typeof args.reason === "string" ? args.reason.trim() : ""
     const { skillsService } = await import("./skills-service")
     const skillById = skillsService.getSkill(skillId)
     const allSkills = skillById ? null : skillsService.getSkills()
@@ -1292,6 +1295,7 @@ const toolHandlers: Record<string, ToolHandler> = {
 
     if (loadedState) {
       const alreadyLoaded = loadedState.loadedSkillIds.has(skill.id)
+      const priorForceReloads = loadedState.forceReloadCountBySkillId.get(skill.id) ?? 0
       if (alreadyLoaded && !forceReload) {
         return {
           content: [{
@@ -1300,6 +1304,19 @@ const toolHandlers: Record<string, ToolHandler> = {
           }],
           isError: false,
         }
+      }
+      if (alreadyLoaded && forceReload) {
+        const canForceReload = reloadReason.length > 0 && priorForceReloads < 1
+        if (!canForceReload) {
+          return {
+            content: [{
+              type: "text",
+              text: `# ${skill.name}\n\n[Skill already loaded in this session: ${skill.id}. Reuse earlier instructions unless the scope changed materially. To force one reload, pass both {\"forceReload\": true} and a short {\"reason\": \"...\"}. Prefer reading the referenced source files directly instead of repeatedly reloading the skill.]`,
+            }],
+            isError: false,
+          }
+        }
+        loadedState.forceReloadCountBySkillId.set(skill.id, priorForceReloads + 1)
       }
       loadedState.loadedSkillIds.add(skill.id)
       loadedState.lastTouched = Date.now()

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -340,6 +340,56 @@ const getDataImageBytesFromUrl = (url: string): number | null => {
 const getUtf8ByteLength = (value: string): number =>
   Buffer.byteLength(value, "utf8")
 
+interface SessionSkillLoadState {
+  loadedSkillIds: Set<string>
+  lastTouched: number
+}
+
+const loadedSkillStateBySession = new Map<string, SessionSkillLoadState>()
+const SKILL_LOAD_STATE_MAX_SESSIONS = 256
+const SKILL_LOAD_STATE_TTL_MS = 6 * 60 * 60 * 1000
+
+function pruneLoadedSkillState(now: number = Date.now()): void {
+  for (const [sessionId, state] of loadedSkillStateBySession.entries()) {
+    if (now - state.lastTouched > SKILL_LOAD_STATE_TTL_MS) {
+      loadedSkillStateBySession.delete(sessionId)
+    }
+  }
+}
+
+function getOrCreateLoadedSkillState(sessionId: string): SessionSkillLoadState {
+  const now = Date.now()
+  pruneLoadedSkillState(now)
+
+  const existing = loadedSkillStateBySession.get(sessionId)
+  if (existing) {
+    existing.lastTouched = now
+    // Touch as most-recently-used for deterministic eviction.
+    loadedSkillStateBySession.delete(sessionId)
+    loadedSkillStateBySession.set(sessionId, existing)
+    return existing
+  }
+
+  const created: SessionSkillLoadState = {
+    loadedSkillIds: new Set<string>(),
+    lastTouched: now,
+  }
+  loadedSkillStateBySession.set(sessionId, created)
+
+  while (loadedSkillStateBySession.size > SKILL_LOAD_STATE_MAX_SESSIONS) {
+    const oldestSessionId = loadedSkillStateBySession.keys().next().value as string | undefined
+    if (!oldestSessionId) break
+    loadedSkillStateBySession.delete(oldestSessionId)
+  }
+
+  return created
+}
+
+function resolveSkillLoadSessionId(sessionId?: string): string | undefined {
+  if (!sessionId) return undefined
+  return getAppSessionForAcpSession(sessionId) ?? sessionId
+}
+
 async function imagePathToDataUrl(rawPath: string): Promise<string> {
   const resolvedPath = path.isAbsolute(rawPath)
     ? rawPath
@@ -1199,7 +1249,7 @@ const toolHandlers: Record<string, ToolHandler> = {
     }
   },
 
-  load_skill_instructions: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+  load_skill_instructions: async (args: Record<string, unknown>, context: BuiltinToolContext): Promise<MCPToolResult> => {
     // Validate skillId parameter
     if (typeof args.skillId !== "string" || args.skillId.trim() === "") {
       return {
@@ -1209,24 +1259,16 @@ const toolHandlers: Record<string, ToolHandler> = {
     }
 
     const skillId = args.skillId.trim()
+    const forceReload = args.forceReload === true
     const { skillsService } = await import("./skills-service")
-    const skill = skillsService.getSkill(skillId)
+    const skillById = skillsService.getSkill(skillId)
+    const allSkills = skillById ? null : skillsService.getSkills()
+    const skill = skillById
+      ?? allSkills?.find((candidate) => candidate.name.toLowerCase() === skillId.toLowerCase())
+    const sessionId = resolveSkillLoadSessionId(context.sessionId)
+    const loadedState = sessionId ? getOrCreateLoadedSkillState(sessionId) : undefined
 
     if (!skill) {
-      // Try to find by name as fallback
-      const allSkills = skillsService.getSkills()
-      const skillByName = allSkills.find(s => s.name.toLowerCase() === skillId.toLowerCase())
-
-      if (skillByName) {
-        return {
-          content: [{
-            type: "text",
-            text: `# ${skillByName.name}\n\n${skillByName.instructions}`,
-          }],
-          isError: false,
-        }
-      }
-
       return {
         content: [{
           type: "text",
@@ -1237,6 +1279,21 @@ const toolHandlers: Record<string, ToolHandler> = {
         }],
         isError: true,
       }
+    }
+
+    if (loadedState) {
+      const alreadyLoaded = loadedState.loadedSkillIds.has(skill.id)
+      if (alreadyLoaded && !forceReload) {
+        return {
+          content: [{
+            type: "text",
+            text: `# ${skill.name}\n\n[Skill already loaded in this session: ${skill.id}. Reuse earlier instructions unless details changed. Pass {\"forceReload\": true} to reload full instructions.]`,
+          }],
+          isError: false,
+        }
+      }
+      loadedState.loadedSkillIds.add(skill.id)
+      loadedState.lastTouched = Date.now()
     }
 
     return {

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -1070,11 +1070,19 @@ const toolHandlers: Record<string, ToolHandler> = {
           tail
       }
 
-      // Detect shell escaping issues and add guidance
+      // Detect shell-command construction issues and add guidance
+      const hasPrintfLeadingDashIssue = /printf:\s+--:\s+invalid option/i.test(stderr + errorMessage)
       const hasShellEscapingIssue = /unexpected (EOF|end of file)|unterminated (string|quote)|syntax error near/i.test(stderr + errorMessage);
-      const hint = hasShellEscapingIssue
-        ? '\n\nHINT: This command likely failed due to shell escaping issues with special characters or long strings. Try writing the content to a file first (e.g., with write_file or echo > file), then reference the file in your command.'
-        : '';
+      const hint = hasPrintfLeadingDashIssue
+        ? "\n\nHINT: In bash, bare printf strings that start with '-' are parsed like options. Use echo '--- LABEL ---', printf -- '--- LABEL ---\\n', or printf '%s\\n' '--- LABEL ---' instead."
+        : hasShellEscapingIssue
+          ? '\n\nHINT: This command likely failed due to shell escaping issues with special characters or long strings. Try writing the content to a file first (e.g., with write_file or echo > file), then reference the file in your command.'
+          : '';
+      const retrySuggestion = hasPrintfLeadingDashIssue
+        ? "Retry with echo '--- LABEL ---', printf -- '--- LABEL ---\\n', or printf '%s\\n' '--- LABEL ---'."
+        : hasShellEscapingIssue
+          ? "Retry by writing the content to a file first, or simplify the shell quoting."
+          : undefined;
 
       return {
         content: [
@@ -1092,6 +1100,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               exitCode,
               stdout,
               stderr,
+              ...(retrySuggestion ? { retrySuggestion } : {}),
             }, null, 2),
           },
         ],

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -281,6 +281,31 @@ async function normalizeExecuteCommandWorkspacePaths(
     : { command: rawCommand }
 }
 
+function normalizeUnsafePrintfLabelCommands(
+  rawCommand: string,
+): { command: string; normalizedPrintfLabels?: Array<{ from: string; to: string }> } {
+  const rewrites: Array<{ from: string; to: string }> = []
+
+  // Bash printf treats a leading "-" in the format string like an option.
+  // These two forms are common model-generated label separators that should
+  // be rewritten into option-safe equivalents before shell execution.
+  const rewrite = (pattern: RegExp, replacementBuilder: (label: string) => string) => {
+    rawCommand = rawCommand.replace(pattern, (_match, label: string) => {
+      const from = _match
+      const to = replacementBuilder(label)
+      rewrites.push({ from, to })
+      return to
+    })
+  }
+
+  rewrite(/printf\s+'---\s*([^']*?)\s*---\\n'/g, (label) => `printf '%s\\n' '--- ${label.trim()} ---'`)
+  rewrite(/printf\s+'\\n---\s*([^']*?)\s*---\\n'/g, (label) => `printf '\\n%s\\n' '--- ${label.trim()} ---'`)
+
+  return rewrites.length > 0
+    ? { command: rawCommand, normalizedPrintfLabels: rewrites }
+    : { command: rawCommand }
+}
+
 const MAX_RESPOND_TO_USER_IMAGES = 4
 const MAX_RESPOND_TO_USER_IMAGE_FILE_BYTES = 8 * 1024 * 1024
 const MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES = 12 * 1024 * 1024
@@ -949,7 +974,8 @@ const toolHandlers: Record<string, ToolHandler> = {
 
     const effectiveCwd = cwd || process.cwd()
     const normalizedCommandResult = await normalizeExecuteCommandWorkspacePaths(command, effectiveCwd)
-    const effectiveCommand = normalizedCommandResult.command
+    const printfNormalizedCommandResult = normalizeUnsafePrintfLabelCommands(normalizedCommandResult.command)
+    const effectiveCommand = printfNormalizedCommandResult.command
     const preferredPackageManager = await detectPreferredPackageManager(effectiveCwd)
     const packageManagerMismatch = detectPackageManagerMismatch(effectiveCommand, preferredPackageManager)
 
@@ -966,6 +992,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               skillName,
               ...(ignoredInvalidSkillIdWarning ?? {}),
               ...(normalizedCommandResult.normalizedPaths ? { normalizedPaths: normalizedCommandResult.normalizedPaths } : {}),
+              ...(printfNormalizedCommandResult.normalizedPrintfLabels ? { normalizedPrintfLabels: printfNormalizedCommandResult.normalizedPrintfLabels } : {}),
               ...packageManagerMismatch,
             }, null, 2),
           },
@@ -990,6 +1017,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               skillName,
               ...(ignoredInvalidSkillIdWarning ?? {}),
               ...(normalizedCommandResult.normalizedPaths ? { normalizedPaths: normalizedCommandResult.normalizedPaths } : {}),
+              ...(printfNormalizedCommandResult.normalizedPrintfLabels ? { normalizedPrintfLabels: printfNormalizedCommandResult.normalizedPrintfLabels } : {}),
               ...contextGatheringCommandBlock,
             }, null, 2),
           },
@@ -1045,6 +1073,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               skillName,
               ...(ignoredInvalidSkillIdWarning ?? {}),
               ...(normalizedCommandResult.normalizedPaths ? { normalizedPaths: normalizedCommandResult.normalizedPaths } : {}),
+              ...(printfNormalizedCommandResult.normalizedPrintfLabels ? { normalizedPrintfLabels: printfNormalizedCommandResult.normalizedPrintfLabels } : {}),
               stdout: truncatedStdout,
               stderr: stderr || "",
               ...(outputTruncated ? { outputTruncated: true, hint: "Output was truncated. Use head -n/tail -n/sed -n 'X,Yp' to read specific sections." } : {}),
@@ -1098,6 +1127,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               skillName,
               ...(ignoredInvalidSkillIdWarning ?? {}),
               ...(normalizedCommandResult.normalizedPaths ? { normalizedPaths: normalizedCommandResult.normalizedPaths } : {}),
+              ...(printfNormalizedCommandResult.normalizedPrintfLabels ? { normalizedPrintfLabels: printfNormalizedCommandResult.normalizedPrintfLabels } : {}),
               error: errorMessage + hint,
               exitCode,
               stdout,

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -182,6 +182,7 @@ describe("constructSystemPrompt", () => {
     ] as any, undefined, true)
 
     expect(prompt).toContain("Load each needed skill once per session")
+    expect(prompt).toContain("pass forceReload with a short reason")
     expect(prompt).toContain('load_skill_instructions with skillId: "dotagents-config-admin"')
   })
 

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -51,7 +51,6 @@ describe("constructSystemPrompt", () => {
     const { DEFAULT_SYSTEM_PROMPT } = await import("./system-prompts")
 
     expect(DEFAULT_SYSTEM_PROMPT).toContain("check relevant knowledge notes and prior conversations first")
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("user-specific facts are still missing after checking relevant notes/conversations")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("~/.agents/knowledge/")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("./.agents/knowledge/")
     expect(DEFAULT_SYSTEM_PROMPT).toContain(".agents/knowledge/<slug>/<slug>.md")
@@ -93,7 +92,7 @@ describe("constructSystemPrompt", () => {
     const prompt = constructMinimalSystemPrompt([], true)
 
     expect(prompt).toContain("check relevant knowledge notes and prior conversations first")
-    expect(prompt).toContain("generic checklist")
+    expect(prompt).toContain("minimum high-signal follow-ups")
     expect(prompt).toContain("~/.agents/knowledge/")
     expect(prompt).toContain(".agents/knowledge/<slug>/<slug>.md")
     expect(prompt).toContain("context: search-only")
@@ -182,6 +181,7 @@ describe("constructSystemPrompt", () => {
       { name: "load_skill_instructions", description: "Load a skill", inputSchema: { type: "object", properties: {} } },
     ] as any, undefined, true)
 
+    expect(prompt).toContain("Load each needed skill once per session")
     expect(prompt).toContain('load_skill_instructions with skillId: "dotagents-config-admin"')
   })
 

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -104,6 +104,7 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
     sections.push(`SKILLS:
 - Skills are optional instruction modules listed below.
 - Load each needed skill once per session with load_skill_instructions(skillId). Reuse previously loaded skill context unless details changed.
+- If you absolutely need to reload a skill after it was already loaded, pass forceReload with a short reason. Prefer reading the referenced source files directly over repeatedly reloading the same skill.
 - Do not guess a skill's contents from its name/description.`)
   }
 

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -103,7 +103,8 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
   if (hasLoadSkillInstructions) {
     sections.push(`SKILLS:
 - Skills are optional instruction modules listed below.
-- Before using a skill, ALWAYS call load_skill_instructions(skillId). Do not guess a skill's contents from its name/description.`)
+- Load each needed skill once per session with load_skill_instructions(skillId). Reuse previously loaded skill context unless details changed.
+- Do not guess a skill's contents from its name/description.`)
   }
 
   if (hasRespondToUser && hasMarkWorkComplete) {

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -721,6 +721,64 @@ describe("agent progress response history", () => {
     expect(getTextContent(tree)).not.toContain("respond_to_user")
   })
 
+  it("matches split tool-result messages to a single assistant tool-call batch", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const progress = {
+      sessionId: "session-split-tool-results",
+      conversationId: "conversation-split-tool-results",
+      currentIteration: 1,
+      maxIterations: 2,
+      steps: [],
+      isComplete: false,
+      finalContent: "",
+      conversationHistory: [
+        {
+          role: "assistant",
+          content: "",
+          timestamp: 90,
+          toolCalls: [
+            { name: "respond_to_user", arguments: { message: "Working on it" } },
+            { name: "visible_first_tool", arguments: { id: "first" } },
+            { name: "visible_second_tool", arguments: { id: "second" } },
+          ],
+        },
+        {
+          role: "tool",
+          content: "",
+          timestamp: 91,
+          toolResults: [
+            { success: true, content: "meta ok" },
+          ],
+        },
+        {
+          role: "tool",
+          content: "",
+          timestamp: 92,
+          toolResults: [
+            { success: true, content: "first ok" },
+          ],
+        },
+        {
+          role: "tool",
+          content: "",
+          timestamp: 93,
+          toolResults: [
+            { success: true, content: "second ok" },
+          ],
+        },
+      ],
+    }
+
+    const tree = runtime.render(AgentProgress, { progress })
+    const firstRow = findToolRow(tree, "visible_first_tool")
+    const secondRow = findToolRow(tree, "visible_second_tool")
+
+    expect(firstRow.props.className).toContain("text-green-600")
+    expect(secondRow.props.className).toContain("text-green-600")
+    expect(getTextContent(tree)).not.toContain("respond_to_user")
+  })
+
   it("keeps reloaded completed sessions from showing completion-tool rows or duplicate final output", async () => {
     const runtime = createHookRuntime()
     const { AgentProgress } = await loadAgentProgress(runtime)

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -4168,10 +4168,36 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     for (let i = 0; i < messages.length; i++) {
       const message = messages[i]
       if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
-        const next = messages[i + 1]
-        const results = next && next.role === "tool" && next.toolResults ? next.toolResults : []
+        const collectedResults: Array<{ success: boolean; content: string; error?: string } | undefined> = []
+        let lastToolTimestamp = message.timestamp
+        let consumedToolMessages = 0
+        let resultMessageIndex = i + 1
+
+        while (
+          resultMessageIndex < messages.length &&
+          messages[resultMessageIndex].role === "tool" &&
+          collectedResults.length < message.toolCalls.length
+        ) {
+          const toolMessage = messages[resultMessageIndex]
+          const toolResults = toolMessage.toolResults ?? []
+
+          if (toolResults.length > 0) {
+            collectedResults.push(...toolResults)
+          } else {
+            collectedResults.push(undefined)
+          }
+
+          lastToolTimestamp = toolMessage.timestamp ?? lastToolTimestamp
+          consumedToolMessages += 1
+          resultMessageIndex += 1
+        }
+
+        const results = collectedResults.slice(0, message.toolCalls.length)
+        while (results.length < message.toolCalls.length) {
+          results.push(undefined)
+        }
         const assistantIndex = ++roleCounters.assistant
-        const execTimestamp = next?.timestamp ?? message.timestamp
+        const execTimestamp = lastToolTimestamp
         const toolExecId = generateToolExecutionId(message.toolCalls, execTimestamp)
         const toolCallNames = message.toolCalls.map((call) => call.name)
         const visibleToolCalls = message.toolCalls
@@ -4218,8 +4244,8 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           })
         }
 
-        if (next && next.role === "tool" && next.toolResults) {
-          i++
+        if (consumedToolMessages > 0) {
+          i += consumedToolMessages
         }
       } else if (
         message.role === "tool" &&

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1227,6 +1227,9 @@ export type Config = {
   // Context Reduction Configuration
   mcpContextReductionEnabled?: boolean
   mcpContextTargetRatio?: number
+  // Absolute upper bound for context-target tokens after ratio is applied.
+  // Helps keep prompts bounded on very large-context models.
+  mcpContextAbsoluteTokenCap?: number
   mcpContextLastNMessages?: number
   mcpContextSummarizeCharThreshold?: number
   mcpMaxContextTokensOverride?: number

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -312,6 +312,7 @@ export interface Settings {
 
   // Context Reduction & Tool Response Processing
   mcpContextReductionEnabled?: boolean;
+  mcpContextAbsoluteTokenCap?: number;
   mcpToolResponseProcessingEnabled?: boolean;
   mcpParallelToolExecution?: boolean;
   mcpMessageQueueEnabled?: boolean;
@@ -440,6 +441,7 @@ export interface SettingsUpdate {
 
   // Context Reduction & Tool Response Processing
   mcpContextReductionEnabled?: boolean;
+  mcpContextAbsoluteTokenCap?: number;
   mcpToolResponseProcessingEnabled?: boolean;
   mcpParallelToolExecution?: boolean;
   mcpMessageQueueEnabled?: boolean;


### PR DESCRIPTION
## Summary
- add an absolute context target cap and smarter retruncation for oversized already-truncated tool payloads
- store tool outputs as one transcript message per tool call so context compaction can work per payload
- dedupe `load_skill_instructions` per session and soften prompt guidance to load each skill once per session unless needed
- expose the new context cap through remote-server settings and add focused regression tests

## Validation
- `pnpm run pretest && pnpm exec vitest run src/main/context-budget.test.ts src/main/runtime-tools.execute-command.test.ts src/main/runtime-tools.load-skill.test.ts src/main/system-prompts.test.ts src/main/llm.respond-to-user-history.test.ts`

## Notes
- `pnpm run typecheck` still fails on pre-existing renderer errors in `apps/desktop/src/renderer/src/components/agent-progress.tsx` about passing `string` to a `"default" | "overlay" | "tile"` parameter. This branch does not touch that file.
