### PR TITLE
Stop auto-writing top-level ~/.agents/system-prompt.md and agents.md

### DIFF
--- a/apps/desktop/src/main/agent-profile-service.ts
+++ b/apps/desktop/src/main/agent-profile-service.ts
@@ -27,14 +27,13 @@ import { randomUUID } from "crypto"
 import { logApp } from "./debug"
 import { configStore, globalAgentsFolder, resolveWorkspaceAgentsFolder } from "./config"
 import { getRuntimeToolNames } from "./runtime-tool-definitions"
-import { getAgentsLayerPaths, writeAgentsPrompts, loadAgentsPrompts } from "./agents-files/modular-config"
+import { getAgentsLayerPaths } from "./agents-files/modular-config"
 import {
   loadAgentProfilesLayer,
   writeAgentsProfileFiles,
   writeAllAgentsProfileFiles,
   deleteAgentProfileFiles,
 } from "./agents-files/agent-profiles"
-import { DEFAULT_SYSTEM_PROMPT } from "./system-prompts-default"
 
 /**
  * Path to the agent profiles storage file.
@@ -304,43 +303,6 @@ class AgentProfileService {
     }
   }
 
-  private syncPromptsFromLayer(data: AgentProfilesData) {
-    const layerPath = resolveWorkspaceAgentsFolder() || globalAgentsFolder
-    const agentsLayerPaths = getAgentsLayerPaths(layerPath)
-
-    const { systemPrompt, agentsGuidelines } = loadAgentsPrompts(agentsLayerPaths)
-
-    const mainAgent = data.profiles.find((p) => p.name === "main-agent")
-    if (mainAgent) {
-      if (systemPrompt !== null) {
-        mainAgent.systemPrompt = systemPrompt
-      } else {
-        mainAgent.systemPrompt = DEFAULT_SYSTEM_PROMPT
-      }
-      if (agentsGuidelines !== null) {
-        mainAgent.guidelines = agentsGuidelines
-      } else {
-        mainAgent.guidelines = ""
-      }
-    }
-  }
-
-  private syncPromptsToLayer() {
-    if (!this.profilesData) return
-    const mainAgent = this.profilesData.profiles.find((p) => p.name === "main-agent")
-    if (!mainAgent) return
-
-    const layerPath = resolveWorkspaceAgentsFolder() || globalAgentsFolder
-    const agentsLayerPaths = getAgentsLayerPaths(layerPath)
-
-    writeAgentsPrompts(
-      agentsLayerPaths,
-      mainAgent.systemPrompt || DEFAULT_SYSTEM_PROMPT,
-      mainAgent.guidelines || "",
-      DEFAULT_SYSTEM_PROMPT
-    )
-  }
-
   /**
    * Load profiles from storage, migrating from legacy formats if needed.
    *
@@ -382,7 +344,6 @@ class AgentProfileService {
         profiles: Array.from(mergedById.values()),
         currentProfileId,
       }
-      this.syncPromptsFromLayer(this.profilesData)
       logApp(`Loaded ${this.profilesData.profiles.length} agent profile(s) from .agents/agents/`)
       return this.profilesData
     }
@@ -392,7 +353,6 @@ class AgentProfileService {
       if (fs.existsSync(agentProfilesPath)) {
         const data = JSON.parse(fs.readFileSync(agentProfilesPath, "utf8")) as AgentProfilesData
         this.profilesData = data
-        this.syncPromptsFromLayer(this.profilesData)
         // Migrate: write each profile as modular files
         this.migrateToModularFiles(data.profiles)
         return data
@@ -405,7 +365,6 @@ class AgentProfileService {
     const migratedProfiles = this.migrateFromLegacy()
     if (migratedProfiles.length > 0) {
       this.profilesData = { profiles: migratedProfiles }
-      this.syncPromptsFromLayer(this.profilesData)
       this.saveProfiles()
       return this.profilesData
     }
@@ -420,7 +379,6 @@ class AgentProfileService {
     }))
 
     this.profilesData = { profiles: defaultProfiles }
-    this.syncPromptsFromLayer(this.profilesData)
     this.saveProfiles()
     return this.profilesData
   }
@@ -507,8 +465,6 @@ class AgentProfileService {
   private saveProfiles(): void {
     if (!this.profilesData) return
     try {
-      this.syncPromptsToLayer()
-
       // Canonical: write modular .agents/agents/ files
       const globalLayer = getAgentsLayerPaths(globalAgentsFolder)
       writeAllAgentsProfileFiles(globalLayer, this.profilesData.profiles, { maxBackups: 10 })
@@ -820,17 +776,6 @@ class AgentProfileService {
     this.profilesData = undefined
     this.loadProfiles()
     this.loadConversations()
-  }
-
-  /**
-   * Reload just the main-agent's system prompt + guidelines from
-   * `~/.agents/system-prompt.md` and `~/.agents/agents.md`. Used by the
-   * `.agents` folder watcher to pick up external edits without touching the
-   * rest of the profile data on disk.
-   */
-  reloadPromptsFromLayer(): void {
-    if (!this.profilesData) return
-    this.syncPromptsFromLayer(this.profilesData)
   }
 
   // ============================================================================

