### PR TITLE
Fix chat image response rendering and persistence

### DIFF
--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -1,0 +1,47 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe("conversation image assets", () => {
+  it("materializes inline data images into lightweight conversation asset URLs", async () => {
+    const conversationsFolder = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-conv-images-"))
+    tempDirs.push(conversationsFolder)
+    vi.doMock("./config", () => ({
+      appId: "app.dotagents.test",
+      dataFolder: conversationsFolder,
+      recordingsFolder: path.join(conversationsFolder, "recordings"),
+      conversationsFolder,
+      configPath: path.join(conversationsFolder, "config.json"),
+      configStore: { get: vi.fn(), save: vi.fn(), reload: vi.fn(), config: undefined },
+    }))
+    vi.doMock("./context-budget", () => ({ summarizeContent: vi.fn((content: string) => content) }))
+    vi.doMock("./llm-fetch", () => ({ makeTextCompletionWithFetch: vi.fn() }))
+
+    const { ConversationService } = await import("./conversation-service")
+    const service = ConversationService.getInstance()
+    const base64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")
+
+    const materialized = await service.materializeInlineDataImagesInContent(
+      "conv_image_test",
+      `Here is the preview.\n\n![Preview](data:image/png;base64,${base64})`,
+    )
+
+    expect(materialized).toContain("Here is the preview.")
+    expect(materialized).toContain("![Preview](assets://conversation-image/conv_image_test/")
+    expect(materialized).not.toContain("data:image")
+
+    const fileName = materialized.match(/conv_image_test\/([a-f0-9]{64}\.png)\)/)?.[1]
+    expect(fileName).toBeTruthy()
+    const storedImage = await fs.readFile(path.join(conversationsFolder, "_images", "conv_image_test", fileName!))
+    expect([...storedImage]).toEqual([0x89, 0x50, 0x4e, 0x47])
+  })
+})

--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -5,6 +5,24 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const tempDirs: string[] = []
 
