### PR TITLE
fix(panel): stop panel TTS on ESC and prevent double TTS with main tile

### DIFF
--- a/apps/desktop/src/main/renderer-handlers.ts
+++ b/apps/desktop/src/main/renderer-handlers.ts
@@ -26,6 +26,9 @@ export type RendererHandlers = {
   // Stop all in-progress TTS playback in this renderer window
   stopAllTts: () => void
 
+  // Floating panel visibility changed (broadcast to all windows)
+  panelVisibilityChanged: (data: { visible: boolean }) => void
+
   agentSessionsUpdated: (data: {
     activeSessions: AgentSession[]
     recentCompletedSessions: AgentSession[]

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -923,6 +923,10 @@ export const router = {
     hideFloatingPanelWindow()
   }),
 
+  getFloatingPanelVisibility: t.procedure.action(async () => {
+    return { visible: WINDOWS.get("panel")?.isVisible?.() ?? false }
+  }),
+
   snoozeAgentSessionsAndHidePanelWindow: t.procedure
     .input<{ sessionIds?: string[] }>()
     .action(async ({ input }) => {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -246,9 +246,10 @@ function broadcastPanelVisibility(visible: boolean) {
   }
 }
 
-// Stop TTS playing in the floating panel renderer only. Called from ESC-driven
-// panel-hide paths so that dismissing the panel silences its TTS without
-// affecting TTS playing in the main window.
+// Stop TTS playing in the floating panel renderer only. Invoked from the
+// panel's `hide` handler so every hide path (ESC, hideFloatingPanelWindow,
+// main-window focus auto-hide, etc.) silences panel TTS without affecting
+// TTS playing in the main window.
 function stopPanelRendererTts() {
   const panel = WINDOWS.get("panel")
   if (!panel) return
@@ -1020,6 +1021,7 @@ export function createPanelWindow(): BrowserWindow | undefined {
       snapshot: getWindowFocusDebugSnapshot(),
     })
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()
+    stopPanelRendererTts()
     broadcastPanelVisibility(false)
   })
 
@@ -1238,7 +1240,6 @@ export const stopRecordingAndHidePanelWindow = () => {
     state.isRecordingMcpMode = false
 
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()
-    stopPanelRendererTts()
 
     if (win.isVisible()) {
       // Clear the "opened with main" flag since panel is being hidden
@@ -1260,7 +1261,6 @@ export const stopTextInputAndHidePanelWindow = () => {
     markIntentionalTextInputPanelHide("stopTextInputAndHidePanelWindow")
     state.isTextInputActive = false
     getRendererHandlers<RendererHandlers>(win.webContents).hideTextInput.send()
-    stopPanelRendererTts()
 
     if (win.isVisible()) {
       // Clear the "opened with main" flag since panel is being hidden
@@ -1303,7 +1303,6 @@ export const minimizeAgentModeAndHidePanelWindow = () => {
     state.agentIterationCount = 0
 
     clearPanelHiddenByMainFocus()
-    stopPanelRendererTts()
 
     if (win.isVisible()) {
       clearPanelOpenedWithMain()

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -235,6 +235,28 @@ export function clearPanelOpenedWithMain() {
   panelOpenedWithMain = false
 }
 
+// Broadcast the floating panel's current visibility to all renderer windows so
+// they can coordinate behavior like TTS auto-play (avoid double playback when
+// the same session renders in both panel and main-window tile).
+function broadcastPanelVisibility(visible: boolean) {
+  for (const win of WINDOWS.values()) {
+    try {
+      getRendererHandlers<RendererHandlers>(win.webContents).panelVisibilityChanged?.send({ visible })
+    } catch {}
+  }
+}
+
+// Stop TTS playing in the floating panel renderer only. Called from ESC-driven
+// panel-hide paths so that dismissing the panel silences its TTS without
+// affecting TTS playing in the main window.
+function stopPanelRendererTts() {
+  const panel = WINDOWS.get("panel")
+  if (!panel) return
+  try {
+    getRendererHandlers<RendererHandlers>(panel.webContents).stopAllTts?.send()
+  } catch {}
+}
+
 // One-shot flag for intentional main-window hide paths.
 // If main is hidden without this flag, we treat it as accidental and recover.
 let allowExpectedMainHide = false
@@ -998,6 +1020,7 @@ export function createPanelWindow(): BrowserWindow | undefined {
       snapshot: getWindowFocusDebugSnapshot(),
     })
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()
+    broadcastPanelVisibility(false)
   })
 
   // Reassert z-order on lifecycle changes and reset stale focus-hide flag
@@ -1006,6 +1029,7 @@ export function createPanelWindow(): BrowserWindow | undefined {
     // Clear the flag when panel becomes visible through any means.
     // This prevents stale state if user manually shows panel while main is focused.
     clearPanelHiddenByMainFocus()
+    broadcastPanelVisibility(true)
   })
   win.on("blur", () => {
     // Skip z-order reassertion in textInput mode.
@@ -1214,6 +1238,7 @@ export const stopRecordingAndHidePanelWindow = () => {
     state.isRecordingMcpMode = false
 
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()
+    stopPanelRendererTts()
 
     if (win.isVisible()) {
       // Clear the "opened with main" flag since panel is being hidden
@@ -1235,6 +1260,7 @@ export const stopTextInputAndHidePanelWindow = () => {
     markIntentionalTextInputPanelHide("stopTextInputAndHidePanelWindow")
     state.isTextInputActive = false
     getRendererHandlers<RendererHandlers>(win.webContents).hideTextInput.send()
+    stopPanelRendererTts()
 
     if (win.isVisible()) {
       // Clear the "opened with main" flag since panel is being hidden
@@ -1277,6 +1303,7 @@ export const minimizeAgentModeAndHidePanelWindow = () => {
     state.agentIterationCount = 0
 
     clearPanelHiddenByMainFocus()
+    stopPanelRendererTts()
 
     if (win.isVisible()) {
       clearPanelOpenedWithMain()

--- a/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
@@ -6,17 +6,19 @@ const agentProgressSource = readFileSync(new URL("./agent-progress.tsx", import.
 describe("agent progress TTS guardrails", () => {
   it("disables overlay auto-play generation when the session is snoozed", () => {
     expect(agentProgressSource).toContain('function shouldAutoPlayTTSForVariant')
-    expect(agentProgressSource).toContain('return variant === "tile" ? isFocused : !isSnoozed')
+    expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
+    expect(agentProgressSource).toContain('return !isSnoozed')
   })
 
   it("threads snoozed state through overlay and tile TTS players", () => {
     expect(agentProgressSource).toContain('isSnoozed={progress.isSnoozed}')
-    expect(agentProgressSource).toContain('autoPlay={shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused) && (configQuery.data?.ttsAutoPlay ?? true)}')
+    expect(agentProgressSource).toContain('autoPlay={shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible) && (configQuery.data?.ttsAutoPlay ?? true)}')
   })
 
-  it("allows focused session tiles to auto-play even when they are snoozed for floating-panel purposes", () => {
-    expect(agentProgressSource).toContain('return variant === "tile" ? isFocused : !isSnoozed')
-    expect(agentProgressSource).toContain('shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused)')
+  it("suppresses tile auto-play while the floating panel is visible so the same session is not spoken twice", () => {
+    expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
+    expect(agentProgressSource).toContain('shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible)')
+    expect(agentProgressSource).toContain('const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)')
   })
 
   it("keeps response-linked assistant messages replayable but only auto-plays the latest assistant message", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -279,7 +279,7 @@ describe("agent progress tile layout", () => {
 
   it("does not auto-play TTS for tile expansion/collapse interactions", () => {
     expect(agentProgressSource).toContain('function shouldAutoPlayTTSForVariant')
-    expect(agentProgressSource).toContain('return variant === "tile" ? isFocused : !isSnoozed')
+    expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
   })
 
   it("uses shared conversation-state normalization across agent progress surfaces", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -162,8 +162,16 @@ function normalizeAssistantResponseForDedupe(content: string | undefined): strin
   return (content ?? "").replace(/\s+/g, " ").trim()
 }
 
-function shouldAutoPlayTTSForVariant(variant: "default" | "overlay" | "tile", isSnoozed: boolean, isFocused: boolean = false): boolean {
-  return variant === "tile" ? isFocused : !isSnoozed
+function shouldAutoPlayTTSForVariant(
+  variant: "default" | "overlay" | "tile",
+  isSnoozed: boolean,
+  isFocused: boolean = false,
+  isFloatingPanelVisible: boolean = false,
+): boolean {
+  // The floating panel owns TTS auto-play while it is visible. Tile surfaces
+  // in the main window defer so the same session isn't spoken twice.
+  if (variant === "tile") return isFocused && !isFloatingPanelVisible
+  return !isSnoozed
 }
 
 function getActionErrorMessage(error: unknown, fallback: string): string {
@@ -259,6 +267,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   // Track the last ttsSource that was successfully auto-played to prevent replay on follow-up messages
   const lastAutoPlayedSourceRef = useRef<string | null>(null)
   const configQuery = useConfigQuery()
+  const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)
 
   // Cleanup copy timeout on unmount
   // NOTE: We intentionally do NOT remove TTS tracking keys on unmount.
@@ -417,7 +426,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const shouldAutoPlayTTS = shouldShowTTSButton && isLast
   const shouldAutoPlayLoadedAudio =
     shouldAutoPlayTTS &&
-    shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused) &&
+    shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible) &&
     (configQuery.data?.ttsAutoPlay ?? true) &&
     lastAutoPlayedSourceRef.current === ttsSource
 
@@ -432,7 +441,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   //   to prevent double playback when AgentProgress remounts (e.g., when switching between
   //   single-session and multi-session views in the panel)
   useEffect(() => {
-    const shouldAutoPlay = shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused)
+    const shouldAutoPlay = shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible)
     const ttsAutoPlayEnabled = configQuery.data?.ttsAutoPlay ?? true
 
     if (!shouldAutoPlay || !shouldAutoPlayTTS || !ttsAutoPlayEnabled || audioData || isGeneratingAudio || ttsError || wasStopped) {
@@ -488,7 +497,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
         }
         // Error is already handled in generateAudio function
       })
-  }, [shouldAutoPlayTTS, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isFocused, isSnoozed, ttsError, wasStopped, variant, sessionId, ttsSource, message.responseEvent])
+  }, [shouldAutoPlayTTS, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isFocused, isSnoozed, isFloatingPanelVisible, ttsError, wasStopped, variant, sessionId, ttsSource, message.responseEvent])
 
   const getRoleStyle = () => {
     switch (message.role) {
@@ -3060,6 +3069,7 @@ const MidTurnUserResponseBubble: React.FC<{
   const sequenceGenerationIdRef = useRef(0)
   const sequenceIndexRef = useRef(-1)
   const configQuery = useConfigQuery()
+  const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)
   const ttsGenerationIdRef = useRef(0)
   const ttsSource = sanitizeMessageContentForSpeech(userResponse)
   const latestTtsSourceRef = useRef(ttsSource)
@@ -3147,7 +3157,7 @@ const MidTurnUserResponseBubble: React.FC<{
 
   // Auto-play TTS for mid-turn userResponse in primary conversation surfaces.
   useEffect(() => {
-    const shouldAutoPlay = shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused)
+    const shouldAutoPlay = shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible)
     if (!shouldAutoPlay || !ttsSource || !configQuery.data?.ttsEnabled || !(configQuery.data?.ttsAutoPlay ?? true) || audioData || isGeneratingAudio || ttsError || isComplete) {
       return
     }
@@ -3175,7 +3185,7 @@ const MidTurnUserResponseBubble: React.FC<{
           inFlightCompletionTTSKeysRef.current = []
         }
       })
-  }, [currentResponse.id, ttsSource, configQuery.data?.ttsEnabled, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isFocused, isSnoozed, ttsError, variant, sessionId, isComplete])
+  }, [currentResponse.id, ttsSource, configQuery.data?.ttsEnabled, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isFocused, isSnoozed, isFloatingPanelVisible, ttsError, variant, sessionId, isComplete])
 
   // NOTE: We intentionally do NOT remove TTS tracking keys on unmount.
   // See CompactMessage cleanup comment for rationale — removing keys on unmount
@@ -3209,7 +3219,7 @@ const MidTurnUserResponseBubble: React.FC<{
 
   const shouldKeepAudioPlayerMounted =
     shouldShowTTSButton &&
-    (isExpanded || (shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused) && (configQuery.data?.ttsAutoPlay ?? true)))
+    (isExpanded || (shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible) && (configQuery.data?.ttsAutoPlay ?? true)))
   const isCurrentSequentialResponseHighlighted = activeSequentialKey === `current-${currentResponse.id}`
 
   const handleHeaderClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -3469,7 +3479,7 @@ const MidTurnUserResponseBubble: React.FC<{
             isGenerating={isGeneratingAudio}
             error={ttsError}
             compact={true}
-            autoPlay={shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused) && (configQuery.data?.ttsAutoPlay ?? true)}
+            autoPlay={shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible) && (configQuery.data?.ttsAutoPlay ?? true)}
             onPlayStateChange={handleAudioPlayStateChange}
             autoPlaySuppressionKey={`response-group:${sessionId ?? "no-session"}:${currentResponse.id}`}
           />

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -28,6 +28,7 @@ export function useStoreSync() {
   const setPinnedSessionIds = useAgentStore((s) => s.setPinnedSessionIds)
   const archivedSessionIds = useAgentStore((s) => s.archivedSessionIds)
   const setArchivedSessionIds = useAgentStore((s) => s.setArchivedSessionIds)
+  const setFloatingPanelVisible = useAgentStore((s) => s.setFloatingPanelVisible)
   const markConversationCompleted = useConversationStore((s) => s.markConversationCompleted)
   const initialPinnedSessionIdsRef = useRef(Array.from(pinnedSessionIds))
   const pinnedSessionIdsHydratedRef = useRef(false)
@@ -95,6 +96,27 @@ export function useStoreSync() {
     })
     return unlisten
   }, [])
+
+  // Track floating panel visibility so the main window can suppress duplicate
+  // TTS auto-play when the panel is already speaking the same session.
+  useEffect(() => {
+    const unlisten = rendererHandlers.panelVisibilityChanged.listen(
+      ({ visible }: { visible: boolean }) => {
+        setFloatingPanelVisible(visible)
+      }
+    )
+    return unlisten
+  }, [setFloatingPanelVisible])
+
+  // Hydrate initial floating panel visibility on mount in case the panel is
+  // already visible before this renderer started listening.
+  useEffect(() => {
+    tipcClient.getFloatingPanelVisibility().then((result: { visible: boolean }) => {
+      setFloatingPanelVisible(result.visible)
+    }).catch(() => {
+      // Best-effort hydration; default remains false.
+    })
+  }, [setFloatingPanelVisible])
 
   useEffect(() => {
     const unlisten = rendererHandlers.focusAgentSession.listen(

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -71,6 +71,11 @@ interface AgentState {
   pinnedSessionIds: Set<string>
   archivedSessionIds: Set<string>
 
+  // Whether the floating panel window is currently visible. Used by the main
+  // window to suppress duplicate TTS auto-play when the panel is playing the
+  // same session's audio.
+  isFloatingPanelVisible: boolean
+
   updateSessionProgress: (update: AgentProgressUpdate) => void
   clearAllProgress: () => void
   clearSessionProgress: (sessionId: string) => void
@@ -99,6 +104,8 @@ interface AgentState {
   setArchivedSessionIds: (sessionIds: Iterable<string>) => void
   toggleArchiveSession: (sessionId: string) => void
   isArchived: (sessionId: string) => boolean
+
+  setFloatingPanelVisible: (visible: boolean) => void
 }
 
 export const useAgentStore = create<AgentState>((set, get) => ({
@@ -116,6 +123,8 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   sortBy: 'recent' as SessionSortBy,
   pinnedSessionIds: new Set<string>(),
   archivedSessionIds: new Set<string>(),
+
+  isFloatingPanelVisible: false,
 
   updateSessionProgress: (incomingUpdate: AgentProgressUpdate) => {
     const update = sanitizeAgentProgressUpdateForDisplay(incomingUpdate)
@@ -630,6 +639,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   isArchived: (sessionId: string) => {
     return get().archivedSessionIds.has(sessionId)
   },
+
+  setFloatingPanelVisible: (visible: boolean) => {
+    set({ isFloatingPanelVisible: visible })
+  },
 }))
 
 const EMPTY_MESSAGE_QUEUE: QueuedMessage[] = []
@@ -663,4 +676,8 @@ export const useIsQueuePaused = (conversationId: string | undefined) => {
   const pausedQueueConversations = useAgentStore((state) => state.pausedQueueConversations)
   if (!conversationId) return false
   return pausedQueueConversations.has(conversationId)
+}
+
+export const useIsFloatingPanelVisible = () => {
+  return useAgentStore((state) => state.isFloatingPanelVisible)
 }

--- a/apps/desktop/src/renderer/src/stores/index.ts
+++ b/apps/desktop/src/renderer/src/stores/index.ts
@@ -1,5 +1,5 @@
 // Zustand stores for state management
-export { useAgentStore, useAgentSessionProgress, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused } from './agent-store'
+export { useAgentStore, useAgentSessionProgress, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused, useIsFloatingPanelVisible } from './agent-store'
 export type { SessionViewMode, SessionFilter, SessionSortBy } from './agent-store'
 export { useConversationStore } from './conversation-store'
 


### PR DESCRIPTION
## Problem

Two related TTS coordination bugs in the floating panel:

1. **ESC doesn't stop panel TTS.** Pressing ESC to close the floating panel while TTS is playing leaves the audio running in the background. ESC routes through `snoozeAgentSessionsAndHidePanelWindow` → `minimizeAgentModeAndHidePanelWindow`, none of which touch TTS.
2. **Double TTS playback.** When a session renders in both the floating panel (overlay variant) and the main-window sessions dashboard (tile variant), the same assistant response can auto-play twice — once per renderer.

## Fix

### 1. ESC stops panel TTS only (main-window TTS keeps playing)

Added a `stopPanelRendererTts()` helper in `window.ts` that sends `stopAllTts` only to the panel's `webContents`. Because `ttsManager` is a per-renderer singleton, main-window TTS is unaffected. Wired it into all three ESC-driven hide paths:

- `stopRecordingAndHidePanelWindow` (ESC while recording)
- `stopTextInputAndHidePanelWindow` (ESC while text input active)
- `minimizeAgentModeAndHidePanelWindow` (ESC / minimize while agent mode — the common TTS case, also used by the panel's minimize button and `snoozeAgentSessionsAndHidePanelWindow`)

### 2. Suppress tile auto-play while panel is visible

Added cross-window panel-visibility sync:

- `window.ts`: new `broadcastPanelVisibility()` called from the panel's `show`/`hide` lifecycle events.
- `renderer-handlers.ts`: new `panelVisibilityChanged` handler type.
- `tipc.ts`: new `getFloatingPanelVisibility` action for initial hydration.
- `agent-store.ts`: new `isFloatingPanelVisible` state, `setFloatingPanelVisible` action, and `useIsFloatingPanelVisible` selector hook.
- `use-store-sync.ts`: listens for `panelVisibilityChanged` and hydrates the flag on mount.
- `agent-progress.tsx`: extended `shouldAutoPlayTTSForVariant` with `isFloatingPanelVisible`; the `tile` variant now defers while the panel is visible. Updated all 5 call sites in `CompactMessageBase` and `MidTurnUserResponseBubble` to read the flag from the store.

When ESC dismisses the panel, tile auto-play becomes eligible again for future responses. Past-played keys are still tracked in `tts-tracking.ts` so already-spoken content isn't replayed.

## Validation

- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/agent-progress.snoozed-tts.test.ts src/renderer/src/components/agent-progress.tile-layout.test.ts src/main/keyboard.test.ts src/renderer/src/pages/panel.recording-layout.test.ts src/renderer/src/lib/tts-manager.test.ts src/main/emit-agent-progress.snoozed.test.ts` — 49/49 pass.
- Updated source-level assertion tests in `agent-progress.snoozed-tts.test.ts` and `agent-progress.tile-layout.test.ts` to reflect the new signature.
- Full desktop vitest run: same 63 pre-existing failures (unrelated `window is not defined` / React `useContext` setup issues) with and without these changes — no new regressions.
- `pnpm --filter @dotagents/desktop typecheck`: same 5 pre-existing errors on `variant: string` prop widening at call sites in `agent-progress.tsx`; no new errors introduced.

## Behavior

- ESC on floating panel → panel TTS stops; main-window TTS keeps playing.
- Panel + main-window dashboard open → only the panel speaks; the tile defers. On ESC, tile auto-play resumes for future responses.
