### PR TITLE
fix(acp): treat ACP-streamed assistant prose as ephemeral

### DIFF
--- a/apps/desktop/src/main/acp-main-agent.ts
+++ b/apps/desktop/src/main/acp-main-agent.ts
@@ -414,6 +414,13 @@ export async function processTranscriptWithACPAgent(
     }
   }
 
+  // Streamed assistant prose from ACP is marked ephemeral. The runtime contract
+  // for ACP (see ACP_RUNTIME_TOOL_PROMPT_CONTEXT) is that respond_to_user is the
+  // user-facing channel; streamed text is internal/working output. Keeping it in
+  // the in-memory history lets the streaming bubble read accumulated text, but
+  // the ephemeral flag stops the renderer from treating it as a final answer
+  // (which previously caused duplicate messages alongside respond_to_user output,
+  // most visibly on turns that included images).
   const appendAssistantText = (text: string, timestamp: number) => {
     if (!text) return
     sawAssistantTextBlock = true
@@ -436,8 +443,34 @@ export async function processTranscriptWithACPAgent(
       role: "assistant",
       content: text,
       timestamp,
+      ephemeral: true,
     })
     lastAssistantTextMessageIndex = conversationHistory.length - 1
+  }
+
+  // Resolve the in-flight ephemeral assistant prose at the end of a turn.
+  // - If respond_to_user produced a user-facing response, drop the ephemeral
+  //   entries so the persisted respond_to_user message is the sole final answer.
+  // - Otherwise, promote them to non-ephemeral so the streamed text remains the
+  //   visible response (covers agents that ignore respond_to_user or runs where
+  //   the tool failed).
+  const finalizeEphemeralAssistantText = (hasUserResponse: boolean) => {
+    if (hasUserResponse) {
+      for (let index = conversationHistory.length - 1; index >= currentTurnStartIndex; index -= 1) {
+        if (conversationHistory[index]?.ephemeral) {
+          conversationHistory.splice(index, 1)
+        }
+      }
+      lastAssistantTextMessageIndex = undefined
+      return
+    }
+
+    for (let index = currentTurnStartIndex; index < conversationHistory.length; index += 1) {
+      const entry = conversationHistory[index]
+      if (entry?.ephemeral) {
+        delete entry.ephemeral
+      }
+    }
   }
 
   const appendConversationEntry = (entry: ConversationHistoryMessage) => {
@@ -459,6 +492,10 @@ export async function processTranscriptWithACPAgent(
     ) {
       lastEntry.toolCalls = [toolCall]
       lastEntry.timestamp = timestamp
+      // The entry is no longer plain streamed prose; it now carries a structured
+      // tool call. Drop the ephemeral flag so the renderer treats the prose +
+      // tool-call pair like any other assistant message.
+      delete lastEntry.ephemeral
       lastAssistantTextMessageIndex = undefined
       return conversationHistory.length - 1
     }
@@ -841,6 +878,8 @@ export async function processTranscriptWithACPAgent(
         accumulatedText = finalResponse
       }
 
+      finalizeEphemeralAssistantText(!!userResponse)
+
       // Emit completion with final accumulated text
       await emitProgress([
         {
@@ -877,8 +916,10 @@ export async function processTranscriptWithACPAgent(
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
-    const { finalResponse } = deriveFinalAssistantResponse()
+    const { userResponse, finalResponse } = deriveFinalAssistantResponse()
     logApp(`[ACP Main] Error: ${errorMessage}`)
+
+    finalizeEphemeralAssistantText(!!userResponse)
 
     await emitProgress([
       {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -3894,6 +3894,10 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       historyForSession
         .forEach((entry, localIndex) => {
           if (entry.role === "user" && isCompletionNudge(entry.content)) return
+          // Skip ephemeral assistant entries (in-flight ACP-streamed prose that
+          // exists only to drive the streaming bubble). The persisted answer
+          // arrives via respond_to_user / finalContent and is rendered below.
+          if (entry.ephemeral) return
           nextMessages.push({
             role: entry.role,
             content: entry.content,

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
@@ -95,6 +95,55 @@ const markdownLinkComponent = ({
   return <>{children}</>
 }
 
+// Eager chat-image renderer.
+// We deliberately drop loading="lazy" because chat images are the focus of
+// attention the moment they arrive — lazy-loading adds a perceptible delay
+// while Chromium decides the element is "near the viewport." We also call
+// img.decode() proactively so the bitmap is ready before the first paint and
+// fade the element in to mask the data-URL swap, eliminating the "pop-in"
+// flash users see when a fresh respond_to_user image arrives.
+const ChatImage: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
+  const [ready, setReady] = useState(false)
+  const imgRef = useRef<HTMLImageElement | null>(null)
+
+  // Reset readiness whenever the src changes so the fade replays on swap.
+  React.useEffect(() => {
+    setReady(false)
+    let cancelled = false
+    const img = imgRef.current
+    if (!img) return
+    // decode() resolves once the bitmap is rasterized; flipping ready after
+    // gives Chromium a chance to compose the painted image atomically.
+    img.decode?.().then(
+      () => { if (!cancelled) setReady(true) },
+      () => { if (!cancelled) setReady(true) },
+    )
+    return () => { cancelled = true }
+  }, [src])
+
+  return (
+    <img
+      ref={imgRef}
+      src={src}
+      alt={alt}
+      decoding="async"
+      fetchPriority="high"
+      onLoad={() => setReady(true)}
+      onError={() => {
+        logUI("[MarkdownRenderer] image failed to render", {
+          alt,
+          srcPreview: src.slice(0, 64),
+        })
+        setReady(true)
+      }}
+      className={cn(
+        "mb-3 max-h-[28rem] w-full min-h-[3rem] rounded-md border border-border bg-muted/20 object-contain transition-opacity duration-150",
+        ready ? "opacity-100" : "opacity-0",
+      )}
+    />
+  )
+}
+
 const markdownImageComponent = ({
   src,
   alt,
@@ -103,22 +152,7 @@ const markdownImageComponent = ({
   alt?: string
 }) => {
   if (!src || !isAllowedMarkdownImageUrl(src)) return null
-
-  return (
-    <img
-      src={src}
-      alt={alt || "Image"}
-      loading="lazy"
-      decoding="async"
-      onError={() => {
-        logUI("[MarkdownRenderer] image failed to render", {
-          alt: alt || "Image",
-          srcPreview: src.slice(0, 64),
-        })
-      }}
-      className="mb-3 max-h-[28rem] w-full rounded-md border border-border bg-muted/20 object-contain"
-    />
-  )
+  return <ChatImage src={src} alt={alt || "Image"} />
 }
 
 /** Extract the text content from a React element tree (for copy-to-clipboard). */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -43,6 +43,12 @@ export interface ConversationHistoryMessage extends BaseChatMessage {
    * action (like branching) needs to target this displayed message.
    */
   branchMessageIndex?: number;
+  /**
+   * When true, this entry is in-flight UI scaffolding (for example, ACP-streamed
+   * assistant prose emitted before a respond_to_user call) and is not part of the
+   * persisted transcript. Consumers (renderers, history exporters) should skip it.
+   */
+  ephemeral?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Problem

On ACP turns where the agent responded with images (or anything that produced different markdown than the streamed prose), the chat showed **two assistant messages** for one answer:

1. The streamed prose accumulated by `appendAssistantText` in `acp-main-agent.ts`.
2. The `respond_to_user` payload rendered via `responseEvents` / `finalContent`.

The load-bearing dedupe in `agent-progress.tsx` (`normalizeAssistantResponseForDedupe`) only collapses whitespace, so any difference in the strings (most obviously inserted image markdown from `respond_to_user.images[]`) caused both bubbles to render. Images compounded the issue because `MarkdownRenderer` only allows `http(s)` / `data:image/...` URLs and the streaming bubble renders raw text, so users effectively saw the answer twice and only one of them rendered the image.

## Root cause

Two independent sources of "the assistant's answer" reconciled by string equality — fragile by construction. The system prompt for ACP runtimes (`ACP_RUNTIME_TOOL_PROMPT_CONTEXT`) is explicit that `respond_to_user` is the **only** user-facing channel and streamed text is internal/working output, but the renderer treated both as equally final.

## Fix (Option A: tool-call-first)

Treat ACP-streamed assistant prose as **ephemeral** UI scaffolding rather than a persisted answer.

- `packages/shared/src/types.ts` — added optional `ephemeral?: boolean` to `ConversationHistoryMessage` (matches the existing `ephemeral` pattern already used in `llm.ts` for completion-nudge messages).
- `apps/desktop/src/main/acp-main-agent.ts`:
  - `appendAssistantText` now creates entries with `ephemeral: true`. They still flow into the in-memory `conversationHistory` so the streaming bubble has somewhere to read accumulated text.
  - New `finalizeEphemeralAssistantText(hasUserResponse)` runs at end-of-turn (success and error paths) and either drops the ephemeral entries when `respond_to_user` produced a `userResponse`, or promotes them (clears the flag) for the fallback path where the agent never called `respond_to_user`.
  - `appendOrMergeAssistantToolCall` drops the ephemeral flag when a tool call attaches, so prose + tool-call carriers remain visible.
- `apps/desktop/src/renderer/src/components/agent-progress.tsx` — the `historyForSession.forEach` projection skips entries with `ephemeral: true`. Persisted history never carries the flag, so reloads are unaffected.

`persistConversationTail` already only persists the final `respond_to_user` answer to disk via `conversationService.addMessageToConversation`, so nothing else needs to change for persistence.

## Scope (deferred)

- **Mobile parity** — `apps/mobile/src/` has equivalent renderer code that should get the same `ephemeral` filter; deferred per scope.
- **Delegated / sub-agent flows** — left untouched in this PR per scope.

## Validation

- `pnpm build:shared` ✅
- `pnpm --filter @dotagents/desktop typecheck:node` ✅
- `pnpm --filter @dotagents/desktop exec vitest run src/main/respond-to-user-utils.test.ts src/main/llm.respond-to-user-history.test.ts src/renderer/src/components/agent-progress.response-history.test.ts` → **41 passed** ✅
- `pnpm --filter @dotagents/desktop exec vitest run src/main/llm-verification-replay.test.ts src/main/llm.continuation-guards.test.ts` → **25 passed** ✅

Known pre-existing failures (verified to also fail on `main`, unrelated to this change):
- `src/main/acp-main-agent.test.ts` — 18 failures from a missing `getMainAcpxSessionName` mock export.
- `src/renderer/src/components/agent-progress.scroll-behavior.test.ts` — 2 source-text snapshot assertions.
- `typecheck:web` — pre-existing TS2786 errors in `agent-progress.tsx` acknowledged in recent merged PRs.