+async function setupConversationImageAssetTest() {
+  const conversationsFolder = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-conv-images-"))
+  tempDirs.push(conversationsFolder)
+  vi.doMock("./config", () => ({
+    appId: "app.dotagents.test",
+    dataFolder: conversationsFolder,
+    recordingsFolder: path.join(conversationsFolder, "recordings"),
+    conversationsFolder,
+    configPath: path.join(conversationsFolder, "config.json"),
+    configStore: { get: vi.fn(), save: vi.fn(), reload: vi.fn(), config: undefined },
+  }))
+  vi.doMock("./context-budget", () => ({ summarizeContent: vi.fn((content: string) => content) }))
+  vi.doMock("./llm-fetch", () => ({ makeTextCompletionWithFetch: vi.fn() }))
+
+  const { ConversationService } = await import("./conversation-service")
+  return { service: ConversationService.getInstance(), conversationsFolder }
+}
+
 afterEach(async () => {
   vi.resetModules()
   vi.clearAllMocks()
@@ -13,21 +31,7 @@ afterEach(async () => {
 
 describe("conversation image assets", () => {
   it("materializes inline data images into lightweight conversation asset URLs", async () => {
-    const conversationsFolder = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-conv-images-"))
-    tempDirs.push(conversationsFolder)
-    vi.doMock("./config", () => ({
-      appId: "app.dotagents.test",
-      dataFolder: conversationsFolder,
-      recordingsFolder: path.join(conversationsFolder, "recordings"),
-      conversationsFolder,
-      configPath: path.join(conversationsFolder, "config.json"),
-      configStore: { get: vi.fn(), save: vi.fn(), reload: vi.fn(), config: undefined },
-    }))
-    vi.doMock("./context-budget", () => ({ summarizeContent: vi.fn((content: string) => content) }))
-    vi.doMock("./llm-fetch", () => ({ makeTextCompletionWithFetch: vi.fn() }))
-
-    const { ConversationService } = await import("./conversation-service")
-    const service = ConversationService.getInstance()
+    const { service, conversationsFolder } = await setupConversationImageAssetTest()
     const base64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")
 
     const materialized = await service.materializeInlineDataImagesInContent(
@@ -43,5 +47,30 @@ describe("conversation image assets", () => {
     expect(fileName).toBeTruthy()
     const storedImage = await fs.readFile(path.join(conversationsFolder, "_images", "conv_image_test", fileName!))
     expect([...storedImage]).toEqual([0x89, 0x50, 0x4e, 0x47])
+  })
+
+  it("uses independent inline image matching for concurrent materialization calls", async () => {
+    const { service } = await setupConversationImageAssetTest()
+    const pngBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")
+    const gifBase64 = Buffer.from([0x47, 0x49, 0x46, 0x38]).toString("base64")
+
+    const [first, second] = await Promise.all([
+      service.materializeInlineDataImagesInContent(
+        "conv_one",
+        `A ![one](data:image/png;base64,${pngBase64}) B ![two](data:image/gif;base64,${gifBase64}) C`,
+      ),
+      service.materializeInlineDataImagesInContent(
+        "conv_two",
+        `X ![alpha](data:image/gif;base64,${gifBase64}) Y ![beta](data:image/png;base64,${pngBase64}) Z`,
+      ),
+    ])
+
+    expect(first).toContain("A ![one](assets://conversation-image/conv_one/")
+    expect(first).toContain(" B ![two](assets://conversation-image/conv_one/")
+    expect(first).toContain(" C")
+    expect(second).toContain("X ![alpha](assets://conversation-image/conv_two/")
+    expect(second).toContain(" Y ![beta](assets://conversation-image/conv_two/")
+    expect(second).toContain(" Z")
+    expect(`${first}${second}`).not.toContain("data:image")
   })
 })

--- a/apps/desktop/src/main/conversation-image-assets.ts
+++ b/apps/desktop/src/main/conversation-image-assets.ts
@@ -1,0 +1,40 @@
+import path from "path"
+import { conversationsFolder } from "./config"
+import { assertSafeConversationId } from "./conversation-id"
+
+export const CONVERSATION_IMAGE_ASSET_HOST = "conversation-image"
+export const CONVERSATION_IMAGE_ASSETS_DIR_NAME = "_images"
+
+const SAFE_IMAGE_ASSET_FILE_REGEX = /^[a-f0-9]{16,64}\.(?:png|apng|gif|jpe?g|webp|bmp|avif)$/u
+
+export function getConversationImageAssetsRoot(): string {
+  return path.join(conversationsFolder, CONVERSATION_IMAGE_ASSETS_DIR_NAME)
+}
+
+export function getConversationImageAssetDir(conversationId: string): string {
+  assertSafeConversationId(conversationId)
+  const root = path.resolve(getConversationImageAssetsRoot())
+  const resolved = path.resolve(root, conversationId)
+  if (!resolved.startsWith(root + path.sep)) {
+    throw new Error("Invalid conversation image asset directory")
+  }
+  return resolved
+}
+
+export function getConversationImageAssetPath(conversationId: string, fileName: string): string {
+  assertSafeConversationId(conversationId)
+  if (path.basename(fileName) !== fileName || !SAFE_IMAGE_ASSET_FILE_REGEX.test(fileName)) {
+    throw new Error("Invalid conversation image asset filename")
+  }
+
+  const dir = getConversationImageAssetDir(conversationId)
+  const resolved = path.resolve(dir, fileName)
+  if (!resolved.startsWith(dir + path.sep)) {
+    throw new Error("Invalid conversation image asset path")
+  }
+  return resolved
+}
+
+export function buildConversationImageAssetUrl(conversationId: string, fileName: string): string {
+  return `assets://${CONVERSATION_IMAGE_ASSET_HOST}/${encodeURIComponent(conversationId)}/${encodeURIComponent(fileName)}`
+}

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -37,7 +37,8 @@ const CONVERSATION_REPAIR_MAX_PARSE_ATTEMPTS = 50
 const CONVERSATION_REPAIR_MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
 const MAX_SESSION_TITLE_CHARS = 80
 const MAX_AGENT_SESSION_TITLE_WORDS = 10
-const INLINE_DATA_IMAGE_MARKDOWN_REGEX = /!\[([^\]]*)\]\((data:image\/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+))\)/g
+const createInlineDataImageMarkdownRegex = () =>
+  /!\[([^\]]*)\]\((data:image\/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+))\)/g
 const DATA_IMAGE_URL_REGEX = /^data:image\/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)$/i
 const IMAGE_EXTENSION_BY_MIME_SUBTYPE: Record<string, string> = {
   png: "png",
@@ -169,9 +170,9 @@ export class ConversationService {
 
     let nextContent = ""
     let lastIndex = 0
-    INLINE_DATA_IMAGE_MARKDOWN_REGEX.lastIndex = 0
+    const matches = Array.from(content.matchAll(createInlineDataImageMarkdownRegex()))
 
-    for (const match of content.matchAll(INLINE_DATA_IMAGE_MARKDOWN_REGEX)) {
+    for (const match of matches) {
       const matchIndex = match.index ?? 0
       const [fullMatch, altText, dataUrl] = match
       nextContent += content.slice(lastIndex, matchIndex)

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -1,6 +1,7 @@
 import fs from "fs"
 import fsPromises from "fs/promises"
 import path from "path"
+import { createHash } from "crypto"
 import { conversationsFolder } from "./config"
 import { logApp } from "./debug"
 import {
@@ -14,6 +15,11 @@ import { summarizeContent } from "./context-budget"
 import { assertSafeConversationId, validateAndSanitizeConversationId } from "./conversation-id"
 import { filterVisibleChatMessages, sanitizeMessageContentForDisplay } from "@dotagents/shared"
 import { makeTextCompletionWithFetch } from "./llm-fetch"
+import {
+  buildConversationImageAssetUrl,
+  getConversationImageAssetDir,
+  getConversationImageAssetPath,
+} from "./conversation-image-assets"
 
 // Threshold for compacting conversations on load
 // When a conversation exceeds this many messages, older ones are summarized
@@ -31,6 +37,28 @@ const CONVERSATION_REPAIR_MAX_PARSE_ATTEMPTS = 50
 const CONVERSATION_REPAIR_MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
 const MAX_SESSION_TITLE_CHARS = 80
 const MAX_AGENT_SESSION_TITLE_WORDS = 10
+const INLINE_DATA_IMAGE_MARKDOWN_REGEX = /!\[([^\]]*)\]\((data:image\/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+))\)/g
+const DATA_IMAGE_URL_REGEX = /^data:image\/([a-zA-Z0-9.+-]+);base64,([A-Za-z0-9+/=\r\n]+)$/i
+const IMAGE_EXTENSION_BY_MIME_SUBTYPE: Record<string, string> = {
+  png: "png",
+  apng: "apng",
+  gif: "gif",
+  jpeg: "jpg",
+  jpg: "jpg",
+  webp: "webp",
+  bmp: "bmp",
+  avif: "avif",
+}
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  ".png": "image/png",
+  ".apng": "image/apng",
+  ".gif": "image/gif",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+  ".avif": "image/avif",
+}
 
 export class ConversationService {
   private static instance: ConversationService | null = null
@@ -76,6 +104,108 @@ export class ConversationService {
 
   private getConversationIndexPath(): string {
     return path.join(conversationsFolder, "index.json")
+  }
+
+  private getImageExtensionForMimeType(mimeType: string): string | null {
+    const normalized = mimeType.toLowerCase().replace(/^image\//u, "")
+    return IMAGE_EXTENSION_BY_MIME_SUBTYPE[normalized] ?? null
+  }
+
+  private getImageMimeTypeFromPath(imagePath: string): string | null {
+    return IMAGE_MIME_BY_EXTENSION[path.extname(imagePath).toLowerCase()] ?? null
+  }
+
+  private async storeConversationImageBuffer(
+    conversationId: string,
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<string> {
+    const extension = this.getImageExtensionForMimeType(mimeType)
+    if (!extension || buffer.length <= 0) {
+      throw new Error(`Unsupported or empty conversation image: ${mimeType}`)
+    }
+
+    const hash = createHash("sha256").update(buffer).digest("hex")
+    const fileName = `${hash}.${extension}`
+    const assetPath = getConversationImageAssetPath(conversationId, fileName)
+
+    await fsPromises.mkdir(getConversationImageAssetDir(conversationId), { recursive: true })
+    try {
+      await fsPromises.writeFile(assetPath, buffer, { flag: "wx" })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error
+      }
+    }
+
+    return buildConversationImageAssetUrl(conversationId, fileName)
+  }
+
+  async storeImagePathAsConversationAsset(conversationId: string, imagePath: string): Promise<string> {
+    const mimeType = this.getImageMimeTypeFromPath(imagePath)
+    if (!mimeType) {
+      throw new Error(`Unsupported image extension for path: ${imagePath}`)
+    }
+
+    const buffer = await fsPromises.readFile(imagePath)
+    return this.storeConversationImageBuffer(conversationId, buffer, mimeType)
+  }
+
+  async storeDataImageUrlAsConversationAsset(conversationId: string, dataUrl: string): Promise<string> {
+    const match = dataUrl.match(DATA_IMAGE_URL_REGEX)
+    if (!match) {
+      throw new Error("Invalid data:image URL")
+    }
+
+    const [, subtype, rawBase64] = match
+    const buffer = Buffer.from(rawBase64.replace(/\s+/g, ""), "base64")
+    return this.storeConversationImageBuffer(conversationId, buffer, `image/${subtype.toLowerCase()}`)
+  }
+
+  async materializeInlineDataImagesInContent(conversationId: string, content: string): Promise<string> {
+    if (!/data:image\//i.test(content)) {
+      return content
+    }
+
+    let nextContent = ""
+    let lastIndex = 0
+    INLINE_DATA_IMAGE_MARKDOWN_REGEX.lastIndex = 0
+
+    for (const match of content.matchAll(INLINE_DATA_IMAGE_MARKDOWN_REGEX)) {
+      const matchIndex = match.index ?? 0
+      const [fullMatch, altText, dataUrl] = match
+      nextContent += content.slice(lastIndex, matchIndex)
+      try {
+        const assetUrl = await this.storeDataImageUrlAsConversationAsset(conversationId, dataUrl)
+        nextContent += `![${altText}](${assetUrl})`
+      } catch (error) {
+        logApp(`[ConversationService] Failed to materialize inline image for ${conversationId}`, error)
+        nextContent += fullMatch
+      }
+      lastIndex = matchIndex + fullMatch.length
+    }
+
+    return nextContent + content.slice(lastIndex)
+  }
+
+  private async materializeConversationInlineImages(conversation: Conversation): Promise<boolean> {
+    let changed = false
+    const seenMessages = new Set<ConversationMessage>()
+    const messageGroups = [conversation.messages, conversation.rawMessages].filter(Array.isArray) as ConversationMessage[][]
+
+    for (const messages of messageGroups) {
+      for (const message of messages) {
+        if (seenMessages.has(message)) continue
+        seenMessages.add(message)
+        const nextContent = await this.materializeInlineDataImagesInContent(conversation.id, message.content)
+        if (nextContent !== message.content) {
+          message.content = nextContent
+          changed = true
+        }
+      }
+    }
+
+    return changed
   }
 
   private generateConversationId(): string {
@@ -519,8 +649,9 @@ export class ConversationService {
     conversationPath: string,
     conversation: Conversation,
   ): Promise<void> {
+    const imageStorageChanged = await this.materializeConversationInlineImages(conversation)
     const storageMetadataChanged = this.syncConversationStorageMetadata(conversation)
-    if (!storageMetadataChanged) {
+    if (!imageStorageChanged && !storageMetadataChanged) {
       return
     }
 
@@ -555,6 +686,7 @@ export class ConversationService {
       conversation.updatedAt = Date.now()
     }
 
+    await this.materializeConversationInlineImages(conversation)
     this.syncConversationStorageMetadata(conversation)
 
     await this.writeConversationFileAtomic(
@@ -842,9 +974,11 @@ export class ConversationService {
 
         const storedMessages = this.getStoredRawMessages(conversation)
 
+        const storedContent = await this.materializeInlineDataImagesInContent(conversationId, content)
+
         // Idempotency guard: avoid pushing consecutive duplicate messages
         const last = storedMessages[storedMessages.length - 1]
-        if (this.isConsecutiveDuplicate(last, role, content)) {
+        if (this.isConsecutiveDuplicate(last, role, storedContent)) {
           conversation.updatedAt = Date.now()
           await this.saveConversationUnlocked(conversation)
           return conversation
@@ -854,7 +988,7 @@ export class ConversationService {
         const message: ConversationMessage = {
           id: messageId,
           role,
-          content,
+          content: storedContent,
           timestamp: Date.now(),
           toolCalls,
           toolResults,

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -627,10 +627,13 @@ export async function processTranscriptWithAgentMode(
     const profileName = session?.profileSnapshot?.profileName
     const responseEvents = getSessionRunUserResponseEvents(currentSessionId, effectiveRunId)
     const storedUserResponse = getSessionUserResponse(currentSessionId, effectiveRunId)
+    // Live progress should only surface executed respond_to_user output. Falling
+    // back to the current conversationHistory can read the planned tool-call args
+    // before runtime-tools has materialized local image paths into renderable
+    // conversation assets, causing a duplicate non-renderable "Local image" bubble.
     const normalizedStoredUserResponse = resolveLatestUserFacingResponse({
       storedResponse: storedUserResponse,
       responseEvents,
-      conversationHistory: update.conversationHistory as any,
     })
     const isKillSwitchCompletion =
       update.isComplete &&

--- a/apps/desktop/src/main/respond-to-user-utils.test.ts
+++ b/apps/desktop/src/main/respond-to-user-utils.test.ts
@@ -10,11 +10,11 @@ import {
 } from "./respond-to-user-utils"
 
 describe("respond-to-user-utils", () => {
-  it("extracts text and image markdown from respond_to_user args", () => {
+  it("skips path-only images when extracting planned respond_to_user args", () => {
     expect(extractRespondToUserContentFromArgs({
       text: "Done",
       images: [{ alt: "Preview", path: "/tmp/result.png" }],
-    })).toBe("Done\n\n![Preview](/tmp/result.png)")
+    })).toBe("Done")
   })
 
   it("extracts image markdown from respond_to_user images[].url", () => {

--- a/apps/desktop/src/main/respond-to-user-utils.ts
+++ b/apps/desktop/src/main/respond-to-user-utils.ts
@@ -34,9 +34,8 @@ export function extractRespondToUserContentFromArgs(args: unknown): string | und
         ? parsedImage.alt.trim()
         : `Image ${index + 1}`
       const url = typeof parsedImage.url === "string" ? parsedImage.url.trim() : ""
-      const path = typeof parsedImage.path === "string" ? parsedImage.path.trim() : ""
       const dataUrl = typeof parsedImage.dataUrl === "string" ? parsedImage.dataUrl.trim() : ""
-      const uri = url || dataUrl || path
+      const uri = url || dataUrl
       if (!uri) return ""
       return `![${alt}](${uri})`
     })

--- a/apps/desktop/src/main/runtime-tools.respond-to-user.test.ts
+++ b/apps/desktop/src/main/runtime-tools.respond-to-user.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
 
 const mockGetSession = vi.fn()
 const mockGetAppSessionForAcpSession = vi.fn()
 const mockAppendSessionUserResponse = vi.fn()
 const mockGetSessionRunId = vi.fn()
+const mockStoreDataImageUrlAsConversationAsset = vi.fn()
+const mockStoreImagePathAsConversationAsset = vi.fn()
 
 vi.mock("./mcp-service", () => ({
   mcpService: { getAvailableTools: vi.fn(() => []) },
@@ -25,7 +30,12 @@ vi.mock("./emergency-stop", () => ({ emergencyStopAll: vi.fn() }))
 vi.mock("./acp/acp-router-tools", () => ({ executeACPRouterTool: vi.fn(), isACPRouterTool: vi.fn(() => false) }))
 vi.mock("./message-queue-service", () => ({ messageQueueService: {} }))
 vi.mock("./session-user-response-store", () => ({ appendSessionUserResponse: mockAppendSessionUserResponse }))
-vi.mock("./conversation-service", () => ({ conversationService: {} }))
+vi.mock("./conversation-service", () => ({
+  conversationService: {
+    storeDataImageUrlAsConversationAsset: mockStoreDataImageUrlAsConversationAsset,
+    storeImagePathAsConversationAsset: mockStoreImagePathAsConversationAsset,
+  },
+}))
 vi.mock("./context-budget", () => ({ readMoreContext: vi.fn() }))
 vi.mock("./acp-session-state", () => ({
   getAppSessionForAcpSession: mockGetAppSessionForAcpSession,
@@ -39,6 +49,8 @@ describe("runtime-tools respond_to_user", () => {
 
     mockGetAppSessionForAcpSession.mockReturnValue(undefined)
     mockGetSessionRunId.mockReturnValue(7)
+    mockStoreDataImageUrlAsConversationAsset.mockImplementation(async (_conversationId: string, _url: string) => "assets://conversation-image/conversation-1/data.png")
+    mockStoreImagePathAsConversationAsset.mockImplementation(async (_conversationId: string, _imagePath: string) => "assets://conversation-image/conversation-1/local.png")
     mockGetSession.mockImplementation((sessionId: string) =>
       sessionId === "app-session-1"
         ? { id: "app-session-1", conversationId: "conversation-1", conversationTitle: "Delegated session" }
@@ -77,6 +89,31 @@ describe("runtime-tools respond_to_user", () => {
         },
       ],
       isError: false,
+    })
+  })
+
+  it("stores local image responses as lightweight conversation asset URLs", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-respond-image-"))
+    const imagePath = path.join(tempDir, "preview.png")
+    await fs.writeFile(imagePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool(
+      "respond_to_user",
+      { text: "Preview ready", images: [{ path: imagePath, alt: "Preview" }] },
+      "app-session-1",
+    )
+
+    expect(mockStoreImagePathAsConversationAsset).toHaveBeenCalledWith("conversation-1", imagePath)
+    expect(mockAppendSessionUserResponse).toHaveBeenCalledWith({
+      sessionId: "app-session-1",
+      runId: 7,
+      text: "Preview ready\n\n![Preview](assets://conversation-image/conversation-1/local.png)",
+    })
+    expect(JSON.parse(String(result?.content[0]?.text))).toMatchObject({
+      success: true,
+      responseContentLength: 79,
+      localImageCount: 1,
     })
   })
 

--- a/apps/desktop/src/main/runtime-tools.respond-to-user.test.ts
+++ b/apps/desktop/src/main/runtime-tools.respond-to-user.test.ts
@@ -117,6 +117,27 @@ describe("runtime-tools respond_to_user", () => {
     })
   })
 
+  it("rejects svg image paths before storing conversation assets", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-respond-image-"))
+    const imagePath = path.join(tempDir, "preview.svg")
+    await fs.writeFile(imagePath, "<svg xmlns=\"http://www.w3.org/2000/svg\" />")
+
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool(
+      "respond_to_user",
+      { text: "Preview ready", images: [{ path: imagePath, alt: "Preview" }] },
+      "app-session-1",
+    )
+
+    expect(mockStoreImagePathAsConversationAsset).not.toHaveBeenCalled()
+    expect(mockAppendSessionUserResponse).not.toHaveBeenCalled()
+    expect(JSON.parse(String(result?.content[0]?.text))).toMatchObject({
+      success: false,
+      error: expect.stringContaining("SVG images are not supported for conversation assets"),
+    })
+    expect(result?.isError).toBe(true)
+  })
+
   it("does not instruct the model to send another final response after mark_work_complete", async () => {
     const { executeRuntimeTool } = await import("./runtime-tools")
     const result = await executeRuntimeTool("mark_work_complete", { summary: "Done", confidence: 0.8 }, "app-session-1")

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -294,7 +294,6 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   ".gif": "image/gif",
   ".webp": "image/webp",
   ".bmp": "image/bmp",
-  ".svg": "image/svg+xml",
 }
 
 const escapeMarkdownAltText = (value: string) => value.replace(/[\[\]\\]/g, "").trim()
@@ -344,6 +343,10 @@ async function resolveValidImagePath(rawPath: string): Promise<{ resolvedPath: s
   const resolvedPath = path.isAbsolute(rawPath)
     ? rawPath
     : path.resolve(process.cwd(), rawPath)
+
+  if (path.extname(resolvedPath).toLowerCase() === ".svg") {
+    throw new Error(`SVG images are not supported for conversation assets; use a raster image path: ${rawPath}`)
+  }
 
   const stat = await fs.stat(resolvedPath)
   if (!stat.isFile()) {

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -340,7 +340,7 @@ const getDataImageBytesFromUrl = (url: string): number | null => {
 const getUtf8ByteLength = (value: string): number =>
   Buffer.byteLength(value, "utf8")
 
-async function imagePathToDataUrl(rawPath: string): Promise<string> {
+async function resolveValidImagePath(rawPath: string): Promise<{ resolvedPath: string; fileBytes: number }> {
   const resolvedPath = path.isAbsolute(rawPath)
     ? rawPath
     : path.resolve(process.cwd(), rawPath)
@@ -362,8 +362,7 @@ async function imagePathToDataUrl(rawPath: string): Promise<string> {
     throw new Error(`Unsupported image extension for path: ${rawPath}`)
   }
 
-  const fileBuffer = await fs.readFile(resolvedPath)
-  return `data:${mimeType};base64,${fileBuffer.toString("base64")}`
+  return { resolvedPath, fileBytes: stat.size }
 }
 
 // Tool execution handlers
@@ -584,6 +583,27 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
+    const mappedAppSessionId = getAppSessionForAcpSession(context.sessionId)
+    const trackedSessionId = mappedAppSessionId ?? context.sessionId
+
+    // Guard: don't store the response if the session was already stopped/cancelled.
+    // This prevents zombie sessions from reappearing after the user stops them.
+    const activeSession = agentSessionTracker.getSession(trackedSessionId)
+    if (!activeSession) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Session is no longer active (was stopped or completed)" }) }],
+        isError: true,
+      }
+    }
+
+    const conversationId = activeSession.conversationId
+    if (imageInputs.length > 0 && !conversationId) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Images require an active conversation" }) }],
+        isError: true,
+      }
+    }
+
     const imageMarkdownBlocks: string[] = []
     let localImageCount = 0
     let embeddedImageBytes = 0
@@ -643,32 +663,49 @@ const toolHandlers: Record<string, ToolHandler> = {
               isError: true,
             }
           }
-          const dataImageUrlBytes = getUtf8ByteLength(url)
-          if (embeddedImageBytes + dataImageUrlBytes > MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES) {
+          if (embeddedImageBytes + dataImageBytes > MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES) {
             const maxMb = Math.round(MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES / (1024 * 1024))
             return {
               content: [{ type: "text", text: JSON.stringify({ success: false, error: `Total embedded image payload exceeds the ${maxMb}MB limit` }) }],
               isError: true,
             }
           }
-          embeddedImageBytes += dataImageUrlBytes
+          embeddedImageBytes += dataImageBytes
+          try {
+            const assetUrl = await conversationService.storeDataImageUrlAsConversationAsset(conversationId!, url)
+            imageMarkdownBlocks.push(`![${safeAlt}](${assetUrl})`)
+          } catch (error) {
+            return {
+              content: [{
+                type: "text",
+                text: JSON.stringify({
+                  success: false,
+                  error: error instanceof Error
+                    ? `Failed to store images[${index}].url: ${error.message}`
+                    : `Failed to store images[${index}].url`,
+                }),
+              }],
+              isError: true,
+            }
+          }
+          continue
         }
         imageMarkdownBlocks.push(`![${safeAlt}](${url})`)
         continue
       }
 
       try {
-        const dataUrl = await imagePathToDataUrl(imagePath)
-        const dataImageUrlBytes = getUtf8ByteLength(dataUrl)
-        if (embeddedImageBytes + dataImageUrlBytes > MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES) {
+        const { resolvedPath, fileBytes } = await resolveValidImagePath(imagePath)
+        if (embeddedImageBytes + fileBytes > MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES) {
           const maxMb = Math.round(MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES / (1024 * 1024))
           return {
             content: [{ type: "text", text: JSON.stringify({ success: false, error: `Total embedded image payload exceeds the ${maxMb}MB limit` }) }],
             isError: true,
           }
         }
-        embeddedImageBytes += dataImageUrlBytes
-        imageMarkdownBlocks.push(`![${safeAlt}](${dataUrl})`)
+        embeddedImageBytes += fileBytes
+        const assetUrl = await conversationService.storeImagePathAsConversationAsset(conversationId!, resolvedPath)
+        imageMarkdownBlocks.push(`![${safeAlt}](${assetUrl})`)
         localImageCount++
       } catch (error) {
         return {
@@ -701,19 +738,6 @@ const toolHandlers: Record<string, ToolHandler> = {
       const maxMb = Math.round(MAX_RESPOND_TO_USER_RESPONSE_CONTENT_BYTES / (1024 * 1024))
       return {
         content: [{ type: "text", text: JSON.stringify({ success: false, error: `Response content exceeds the ${maxMb}MB limit` }) }],
-        isError: true,
-      }
-    }
-
-    const mappedAppSessionId = getAppSessionForAcpSession(context.sessionId)
-    const trackedSessionId = mappedAppSessionId ?? context.sessionId
-
-    // Guard: don't store the response if the session was already stopped/cancelled.
-    // This prevents zombie sessions from reappearing after the user stops them.
-    const activeSession = agentSessionTracker.getSession(trackedSessionId)
-    if (!activeSession) {
-      return {
-        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Session is no longer active (was stopped or completed)" }) }],
         isError: true,
       }
     }

--- a/apps/desktop/src/main/serve.test.ts
+++ b/apps/desktop/src/main/serve.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getConversationImageAssetPath: vi.fn(
+    (conversationId: string, fileName: string) => `/images/${conversationId}/${fileName}`,
+  ),
+  registerFileProtocol: vi.fn(),
+  registerSchemesAsPrivileged: vi.fn(),
+}))
+
+vi.mock("electron", () => ({
+  protocol: {
+    registerFileProtocol: mocks.registerFileProtocol,
+    registerSchemesAsPrivileged: mocks.registerSchemesAsPrivileged,
+  },
+}))
+
+vi.mock("./config", () => ({
+  recordingsFolder: "/tmp/recordings",
+}))
+
+vi.mock("./conversation-image-assets", () => ({
+  CONVERSATION_IMAGE_ASSET_HOST: "conversation-image",
+  getConversationImageAssetPath: mocks.getConversationImageAssetPath,
+}))
+
+describe("serve protocol", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns FILE_NOT_FOUND for malformed conversation image asset paths", async () => {
+    const { registerServeProtocol } = await import("./serve")
+    registerServeProtocol()
+
+    const handler = mocks.registerFileProtocol.mock.calls[0][1]
+    const callback = vi.fn()
+
+    handler({ url: "assets://conversation-image/%E0%A4%A/file.png" }, callback)
+
+    expect(callback).toHaveBeenCalledWith({ error: -6 })
+    expect(mocks.getConversationImageAssetPath).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/main/serve.ts
+++ b/apps/desktop/src/main/serve.ts
@@ -90,10 +90,18 @@ export function registerServeProtocol() {
     }
 
     if (host === CONVERSATION_IMAGE_ASSET_HOST) {
-      const [conversationId, fileName] = pathname
-        .split("/")
-        .filter(Boolean)
-        .map((segment) => decodeURIComponent(segment))
+      let pathSegments: string[] = []
+
+      try {
+        pathSegments = pathname
+          .split("/")
+          .filter(Boolean)
+          .map((segment) => decodeURIComponent(segment))
+      } catch {
+        return callback({ error: FILE_NOT_FOUND })
+      }
+
+      const [conversationId, fileName] = pathSegments
 
       if (conversationId && fileName) {
         try {

--- a/apps/desktop/src/main/serve.ts
+++ b/apps/desktop/src/main/serve.ts
@@ -2,6 +2,10 @@ import { protocol, ProtocolRequest, ProtocolResponse } from "electron"
 import path from "path"
 import fs from "fs"
 import { recordingsFolder } from "./config"
+import {
+  CONVERSATION_IMAGE_ASSET_HOST,
+  getConversationImageAssetPath,
+} from "./conversation-image-assets"
 
 const rendererDir = path.join(__dirname, "../renderer")
 
@@ -83,6 +87,21 @@ export function registerServeProtocol() {
 
     if (host === "app") {
       return handleApp(request, callback)
+    }
+
+    if (host === CONVERSATION_IMAGE_ASSET_HOST) {
+      const [conversationId, fileName] = pathname
+        .split("/")
+        .filter(Boolean)
+        .map((segment) => decodeURIComponent(segment))
+
+      if (conversationId && fileName) {
+        try {
+          return callback({ path: getConversationImageAssetPath(conversationId, fileName) })
+        } catch {
+          return callback({ error: FILE_NOT_FOUND })
+        }
+      }
     }
 
     callback({ error: FILE_NOT_FOUND })

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' blob: assets:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:"
+      content="default-src 'self' blob: assets:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: assets://conversation-image"
     />
     <script>
       function toggleThemeClass(darkMode) {

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -300,7 +300,10 @@ async function loadAgentProgress(
     buildContentTTSKey: vi.fn(() => null),
   }))
   vi.doMock("@renderer/lib/tts-manager", () => ttsManagerMock)
-  vi.doMock("@dotagents/shared/message-display-utils", () => ({ sanitizeMessageContentForSpeech: (text: string) => text }))
+  vi.doMock("@dotagents/shared/message-display-utils", () => ({
+    sanitizeMessageContentForDisplay: (text: string) => text.replace(/!\[([^\]]*)\]\(data:image\/[^)]+\)/gi, (_match: string, alt: string) => `[Image: ${alt}]`),
+    sanitizeMessageContentForSpeech: (text: string) => text,
+  }))
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
 
   const mod = await import("./agent-progress")
@@ -514,6 +517,47 @@ describe("agent progress response history", () => {
     expect(text).toContain("Need your approval")
     expect(text).not.toContain("respond_to_user")
     expect(text).not.toContain("mark_work_complete")
+  })
+
+  it("does not collapse short image responses because of embedded data URL size", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const imageResponse = `Rendered a preview frame.\n\n![Preview](data:image/png;base64,${"A".repeat(2000)})`
+    const progress = {
+      sessionId: "session-image-response",
+      conversationId: "conversation-image-response",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [],
+      isComplete: true,
+      finalContent: "",
+      responseEvents: [
+        {
+          id: "resp-image",
+          sessionId: "session-image-response",
+          ordinal: 1,
+          text: imageResponse,
+          timestamp: 100,
+        },
+      ],
+      conversationHistory: [
+        { role: "assistant", content: "Rendered a preview frame.\n\n[Image: Preview]", timestamp: 110 },
+      ],
+    }
+
+    const tree = runtime.render(AgentProgress, { progress })
+    const clampedMessageContent = findAll(
+      tree,
+      (value) => value?.type === "div"
+        && typeof value?.props?.className === "string"
+        && value.props.className.includes("leading-relaxed")
+        && value.props.className.includes("line-clamp-2"),
+    )
+
+    expect(getTextContent(tree)).toContain("Rendered a preview frame.")
+    expect(countTextOccurrences(getTextContent(tree), "Rendered a preview frame.")).toBe(1)
+    expect(getTextContent(tree)).not.toContain("[Image: Preview]")
+    expect(clampedMessageContent).toHaveLength(0)
   })
 
   it("keeps visible tool result status aligned after hiding completion-control tools", async () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -36,7 +36,7 @@ import { LoadingSpinner } from "./ui/loading-spinner"
 import { extractSubAgentToolDisplayContent } from "@shared/delegation-tool-display"
 import { buildContentTTSKey, buildResponseEventTTSKey, hasTTSPlayed, markTTSPlayed, removeTTSKey } from "@renderer/lib/tts-tracking"
 import { ttsManager } from "@renderer/lib/tts-manager"
-import { sanitizeMessageContentForSpeech } from "@dotagents/shared/message-display-utils"
+import { sanitizeMessageContentForDisplay, sanitizeMessageContentForSpeech } from "@dotagents/shared/message-display-utils"
 import { toast } from "sonner"
 
 interface AgentProgressProps {
@@ -134,6 +134,16 @@ function isCompletionControlTool(toolName: string): boolean {
   return toolName === RESPOND_TO_USER_TOOL || toolName === MARK_WORK_COMPLETE_TOOL
 }
 
+const MARKDOWN_IMAGE_PAYLOAD_REGEX = /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/gi
+
+function stripMarkdownImagePayloads(content: string): string {
+  return content.replace(MARKDOWN_IMAGE_PAYLOAD_REGEX, "")
+}
+
+function hasMarkdownImagePayload(content: string): boolean {
+  return /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/i.test(content)
+}
+
 function extractRespondToUserResponsesFromMessages(
   messages: Array<{
     role: "user" | "assistant" | "tool"
@@ -162,6 +172,10 @@ function shouldAutoPlayTTSForVariant(
   // in the main window defer so the same session isn't spoken twice.
   if (variant === "tile") return isFocused && !isFloatingPanelVisible
   return !isSnoozed
+}
+
+function normalizeProgressVariant(variant: string): "default" | "overlay" | "tile" {
+  return variant === "overlay" || variant === "tile" ? variant : "default"
 }
 
 function getActionErrorMessage(error: unknown, fallback: string): string {
@@ -220,6 +234,7 @@ type CompactMessageProps = {
 
 // Compact message component for space efficiency
 const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default", isFocused = false, sessionId, isSnoozed = false, conversationId, branchMessageIndex }) => {
+  const messageVariant = normalizeProgressVariant(variant)
   const [audioData, setAudioData] = useState<ArrayBuffer | null>(null)
   const [audioMimeType, setAudioMimeType] = useState<string | null>(null)
   const [isGeneratingAudio, setIsGeneratingAudio] = useState(false)
@@ -300,7 +315,9 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const hasExtras =
     (message.toolCalls?.length ?? 0) > 0 ||
     displayResults.length > 0
-  const shouldCollapse = effectiveContent.length > 100 || hasExtras
+  const effectiveTextContentLength = stripMarkdownImagePayloads(effectiveContent).length
+  const collapseLengthLimit = hasMarkdownImagePayload(effectiveContent) ? 500 : 100
+  const shouldCollapse = effectiveTextContentLength > collapseLengthLimit || hasExtras
 
   // Track the computed ttsSource (ttsText || effectiveContent) since that's what determines the
   // ttsKey and should also gate async state updates.
@@ -396,7 +413,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const shouldAutoPlayTTS = shouldShowTTSButton && isLast
   const shouldAutoPlayLoadedAudio =
     shouldAutoPlayTTS &&
-    shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible) &&
+    shouldAutoPlayTTSForVariant(messageVariant, isSnoozed, isFocused, isFloatingPanelVisible) &&
     (configQuery.data?.ttsAutoPlay ?? true) &&
     lastAutoPlayedSourceRef.current === ttsSource
 
@@ -411,7 +428,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   //   to prevent double playback when AgentProgress remounts (e.g., when switching between
   //   single-session and multi-session views in the panel)
   useEffect(() => {
-    const shouldAutoPlay = shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible)
+    const shouldAutoPlay = shouldAutoPlayTTSForVariant(messageVariant, isSnoozed, isFocused, isFloatingPanelVisible)
     const ttsAutoPlayEnabled = configQuery.data?.ttsAutoPlay ?? true
 
     if (!shouldAutoPlay || !shouldAutoPlayTTS || !ttsAutoPlayEnabled || audioData || isGeneratingAudio || ttsError || wasStopped) {
@@ -3110,14 +3127,24 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       attachEvent(event, normalizeAssistantResponseForDedupe(event.text))
     }
 
-    // Pass 2: fuzzy match with image markdown stripped so text+image events
+    // Pass 2: match the renderer-store sanitized history form. Inline data URLs
+    // are replaced in conversationHistory to keep progress state lightweight, but
+    // responseEvents retain the real markdown so the attached message can render
+    // images. Treat those two forms as the same response to avoid duplicate final
+    // bubbles where the second one only shows [Image: ...] placeholders.
+    for (const event of effectiveResponseEvents) {
+      if (usedEventIds.has(event.id)) continue
+      attachEvent(event, normalizeAssistantResponseForDedupe(sanitizeMessageContentForDisplay(event.text)))
+    }
+
+    // Pass 3: fuzzy match with image markdown stripped so text+image events
     // can still bind to the text-only streamed prose that carries the same words.
     for (const event of effectiveResponseEvents) {
       if (usedEventIds.has(event.id)) continue
       attachEvent(event, normalizeAssistantResponseForDedupe(stripImageMarkdown(event.text)))
     }
 
-    // Pass 3: synthesize standalone assistant messages for unmatched events.
+    // Pass 4: synthesize standalone assistant messages for unmatched events.
     for (const event of effectiveResponseEvents) {
       if (usedEventIds.has(event.id)) continue
       copies.push({

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
@@ -34,6 +34,8 @@ const SELECTABLE_MARKDOWN_CLASS_NAME = "markdown-selectable"
 
 const ALLOWED_MARKDOWN_DATA_IMAGE_URL_REGEX =
   /^data:image\/(?:png|apng|gif|jpe?g|webp|bmp|avif)(?:;|,)/
+const ALLOWED_CONVERSATION_IMAGE_ASSET_URL_REGEX =
+  /^assets:\/\/conversation-image\//
 
 export const isAllowedMarkdownLinkUrl = (rawUrl?: string) => {
   if (!rawUrl) return false
@@ -60,6 +62,7 @@ export const isAllowedMarkdownImageUrl = (rawUrl?: string) => {
   return (
     url.startsWith("http://") ||
     url.startsWith("https://") ||
+    ALLOWED_CONVERSATION_IMAGE_ASSET_URL_REGEX.test(url) ||
     ALLOWED_MARKDOWN_DATA_IMAGE_URL_REGEX.test(url)
   )
 }

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.urls.test.ts
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.urls.test.ts
@@ -1,32 +1,38 @@
-import { describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, it, vi } from "vitest"
 
-import {
-  isAllowedMarkdownImageUrl,
-  isAllowedMarkdownLinkUrl,
-  markdownUrlTransform,
-} from "./markdown-renderer"
+vi.stubGlobal("window", { electron: { ipcRenderer: { invoke: vi.fn() } } })
+vi.mock("@renderer/lib/clipboard", () => ({ copyTextToClipboard: vi.fn() }))
+
+let markdownRenderer: typeof import("./markdown-renderer")
+
+beforeAll(async () => {
+  vi.stubGlobal("window", { electron: { ipcRenderer: { invoke: vi.fn() } } })
+  markdownRenderer = await import("./markdown-renderer")
+})
 
 describe("markdown renderer URL guardrails", () => {
   it("allows only safe markdown link schemes", () => {
-    expect(isAllowedMarkdownLinkUrl("https://dotagents.app/docs")).toBe(true)
-    expect(isAllowedMarkdownLinkUrl("mailto:hello@dotagents.app")).toBe(true)
-    expect(isAllowedMarkdownLinkUrl("#usage")).toBe(true)
-    expect(isAllowedMarkdownLinkUrl("javascript:alert(1)")).toBe(false)
-    expect(isAllowedMarkdownLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(false)
+    expect(markdownRenderer.isAllowedMarkdownLinkUrl("https://dotagents.app/docs")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownLinkUrl("mailto:hello@dotagents.app")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownLinkUrl("#usage")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownLinkUrl("javascript:alert(1)")).toBe(false)
+    expect(markdownRenderer.isAllowedMarkdownLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(false)
   })
 
   it("allows http(s) and raster data image URLs, but blocks svg data URLs", () => {
-    expect(isAllowedMarkdownImageUrl("https://example.com/image.png")).toBe(true)
-    expect(isAllowedMarkdownImageUrl("data:image/png;base64,AAAA")).toBe(true)
-    expect(isAllowedMarkdownImageUrl("data:image/jpeg;base64,BBBB")).toBe(true)
-    expect(isAllowedMarkdownImageUrl("data:image/svg+xml;base64,PHN2Zz4=")).toBe(false)
-    expect(isAllowedMarkdownImageUrl("javascript:alert(1)")).toBe(false)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("https://example.com/image.png")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("data:image/png;base64,AAAA")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("data:image/jpeg;base64,BBBB")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("assets://conversation-image/conv_1/abcd1234abcd1234.png")).toBe(true)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("data:image/svg+xml;base64,PHN2Zz4=")).toBe(false)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("assets://file?path=/tmp/secret.png")).toBe(false)
+    expect(markdownRenderer.isAllowedMarkdownImageUrl("javascript:alert(1)")).toBe(false)
   })
 
   it("strips blocked URLs during markdown transform", () => {
-    expect(markdownUrlTransform("javascript:alert(1)", "href")).toBe("")
-    expect(markdownUrlTransform("data:image/svg+xml;base64,PHN2Zz4=", "src")).toBe("")
-    expect(markdownUrlTransform("data:image/webp;base64,UklGRg==", "src")).toBe(
+    expect(markdownRenderer.markdownUrlTransform("javascript:alert(1)", "href")).toBe("")
+    expect(markdownRenderer.markdownUrlTransform("data:image/svg+xml;base64,PHN2Zz4=", "src")).toBe("")
+    expect(markdownRenderer.markdownUrlTransform("data:image/webp;base64,UklGRg==", "src")).toBe(
       "data:image/webp;base64,UklGRg==",
     )
   })

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -27,6 +27,26 @@ describe('shouldCollapseMessage', () => {
     expect(shouldCollapseMessage(longContent)).toBe(true)
   })
 
+  it('ignores data URL markdown image payload length', () => {
+    const content = `Here is the image:\n\n![diagram](data:image/png;base64,${'a'.repeat(500)})`
+    expect(shouldCollapseMessage(content)).toBe(false)
+  })
+
+  it('ignores http markdown image payload length', () => {
+    const content = `Looks good\n\n![remote image](https://example.com/${'a'.repeat(500)}.png)`
+    expect(shouldCollapseMessage(content)).toBe(false)
+  })
+
+  it('ignores conversation asset markdown image payload length', () => {
+    const content = `Screenshot attached\n\n![screenshot](assets://conversation-image/${'a'.repeat(500)})`
+    expect(shouldCollapseMessage(content)).toBe(false)
+  })
+
+  it('still collapses when non-image text exceeds the threshold', () => {
+    const content = `${'a'.repeat(201)}\n\n![diagram](data:image/png;base64,${'b'.repeat(500)})`
+    expect(shouldCollapseMessage(content)).toBe(true)
+  })
+
   it('returns true when tool calls are present', () => {
     expect(shouldCollapseMessage('short', [{ name: 'search', arguments: {} }])).toBe(true)
   })

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -151,29 +151,29 @@ describe('extractRespondToUserContentFromArgs', () => {
     expect(extractRespondToUserContentFromArgs(args)).toBe('![diagram draft v1](https://example.com/img.png)')
   })
 
-  it('renders path-only images as a text placeholder', () => {
+  it('does not synthesize non-renderable path-only images', () => {
     const args = {
       images: [{ alt: 'local diagram', path: '/tmp/diagram.png' }],
     }
 
-    expect(extractRespondToUserContentFromArgs(args)).toBe('Local image (local diagram): `/tmp/diagram.png`')
+    expect(extractRespondToUserContentFromArgs(args)).toBeNull()
   })
 
-  it('preserves text alongside path-only image placeholders', () => {
+  it('preserves text while skipping path-only image placeholders', () => {
     const args = {
       text: 'Saved locally:',
       images: [{ alt: 'desktop capture', path: '/tmp/capture.png' }],
     }
 
-    expect(extractRespondToUserContentFromArgs(args)).toBe('Saved locally:\n\nLocal image (desktop capture): `/tmp/capture.png`')
+    expect(extractRespondToUserContentFromArgs(args)).toBe('Saved locally:')
   })
 
-  it('sanitizes local image placeholder alt text that can break formatting', () => {
+  it('skips path-only images even when they have markdown-sensitive alt text', () => {
     const args = {
       images: [{ altText: 'lo[cal] (draft) `shot`', path: '/tmp/diagram.png' }],
     }
 
-    expect(extractRespondToUserContentFromArgs(args)).toBe('Local image (local draft shot): `/tmp/diagram.png`')
+    expect(extractRespondToUserContentFromArgs(args)).toBeNull()
   })
 
   it('falls back to indexed image labels when sanitizing removes all alt text', () => {

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -277,12 +277,6 @@ export function extractRespondToUserContentFromArgs(args: unknown): string | nul
   const images = Array.isArray(parsedArgs.images) ? parsedArgs.images : [];
   const sanitizeImageAltText = (alt: string) => alt.replace(/[\[\]\(\)`\\]/g, '').trim();
 
-  const formatLocalImagePlaceholder = (alt: string, imagePath: string) => {
-    const safeAlt = alt.trim() || 'Image';
-    const escapedPath = imagePath.replace(/`/g, '\\`');
-    return `Local image (${safeAlt}): \`${escapedPath}\``;
-  };
-
   const imagesMd = images
     .map((img, index) => {
       if (!img || typeof img !== 'object') return '';
@@ -297,14 +291,12 @@ export function extractRespondToUserContentFromArgs(args: unknown): string | nul
 
       const url = typeof image.url === 'string' ? image.url.trim() : '';
       const dataUrl = typeof image.dataUrl === 'string' ? image.dataUrl.trim() : '';
-      const path = typeof image.path === 'string' ? image.path.trim() : '';
       const mimeType = typeof image.mimeType === 'string' ? image.mimeType.trim() : '';
       const data = typeof image.data === 'string' ? image.data.trim() : '';
       const legacyDataUrl = mimeType && data ? `data:${mimeType};base64,${data}` : '';
       const uri = url || dataUrl || legacyDataUrl;
 
       if (uri) return `![${safeAlt}](${uri})`;
-      if (path) return formatLocalImagePlaceholder(safeAlt, path);
       return '';
     })
     .filter(Boolean)

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -9,6 +9,7 @@ import type { AgentUserResponseEvent } from './agent-progress';
 import { ToolCall, ToolResult } from './types';
 
 const COLLAPSE_THRESHOLD = 200;
+const MARKDOWN_IMAGE_PAYLOAD_REGEX = /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/gi;
 
 /**
  * Determine if a message should be collapsible based on its content
@@ -23,7 +24,7 @@ export function shouldCollapseMessage(
   toolResults?: ToolResult[]
 ): boolean {
   const hasExtras = (toolCalls?.length ?? 0) > 0 || (toolResults?.length ?? 0) > 0;
-  const contentLength = content?.length ?? 0;
+  const contentLength = content?.replace(MARKDOWN_IMAGE_PAYLOAD_REGEX, '').length ?? 0;
   return contentLength > COLLAPSE_THRESHOLD || hasExtras;
 }
 


### PR DESCRIPTION
## Summary
- Store chat image responses as conversation image assets instead of inline base64 data URLs
- Migrate legacy inline data-image markdown to lightweight `assets://conversation-image/...` URLs on load/save
- Serve conversation image assets through the Electron assets protocol and allow them through CSP/markdown image filtering
- Prevent planned local image paths from rendering as duplicate non-image final responses
- Keep respond_to_user image events deduped with persisted history and avoid collapsing image replies due to payload length

## Validation
- `pnpm --filter @dotagents/shared test -- chat-utils.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/main/respond-to-user-utils.test.ts src/main/runtime-tools.respond-to-user.test.ts src/main/conversation-image-assets.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/agent-progress.response-history.test.ts src/renderer/src/components/markdown-renderer.urls.test.ts`
- `pnpm build:shared`
- `pnpm --filter @dotagents/desktop typecheck`
- `pnpm --filter @dotagents/desktop test:respond-to-user-regressions`
- `pnpm --filter @dotagents/desktop typecheck:web`

## Notes
- Existing legacy conversations with inline `data:image` markdown may take one load to migrate, then should reopen much faster.
- Left unrelated untracked `.agents/` and `apps/desktop/assets/` files out of this PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author