--- a/apps/desktop/src/main/agents-folder-watcher.test.ts
+++ b/apps/desktop/src/main/agents-folder-watcher.test.ts
@@ -38,7 +38,6 @@ const mocks = vi.hoisted(() => {
     ]),
     configReload: vi.fn(),
     profileReload: vi.fn(),
-    promptsReload: vi.fn(),
     closeSpy,
   }
 })
@@ -70,7 +69,6 @@ vi.mock("./config", () => ({
 vi.mock("./agent-profile-service", () => ({
   agentProfileService: {
     reload: mocks.profileReload,
-    reloadPromptsFromLayer: mocks.promptsReload,
   },
 }))
 
@@ -98,7 +96,6 @@ describe("AgentsFolderWatcher (Linux per-subdir filename resolution)", () => {
     mocks.readdirSync.mockClear()
     mocks.configReload.mockClear()
     mocks.profileReload.mockClear()
-    mocks.promptsReload.mockClear()
     mocks.closeSpy.mockClear()
     setPlatform("linux")
   })
@@ -130,14 +127,15 @@ describe("AgentsFolderWatcher (Linux per-subdir filename resolution)", () => {
     expect(mocks.profileReload).toHaveBeenCalledTimes(1)
   })
 
-  it("still reloads prompts when `system-prompt.md` fires on the root watcher", async () => {
+  it("ignores top-level `system-prompt.md` and `agents.md` changes (ecosystem-shared overrides)", async () => {
     const mod = await import("./agents-folder-watcher")
     mod.startAgentsFolderWatcher()
 
     findCallback("/mock/.agents")("change", "system-prompt.md")
+    findCallback("/mock/.agents")("change", "agents.md")
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(mocks.promptsReload).toHaveBeenCalledTimes(1)
+    expect(mocks.configReload).not.toHaveBeenCalled()
     expect(mocks.profileReload).not.toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/main/agents-folder-watcher.ts
+++ b/apps/desktop/src/main/agents-folder-watcher.ts
@@ -3,16 +3,18 @@
  *
  * Watches the user-editable files in `~/.agents/` (and the optional workspace
  * overlay) and syncs external edits back into the in-memory stores. Without
- * this, a user editing `system-prompt.md`, `agents.md`, `layouts/ui.json`, or
- * `agents/<id>/agent.md` directly on disk would have their changes silently
- * overwritten the next time any unrelated code path called `configStore.save()`
- * or `agentProfileService.saveProfiles()`, because those writers serialize
- * from in-memory values that haven't seen the external edit.
+ * this, a user editing `layouts/ui.json` or `agents/<id>/agent.md` directly on
+ * disk would have their changes silently overwritten the next time any
+ * unrelated code path called `configStore.save()` or
+ * `agentProfileService.saveProfiles()`, because those writers serialize from
+ * in-memory values that haven't seen the external edit.
  *
  * Watcher scope is intentionally narrow — it only triggers reloads for the
  * files that are round-tripped through the save paths guarded by
  * `skipIfUnchanged` in `safe-file.ts`. Other `.agents/` subtrees (skills,
- * tasks, memories) already have their own watchers.
+ * tasks, memories) already have their own watchers. The top-level
+ * `system-prompt.md` and `agents.md` are ecosystem-shared overrides that
+ * DotAgents never writes, so they have no in-memory state to keep in sync.
  */
 
 import fs from "fs"
@@ -27,7 +29,6 @@ let watchers: fs.FSWatcher[] = []
 let debounceTimer: NodeJS.Timeout | null = null
 let pendingReloads = {
   config: false,
-  prompts: false,
   profiles: false,
 }
 
@@ -44,7 +45,6 @@ function classifyChange(filename: string | null): void {
   if (!filename) {
     // Unknown change — be safe and reload everything watched.
     pendingReloads.config = true
-    pendingReloads.prompts = true
     pendingReloads.profiles = true
     return
   }
@@ -62,11 +62,6 @@ function classifyChange(filename: string | null): void {
     return
   }
 
-  if (normalized === "system-prompt.md" || normalized === "agents.md") {
-    pendingReloads.prompts = true
-    return
-  }
-
   if (normalized.startsWith("agents/") && normalized.endsWith(".md")) {
     pendingReloads.profiles = true
     return
@@ -80,7 +75,7 @@ function classifyChange(filename: string | null): void {
 
 function flushPendingReloads(): void {
   const snapshot = { ...pendingReloads }
-  pendingReloads = { config: false, prompts: false, profiles: false }
+  pendingReloads = { config: false, profiles: false }
 
   if (snapshot.config) {
     try {
@@ -91,18 +86,10 @@ function flushPendingReloads(): void {
   }
 
   if (snapshot.profiles) {
-    // A full profiles reload also re-runs `syncPromptsFromLayer`, so this
-    // covers the prompts case too.
     try {
       agentProfileService.reload()
     } catch (error) {
       logApp("[AgentsFolderWatcher] Failed to reload agent profiles:", error)
-    }
-  } else if (snapshot.prompts) {
-    try {
-      agentProfileService.reloadPromptsFromLayer()
-    } catch (error) {
-      logApp("[AgentsFolderWatcher] Failed to reload prompts:", error)
     }
   }
 }
@@ -135,7 +122,7 @@ function handleWatcherEvent(
     : null
   classifyChange(relative)
 
-  if (!pendingReloads.config && !pendingReloads.prompts && !pendingReloads.profiles) {
+  if (!pendingReloads.config && !pendingReloads.profiles) {
     return
   }
 
@@ -242,5 +229,5 @@ export function stopAgentsFolderWatcher(): void {
   }
   // Reset any classified-but-not-yet-flushed reload flags so a later
   // restart doesn't fire a stale reload on its first event.
-  pendingReloads = { config: false, prompts: false, profiles: false }
+  pendingReloads = { config: false, profiles: false }
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -579,8 +579,8 @@ if (!gotSingleInstanceLock) {
     }
 
     // Start watching the rest of `.agents/` so external edits to
-    // system-prompt.md, agents.md, layouts/ui.json, and agents/<id>/agent.md
-    // are picked up before the next save overwrites them.
+    // layouts/ui.json and agents/<id>/agent.md are picked up before the next
+    // save overwrites them.
     try {
       startAgentsFolderWatcher()
     } catch (error) {


### PR DESCRIPTION
## Problem

`~/.agents/system-prompt.md` and `~/.agents/agents.md` were being rewritten by DotAgents on every profile save, even when the user hadn't changed anything in the UI. This is visible as constant mtime churn in those files.

These files are **ecosystem-shared overrides** per the [dotagents protocol](https://dotagentsprotocol.com) — they should be user-authored and treated as opt-in, matching how Claude Code, OpenAI Codex, OpenCode, and Pi's `SYSTEM.md` handle the analogous concept. DotAgents shouldn't auto-generate or round-trip them.

## Root cause

`agent-profile-service.ts` had a `syncPromptsToLayer()` method called from `saveProfiles()` that wrote `DEFAULT_SYSTEM_PROMPT` (or the main-agent's in-memory prompt) to those files on every save. A companion `syncPromptsFromLayer()` also forced the main-agent's prompt to whatever was on disk (or the default), coupling the two.

## Fix

Remove the auto-write path entirely. The main-agent's prompt + guidelines now come only from `agents/main-agent/agent.md` (the canonical modular location).

- Delete `syncPromptsToLayer()` and its call in `saveProfiles()`.
- Delete `syncPromptsFromLayer()` / `reloadPromptsFromLayer()` and their 4 call sites in `loadProfiles`.
- Remove the `prompts` branch from `agents-folder-watcher.ts`; top-level `system-prompt.md` / `agents.md` changes are no longer reload triggers.
- Update the corresponding watcher test to assert those files are ignored.
- Update comments in `index.ts` and the watcher to reflect the new semantics.

`writeAgentsPrompts` and `loadAgentsPrompts` remain exported — the TIPC "Open file" handlers still use them (guarded by `onlyIfMissing`) to create the file on demand when the user explicitly opens it from the UI.

## Validation

- Main-process typecheck: passes
- Targeted tests pass: `agents-folder-watcher.test.ts`, desktop + core `modular-config.test.ts`, `agent-profile-mcp-cleanup.test.ts`, `agent-profile-skill-cleanup.test.ts`, `main-agent-selection.test.ts`
- Pre-existing failures on `main` (unrelated): `packages/core/src/config.test.ts` mock typing, `agent-progress.tsx` web typecheck, 2 `system-prompts.test.ts` content assertions.

## Net impact

4 files changed, 17 insertions / 87 deletions.
