### PR TITLE
feat(mcp): emit Context refs on MCP tool-response summarization

### DIFF
--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -66,6 +66,7 @@ import {
   clearIterativeSummary,
   readMoreContext,
   recordActualTokenUsage,
+  registerContextRef,
   shrinkMessagesForLLM,
 } from './context-budget'
 
@@ -587,5 +588,44 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(batchSummaryPrompts.some((prompt) => prompt.includes('Payload truncated for context management'))).toBe(false)
 
     expect(result.messages.some((msg) => msg.content.includes('condensed remaining conversation'))).toBe(true)
+  })
+})
+
+describe('registerContextRef export for MCP tool summarization', () => {
+  beforeEach(() => {
+    clearContextRefs('session-mcp-ref')
+  })
+
+  it('registers a ref that read_more_context can resolve', () => {
+    const original = `full tool output ${'z'.repeat(1000)} END`
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: original,
+      toolName: 'exa:web_search_advanced_exa',
+    })
+
+    expect(ref).toMatch(/^ctx_[a-z0-9]+$/)
+
+    const overview = readMoreContext('session-mcp-ref', ref!)
+    expect(overview).toEqual(expect.objectContaining({
+      success: true,
+      contextRef: ref,
+      kind: 'truncated_tool',
+      toolName: 'exa:web_search_advanced_exa',
+      totalChars: original.length,
+    }))
+
+    const search = readMoreContext('session-mcp-ref', ref!, { mode: 'search', query: 'END' })
+    expect(search).toEqual(expect.objectContaining({ success: true, matchCount: 1 }))
+  })
+
+  it('returns undefined when sessionId is missing', () => {
+    const ref = registerContextRef(undefined, {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: 'anything',
+    })
+    expect(ref).toBeUndefined()
   })
 })

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -536,7 +536,7 @@ function makeContextRef(): string {
   return `ctx_${Math.random().toString(36).slice(2, 10)}`
 }
 
