### PR TITLE
feat(tasks): event-triggered tasks with loop-safety guards

### DIFF
--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -244,7 +244,9 @@ class AgentSessionTracker {
       isSnoozed: startSnoozed, // Start snoozed by default - no floating panel auto-show
       profileSnapshot, // Capture profile settings at session creation for isolation
       triggeringLoopId: triggerMeta?.triggeringLoopId,
-      triggerDepth: triggerMeta?.triggerDepth,
+      // Always a number so downstream spawn-depth math (sourceDepth + 1) stays
+      // correct even for user-initiated (untriggered) sessions at depth 0.
+      triggerDepth: triggerMeta?.triggerDepth ?? 0,
     }
 
     this.sessions.set(sessionId, session)

--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -12,6 +12,7 @@ import type { SessionProfileSnapshot } from "../shared/types"
 import { clearSessionUserResponse } from "./session-user-response-store"
 import { dataFolder } from "./config"
 import { loadPersistedJson, savePersistedJson } from "./session-persistence"
+import { taskEventBus } from "./task-event-bus"
 
 export interface AgentSession {
   id: string
@@ -30,6 +31,18 @@ export interface AgentSession {
    * This ensures session isolation - changes to the global profile don't affect running sessions.
    */
   profileSnapshot?: SessionProfileSnapshot
+  /**
+   * Loop id that caused this session to start (if any). Set by LoopService when
+   * spawning a session in response to a trigger event; used to prevent a task
+   * from triggering itself via its own spawned session's events.
+   */
+  triggeringLoopId?: string
+  /**
+   * Causality depth. 0 for user-initiated sessions; N+1 for sessions spawned
+   * by a task fired from an event in a session of depth N. TaskEventBus uses
+   * this to enforce maxTriggerDepth and prevent runaway chains.
+   */
+  triggerDepth?: number
 }
 
 type PersistedAgentSessionState = {
@@ -215,7 +228,8 @@ class AgentSessionTracker {
     conversationId?: string,
     conversationTitle?: string,
     startSnoozed: boolean = true,
-    profileSnapshot?: SessionProfileSnapshot
+    profileSnapshot?: SessionProfileSnapshot,
+    triggerMeta?: { triggeringLoopId?: string; triggerDepth?: number }
   ): string {
     const sessionId = `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
 
@@ -229,6 +243,8 @@ class AgentSessionTracker {
       maxIterations: 10,
       isSnoozed: startSnoozed, // Start snoozed by default - no floating panel auto-show
       profileSnapshot, // Capture profile settings at session creation for isolation
+      triggeringLoopId: triggerMeta?.triggeringLoopId,
+      triggerDepth: triggerMeta?.triggerDepth,
     }
 
     this.sessions.set(sessionId, session)
@@ -276,6 +292,17 @@ class AgentSessionTracker {
     logApp(`[AgentSessionTracker] Completing session: ${sessionId}, remaining sessions: ${this.sessions.size}`)
     this.persistState()
 
+    taskEventBus.emit("onSessionEnd", {
+      sessionId,
+      conversationId: session.conversationId,
+      profileId: session.profileSnapshot?.profileId,
+      triggerDepth: session.triggerDepth,
+      triggeringLoopId: session.triggeringLoopId,
+      timestamp: Date.now(),
+      status: "completed",
+      finalActivity,
+    })
+
     // Emit update to UI
     emitSessionUpdate()
   }
@@ -295,6 +322,16 @@ class AgentSessionTracker {
     this.sessions.delete(sessionId)
     logApp(`[AgentSessionTracker] Stopping session: ${sessionId}, remaining sessions: ${this.sessions.size}`)
     this.persistState()
+
+    taskEventBus.emit("onSessionEnd", {
+      sessionId,
+      conversationId: session.conversationId,
+      profileId: session.profileSnapshot?.profileId,
+      triggerDepth: session.triggerDepth,
+      triggeringLoopId: session.triggeringLoopId,
+      timestamp: Date.now(),
+      status: "stopped",
+    })
 
     // Emit update to UI
     emitSessionUpdate()
@@ -316,6 +353,17 @@ class AgentSessionTracker {
     this.sessions.delete(sessionId)
     logApp(`[AgentSessionTracker] Error in session: ${sessionId}, remaining sessions: ${this.sessions.size}`)
     this.persistState()
+
+    taskEventBus.emit("onSessionEnd", {
+      sessionId,
+      conversationId: session.conversationId,
+      profileId: session.profileSnapshot?.profileId,
+      triggerDepth: session.triggerDepth,
+      triggeringLoopId: session.triggeringLoopId,
+      timestamp: Date.now(),
+      status: "error",
+      errorMessage,
+    })
 
     // Emit update to UI
     emitSessionUpdate()

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -547,6 +547,9 @@ if (!gotSingleInstanceLock) {
       loopService.startAllLoops()
       logApp("Repeat tasks started")
       startTasksFolderWatcher()
+      // Fire onAppStart after loops are loaded so any subscribed handlers exist.
+      const { taskEventBus } = await import("./task-event-bus")
+      taskEventBus.emit("onAppStart", { timestamp: Date.now() })
     } catch (error) {
       logApp("Failed to start repeat tasks:", error)
     }

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -15,6 +15,7 @@ import { isDebugLLM, logLLM, isDebugTools, logTools } from "./debug"
 import { shrinkMessagesForLLM, estimateTokensFromMessages, clearActualTokenUsage, clearIterativeSummary, clearContextRefs, clearArchiveFrontier, clearSummarizationFailureFlags } from "./context-budget"
 import { emitAgentProgress } from "./emit-agent-progress"
 import { agentSessionTracker } from "./agent-session-tracker"
+import { taskEventBus } from "./task-event-bus"
 import { conversationService } from "./conversation-service"
 import { getAcpSessionTitleOverride } from "./acp-session-state"
 import { getCurrentPresetName } from "@dotagents/shared"
@@ -903,6 +904,22 @@ export async function processTranscriptWithAgentMode(
     })
   }
 
+  // Emit an onToolCall event after a tool has finished executing (success or error).
+  const emitToolCallEvent = (toolCall: MCPToolCall, isError: boolean) => {
+    const toolSession = agentSessionTracker.getSession(currentSessionId)
+    taskEventBus.emit("onToolCall", {
+      sessionId: currentSessionId,
+      conversationId,
+      profileId: effectiveProfileSnapshot?.profileId,
+      triggerDepth: toolSession?.triggerDepth,
+      triggeringLoopId: toolSession?.triggeringLoopId,
+      timestamp: Date.now(),
+      toolName: toolCall.name,
+      toolArguments: toolCall.arguments,
+      isError,
+    })
+  }
+
   // Helper function to add a message to the in-memory conversation history ONLY (not persisted).
   // Use for internal prompt-engineering nudges that should never appear in saved transcripts.
   const addEphemeralMessage = (
@@ -1175,6 +1192,16 @@ export async function processTranscriptWithAgentMode(
   if (!userMessageAlreadyExists && shouldPersistInitialUserMessage) {
     saveMessageIncremental("user", transcript).catch(err => {
       logLLM("[processTranscriptWithAgentMode] Failed to save initial user message:", err)
+    })
+    const userMsgSession = agentSessionTracker.getSession(currentSessionId)
+    taskEventBus.emit("onUserMessage", {
+      sessionId: currentSessionId,
+      conversationId,
+      profileId: effectiveProfileSnapshot?.profileId,
+      triggerDepth: userMsgSession?.triggerDepth,
+      triggeringLoopId: userMsgSession?.triggeringLoopId,
+      timestamp: Date.now(),
+      content: transcript,
     })
   }
 
@@ -2454,6 +2481,8 @@ export async function processTranscriptWithAgentMode(
           2, // maxRetries
         )
 
+        emitToolCallEvent(toolCall, !!execResult.result.isError)
+
         // Update the progress step with the result
         toolCallStep.status = execResult.result.isError ? "error" : "completed"
         toolCallStep.toolResult = {
@@ -2571,6 +2600,8 @@ export async function processTranscriptWithAgentMode(
           onToolProgress,
           2, // maxRetries
         )
+
+        emitToolCallEvent(toolCall, !!execResult.result.isError)
 
         if (execResult.cancelledByKill) {
           // Mark step and emit final progress, then break out of tool loop

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1193,6 +1193,10 @@ export async function processTranscriptWithAgentMode(
     saveMessageIncremental("user", transcript).catch(err => {
       logLLM("[processTranscriptWithAgentMode] Failed to save initial user message:", err)
     })
+  }
+  // Emit onUserMessage for any real user submission — including retries of the
+  // same content — but skip internal resume transcripts which aren't user input.
+  if (shouldPersistInitialUserMessage) {
     const userMsgSession = agentSessionTracker.getSession(currentSessionId)
     taskEventBus.emit("onUserMessage", {
       sessionId: currentSessionId,

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -46,6 +46,8 @@ class LoopService {
   private isStopping: boolean = false
   /** In-memory cache of all tasks (merged from global + workspace layers). */
   private loops: LoopConfig[] = []
+  /** Loop IDs currently registered with TaskEventBus, so rebuild can unsubscribe removed ones. */
+  private subscribedLoopIds: Set<string> = new Set()
 
   static getInstance(): LoopService {
     if (!LoopService.instance) {
@@ -394,7 +396,9 @@ class LoopService {
    * Called after loadFromDisk / reload so disk edits take effect.
    */
   rebuildEventSubscriptions(): void {
+    const currentIds = new Set<string>()
     for (const loop of this.loops) {
+      currentIds.add(loop.id)
       const handlers: TaskEventHandler[] = []
       if (loop.enabled && loop.triggers && loop.triggers.length > 0) {
         for (const event of loop.triggers) {
@@ -417,6 +421,14 @@ class LoopService {
       }
       taskEventBus.setHandlersForLoop(loop.id, handlers)
     }
+    // Unsubscribe handlers for loops that were previously registered but are
+    // no longer present in memory (e.g., task files deleted off disk).
+    for (const prevId of this.subscribedLoopIds) {
+      if (!currentIds.has(prevId)) {
+        taskEventBus.setHandlersForLoop(prevId, [])
+      }
+    }
+    this.subscribedLoopIds = currentIds
   }
 
   private scheduleNextRun(loopId: string, delayMs: number): void {

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -14,7 +14,8 @@ import { logApp } from "./debug"
 import { conversationService } from "./conversation-service"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { agentProfileService, createSessionSnapshotFromProfile } from "./agent-profile-service"
-import type { LoopConfig, SessionProfileSnapshot } from "../shared/types"
+import { taskEventBus, type TaskEventHandler, type EventPayloadMap } from "./task-event-bus"
+import type { LoopConfig, LoopTriggerEvent, SessionProfileSnapshot } from "../shared/types"
 import type { RendererHandlers } from "./renderer-handlers"
 import { WINDOWS } from "./window"
 import { getAgentsLayerPaths } from "./agents-files/modular-config"
@@ -166,6 +167,7 @@ class LoopService {
     }
 
     this.loops = nextLoops
+    this.rebuildEventSubscriptions()
     return true
   }
 
@@ -176,12 +178,14 @@ class LoopService {
     this.loops.splice(idx, 1)
     this.stopLoop(loopId)
     this.removeTaskFiles(loopId)
+    taskEventBus.setHandlersForLoop(loopId, [])
     return true
   }
 
   /** Reload tasks from disk (for external changes). */
   reload(): void {
     this.loadFromDisk()
+    this.rebuildEventSubscriptions()
   }
 
   /** Reload tasks from disk and rebuild scheduling state for external file changes. */
@@ -198,6 +202,10 @@ class LoopService {
 
   startAllLoops(): void {
     logApp(`[LoopService] Starting all loops. Found ${this.loops.length} configured loops.`)
+
+    // Register event-trigger handlers before starting timers so bootup events
+    // (onAppStart, any immediate onUserMessage) reach the correct handlers.
+    this.rebuildEventSubscriptions()
 
     for (const loop of this.loops) {
       if (loop.enabled) {
@@ -309,7 +317,13 @@ class LoopService {
     }
   }
 
-  private async executeLoop(loopId: string, options: { rescheduleAfterRun: boolean }): Promise<void> {
+  private async executeLoop(
+    loopId: string,
+    options: {
+      rescheduleAfterRun: boolean
+      triggerSource?: { sourceTriggerDepth?: number }
+    },
+  ): Promise<void> {
     const loop = this.getLoop(loopId)
 
     if (!loop) {
@@ -342,14 +356,17 @@ class LoopService {
 
       const conversation = await conversationService.createConversation(loop.prompt, "user")
       const conversationTitle = `[Repeat] ${loop.name}`
+      const sourceDepth = options.triggerSource?.sourceTriggerDepth
+      const spawnDepth = typeof sourceDepth === "number" ? sourceDepth + 1 : 0
       const sessionId = agentSessionTracker.startSession(
         conversation.id,
         conversationTitle,
         true,
-        profileSnapshot
+        profileSnapshot,
+        { triggeringLoopId: loopId, triggerDepth: spawnDepth },
       )
 
-      logApp(`[LoopService] Created session ${sessionId} for loop "${loop.name}"`)
+      logApp(`[LoopService] Created session ${sessionId} for loop "${loop.name}" (triggerDepth=${spawnDepth})`)
 
       // Reuse the main agent execution flow.
       const { runAgentLoopSession } = await import("./tipc")
@@ -365,6 +382,40 @@ class LoopService {
           this.scheduleNextRun(loopId, this.getNextDelayMs(latestLoop))
         }
       }
+    }
+  }
+
+  // ============================================================================
+  // Event subscriptions (triggers)
+  // ============================================================================
+
+  /**
+   * Rebuild TaskEventBus subscriptions from the current loops in memory.
+   * Called after loadFromDisk / reload so disk edits take effect.
+   */
+  rebuildEventSubscriptions(): void {
+    for (const loop of this.loops) {
+      const handlers: TaskEventHandler[] = []
+      if (loop.enabled && loop.triggers && loop.triggers.length > 0) {
+        for (const event of loop.triggers) {
+          handlers.push({
+            loopId: loop.id,
+            event,
+            config: loop.triggerConfig,
+            fire: async (payload) => {
+              const sourceDepth = (payload as EventPayloadMap[LoopTriggerEvent] & { triggerDepth?: number }).triggerDepth
+              // Re-check enabled at fire time so a just-disabled task doesn't run.
+              const latest = this.getLoop(loop.id)
+              if (!latest?.enabled) return
+              await this.executeLoop(loop.id, {
+                rescheduleAfterRun: false,
+                triggerSource: { sourceTriggerDepth: sourceDepth },
+              })
+            },
+          })
+        }
+      }
+      taskEventBus.setHandlersForLoop(loop.id, handlers)
     }
   }
 

--- a/apps/desktop/src/main/task-event-bus.limits.test.ts
+++ b/apps/desktop/src/main/task-event-bus.limits.test.ts
@@ -41,6 +41,28 @@ describe("TaskEventBus limits", () => {
     expect(fire).toHaveBeenCalledTimes(1)
   })
 
+  it("debounce is per-event, not cross-event within the same loop", async () => {
+    const fireUser = vi.fn()
+    const fireTool = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      handler("loopA", "onUserMessage", { minIntervalMs: 5000, excludeTriggered: false }, fireUser),
+      handler("loopA", "onToolCall", { minIntervalMs: 5000, excludeTriggered: false }, fireTool),
+    ])
+    taskEventBus.emit("onUserMessage", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      content: "hi",
+    })
+    taskEventBus.emit("onToolCall", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      toolName: "t",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fireUser).toHaveBeenCalledTimes(1)
+    expect(fireTool).toHaveBeenCalledTimes(1)
+  })
+
   it("enforces maxRunsPerSession", async () => {
     const fire = vi.fn()
     taskEventBus.setHandlersForLoop("loopA", [

--- a/apps/desktop/src/main/task-event-bus.limits.test.ts
+++ b/apps/desktop/src/main/task-event-bus.limits.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./debug", () => ({
+  logApp: vi.fn(),
+}))
+
+import { taskEventBus } from "./task-event-bus"
+import type { TaskEventHandler } from "./task-event-bus"
+
+function handler(
+  loopId: string,
+  event: TaskEventHandler["event"],
+  config: TaskEventHandler["config"],
+  fire: ReturnType<typeof vi.fn>,
+): TaskEventHandler {
+  return { loopId, event, config, fire: fire as unknown as TaskEventHandler["fire"] }
+}
+
+describe("TaskEventBus limits", () => {
+  beforeEach(() => {
+    taskEventBus._debugResetAll()
+  })
+
+  it("debounces consecutive fires below minIntervalMs", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      handler("loopA", "onUserMessage", { minIntervalMs: 5000, excludeTriggered: false }, fire),
+    ])
+    const base = Date.now()
+    taskEventBus.emit("onUserMessage", {
+      sessionId: "s1",
+      timestamp: base,
+      content: "hi",
+    })
+    taskEventBus.emit("onUserMessage", {
+      sessionId: "s1",
+      timestamp: base + 100,
+      content: "hi again",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).toHaveBeenCalledTimes(1)
+  })
+
+  it("enforces maxRunsPerSession", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      handler(
+        "loopA",
+        "onToolCall",
+        { maxRunsPerSession: 2, minIntervalMs: 0, excludeTriggered: false },
+        fire,
+      ),
+    ])
+    for (let i = 0; i < 5; i++) {
+      taskEventBus.emit("onToolCall", {
+        sessionId: "s1",
+        timestamp: Date.now() + i,
+        toolName: "t",
+      })
+      await new Promise((r) => setImmediate(r))
+    }
+    expect(fire).toHaveBeenCalledTimes(2)
+  })
+
+  it("resets per-session counter on onSessionEnd", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      handler(
+        "loopA",
+        "onToolCall",
+        { maxRunsPerSession: 1, minIntervalMs: 0, excludeTriggered: false },
+        fire,
+      ),
+    ])
+    taskEventBus.emit("onToolCall", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      toolName: "t",
+    })
+    await new Promise((r) => setImmediate(r))
+    taskEventBus.emit("onToolCall", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      toolName: "t",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).toHaveBeenCalledTimes(1)
+
+    // End session, counter resets.
+    taskEventBus.emit("onSessionEnd", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      status: "completed",
+    })
+
+    taskEventBus.emit("onToolCall", {
+      sessionId: "s1",
+      timestamp: Date.now() + 2000,
+      toolName: "t",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).toHaveBeenCalledTimes(2)
+  })
+
+  it("setHandlersForLoop with empty array unsubscribes", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      handler("loopA", "onUserMessage", { excludeTriggered: false }, fire),
+    ])
+    taskEventBus.setHandlersForLoop("loopA", [])
+    taskEventBus.emit("onUserMessage", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      content: "x",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/task-event-bus.test.ts
+++ b/apps/desktop/src/main/task-event-bus.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./debug", () => ({
+  logApp: vi.fn(),
+}))
+
+import { taskEventBus } from "./task-event-bus"
+import type { TaskEventHandler } from "./task-event-bus"
+
+function makeHandler(
+  loopId: string,
+  event: Parameters<typeof taskEventBus.setHandlersForLoop>[1][number]["event"],
+  overrides: Partial<TaskEventHandler> = {},
+  fire: ReturnType<typeof vi.fn> = vi.fn(),
+): TaskEventHandler {
+  return {
+    loopId,
+    event,
+    config: undefined,
+    fire: fire as unknown as TaskEventHandler["fire"],
+    ...overrides,
+  }
+}
+
+describe("TaskEventBus", () => {
+  beforeEach(() => {
+    taskEventBus._debugResetAll()
+  })
+
+  it("delivers onSessionEnd to subscribed handlers", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [makeHandler("loopA", "onSessionEnd", {}, fire)])
+    taskEventBus.emit("onSessionEnd", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      status: "completed",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).toHaveBeenCalledTimes(1)
+  })
+
+  it("blocks self-trigger: task cannot fire on its own spawned session's events", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [makeHandler("loopA", "onSessionEnd", {}, fire)])
+    taskEventBus.emit("onSessionEnd", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      status: "completed",
+      triggeringLoopId: "loopA", // spawned by this same loop
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).not.toHaveBeenCalled()
+  })
+
+  it("enforces maxTriggerDepth (default 1)", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [makeHandler("loopA", "onSessionEnd", {}, fire)])
+    // depth 2 should be blocked by default maxTriggerDepth of 1
+    taskEventBus.emit("onSessionEnd", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      status: "completed",
+      triggerDepth: 2,
+      triggeringLoopId: "loopB",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).not.toHaveBeenCalled()
+  })
+
+  it("excludeTriggered default skips sessions spawned from any task", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [makeHandler("loopA", "onSessionEnd", {}, fire)])
+    taskEventBus.emit("onSessionEnd", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      status: "completed",
+      triggeringLoopId: "loopB", // another task spawned this session
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).not.toHaveBeenCalled()
+  })
+
+  it("respects excludeTriggered=false opt-in", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      makeHandler("loopA", "onSessionEnd", { config: { excludeTriggered: false } }, fire),
+    ])
+    taskEventBus.emit("onSessionEnd", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      status: "completed",
+      triggeringLoopId: "loopB",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).toHaveBeenCalledTimes(1)
+  })
+
+  it("filters onToolCall by toolName", async () => {
+    const fire = vi.fn()
+    taskEventBus.setHandlersForLoop("loopA", [
+      makeHandler("loopA", "onToolCall", { config: { toolName: "web_search" } }, fire),
+    ])
+    taskEventBus.emit("onToolCall", {
+      sessionId: "s1",
+      timestamp: Date.now(),
+      toolName: "shell",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).not.toHaveBeenCalled()
+
+    taskEventBus.emit("onToolCall", {
+      sessionId: "s1",
+      timestamp: Date.now() + 2000,
+      toolName: "web_search",
+    })
+    await new Promise((r) => setImmediate(r))
+    expect(fire).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/main/task-event-bus.ts
+++ b/apps/desktop/src/main/task-event-bus.ts
@@ -145,7 +145,7 @@ function matchesFilters<E extends LoopTriggerEvent>(
 class TaskEventBus {
   private static instance: TaskEventBus | null = null
   private handlers: Map<LoopTriggerEvent, TaskEventHandler[]> = new Map()
-  /** Last-fire timestamp per loopId for debounce. */
+  /** Last-fire timestamp per `${loopId}::${event}` for per-handler debounce. */
   private lastFiredByLoop: Map<string, number> = new Map()
   /** Per-(loopId, sessionId) run counter. */
   private runsByLoopSession: Map<string, number> = new Map()
@@ -226,12 +226,21 @@ class TaskEventBus {
       return
     }
 
-    // Debounce.
+    // Debounce — keyed by (loopId, event) so two different events subscribed
+    // by the same loop don't suppress each other within minIntervalMs.
     const now = Date.now()
-    const last = this.lastFiredByLoop.get(loopId) ?? 0
+    const debounceKey = `${loopId}::${event}`
+    const last = this.lastFiredByLoop.get(debounceKey) ?? 0
     const minInterval = getMinIntervalMs(config)
     if (now - last < minInterval) {
       logApp(`[TaskEventBus] Skip loop ${loopId} on ${event}: debounce (${now - last}ms < ${minInterval}ms)`)
+      return
+    }
+
+    // Global pending ceiling: refuse BEFORE consuming per-session quota so a
+    // dropped-under-load fire doesn't permanently eat budget.
+    if (this.pendingCount >= GLOBAL_PENDING_CEILING) {
+      logApp(`[TaskEventBus] Drop loop ${loopId} on ${event}: global pending ceiling ${this.pendingCount}/${GLOBAL_PENDING_CEILING}`)
       return
     }
 
@@ -248,14 +257,7 @@ class TaskEventBus {
       this.runsByLoopSession.set(key, runs + 1)
     }
 
-
-    // Global pending ceiling: refuse if too many task runs are already in flight.
-    if (this.pendingCount >= GLOBAL_PENDING_CEILING) {
-      logApp(`[TaskEventBus] Drop loop ${loopId} on ${event}: global pending ceiling ${this.pendingCount}/${GLOBAL_PENDING_CEILING}`)
-      return
-    }
-
-    this.lastFiredByLoop.set(loopId, now)
+    this.lastFiredByLoop.set(debounceKey, now)
     this.pendingCount++
 
     try {

--- a/apps/desktop/src/main/task-event-bus.ts
+++ b/apps/desktop/src/main/task-event-bus.ts
@@ -1,0 +1,288 @@
+/**
+ * TaskEventBus — central hub for event-triggered tasks.
+ *
+ * Emits typed events from existing choke points (session lifecycle, tool calls,
+ * user messages, app boot) and routes them to LoopService-registered handlers.
+ * All loop-prevention / debounce / per-session cap logic lives here so the
+ * emission sites and LoopService stay simple.
+ */
+
+import { logApp } from "./debug"
+import type { LoopTriggerConfig, LoopTriggerEvent } from "../shared/types"
+
+// ============================================================================
+// Event payload types
+// ============================================================================
+
+export interface BaseEventPayload {
+  sessionId?: string
+  conversationId?: string
+  profileId?: string
+  /** triggerDepth of the source session, if any. */
+  triggerDepth?: number
+  /** triggeringLoopId of the source session, if any. */
+  triggeringLoopId?: string
+  timestamp: number
+}
+
+export interface SessionEndPayload extends BaseEventPayload {
+  status: "completed" | "stopped" | "error"
+  finalActivity?: string
+  errorMessage?: string
+}
+
+export interface ToolCallPayload extends BaseEventPayload {
+  toolName: string
+  toolArguments?: Record<string, unknown>
+  isError?: boolean
+}
+
+export interface UserMessagePayload extends BaseEventPayload {
+  content: string
+}
+
+export interface AppStartPayload {
+  timestamp: number
+}
+
+export type EventPayloadMap = {
+  onSessionEnd: SessionEndPayload
+  onToolCall: ToolCallPayload
+  onUserMessage: UserMessagePayload
+  onAppStart: AppStartPayload
+}
+
+// ============================================================================
+// Handler registration
+// ============================================================================
+
+export interface TaskEventHandler<E extends LoopTriggerEvent = LoopTriggerEvent> {
+  loopId: string
+  event: E
+  config: LoopTriggerConfig | undefined
+  fire: (payload: EventPayloadMap[E]) => Promise<void>
+}
+
+// ============================================================================
+// Defaults & constants
+// ============================================================================
+
+const DEFAULT_MIN_INTERVAL_MS = 1000
+const DEFAULT_MAX_TRIGGER_DEPTH = 1
+const DEFAULT_MAX_RUNS_PER_SESSION_SESSION_END = 1
+const DEFAULT_MAX_RUNS_PER_SESSION_OTHER = 10
+const GLOBAL_PENDING_CEILING = 50
+
+function getMaxRunsPerSession(event: LoopTriggerEvent, cfg: LoopTriggerConfig | undefined): number {
+  if (cfg?.maxRunsPerSession !== undefined) return cfg.maxRunsPerSession
+  return event === "onSessionEnd"
+    ? DEFAULT_MAX_RUNS_PER_SESSION_SESSION_END
+    : DEFAULT_MAX_RUNS_PER_SESSION_OTHER
+}
+
+function getMaxTriggerDepth(cfg: LoopTriggerConfig | undefined): number {
+  return cfg?.maxTriggerDepth ?? DEFAULT_MAX_TRIGGER_DEPTH
+}
+
+function getMinIntervalMs(cfg: LoopTriggerConfig | undefined): number {
+  return cfg?.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS
+}
+
+function getExcludeTriggered(cfg: LoopTriggerConfig | undefined): boolean {
+  return cfg?.excludeTriggered ?? true
+}
+
+
+// ============================================================================
+// Filter logic
+// ============================================================================
+
+function matchesFilters<E extends LoopTriggerEvent>(
+  event: E,
+  payload: EventPayloadMap[E],
+  cfg: LoopTriggerConfig | undefined,
+  loopId: string,
+): { ok: true } | { ok: false; reason: string } {
+  const p = payload as BaseEventPayload & Partial<ToolCallPayload>
+
+  // Self-trigger guard: task cannot fire on events from its own spawned session.
+  if (p.triggeringLoopId && p.triggeringLoopId === loopId) {
+    return { ok: false, reason: "self-trigger" }
+  }
+
+  // Causality depth guard.
+  const depth = p.triggerDepth ?? 0
+  const maxDepth = getMaxTriggerDepth(cfg)
+  if (depth > maxDepth) {
+    return { ok: false, reason: `depth ${depth} > maxTriggerDepth ${maxDepth}` }
+  }
+
+  // excludeTriggered (default true): on session-end, skip sessions that came
+  // from a task. Applies only when the source session has a triggeringLoopId.
+  if (event === "onSessionEnd" && getExcludeTriggered(cfg) && p.triggeringLoopId) {
+    return { ok: false, reason: "excludeTriggered" }
+  }
+
+  // profileId filter.
+  if (cfg?.profileId && p.profileId !== cfg.profileId) {
+    return { ok: false, reason: `profileId ${p.profileId} != ${cfg.profileId}` }
+  }
+
+  // toolName filter (onToolCall only).
+  if (event === "onToolCall" && cfg?.toolName) {
+    if ((p as ToolCallPayload).toolName !== cfg.toolName) {
+      return { ok: false, reason: `toolName ${(p as ToolCallPayload).toolName} != ${cfg.toolName}` }
+    }
+  }
+
+  return { ok: true }
+}
+
+// ============================================================================
+// TaskEventBus singleton
+// ============================================================================
+
+class TaskEventBus {
+  private static instance: TaskEventBus | null = null
+  private handlers: Map<LoopTriggerEvent, TaskEventHandler[]> = new Map()
+  /** Last-fire timestamp per loopId for debounce. */
+  private lastFiredByLoop: Map<string, number> = new Map()
+  /** Per-(loopId, sessionId) run counter. */
+  private runsByLoopSession: Map<string, number> = new Map()
+  /** Count of in-flight handler invocations for the global ceiling. */
+  private pendingCount = 0
+
+  static getInstance(): TaskEventBus {
+    if (!TaskEventBus.instance) TaskEventBus.instance = new TaskEventBus()
+    return TaskEventBus.instance
+  }
+
+  private constructor() {}
+
+  /**
+   * Replace all handlers for a given loopId. Called on LoopService reload.
+   * Pass an empty array to unsubscribe a loop entirely.
+   */
+  setHandlersForLoop(loopId: string, handlers: TaskEventHandler[]): void {
+    // Remove existing entries for this loopId across all event buckets.
+    for (const [ev, list] of this.handlers.entries()) {
+      const filtered = list.filter((h) => h.loopId !== loopId)
+      this.handlers.set(ev, filtered)
+    }
+    // Insert new handlers.
+    for (const h of handlers) {
+      const bucket = this.handlers.get(h.event) ?? []
+      bucket.push(h)
+      this.handlers.set(h.event, bucket)
+    }
+  }
+
+  /** Unregister all handlers (used on shutdown / full clear). */
+  clearAllHandlers(): void {
+    this.handlers.clear()
+    this.lastFiredByLoop.clear()
+    this.runsByLoopSession.clear()
+  }
+
+  /** Reset per-session counters when a session ends (called from onSessionEnd). */
+  private resetSessionCounters(sessionId: string | undefined): void {
+    if (!sessionId) return
+    for (const key of Array.from(this.runsByLoopSession.keys())) {
+      if (key.endsWith(`::${sessionId}`)) this.runsByLoopSession.delete(key)
+    }
+  }
+
+  /** Emit an event to all subscribed handlers. Fire-and-forget. */
+  emit<E extends LoopTriggerEvent>(event: E, payload: EventPayloadMap[E]): void {
+    const bucket = this.handlers.get(event)
+    if (!bucket || bucket.length === 0) {
+      if (event === "onSessionEnd") {
+        this.resetSessionCounters((payload as SessionEndPayload).sessionId)
+      }
+      return
+    }
+
+    for (const handler of bucket) {
+      void this.dispatch(handler, payload as EventPayloadMap[LoopTriggerEvent])
+    }
+
+    // Reset per-session counters AFTER dispatching, so onSessionEnd fires can
+    // still consult counters from mid-session events.
+    if (event === "onSessionEnd") {
+      this.resetSessionCounters((payload as SessionEndPayload).sessionId)
+    }
+  }
+
+  private async dispatch(
+    handler: TaskEventHandler,
+    payload: EventPayloadMap[LoopTriggerEvent],
+  ): Promise<void> {
+    const { loopId, event, config, fire } = handler
+
+    const filter = matchesFilters(event, payload, config, loopId)
+    if (!filter.ok) {
+      const reason = (filter as { ok: false; reason: string }).reason
+      logApp(`[TaskEventBus] Skip loop ${loopId} on ${event}: ${reason}`)
+      return
+    }
+
+    // Debounce.
+    const now = Date.now()
+    const last = this.lastFiredByLoop.get(loopId) ?? 0
+    const minInterval = getMinIntervalMs(config)
+    if (now - last < minInterval) {
+      logApp(`[TaskEventBus] Skip loop ${loopId} on ${event}: debounce (${now - last}ms < ${minInterval}ms)`)
+      return
+    }
+
+    // Per-session run cap.
+    const sessionId = (payload as BaseEventPayload).sessionId
+    if (sessionId) {
+      const key = `${loopId}::${sessionId}`
+      const runs = this.runsByLoopSession.get(key) ?? 0
+      const maxRuns = getMaxRunsPerSession(event, config)
+      if (runs >= maxRuns) {
+        logApp(`[TaskEventBus] Skip loop ${loopId} on ${event}: session cap ${runs}/${maxRuns}`)
+        return
+      }
+      this.runsByLoopSession.set(key, runs + 1)
+    }
+
+
+    // Global pending ceiling: refuse if too many task runs are already in flight.
+    if (this.pendingCount >= GLOBAL_PENDING_CEILING) {
+      logApp(`[TaskEventBus] Drop loop ${loopId} on ${event}: global pending ceiling ${this.pendingCount}/${GLOBAL_PENDING_CEILING}`)
+      return
+    }
+
+    this.lastFiredByLoop.set(loopId, now)
+    this.pendingCount++
+
+    try {
+      await fire(payload)
+    } catch (err) {
+      logApp(`[TaskEventBus] Handler for loop ${loopId} (${event}) threw: ${err}`)
+    } finally {
+      this.pendingCount--
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Test-only inspection helpers. Not exported; accessed via __testUtils below.
+  // --------------------------------------------------------------------------
+
+  _debugHandlerCount(event: LoopTriggerEvent): number {
+    return (this.handlers.get(event) ?? []).length
+  }
+
+  _debugRunsForSession(loopId: string, sessionId: string): number {
+    return this.runsByLoopSession.get(`${loopId}::${sessionId}`) ?? 0
+  }
+
+  _debugResetAll(): void {
+    this.clearAllHandlers()
+    this.pendingCount = 0
+  }
+}
+
+export const taskEventBus = TaskEventBus.getInstance()

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -11,7 +11,7 @@ import { Trash2, Plus, Edit2, Save, X, Play, Clock, FileText } from "lucide-reac
 import { tipcClient, rendererHandlers } from "@renderer/lib/tipc-client"
 import { cn } from "@renderer/lib/utils"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { LoopConfig, LoopSchedule, LoopTriggerEvent } from "@shared/types"
+import { LoopConfig, LoopSchedule, LoopTriggerConfig, LoopTriggerEvent } from "@shared/types"
 import { toast } from "sonner"
 
 type ScheduleMode = "interval" | "daily" | "weekly"
@@ -28,6 +28,11 @@ interface EditingLoop {
   scheduleDaysOfWeek: number[]  // 0-6 Sun..Sat (used by weekly)
   triggers: LoopTriggerEvent[]  // event triggers (onSessionEnd, etc.)
   triggerToolName: string       // onToolCall: fire only when tool name matches (blank = any)
+  /** Original triggerConfig fields not surfaced in the UI (profileId,
+   *  minIntervalMs, maxRunsPerSession, maxTriggerDepth, excludeTriggered).
+   *  Preserved so round-tripping through the form doesn't drop frontmatter
+   *  config. `toolName` is ignored here — it is driven by triggerToolName. */
+  triggerConfigExtras: Omit<LoopTriggerConfig, "toolName">
 }
 
 const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
@@ -57,6 +62,7 @@ const emptyLoop: EditingLoop = {
   scheduleDaysOfWeek: [1, 2, 3, 4, 5],
   triggers: [],
   triggerToolName: "",
+  triggerConfigExtras: {},
 }
 
 const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
@@ -185,6 +191,13 @@ export function SettingsLoops() {
       scheduleDaysOfWeek,
       triggers: loop.triggers ? [...loop.triggers] : [],
       triggerToolName: loop.triggerConfig?.toolName ?? "",
+      // Snapshot everything except toolName (the form owns that field).
+      triggerConfigExtras: (() => {
+        if (!loop.triggerConfig) return {}
+        const { toolName: _toolName, ...rest } = loop.triggerConfig
+        void _toolName
+        return rest
+      })(),
     })
   }
 
@@ -232,9 +245,15 @@ export function SettingsLoops() {
 
     const slugify = (s: string) => s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64) || crypto.randomUUID()
     const trimmedToolName = editing.triggerToolName.trim()
-    const triggerConfig = editing.triggers.includes("onToolCall") && trimmedToolName
-      ? { toolName: trimmedToolName }
-      : undefined
+    // Merge preserved non-UI fields with the UI-owned toolName. Leave
+    // triggerConfig undefined only if nothing at all would be stored.
+    const mergedTriggerConfig: LoopTriggerConfig = {
+      ...editing.triggerConfigExtras,
+      ...(editing.triggers.includes("onToolCall") && trimmedToolName
+        ? { toolName: trimmedToolName }
+        : {}),
+    }
+    const triggerConfig = Object.keys(mergedTriggerConfig).length > 0 ? mergedTriggerConfig : undefined
     const loopData: LoopConfig = {
       id: editing.id || slugify(editing.name),
       name: editing.name.trim(),

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -11,7 +11,7 @@ import { Trash2, Plus, Edit2, Save, X, Play, Clock, FileText } from "lucide-reac
 import { tipcClient, rendererHandlers } from "@renderer/lib/tipc-client"
 import { cn } from "@renderer/lib/utils"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { LoopConfig, LoopSchedule } from "@shared/types"
+import { LoopConfig, LoopSchedule, LoopTriggerEvent } from "@shared/types"
 import { toast } from "sonner"
 
 type ScheduleMode = "interval" | "daily" | "weekly"
@@ -26,9 +26,18 @@ interface EditingLoop {
   scheduleMode: ScheduleMode
   scheduleTimes: string[]       // HH:MM entries (used by daily + weekly)
   scheduleDaysOfWeek: number[]  // 0-6 Sun..Sat (used by weekly)
+  triggers: LoopTriggerEvent[]  // event triggers (onSessionEnd, etc.)
+  triggerToolName: string       // onToolCall: fire only when tool name matches (blank = any)
 }
 
 const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+const TRIGGER_EVENTS: { value: LoopTriggerEvent; label: string; description: string }[] = [
+  { value: "onSessionEnd", label: "On session end", description: "After any agent conversation finishes" },
+  { value: "onToolCall", label: "On tool call", description: "After each tool call completes" },
+  { value: "onUserMessage", label: "On user message", description: "Each time the user submits a message" },
+  { value: "onAppStart", label: "On app start", description: "Once when the desktop app starts" },
+]
 
 interface LoopRuntimeStatus {
   id: string
@@ -46,6 +55,8 @@ const emptyLoop: EditingLoop = {
   scheduleMode: "interval",
   scheduleTimes: ["09:00"],
   scheduleDaysOfWeek: [1, 2, 3, 4, 5],
+  triggers: [],
+  triggerToolName: "",
 }
 
 const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
@@ -172,6 +183,8 @@ export function SettingsLoops() {
       scheduleMode,
       scheduleTimes,
       scheduleDaysOfWeek,
+      triggers: loop.triggers ? [...loop.triggers] : [],
+      triggerToolName: loop.triggerConfig?.toolName ?? "",
     })
   }
 
@@ -218,6 +231,10 @@ export function SettingsLoops() {
     }
 
     const slugify = (s: string) => s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64) || crypto.randomUUID()
+    const trimmedToolName = editing.triggerToolName.trim()
+    const triggerConfig = editing.triggers.includes("onToolCall") && trimmedToolName
+      ? { toolName: trimmedToolName }
+      : undefined
     const loopData: LoopConfig = {
       id: editing.id || slugify(editing.name),
       name: editing.name.trim(),
@@ -226,6 +243,8 @@ export function SettingsLoops() {
       enabled: editing.enabled,
       runOnStartup: editing.runOnStartup,
       ...(schedule ? { schedule } : {}),
+      ...(editing.triggers.length > 0 ? { triggers: editing.triggers } : {}),
+      ...(triggerConfig ? { triggerConfig } : {}),
     }
 
     try {
@@ -541,6 +560,50 @@ export function SettingsLoops() {
               </div>
             </div>
           )}
+          <div className="space-y-2">
+            <Label>Event triggers</Label>
+            <p className="text-xs text-muted-foreground">
+              Run this task in addition to its schedule when the selected events occur.
+            </p>
+            <div className="space-y-1.5">
+              {TRIGGER_EVENTS.map((evt) => {
+                const active = editing.triggers.includes(evt.value)
+                return (
+                  <div key={evt.value} className="flex items-start gap-2">
+                    <Switch
+                      id={`trigger-${evt.value}`}
+                      checked={active}
+                      onCheckedChange={(v) => {
+                        const next = v
+                          ? [...editing.triggers, evt.value]
+                          : editing.triggers.filter((t) => t !== evt.value)
+                        setEditing({ ...editing, triggers: next })
+                      }}
+                    />
+                    <div className="min-w-0">
+                      <Label htmlFor={`trigger-${evt.value}`} className="text-xs">
+                        {evt.label}
+                      </Label>
+                      <p className="text-[11px] text-muted-foreground">{evt.description}</p>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            {editing.triggers.includes("onToolCall") && (
+              <div className="space-y-1 pt-1">
+                <Label htmlFor="triggerToolName" className="text-xs">
+                  Only fire for tool (optional)
+                </Label>
+                <Input
+                  id="triggerToolName"
+                  value={editing.triggerToolName}
+                  onChange={(e) => setEditing({ ...editing, triggerToolName: e.target.value })}
+                  placeholder="e.g. web_search (blank = any tool)"
+                />
+              </div>
+            )}
+          </div>
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
             <div className="flex items-center space-x-2">
               <Switch

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -993,6 +993,21 @@ export type LoopSchedule =
   | { type: "daily"; times: string[] }
   | { type: "weekly"; times: string[]; daysOfWeek: number[] }
 
+export type LoopTriggerEvent =
+  | "onSessionEnd"
+  | "onToolCall"
+  | "onUserMessage"
+  | "onAppStart"
+
+export interface LoopTriggerConfig {
+  profileId?: string
+  toolName?: string
+  excludeTriggered?: boolean
+  minIntervalMs?: number
+  maxRunsPerSession?: number
+  maxTriggerDepth?: number
+}
+
 export interface LoopConfig {
   id: string               // unique identifier (uuid)
   name: string             // display name
@@ -1003,6 +1018,8 @@ export interface LoopConfig {
   lastRunAt?: number       // timestamp (ms) of last execution
   runOnStartup?: boolean   // if true, fires immediately on app start before first interval
   schedule?: LoopSchedule  // wall-clock schedule; supersedes intervalMinutes when present
+  triggers?: LoopTriggerEvent[]      // event triggers; task fires on named events
+  triggerConfig?: LoopTriggerConfig  // per-task trigger filters and guards
 }
 
 export type Config = {

--- a/packages/core/src/agents-files/tasks.triggers.test.ts
+++ b/packages/core/src/agents-files/tasks.triggers.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest"
+import { parseTaskMarkdown, stringifyTaskMarkdown } from "./tasks"
+import type { LoopConfig } from "../types"
+
+describe("tasks frontmatter - triggers", () => {
+  it("parses triggers list", () => {
+    const md = [
+      "---",
+      "kind: task",
+      "id: t1",
+      "name: My Task",
+      "intervalMinutes: 60",
+      "enabled: true",
+      "triggers: onSessionEnd, onToolCall",
+      "---",
+      "prompt body",
+    ].join("\n")
+
+    const task = parseTaskMarkdown(md)
+    expect(task).not.toBeNull()
+    expect(task!.triggers).toEqual(["onSessionEnd", "onToolCall"])
+    expect(task!.triggerConfig).toBeUndefined()
+  })
+
+  it("parses triggerConfig JSON", () => {
+    const md = [
+      "---",
+      "kind: task",
+      "id: t1",
+      "name: My Task",
+      "intervalMinutes: 60",
+      "enabled: true",
+      "triggers: onToolCall",
+      `triggerConfig: {"toolName":"web_search","minIntervalMs":2000,"maxRunsPerSession":5,"maxTriggerDepth":2,"excludeTriggered":false}`,
+      "---",
+      "prompt body",
+    ].join("\n")
+
+    const task = parseTaskMarkdown(md)
+    expect(task).not.toBeNull()
+    expect(task!.triggerConfig).toEqual({
+      toolName: "web_search",
+      minIntervalMs: 2000,
+      maxRunsPerSession: 5,
+      maxTriggerDepth: 2,
+      excludeTriggered: false,
+    })
+  })
+
+  it("ignores unknown trigger names", () => {
+    const md = [
+      "---",
+      "kind: task",
+      "id: t1",
+      "name: My Task",
+      "intervalMinutes: 60",
+      "enabled: true",
+      "triggers: onSessionEnd, onBogus, onAppStart",
+      "---",
+      "",
+    ].join("\n")
+
+    const task = parseTaskMarkdown(md)
+    expect(task!.triggers).toEqual(["onSessionEnd", "onAppStart"])
+  })
+
+  it("round-trips triggers and triggerConfig through stringify/parse", () => {
+    const original: LoopConfig = {
+      id: "t1",
+      name: "My Task",
+      prompt: "do the thing",
+      intervalMinutes: 30,
+      enabled: true,
+      triggers: ["onSessionEnd", "onUserMessage"],
+      triggerConfig: {
+        profileId: "researcher",
+        minIntervalMs: 1500,
+        excludeTriggered: false,
+      },
+    }
+
+    const md = stringifyTaskMarkdown(original)
+    const parsed = parseTaskMarkdown(md)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.triggers).toEqual(["onSessionEnd", "onUserMessage"])
+    expect(parsed!.triggerConfig).toEqual({
+      profileId: "researcher",
+      minIntervalMs: 1500,
+      excludeTriggered: false,
+    })
+  })
+
+  it("omits triggers/triggerConfig from frontmatter when absent (backward compat)", () => {
+    const legacy: LoopConfig = {
+      id: "t1",
+      name: "Legacy",
+      prompt: "x",
+      intervalMinutes: 60,
+      enabled: true,
+    }
+    const md = stringifyTaskMarkdown(legacy)
+    expect(md).not.toMatch(/triggers:/)
+    expect(md).not.toMatch(/triggerConfig:/)
+    const parsed = parseTaskMarkdown(md)
+    expect(parsed!.triggers).toBeUndefined()
+    expect(parsed!.triggerConfig).toBeUndefined()
+  })
+})

--- a/packages/core/src/agents-files/tasks.ts
+++ b/packages/core/src/agents-files/tasks.ts
@@ -1,10 +1,22 @@
 import fs from "fs"
 import path from "path"
-import type { LoopConfig, LoopSchedule } from "../types"
+import type {
+  LoopConfig,
+  LoopSchedule,
+  LoopTriggerConfig,
+  LoopTriggerEvent,
+} from "../types"
 import type { AgentsLayerPaths } from "./modular-config"
 import { AGENTS_TASKS_DIR } from "./modular-config"
 import { parseFrontmatterOrBody, stringifyFrontmatterDocument } from "./frontmatter"
 import { readTextFileIfExistsSync, safeWriteFileSync } from "./safe-file"
+
+const VALID_TRIGGER_EVENTS: readonly LoopTriggerEvent[] = [
+  "onSessionEnd",
+  "onToolCall",
+  "onUserMessage",
+  "onAppStart",
+]
 
 export const TASK_CANONICAL_FILENAME = "task.md"
 
@@ -95,6 +107,56 @@ function stringifySchedule(schedule: LoopSchedule): string {
   return JSON.stringify(schedule)
 }
 
+// ---- Triggers (de)serialization ---------------------------------------------
+
+function parseTriggers(raw: string | undefined): LoopTriggerEvent[] | undefined {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return undefined
+  const parts = trimmed.split(",").map((p) => p.trim()).filter(Boolean)
+  const out: LoopTriggerEvent[] = []
+  for (const p of parts) {
+    if ((VALID_TRIGGER_EVENTS as readonly string[]).includes(p) && !out.includes(p as LoopTriggerEvent)) {
+      out.push(p as LoopTriggerEvent)
+    }
+  }
+  return out.length > 0 ? out : undefined
+}
+
+function stringifyTriggers(triggers: LoopTriggerEvent[]): string {
+  return triggers.join(", ")
+}
+
+function parseTriggerConfig(raw: string | undefined): LoopTriggerConfig | undefined {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return undefined
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== "object") return undefined
+  const obj = parsed as Record<string, unknown>
+  const out: LoopTriggerConfig = {}
+  if (typeof obj.profileId === "string" && obj.profileId.trim()) out.profileId = obj.profileId.trim()
+  if (typeof obj.toolName === "string" && obj.toolName.trim()) out.toolName = obj.toolName.trim()
+  if (typeof obj.excludeTriggered === "boolean") out.excludeTriggered = obj.excludeTriggered
+  if (typeof obj.minIntervalMs === "number" && Number.isFinite(obj.minIntervalMs) && obj.minIntervalMs >= 0) {
+    out.minIntervalMs = Math.floor(obj.minIntervalMs)
+  }
+  if (typeof obj.maxRunsPerSession === "number" && Number.isFinite(obj.maxRunsPerSession) && obj.maxRunsPerSession >= 1) {
+    out.maxRunsPerSession = Math.floor(obj.maxRunsPerSession)
+  }
+  if (typeof obj.maxTriggerDepth === "number" && Number.isFinite(obj.maxTriggerDepth) && obj.maxTriggerDepth >= 0) {
+    out.maxTriggerDepth = Math.floor(obj.maxTriggerDepth)
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+function stringifyTriggerConfig(cfg: LoopTriggerConfig): string {
+  return JSON.stringify(cfg)
+}
+
 // ============================================================================
 // Path helpers
 // ============================================================================
@@ -132,6 +194,12 @@ export function stringifyTaskMarkdown(task: LoopConfig): string {
   if (task.runOnStartup) frontmatter.runOnStartup = "true"
   if (task.lastRunAt) frontmatter.lastRunAt = String(task.lastRunAt)
   if (task.schedule) frontmatter.schedule = stringifySchedule(task.schedule)
+  if (task.triggers && task.triggers.length > 0) {
+    frontmatter.triggers = stringifyTriggers(task.triggers)
+  }
+  if (task.triggerConfig && Object.keys(task.triggerConfig).length > 0) {
+    frontmatter.triggerConfig = stringifyTriggerConfig(task.triggerConfig)
+  }
 
   return stringifyFrontmatterDocument({ frontmatter, body: task.prompt || "" })
 }
@@ -154,6 +222,8 @@ export function parseTaskMarkdown(
   const intervalMinutes = parseNumber(fm.intervalMinutes, 60)
 
   const schedule = parseSchedule(fm.schedule)
+  const triggers = parseTriggers(fm.triggers)
+  const triggerConfig = parseTriggerConfig(fm.triggerConfig)
 
   return {
     id,
@@ -165,6 +235,8 @@ export function parseTaskMarkdown(
     runOnStartup: parseBoolean(fm.runOnStartup, false) || undefined,
     lastRunAt: fm.lastRunAt ? parseNumber(fm.lastRunAt, 0) || undefined : undefined,
     schedule,
+    triggers,
+    triggerConfig,
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,6 +67,47 @@ export type LoopSchedule =
   | { type: "daily"; times: string[] }
   | { type: "weekly"; times: string[]; daysOfWeek: number[] }
 
+/**
+ * Named event triggers for tasks. Emitted by TaskEventBus (desktop main process).
+ * - onSessionEnd: agent session reached a terminal state (complete/stop/error)
+ * - onToolCall: a tool call just finished executing inside a session
+ * - onUserMessage: first user message of a turn was submitted
+ * - onAppStart: app main process finished booting
+ */
+export type LoopTriggerEvent =
+  | "onSessionEnd"
+  | "onToolCall"
+  | "onUserMessage"
+  | "onAppStart"
+
+/**
+ * Per-trigger filters and guards. All fields optional; undefined means "no filter".
+ * Defaults applied by TaskEventBus when absent at fire time.
+ */
+export interface LoopTriggerConfig {
+  /** Only fire when the source session's profileId matches. */
+  profileId?: string
+  /** Only fire when the tool call's name matches (onToolCall only). */
+  toolName?: string
+  /**
+   * When true (default), onSessionEnd skips sessions that were themselves
+   * spawned by a task (prevents chain reactions).
+   */
+  excludeTriggered?: boolean
+  /** Minimum ms between consecutive fires for this task. Default 1000. */
+  minIntervalMs?: number
+  /**
+   * Max times this task can fire within a single source session.
+   * Default: 1 for onSessionEnd, 10 for other events.
+   */
+  maxRunsPerSession?: number
+  /**
+   * Max triggerDepth the source session may have for this task to fire.
+   * Default 1 (user-initiated sessions only; triggered sessions don't re-trigger).
+   */
+  maxTriggerDepth?: number
+}
+
 export interface LoopConfig {
   id: string
   name: string
@@ -79,6 +120,10 @@ export interface LoopConfig {
   runOnStartup?: boolean
   /** Wall-clock schedule. When present, supersedes `intervalMinutes`. */
   schedule?: LoopSchedule
+  /** Event triggers. When present, task fires in response to named events. */
+  triggers?: LoopTriggerEvent[]
+  /** Per-task trigger configuration (filters and guards). */
+  triggerConfig?: LoopTriggerConfig
 }
 
 // ============================================================================

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -718,6 +718,21 @@ export type LoopSchedule =
   | { type: "daily"; times: string[] }
   | { type: "weekly"; times: string[]; daysOfWeek: number[] };
 
+export type LoopTriggerEvent =
+  | "onSessionEnd"
+  | "onToolCall"
+  | "onUserMessage"
+  | "onAppStart";
+
+export interface LoopTriggerConfig {
+  profileId?: string;
+  toolName?: string;
+  excludeTriggered?: boolean;
+  minIntervalMs?: number;
+  maxRunsPerSession?: number;
+  maxTriggerDepth?: number;
+}
+
 export interface Loop {
   id: string;
   name: string;
@@ -731,6 +746,8 @@ export interface Loop {
   isRunning: boolean;
   nextRunAt?: number;
   schedule?: LoopSchedule;
+  triggers?: LoopTriggerEvent[];
+  triggerConfig?: LoopTriggerConfig;
 }
 
 export interface LoopsResponse {


### PR DESCRIPTION
Adds event triggers to tasks so they can run on session end, user messages, tool calls, or app start, in addition to the existing interval/schedule triggers.

## Triggers
- `onSessionEnd` — emitted from `agent-session-tracker` when a session completes, stops, or errors
- `onUserMessage` — each time the user submits a message (from `llm.ts`)
- `onToolCall` — after each tool executes; optional `toolName` filter
- `onAppStart` — emitted once after `loopService.startAllLoops`

## Loop-safety
- **Self-trigger guard:** a task cannot re-fire on events from sessions it spawned.
- **`maxTriggerDepth`** (default `1`) limits cascades.
- **`excludeTriggered`** (default `true`) skips events from triggered sessions.
- **`minIntervalMs`** per-handler (per `loopId::event`) debounce.
- **`maxRunsPerSession`** caps fires per session (reset on `onSessionEnd`).
- Global pending-fire ceiling in the bus (checked before consuming per-session quota).

## Back-compat
- Legacy `runOnStartup` is internally mapped to `onAppStart`.
- Tasks without `triggers` keep interval/schedule-only behavior unchanged.
- Task frontmatter omits trigger fields when absent.

## UI
`settings-loops.tsx` gains an **Event triggers** section with a switch per event and an optional tool-name filter for `onToolCall`. Non-UI `triggerConfig` fields (profileId, minIntervalMs, maxRunsPerSession, maxTriggerDepth, excludeTriggered) authored via frontmatter are preserved across edits.

> Mobile app parity (`apps/mobile/src/`) has not been updated and is tracked as a follow-up.

## Tests
- `task-event-bus.test.ts` — filtering, self-trigger guard, depth guard.
- `task-event-bus.limits.test.ts` — debounce (including per-event isolation), per-session cap, cleanup.
- `tasks.triggers.test.ts` — frontmatter round-trip and unknown-trigger filtering.

All new tests pass; existing loop/session-tracker tests still pass; `typecheck:node` clean.
