### PR TITLE
fix(remote-server): raise Fastify bodyLimit to 50MB for chat requests

### DIFF
--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -1873,7 +1873,10 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
   const bind = bindAddressOverride || cfg.remoteServerBindAddress || "127.0.0.1"
   const port = cfg.remoteServerPort || 3210
 
-  const fastify = Fastify({ logger: { level: logLevel } })
+  // Fastify defaults the body limit to 1MB, which is too small for chat requests that
+  // include long conversation histories. Raise it to 50MB to accommodate large payloads
+  // (mobile clients send the full message history on each /v1/chat/completions call).
+  const fastify = Fastify({ logger: { level: logLevel }, bodyLimit: 50 * 1024 * 1024 })
 
   // Configure CORS
   const corsOrigins = cfg.remoteServerCorsOrigins || ["*"]


### PR DESCRIPTION
## Problem

Submitting a small message to a long conversation from the mobile app fails with:

```
Chat failed: 413 {"statusCode":413,"code":"FST_ERR_CTP_BODY_TOO_LARGE","error":"Payload Too Large","message":"Request body is too large"}
```

## Root cause

The desktop remote server (`apps/desktop/src/main/remote-server.ts`) constructs Fastify without an explicit `bodyLimit`, which defaults to **1MB** in Fastify v5.

The mobile client (`apps/mobile/src/lib/openaiClient.ts`) sends the full `messages` array (the entire conversation history) on every `POST /v1/chat/completions` request. As conversations grow, the serialized body eventually exceeds 1MB and every subsequent message is rejected with HTTP 413 before it ever reaches the handler.

## Fix

Raise the Fastify `bodyLimit` to 50MB so long conversations are accepted. This is a minimal, surgical change — no new config field, no new behaviour, just a larger ceiling for the existing endpoint.

```ts
const fastify = Fastify({ logger: { level: logLevel }, bodyLimit: 50 * 1024 * 1024 })
```

## Testing

- Manual: retry sending a small message in a long conversation from the mobile app against a desktop running this branch — the 413 no longer occurs.
- Existing route tests in `remote-server.routes.test.ts` continue to exercise the same routes unchanged.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://app.staging.augmentcode.com/app/session?agentId=01KP9PVXDM47YEWHZ5B68905D2&panel=chat)