-function registerContextRef(
+export function registerContextRef(
   sessionId: string | undefined,
   input: {
     kind: ContextRefKind

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -1209,17 +1209,32 @@ export class MCPService {
    * Filter tool responses to reduce context size
    * Uses a 50KB threshold - MCP servers handle their own pagination
    */
-  private filterToolResponse(
-    _serverName: string,
-    _toolName: string,
-    content: Array<{ type: string; text: string }>
-  ): Array<{ type: string; text: string }> {
+  private async filterToolResponse(
+    serverName: string,
+    toolName: string,
+    content: Array<{ type: string; text: string }>,
+    sessionId?: string
+  ): Promise<Array<{ type: string; text: string }>> {
     const TRUNCATION_LIMIT = 50000
+    // Any truncation registers the raw original under a Context ref so the
+    // agent can recover it via read_more_context.
+    const needsRef = sessionId && content.some((item) => item.text.length > TRUNCATION_LIMIT)
+    const registerContextRef = needsRef
+      ? (await import('./context-budget')).registerContextRef
+      : undefined
+
     return content.map((item) => {
       if (item.text.length > TRUNCATION_LIMIT) {
+        const contextRef = registerContextRef?.(sessionId, {
+          kind: "truncated_tool",
+          role: "tool",
+          content: item.text,
+          toolName: `${serverName}:${toolName}`,
+        })
+        const refNote = contextRef ? `\nContext ref: ${contextRef}` : ""
         return {
           type: item.type,
-          text: item.text.substring(0, TRUNCATION_LIMIT) + '\n\n[truncated]'
+          text: item.text.substring(0, TRUNCATION_LIMIT) + `\n\n[truncated]${refNote}`
         }
       }
       return item
@@ -1233,7 +1248,8 @@ export class MCPService {
     serverName: string,
     toolName: string,
     content: Array<{ type: string; text: string }>,
-    onProgress?: (message: string) => void
+    onProgress?: (message: string) => void,
+    sessionId?: string
   ): Promise<Array<{ type: string; text: string }>> {
     const config = configStore.get()
 
@@ -1246,6 +1262,13 @@ export class MCPService {
       return content // Return unprocessed if disabled
     }
 
+    // Any item that hits the large threshold registers the pre-summary content
+    // under a Context ref so the agent can recover it via read_more_context.
+    const needsRef = sessionId && content.some((item) => item.text.length >= LARGE_RESPONSE_THRESHOLD)
+    const registerContextRef = needsRef
+      ? (await import('./context-budget')).registerContextRef
+      : undefined
+
     return Promise.all(content.map(async (item) => {
       const responseSize = item.text.length
 
@@ -1253,6 +1276,14 @@ export class MCPService {
       if (responseSize < LARGE_RESPONSE_THRESHOLD) {
         return item
       }
+
+      const contextRef = registerContextRef?.(sessionId, {
+        kind: "truncated_tool",
+        role: "tool",
+        content: item.text,
+        toolName: `${serverName}:${toolName}`,
+      })
+      const refNote = contextRef ? `\nContext ref: ${contextRef}` : ""
 
       // Large responses - apply intelligent summarization
       if (responseSize >= CRITICAL_RESPONSE_THRESHOLD) {
@@ -1271,7 +1302,7 @@ export class MCPService {
         )
         return {
           type: item.type,
-          text: `[summarized]\n${summarized}`
+          text: `[summarized]\n${summarized}${refNote}`
         }
       } else {
         // Notify user of processing if enabled
@@ -1289,7 +1320,7 @@ export class MCPService {
         )
         return {
           type: item.type,
-          text: summarized
+          text: `${summarized}${refNote}`
         }
       }
     }))
@@ -1403,7 +1434,8 @@ export class MCPService {
     serverName: string,
     toolName: string,
     arguments_: any,
-    onProgress?: (message: string) => void
+    onProgress?: (message: string) => void,
+    sessionId?: string
   ): Promise<MCPToolResult> {
     const client = this.clients.get(serverName)
     if (!client) {
@@ -1540,14 +1572,15 @@ export class MCPService {
           ]
 
       // Apply response filtering to reduce context size
-      const filteredContent = this.filterToolResponse(serverName, toolName, content)
+      const filteredContent = await this.filterToolResponse(serverName, toolName, content, sessionId)
 
       // Check if response needs further processing for context management
       const processedContent = await this.processLargeToolResponse(
         serverName,
         toolName,
         filteredContent,
-        onProgress
+        onProgress,
+        sessionId
       )
 
       const finalResult: MCPToolResult = {
@@ -2718,7 +2751,8 @@ export class MCPService {
           serverName,
           toolName,
           toolCall.arguments,
-          onProgress
+          onProgress,
+          sessionId
         )
 
         // Track resource information from tool results
@@ -2791,7 +2825,8 @@ export class MCPService {
           serverName,
           toolName,
           toolCall.arguments,
-          onProgress
+          onProgress,
+          sessionId
         )
 
         // Track resource information from tool results

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -86,6 +86,18 @@ function isEssentialRuntimeTool(toolName: string): boolean {
 }
 
 /**
+ * Detects a trailing `[truncated]\nContext ref: ctx_xxxxxxxx` suffix emitted by
+ * filterToolResponse and returns the ref plus the text with that suffix removed.
+ * Used so downstream summarization preserves the original pre-truncation ref
+ * instead of minting a new one that only points at the truncated prefix.
+ */
+function extractExistingContextRef(text: string): { ref: string; strippedText: string } | undefined {
+  const match = text.match(/\n\n\[truncated\]\nContext ref: (ctx_[a-z0-9]+)\s*$/)
+  if (!match) return undefined
+  return { ref: match[1], strippedText: text.slice(0, match.index) }
+}
+
+/**
  * Get paths for the internal WhatsApp MCP server
  * Returns both the script path and node_modules path needed to run the server
  */
@@ -1264,6 +1276,8 @@ export class MCPService {
 
     // Any item that hits the large threshold registers the pre-summary content
     // under a Context ref so the agent can recover it via read_more_context.
+    // If the item was already truncated upstream (filterToolResponse), reuse
+    // that ref so it keeps pointing at the full pre-truncation original.
     const needsRef = sessionId && content.some((item) => item.text.length >= LARGE_RESPONSE_THRESHOLD)
     const registerContextRef = needsRef
       ? (await import('./context-budget')).registerContextRef
@@ -1277,12 +1291,16 @@ export class MCPService {
         return item
       }
 
-      const contextRef = registerContextRef?.(sessionId, {
-        kind: "truncated_tool",
-        role: "tool",
-        content: item.text,
-        toolName: `${serverName}:${toolName}`,
-      })
+      const existing = extractExistingContextRef(item.text)
+      const sourceText = existing ? existing.strippedText : item.text
+      const contextRef = existing
+        ? existing.ref
+        : registerContextRef?.(sessionId, {
+            kind: "truncated_tool",
+            role: "tool",
+            content: item.text,
+            toolName: `${serverName}:${toolName}`,
+          })
       const refNote = contextRef ? `\nContext ref: ${contextRef}` : ""
 
       // Large responses - apply intelligent summarization
@@ -1294,7 +1312,7 @@ export class MCPService {
 
         // For very large responses, use aggressive summarization
         const summarized = await this.summarizeLargeResponse(
-          item.text,
+          sourceText,
           serverName,
           toolName,
           'aggressive',
@@ -1312,7 +1330,7 @@ export class MCPService {
 
         // For moderately large responses, use gentle summarization
         const summarized = await this.summarizeLargeResponse(
-          item.text,
+          sourceText,
           serverName,
           toolName,
           'gentle',


### PR DESCRIPTION
## Why

Logs showed the agent re-issuing near-duplicate MCP tool calls (e.g. `exa:web_search_advanced_exa`) across a single task. Root cause: when an MCP tool response is large, `filterToolResponse` truncates and `processLargeToolResponse` summarizes it — but **neither registers the original content under a Context ref**. The system prompt already tells the agent to use `read_more_context` when it sees a `Context ref: ctx_...`, but no such ref was ever emitted, so the model had no handle on the raw output and tended to re-search.

The plumbing for context refs (`contextRefRegistry`, `read_more_context` runtime tool with `overview`/`head`/`tail`/`window`/`search` modes) already exists in `context-budget.ts`. This PR wires MCP tool summarization/truncation into it.

## What

- Export `registerContextRef` from `context-budget.ts` for reuse from `mcp-service.ts`.
- Thread `sessionId` through `executeServerTool` → `filterToolResponse` → `processLargeToolResponse` so refs can be tied to the current session's registry.
- When a response is:
  - **Truncated** (>50KB in `filterToolResponse`): register pre-truncation content and append `Context ref: ctx_...` after `[truncated]`.
  - **Summarized** (≥ large/critical threshold in `processLargeToolResponse`): register pre-summary content and append `Context ref: ctx_...` to the summarized text.
- Dynamic `await import('./context-budget')` keeps the existing option-b test mock surface intact.

## Effect

After this, a large exa response comes back like:

```
[summarized]
<short summary>
Context ref: ctx_ab12cd34
```

The agent can then call `read_more_context({ contextRef: 'ctx_ab12cd34', mode: 'search', query: '...' })` to pull the exact passage from the original instead of re-searching.

No schema changes, no new tools, no user-facing copy changes.

## Tests

- `apps/desktop/src/main/context-budget.test.ts`: added tests covering the new `registerContextRef` export and that a round-trip via `read_more_context` returns the original content.
- `pnpm --filter @dotagents/desktop test:run`: no new failures vs `main`; `context-budget.test.ts` now passes with the added cases.
- `pnpm --filter @dotagents/desktop typecheck:node`: passes.
- Pre-existing test and `typecheck:web` failures on `main` are unchanged.

## Files

- `apps/desktop/src/main/context-budget.ts` — export `registerContextRef`
- `apps/desktop/src/main/mcp-service.ts` — plumb sessionId, register ref, append note
- `apps/desktop/src/main/context-budget.test.ts` — tests
