### PR TITLE
Add continuous repeat task mode

### DIFF
--- a/apps/desktop/src/main/bundle-service.test.ts
+++ b/apps/desktop/src/main/bundle-service.test.ts
@@ -23,7 +23,7 @@ import { getAgentsLayerPaths } from "./agents-files/modular-config"
 import { loadAgentProfilesLayer, writeAgentsProfileFiles } from "./agents-files/agent-profiles"
 import { loadAgentsSkillsLayer, writeAgentsSkillFile } from "./agents-files/skills"
 import { writeKnowledgeNoteFile } from "./agents-files/knowledge-notes"
-import { writeTaskFile } from "./agents-files/tasks"
+import { loadTasksLayer, writeTaskFile } from "./agents-files/tasks"
 import type { AgentProfile, AgentSkill, KnowledgeNote, LoopConfig } from "@shared/types"
 
 // ============================================================================
@@ -263,6 +263,20 @@ describe("bundle-service", () => {
       expect(bundle.repeatTasks.length).toBe(1)
       expect(bundle.repeatTasks[0].id).toBe("test-task")
       expect((bundle.repeatTasks[0] as any).profileId).toBeUndefined()
+    })
+
+    it("exports continuous repeat tasks without schedules", async () => {
+      const layer = getAgentsLayerPaths(agentsDir)
+      const task = createTestTask("continuous-task", "Continuous Task")
+      task.runContinuously = true
+      task.schedule = { type: "daily", times: ["09:00"] }
+      writeTaskFile(layer, task)
+
+      const bundle = await exportBundle(agentsDir)
+
+      expect(bundle.repeatTasks).toHaveLength(1)
+      expect(bundle.repeatTasks[0].runContinuously).toBe(true)
+      expect(bundle.repeatTasks[0].schedule).toBeUndefined()
     })
 
     it("exports MCP servers from canonical mcpConfig and omits secret-bearing fields", async () => {
@@ -1104,6 +1118,23 @@ describe("bundle-service", () => {
       expect(result.skills[0].action).toBe("imported")
       expect(result.repeatTasks[0].action).toBe("imported")
       expect(result.knowledgeNotes[0].action).toBe("imported")
+    })
+
+    it("imports continuous repeat tasks without schedules", async () => {
+      const bundle = createTestBundle()
+      bundle.repeatTasks[0].runContinuously = true
+      bundle.repeatTasks[0].schedule = { type: "daily", times: ["09:00"] }
+      const bundlePath = path.join(tempDir, "import-continuous-task.dotagents")
+      fs.writeFileSync(bundlePath, JSON.stringify(bundle))
+
+      const result = await importBundle(bundlePath, targetDir, { conflictStrategy: "skip" })
+      const layer = getAgentsLayerPaths(targetDir)
+      const importedTask = loadTasksLayer(layer).tasks.find((task) => task.id === "import-task")
+
+      expect(result.success).toBe(true)
+      expect(result.repeatTasks[0].action).toBe("imported")
+      expect(importedTask?.runContinuously).toBe(true)
+      expect(importedTask?.schedule).toBeUndefined()
     })
 
     it("imports legacy metadata-only bundle skills with empty instructions", async () => {

--- a/apps/desktop/src/main/bundle-service.ts
+++ b/apps/desktop/src/main/bundle-service.ts
@@ -660,25 +660,35 @@ function loadSkillsForBundle(layer: AgentsLayerPaths, options?: BundleItemSelect
     }))
 }
 
+function normalizeBundleRepeatTask(task: BundleRepeatTask): BundleRepeatTask {
+  const normalized = { ...task }
+  if (normalized.runContinuously === true) {
+    delete normalized.schedule
+  }
+  return normalized
+}
+
 function loadRepeatTasksForBundle(layer: AgentsLayerPaths, options?: BundleItemSelectionOptions): BundleRepeatTask[] {
   const tasksResult = loadTasksLayer(layer)
   const selectedRepeatTaskIds = toSelectionSet(options?.repeatTaskIds)
 
   return tasksResult.tasks
     .filter((task) => !selectedRepeatTaskIds || selectedRepeatTaskIds.has(task.id))
-    .map((task): BundleRepeatTask => ({
-      id: task.id,
-      name: task.name,
-      prompt: task.prompt,
-      intervalMinutes: task.intervalMinutes,
-      enabled: task.enabled,
-      runOnStartup: task.runOnStartup,
-      speakOnTrigger: task.speakOnTrigger,
-      continueInSession: task.continueInSession,
-      runContinuously: task.runContinuously,
-      schedule: task.schedule,
-      // profileId intentionally omitted — may not exist in target environment
-    }))
+    .map((task): BundleRepeatTask =>
+      normalizeBundleRepeatTask({
+        id: task.id,
+        name: task.name,
+        prompt: task.prompt,
+        intervalMinutes: task.intervalMinutes,
+        enabled: task.enabled,
+        runOnStartup: task.runOnStartup,
+        speakOnTrigger: task.speakOnTrigger,
+        continueInSession: task.continueInSession,
+        runContinuously: task.runContinuously,
+        schedule: task.schedule,
+        // profileId intentionally omitted — may not exist in target environment
+      })
+    )
 }
 
 function loadKnowledgeNotesForBundle(layer: AgentsLayerPaths, options?: BundleItemSelectionOptions): BundleKnowledgeNote[] {
@@ -1212,7 +1222,9 @@ function validateBundle(bundle: unknown): bundle is ParsedDotAgentsBundle {
 }
 
 function normalizeBundle(bundle: ParsedDotAgentsBundle): DotAgentsBundle {
-  const repeatTasks = Array.isArray(bundle.repeatTasks) ? bundle.repeatTasks : []
+  const repeatTasks = Array.isArray(bundle.repeatTasks)
+    ? bundle.repeatTasks.map(normalizeBundleRepeatTask)
+    : []
   const knowledgeNotes = Array.isArray(bundle.knowledgeNotes) ? bundle.knowledgeNotes : []
   const rawComponents = isRecordObject(bundle.manifest.components)
     ? (bundle.manifest.components as Record<string, unknown>)
@@ -1657,7 +1669,9 @@ export async function importBundle(
           speakOnTrigger: bundleTask.speakOnTrigger,
           continueInSession: bundleTask.continueInSession,
           runContinuously: bundleTask.runContinuously,
-          ...(bundleTask.schedule ? { schedule: bundleTask.schedule } : {}),
+          ...(bundleTask.runContinuously === true || !bundleTask.schedule
+            ? {}
+            : { schedule: bundleTask.schedule }),
           // profileId intentionally not imported — may not exist in target
         }
 

--- a/apps/desktop/src/main/bundle-service.ts
+++ b/apps/desktop/src/main/bundle-service.ts
@@ -111,6 +111,7 @@ export interface BundleRepeatTask {
   runOnStartup?: boolean
   speakOnTrigger?: boolean
   continueInSession?: boolean
+  runContinuously?: boolean
   schedule?: LoopConfig["schedule"]
   // profileId omitted — the profile may not exist in the target environment
   // lastSessionId omitted — installation-local, not meaningful across bundles
@@ -674,6 +675,7 @@ function loadRepeatTasksForBundle(layer: AgentsLayerPaths, options?: BundleItemS
       runOnStartup: task.runOnStartup,
       speakOnTrigger: task.speakOnTrigger,
       continueInSession: task.continueInSession,
+      runContinuously: task.runContinuously,
       schedule: task.schedule,
       // profileId intentionally omitted — may not exist in target environment
     }))
@@ -1155,6 +1157,7 @@ function isBundleRepeatTask(value: unknown): value is BundleRepeatTask {
   if (value.runOnStartup !== undefined && typeof value.runOnStartup !== "boolean") return false
   if (value.speakOnTrigger !== undefined && typeof value.speakOnTrigger !== "boolean") return false
   if (value.continueInSession !== undefined && typeof value.continueInSession !== "boolean") return false
+  if (value.runContinuously !== undefined && typeof value.runContinuously !== "boolean") return false
   return isBundleRepeatTaskSchedule(value.schedule)
 }
 
@@ -1653,6 +1656,7 @@ export async function importBundle(
           runOnStartup: bundleTask.runOnStartup,
           speakOnTrigger: bundleTask.speakOnTrigger,
           continueInSession: bundleTask.continueInSession,
+          runContinuously: bundleTask.runContinuously,
           ...(bundleTask.schedule ? { schedule: bundleTask.schedule } : {}),
           // profileId intentionally not imported — may not exist in target
         }

--- a/apps/desktop/src/main/loop-service.continuous.test.ts
+++ b/apps/desktop/src/main/loop-service.continuous.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const loopServiceSource = readFileSync(new URL("./loop-service.ts", import.meta.url), "utf8")
+
+function getSection(source: string, startMarker: string, endMarker: string): string {
+  const startIndex = source.indexOf(startMarker)
+  const endIndex = source.indexOf(endMarker)
+
+  expect(startIndex).toBeGreaterThanOrEqual(0)
+  expect(endIndex).toBeGreaterThan(startIndex)
+
+  return source.slice(startIndex, endIndex)
+}
+
+describe("continuous repeat tasks", () => {
+  it("starts continuous tasks immediately", () => {
+    const startLoopSection = getSection(loopServiceSource, "  startLoop(loopId: string): boolean {", "  stopLoop(loopId: string): boolean {")
+
+    expect(startLoopSection).toContain("loop.runOnStartup || isContinuousLoop(loop)")
+    expect(startLoopSection).toContain("void this.executeLoop(loopId, { rescheduleAfterRun: true })")
+  })
+
+  it("reschedules continuous tasks without waiting for the interval", () => {
+    const getNextDelaySection = getSection(loopServiceSource, "  private getNextDelayMs(", "  private getIntervalMs(")
+
+    expect(getNextDelaySection).toContain("if (isContinuousLoop(loop))")
+    expect(getNextDelaySection).toContain("return 0")
+  })
+})

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -37,6 +37,10 @@ export interface LoopStatus {
   schedule?: LoopConfig["schedule"]
 }
 
+export function isContinuousLoop(loop: Pick<LoopConfig, "runContinuously">): boolean {
+  return loop.runContinuously === true
+}
+
 class LoopService {
   private static instance: LoopService | null = null
   private activeTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
@@ -234,8 +238,9 @@ class LoopService {
 
     logApp(`[LoopService] Started loop "${loop.name}" (${loopId}), ${describeLoopSchedule(loop)}`)
 
-    if (loop.runOnStartup) {
-      logApp(`[LoopService] Loop "${loop.name}" has runOnStartup=true, triggering immediately`)
+    if (loop.runOnStartup || isContinuousLoop(loop)) {
+      const reason = isContinuousLoop(loop) ? "continuous" : "runOnStartup"
+      logApp(`[LoopService] Loop "${loop.name}" starts immediately (${reason})`)
       setImmediate(() => {
         void this.executeLoop(loopId, { rescheduleAfterRun: true })
       })
@@ -449,6 +454,10 @@ class LoopService {
   }
 
   private getNextDelayMs(loop: LoopConfig, now: number = Date.now()): number {
+    if (isContinuousLoop(loop)) {
+      return 0
+    }
+
     if (loop.schedule) {
       const nextRun = computeNextScheduledRun(loop.schedule, now)
       if (nextRun !== null) {
@@ -521,6 +530,7 @@ export function computeNextScheduledRun(
 }
 
 function describeLoopSchedule(loop: LoopConfig): string {
+  if (isContinuousLoop(loop)) return "continuous"
   if (!loop.schedule) return `interval: ${loop.intervalMinutes}m`
   const s = loop.schedule
   const times = s.times.join(", ")

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -4799,6 +4799,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       speakOnTrigger: loop.speakOnTrigger,
       continueInSession: loop.continueInSession,
       lastSessionId: loop.lastSessionId,
+      runContinuously: loop.runContinuously,
       lastRunAt: status?.lastRunAt ?? loop.lastRunAt,
       isRunning: status?.isRunning ?? false,
       nextRunAt: status?.nextRunAt,
@@ -4830,6 +4831,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
             speakOnTrigger: l.speakOnTrigger,
             continueInSession: l.continueInSession,
             lastSessionId: l.lastSessionId,
+            runContinuously: l.runContinuously,
             lastRunAt: status?.lastRunAt ?? l.lastRunAt,
             isRunning: status?.isRunning ?? false,
             nextRunAt: status?.nextRunAt,
@@ -5062,6 +5064,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         intervalMinutes?: unknown
         enabled?: unknown
         profileId?: unknown
+        runContinuously?: unknown
         schedule?: unknown
       }
 
@@ -5089,12 +5092,16 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       if (body.profileId !== undefined && body.profileId !== null && typeof body.profileId !== "string") {
         return reply.code(400).send({ error: "profileId must be a string when provided" })
       }
+      if (body.runContinuously !== undefined && typeof body.runContinuously !== "boolean") {
+        return reply.code(400).send({ error: "runContinuously must be a boolean when provided" })
+      }
       const scheduleResult = parseScheduleInput(body.schedule)
       if (!scheduleResult.ok) {
         return reply.code(400).send({ error: scheduleResult.error })
       }
       const profileId = typeof body.profileId === "string" ? body.profileId.trim() : undefined
       const enabled = typeof body.enabled === "boolean" ? body.enabled : true
+      const runContinuously = body.runContinuously === true
 
       const id = `loop_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`
 
@@ -5105,7 +5112,8 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         intervalMinutes,
         enabled,
         profileId: profileId || undefined,
-        ...(scheduleResult.schedule && scheduleResult.schedule !== null
+        runContinuously,
+        ...(!runContinuously && scheduleResult.schedule && scheduleResult.schedule !== null
           ? { schedule: scheduleResult.schedule }
           : {}),
       }
@@ -5143,6 +5151,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         intervalMinutes?: unknown
         enabled?: unknown
         profileId?: unknown
+        runContinuously?: unknown
         schedule?: unknown
       }
 
@@ -5188,6 +5197,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       if (body.profileId !== undefined && body.profileId !== null && typeof body.profileId !== "string") {
         return reply.code(400).send({ error: "profileId must be a string when provided" })
       }
+      if (body.runContinuously !== undefined && typeof body.runContinuously !== "boolean") {
+        return reply.code(400).send({ error: "runContinuously must be a boolean when provided" })
+      }
       const scheduleResult = parseScheduleInput(body.schedule)
       if (!scheduleResult.ok) {
         return reply.code(400).send({ error: scheduleResult.error })
@@ -5201,6 +5213,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
           : undefined
       const enabled = typeof body.enabled === "boolean" ? body.enabled : undefined
       const profileId = typeof body.profileId === "string" ? body.profileId.trim() : undefined
+      const runContinuously = typeof body.runContinuously === "boolean" ? body.runContinuously : undefined
       const updated: LoopConfig = {
         ...existing,
         ...(name !== undefined && { name }),
@@ -5208,11 +5221,15 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         ...(intervalMinutes !== undefined && { intervalMinutes }),
         ...(enabled !== undefined && { enabled }),
         ...(body.profileId !== undefined && { profileId: profileId || undefined }),
+        ...(runContinuously !== undefined && { runContinuously }),
       }
-      if (scheduleResult.schedule === null) {
+      if (updated.runContinuously) {
+        delete updated.schedule
+      } else if (scheduleResult.schedule === null) {
         delete updated.schedule
       } else if (scheduleResult.schedule !== undefined) {
         updated.schedule = scheduleResult.schedule
+        updated.runContinuously = false
       }
 
       if (loopService) {

--- a/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.interval-draft.test.tsx
@@ -18,7 +18,9 @@ function createHookRuntime() {
     __esModule: true,
     default: {} as any,
     useState,
+    useEffect: () => undefined,
     useCallback: (fn: any) => fn,
+    forwardRef: (render: (props: any, ref: any) => any) => (props: any) => render(props, null),
   }
   reactMock.default = reactMock
 
@@ -71,6 +73,10 @@ function findButtonWithText(node: any, label: string) {
   return findNode(node, (candidate) => candidate.type === "Button" && textContent(candidate.props?.children).includes(label))
 }
 
+function findButtonWithTitle(node: any, title: string) {
+  return findNode(node, (candidate) => candidate.type === "Button" && candidate.props?.title === title)
+}
+
 function findInputById(node: any, id: string) {
   return findNode(node, (candidate) => candidate.type === "Input" && candidate.props?.id === id)
 }
@@ -79,7 +85,7 @@ function findTextareaById(node: any, id: string) {
   return findNode(node, (candidate) => candidate.type === "Textarea" && candidate.props?.id === id)
 }
 
-async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) {
+async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>, loops: any[] = []) {
   vi.resetModules()
 
   const saveLoop = vi.fn(async () => undefined)
@@ -89,27 +95,44 @@ async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) 
   const error = vi.fn()
   const invalidateQueries = vi.fn()
   const Null = () => null
-
-  vi.doMock("react", () => runtime.reactMock)
-  vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
-  vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
-  vi.doMock("@renderer/components/ui/button", () => ({ Button: (props: any) => ({ type: "Button", props }) }))
-  vi.doMock("@renderer/components/ui/input", () => ({ Input: (props: any) => ({ type: "Input", props }) }))
-  vi.doMock("@renderer/components/ui/label", () => ({ Label: (props: any) => ({ type: "Label", props }) }))
-  vi.doMock("@renderer/components/ui/switch", () => ({ Switch: (props: any) => ({ type: "Switch", props }) }))
-  vi.doMock("@renderer/components/ui/textarea", () => ({ Textarea: (props: any) => ({ type: "Textarea", props }) }))
-  vi.doMock("@renderer/components/ui/card", () => ({
+  const buttonMock = { Button: (props: any) => ({ type: "Button", props }) }
+  const inputMock = { Input: (props: any) => ({ type: "Input", props }) }
+  const labelMock = { Label: (props: any) => ({ type: "Label", props }) }
+  const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
+  const textareaMock = { Textarea: (props: any) => ({ type: "Textarea", props }) }
+  const selectMock = { Select: Null, SelectContent: Null, SelectItem: Null, SelectTrigger: Null, SelectValue: Null }
+  const cardMock = {
     Card: (props: any) => ({ type: "Card", props }),
     CardContent: (props: any) => ({ type: "CardContent", props }),
     CardDescription: (props: any) => ({ type: "CardDescription", props }),
     CardHeader: (props: any) => ({ type: "CardHeader", props }),
     CardTitle: (props: any) => ({ type: "CardTitle", props }),
-  }))
+  }
+
+  vi.doMock("react", () => runtime.reactMock)
+  vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("@renderer/components/ui/button", () => buttonMock)
+  vi.doMock("../components/ui/button", () => buttonMock)
+  vi.doMock("@renderer/components/ui/input", () => inputMock)
+  vi.doMock("../components/ui/input", () => inputMock)
+  vi.doMock("@renderer/components/ui/label", () => labelMock)
+  vi.doMock("../components/ui/label", () => labelMock)
+  vi.doMock("@renderer/components/ui/switch", () => switchMock)
+  vi.doMock("../components/ui/switch", () => switchMock)
+  vi.doMock("@renderer/components/ui/textarea", () => textareaMock)
+  vi.doMock("../components/ui/textarea", () => textareaMock)
+  vi.doMock("@renderer/components/ui/select", () => selectMock)
+  vi.doMock("../components/ui/select", () => selectMock)
+  vi.doMock("@renderer/components/ui/card", () => cardMock)
+  vi.doMock("../components/ui/card", () => cardMock)
   vi.doMock("@renderer/components/ui/badge", () => ({ Badge: (props: any) => ({ type: "Badge", props }) }))
+  vi.doMock("../components/ui/badge", () => ({ Badge: (props: any) => ({ type: "Badge", props }) }))
   vi.doMock("@renderer/lib/tipc-client", () => ({
     tipcClient: {
-      getLoops: vi.fn(async () => []),
+      getLoops: vi.fn(async () => loops),
       getLoopStatuses: vi.fn(async () => []),
+      listAgentSessionCandidates: vi.fn(async () => ({ activeSessions: [], completedSessions: [] })),
       saveLoop,
       startLoop,
       stopLoop,
@@ -117,12 +140,28 @@ async function loadSettingsLoops(runtime: ReturnType<typeof createHookRuntime>) 
       triggerLoop: vi.fn(async () => ({ success: true })),
       openLoopTaskFile: vi.fn(async () => ({ success: true })),
     },
+    rendererHandlers: { loopsFolderChanged: { listen: vi.fn(() => () => undefined) } },
+  }))
+  vi.doMock("../lib/tipc-client", () => ({
+    tipcClient: {
+      getLoops: vi.fn(async () => loops),
+      getLoopStatuses: vi.fn(async () => []),
+      listAgentSessionCandidates: vi.fn(async () => ({ activeSessions: [], completedSessions: [] })),
+      saveLoop,
+      startLoop,
+      stopLoop,
+      deleteLoop: vi.fn(async () => undefined),
+      triggerLoop: vi.fn(async () => ({ success: true })),
+      openLoopTaskFile: vi.fn(async () => ({ success: true })),
+    },
+    rendererHandlers: { loopsFolderChanged: { listen: vi.fn(() => () => undefined) } },
   }))
   vi.doMock("@tanstack/react-query", () => ({
-    useQuery: ({ queryKey }: any) => ({ data: queryKey?.[0] === "loops" ? [] : [] }),
+    useQuery: ({ queryKey }: any) => ({ data: queryKey?.[0] === "loops" ? loops : [] }),
     useQueryClient: () => ({ invalidateQueries }),
   }))
   vi.doMock("@renderer/lib/utils", () => ({ cn: (...values: Array<string | undefined | false | null>) => values.filter(Boolean).join(" ") }))
+  vi.doMock("../lib/utils", () => ({ cn: (...values: Array<string | undefined | false | null>) => values.filter(Boolean).join(" ") }))
   vi.doMock("lucide-react", () => ({ Trash2: Null, Plus: Null, Edit2: Null, Save: Null, X: Null, Play: Null, Clock: Null, FileText: Null }))
   vi.doMock("sonner", () => ({ toast: { success, error } }))
 
@@ -168,7 +207,9 @@ describe("desktop repeat-task interval editing", () => {
 
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
     findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "" } })
 
     tree = runtime.render(Component, {} as any)
@@ -187,7 +228,9 @@ describe("desktop repeat-task interval editing", () => {
 
     tree = runtime.render(Component, {} as any)
     findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
     findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
     findInputById(tree, "interval").props.onChange({ target: { value: "60" } })
 
     tree = runtime.render(Component, {} as any)
@@ -204,5 +247,67 @@ describe("desktop repeat-task interval editing", () => {
     })
     expect(startLoop).toHaveBeenCalledWith({ loopId: "daily-summary" })
     expect(success).toHaveBeenCalledWith("Task created")
+  })
+
+  it.each([
+    { label: "Continuous", expectedSchedule: undefined, expectedRunContinuously: true },
+    { label: "Daily", expectedSchedule: { type: "daily", times: ["09:00"] }, expectedRunContinuously: false },
+    { label: "Weekly", expectedSchedule: { type: "weekly", times: ["09:00"], daysOfWeek: [1, 2, 3, 4, 5] }, expectedRunContinuously: false },
+  ])("preserves the existing interval when saving an edited $label task with an invalid hidden interval draft", async ({ label, expectedSchedule, expectedRunContinuously }) => {
+    const runtime = createHookRuntime()
+    const existingLoop = {
+      id: "standup-summary",
+      name: "Standup Summary",
+      prompt: "Summarize standup notes",
+      intervalMinutes: 45,
+      enabled: true,
+    }
+    const { Component, saveLoop, success } = await loadSettingsLoops(runtime, [existingLoop])
+
+    let tree = runtime.render(Component, {} as any)
+    findButtonWithTitle(tree, "Edit task").props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    findInputById(tree, "interval").props.onChange({ target: { value: "" } })
+    tree = runtime.render(Component, {} as any)
+    findButtonWithText(tree, label).props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    await findButtonWithText(tree, "Save").props.onClick()
+
+    const savedLoop = saveLoop.mock.calls[0][0].loop
+    expect(savedLoop.id).toBe("standup-summary")
+    expect(savedLoop.intervalMinutes).toBe(45)
+    expect(savedLoop.runContinuously).toBe(expectedRunContinuously)
+    expect(savedLoop.schedule).toEqual(expectedSchedule)
+    expect(success).toHaveBeenCalledWith("Task updated")
+  })
+
+  it("uses the default interval when saving a new scheduled task with an invalid hidden interval draft", async () => {
+    const runtime = createHookRuntime()
+    const { Component, saveLoop } = await loadSettingsLoops(runtime)
+
+    let tree = runtime.render(Component, {} as any)
+    findButtonWithText(tree, "Add Task").props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    findInputById(tree, "name").props.onChange({ target: { value: "Daily Summary" } })
+    tree = runtime.render(Component, {} as any)
+    findTextareaById(tree, "prompt").props.onChange({ target: { value: "Summarize recent activity" } })
+    tree = runtime.render(Component, {} as any)
+    findInputById(tree, "interval").props.onChange({ target: { value: "" } })
+    tree = runtime.render(Component, {} as any)
+    findButtonWithText(tree, "Daily").props.onClick()
+
+    tree = runtime.render(Component, {} as any)
+    await findButtonWithText(tree, "Save").props.onClick()
+
+    expect(saveLoop).toHaveBeenCalledWith({
+      loop: expect.objectContaining({
+        name: "Daily Summary",
+        intervalMinutes: 15,
+        schedule: { type: "daily", times: ["09:00"] },
+      }),
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/settings-loops.list-layout.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.list-layout.test.tsx
@@ -31,4 +31,13 @@ describe("desktop repeat-task list layout", () => {
     expect(listSection).toContain('className="h-6 gap-1 px-1.5 text-xs"')
     expect(listSection).not.toContain('<Label className="text-xs">{loop.enabled ? "Enabled" : "Disabled"}</Label>')
   })
+
+  it("shows continuous repeat tasks as a distinct cadence", () => {
+    const listSection = getSection(settingsLoopsSource, "  const renderLoopList = () => (", "  const renderEditForm")
+
+    expect(settingsLoopsSource).toContain('type ScheduleMode = "continuous" | "interval" | "daily" | "weekly"')
+    expect(settingsLoopsSource).toContain('if (loop.runContinuously) return "Continuous"')
+    expect(listSection).toContain("{describeLoopCadence(loop)}")
+    expect(settingsLoopsSource).toContain('{ mode: "continuous", label: "Continuous" }')
+  })
 })

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -21,7 +21,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { LoopConfig, LoopSchedule } from "@shared/types"
 import { toast } from "sonner"
 
-type ScheduleMode = "interval" | "daily" | "weekly"
+type ScheduleMode = "continuous" | "interval" | "daily" | "weekly"
 
 interface EditingLoop {
   id?: string
@@ -76,6 +76,11 @@ function describeSchedule(schedule: LoopSchedule): string {
   if (schedule.type === "daily") return `Daily at ${times}`
   const days = schedule.daysOfWeek.map((d) => DAY_LABELS[d] ?? String(d)).join(", ")
   return `${days} at ${times}`
+}
+
+function describeLoopCadence(loop: LoopConfig): string {
+  if (loop.runContinuously) return "Continuous"
+  return loop.schedule ? describeSchedule(loop.schedule) : `Every ${formatInterval(loop.intervalMinutes)}`
 }
 
 const INTERVAL_PRESETS = [
@@ -259,7 +264,7 @@ export function SettingsLoops() {
 
   const handleEdit = (loop: LoopConfig) => {
     setIsCreating(false)
-    const scheduleMode: ScheduleMode = loop.schedule?.type ?? "interval"
+    const scheduleMode: ScheduleMode = loop.runContinuously ? "continuous" : (loop.schedule?.type ?? "interval")
     const scheduleTimes = loop.schedule?.times.length ? [...loop.schedule.times] : ["09:00"]
     const scheduleDaysOfWeek = loop.schedule?.type === "weekly"
       ? [...loop.schedule.daysOfWeek]
@@ -299,13 +304,13 @@ export function SettingsLoops() {
     }
 
     const parsedIntervalMinutes = parseLoopIntervalDraft(editing.intervalMinutesDraft)
-    if (parsedIntervalMinutes === null) {
+    if (editing.scheduleMode === "interval" && parsedIntervalMinutes === null) {
       toast.error("Interval must be a positive whole number of minutes")
       return
     }
 
     let schedule: LoopSchedule | undefined
-    if (editing.scheduleMode !== "interval") {
+    if (editing.scheduleMode !== "interval" && editing.scheduleMode !== "continuous") {
       const times = sanitizeScheduleTimes(editing.scheduleTimes)
       if (times.length === 0) {
         toast.error("Add at least one time (HH:MM)")
@@ -327,11 +332,12 @@ export function SettingsLoops() {
       id: editing.id || slugify(editing.name),
       name: editing.name.trim(),
       prompt: editing.prompt.trim(),
-      intervalMinutes: parsedIntervalMinutes,
+      intervalMinutes: parsedIntervalMinutes ?? 15,
       enabled: editing.enabled,
       runOnStartup: editing.runOnStartup,
       speakOnTrigger: editing.speakOnTrigger,
       continueInSession: editing.continueInSession,
+      runContinuously: editing.scheduleMode === "continuous",
       ...(editing.continueInSession && editing.lastSessionId
         ? { lastSessionId: editing.lastSessionId }
         : {}),
@@ -486,7 +492,7 @@ export function SettingsLoops() {
             <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] leading-4 text-muted-foreground">
               <div className="flex items-center gap-1">
                 <Clock className="h-3 w-3" />
-                {loop.schedule ? describeSchedule(loop.schedule) : `Every ${formatInterval(loop.intervalMinutes)}`}
+                {describeLoopCadence(loop)}
               </div>
               {loop.runOnStartup && <div>Runs on startup</div>}
               {loop.speakOnTrigger && <div>Speaks on trigger</div>}
@@ -540,6 +546,7 @@ export function SettingsLoops() {
             <div className="flex flex-wrap gap-1.5">
               {([
                 { mode: "interval", label: "Interval" },
+                { mode: "continuous", label: "Continuous" },
                 { mode: "daily", label: "Daily" },
                 { mode: "weekly", label: "Weekly" },
               ] as const).map(({ mode, label }) => (
@@ -584,7 +591,12 @@ export function SettingsLoops() {
               </div>
             </div>
           )}
-          {editing.scheduleMode !== "interval" && (
+          {editing.scheduleMode === "continuous" && (
+            <p className="text-xs text-muted-foreground">
+              Starts the next run as soon as the previous run finishes. Only one run of this task executes at a time.
+            </p>
+          )}
+          {editing.scheduleMode !== "interval" && editing.scheduleMode !== "continuous" && (
             <div className="space-y-2">
               <Label>Time(s)</Label>
               <div className="flex flex-wrap items-center gap-2">

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -328,11 +328,15 @@ export function SettingsLoops() {
     }
 
     const slugify = (s: string) => s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "").slice(0, 64) || crypto.randomUUID()
+    const existingIntervalMinutes = editing.id
+      ? loops.find((loop) => loop.id === editing.id)?.intervalMinutes
+      : undefined
+    const savedIntervalMinutes = parsedIntervalMinutes ?? existingIntervalMinutes ?? 15
     const loopData: LoopConfig = {
       id: editing.id || slugify(editing.name),
       name: editing.name.trim(),
       prompt: editing.prompt.trim(),
-      intervalMinutes: parsedIntervalMinutes ?? 15,
+      intervalMinutes: savedIntervalMinutes,
       enabled: editing.enabled,
       runOnStartup: editing.runOnStartup,
       speakOnTrigger: editing.speakOnTrigger,

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1005,6 +1005,7 @@ export interface LoopConfig {
   speakOnTrigger?: boolean // if true, spawned session starts un-snoozed so TTS auto-plays
   continueInSession?: boolean // if true, reuses the prior session across iterations
   lastSessionId?: string   // session id to resume on next run when continueInSession is on
+  runContinuously?: boolean // if true, starts the next run immediately after the previous run finishes
   schedule?: LoopSchedule  // wall-clock schedule; supersedes intervalMinutes when present
 }
 

--- a/apps/mobile/src/lib/settingsApi.ts
+++ b/apps/mobile/src/lib/settingsApi.ts
@@ -90,6 +90,7 @@ import type {
   AgentProfileCreateRequest,
   AgentProfileUpdateRequest,
   Loop,
+  LoopSchedule,
   LoopsResponse,
   OperatorRemoteServerStatus,
   OperatorTunnelStatus,
@@ -208,6 +209,7 @@ export interface LoopCreateRequest {
   intervalMinutes: number;
   enabled: boolean;
   profileId?: string;
+  runContinuously?: boolean;
   schedule?: LoopSchedule | null;
 }
 
@@ -217,6 +219,7 @@ export interface LoopUpdateRequest {
   intervalMinutes?: number;
   enabled?: boolean;
   profileId?: string;
+  runContinuously?: boolean;
   schedule?: LoopSchedule | null;
 }
 

--- a/apps/mobile/src/screens/LoopEditScreen.tsx
+++ b/apps/mobile/src/screens/LoopEditScreen.tsx
@@ -40,11 +40,12 @@ type LoopFormData = {
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+const DEFAULT_INTERVAL_MINUTES = 60;
 
 const defaultFormData: LoopFormData = {
   name: '',
   prompt: '',
-  intervalMinutes: '60',
+  intervalMinutes: String(DEFAULT_INTERVAL_MINUTES),
   enabled: true,
   profileId: '',
   scheduleMode: 'interval',
@@ -91,6 +92,9 @@ export default function LoopEditScreen({ navigation, route }: any) {
 
   const [formData, setFormData] = useState<LoopFormData>(() =>
     loopFromRoute ? loopToFormData(loopFromRoute) : defaultFormData
+  );
+  const [existingLoopIntervalMinutes, setExistingLoopIntervalMinutes] = useState<number | null>(() =>
+    loopFromRoute?.intervalMinutes ?? null
   );
   const [profiles, setProfiles] = useState<AgentProfile[]>([]);
   const [isLoading, setIsLoading] = useState(isEditing && !loopFromRoute);
@@ -156,6 +160,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
           return;
         }
         setFormData(loopToFormData(loop));
+        setExistingLoopIntervalMinutes(loop.intervalMinutes);
       })
       .catch((err: Error) => {
         if (!cancelled) {
@@ -192,7 +197,11 @@ export default function LoopEditScreen({ navigation, route }: any) {
       setError('Interval must be a positive whole number of minutes');
       return;
     }
-    const savedIntervalMinutes = hasValidInterval ? intervalMinutes : 60;
+    const savedIntervalMinutes = hasValidInterval
+      ? intervalMinutes
+      : isEditing && existingLoopIntervalMinutes !== null
+        ? existingLoopIntervalMinutes
+        : DEFAULT_INTERVAL_MINUTES;
 
     let schedule: LoopSchedule | null = null;
     if (formData.scheduleMode !== 'interval' && formData.scheduleMode !== 'continuous') {
@@ -244,7 +253,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
     } finally {
       setIsSaving(false);
     }
-  }, [effectiveLoopId, formData, isEditing, navigation, settingsClient]);
+  }, [effectiveLoopId, existingLoopIntervalMinutes, formData, isEditing, navigation, settingsClient]);
 
   const isSaveDisabled = isSaving || !settingsClient;
 

--- a/apps/mobile/src/screens/LoopEditScreen.tsx
+++ b/apps/mobile/src/screens/LoopEditScreen.tsx
@@ -25,7 +25,7 @@ import {
 import { createButtonAccessibilityLabel, createMinimumTouchTargetStyle } from '../lib/accessibility';
 import { useConfigContext } from '../store/config';
 
-type ScheduleMode = 'interval' | 'daily' | 'weekly';
+type ScheduleMode = 'continuous' | 'interval' | 'daily' | 'weekly';
 
 type LoopFormData = {
   name: string;
@@ -62,7 +62,7 @@ function sanitizeScheduleTimes(times: string[]): string[] {
 }
 
 function loopToFormData(loop: Loop): LoopFormData {
-  const scheduleMode: ScheduleMode = loop.schedule?.type ?? 'interval';
+  const scheduleMode: ScheduleMode = loop.runContinuously ? 'continuous' : (loop.schedule?.type ?? 'interval');
   const scheduleTimes = loop.schedule?.times.length ? [...loop.schedule.times] : ['09:00'];
   const scheduleDaysOfWeek = loop.schedule?.type === 'weekly'
     ? [...loop.schedule.daysOfWeek]
@@ -187,13 +187,15 @@ export default function LoopEditScreen({ navigation, route }: any) {
       setError('Name and prompt are required');
       return;
     }
-    if (!/^\d+$/.test(intervalInput) || !Number.isInteger(intervalMinutes) || intervalMinutes < 1) {
+    const hasValidInterval = /^\d+$/.test(intervalInput) && Number.isInteger(intervalMinutes) && intervalMinutes >= 1;
+    if (formData.scheduleMode === 'interval' && !hasValidInterval) {
       setError('Interval must be a positive whole number of minutes');
       return;
     }
+    const savedIntervalMinutes = hasValidInterval ? intervalMinutes : 60;
 
     let schedule: LoopSchedule | null = null;
-    if (formData.scheduleMode !== 'interval') {
+    if (formData.scheduleMode !== 'interval' && formData.scheduleMode !== 'continuous') {
       const times = sanitizeScheduleTimes(formData.scheduleTimes);
       if (times.length === 0) {
         setError('Add at least one time in HH:MM format');
@@ -217,9 +219,10 @@ export default function LoopEditScreen({ navigation, route }: any) {
         const updatePayload: LoopUpdateRequest = {
           name,
           prompt,
-          intervalMinutes,
+          intervalMinutes: savedIntervalMinutes,
           enabled: formData.enabled,
           profileId: formData.profileId || undefined,
+          runContinuously: formData.scheduleMode === 'continuous',
           schedule,
         };
         await settingsClient.updateLoop(effectiveLoopId, updatePayload);
@@ -227,9 +230,10 @@ export default function LoopEditScreen({ navigation, route }: any) {
         const createPayload: LoopCreateRequest = {
           name,
           prompt,
-          intervalMinutes,
+          intervalMinutes: savedIntervalMinutes,
           enabled: formData.enabled,
           profileId: formData.profileId || undefined,
+          runContinuously: formData.scheduleMode === 'continuous',
           schedule,
         };
         await settingsClient.createLoop(createPayload);
@@ -290,7 +294,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
 
       <Text style={styles.label}>Schedule</Text>
       <View style={styles.modeRow}>
-        {(['interval', 'daily', 'weekly'] as const).map(mode => {
+        {(['interval', 'continuous', 'daily', 'weekly'] as const).map(mode => {
           const active = formData.scheduleMode === mode;
           return (
             <TouchableOpacity
@@ -301,7 +305,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
               accessibilityState={{ selected: active }}
             >
               <Text style={[styles.modeChipText, active && styles.modeChipTextActive]}>
-                {mode === 'interval' ? 'Interval' : mode === 'daily' ? 'Daily' : 'Weekly'}
+                {mode === 'interval' ? 'Interval' : mode === 'continuous' ? 'Continuous' : mode === 'daily' ? 'Daily' : 'Weekly'}
               </Text>
             </TouchableOpacity>
           );
@@ -322,7 +326,13 @@ export default function LoopEditScreen({ navigation, route }: any) {
         </>
       )}
 
-      {formData.scheduleMode !== 'interval' && (
+      {formData.scheduleMode === 'continuous' && (
+        <Text style={styles.helperText}>
+          Starts the next run as soon as the previous run finishes. Only one run of this task executes at a time.
+        </Text>
+      )}
+
+      {formData.scheduleMode !== 'interval' && formData.scheduleMode !== 'continuous' && (
         <>
           <Text style={styles.label}>Time(s) (HH:MM, local)</Text>
           {formData.scheduleTimes.map((time, idx) => (

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -49,6 +49,17 @@ const TTS_PROVIDERS = [
   { label: 'Supertonic', value: 'supertonic' },
 ] as const;
 
+const LOOP_DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function describeLoopCadence(loop: Loop): string {
+  if (loop.runContinuously) return 'Continuous';
+  if (!loop.schedule) return `Every ${loop.intervalMinutes}min`;
+  const times = loop.schedule.times.join(', ');
+  if (loop.schedule.type === 'daily') return `Daily at ${times}`;
+  const days = loop.schedule.daysOfWeek.map(day => LOOP_DAY_LABELS[day] ?? String(day)).join(', ');
+  return `${days} at ${times}`;
+}
+
 // OpenAI TTS Voice Options
 const OPENAI_TTS_VOICES = [
   { label: 'Alloy', value: 'alloy' },
@@ -2715,7 +2726,7 @@ export default function SettingsScreen({ navigation }: any) {
                           </View>
                           <Text style={styles.serverMeta} numberOfLines={2}>{loop.prompt}</Text>
                           <Text style={styles.serverMeta} numberOfLines={2}>
-                            Every {loop.intervalMinutes}min
+                            {describeLoopCadence(loop)}
                             {loop.profileName && ` • ${loop.profileName}`}
                             {loop.lastRunAt && ` • Last: ${new Date(loop.lastRunAt).toLocaleTimeString()}`}
                           </Text>

--- a/apps/mobile/tests/loop-edit-interval-preservation.test.js
+++ b/apps/mobile/tests/loop-edit-interval-preservation.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const screenSource = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'screens', 'LoopEditScreen.tsx'),
+  'utf8'
+);
+
+test('preserves an existing loop interval when hidden interval text is invalid while editing', () => {
+  assert.match(screenSource, /const DEFAULT_INTERVAL_MINUTES = 60;/);
+  assert.match(screenSource, /existingLoopIntervalMinutes, setExistingLoopIntervalMinutes/);
+  assert.match(screenSource, /setExistingLoopIntervalMinutes\(loop\.intervalMinutes\);/);
+  assert.match(
+    screenSource,
+    /const savedIntervalMinutes = hasValidInterval\s*\? intervalMinutes\s*: isEditing && existingLoopIntervalMinutes !== null\s*\? existingLoopIntervalMinutes\s*: DEFAULT_INTERVAL_MINUTES;/
+  );
+  assert.doesNotMatch(screenSource, /const savedIntervalMinutes = hasValidInterval \? intervalMinutes : 60;/);
+});

--- a/packages/core/src/agents-files/tasks.test.ts
+++ b/packages/core/src/agents-files/tasks.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { parseTaskMarkdown, stringifyTaskMarkdown } from "./tasks"
+import type { LoopConfig } from "../types"
+
+describe("agents-files/tasks", () => {
+  it("roundtrips runContinuously in task frontmatter", () => {
+    const task: LoopConfig = {
+      id: "continuous-task",
+      name: "Continuous task",
+      prompt: "Keep processing the queue.",
+      intervalMinutes: 15,
+      enabled: true,
+      runContinuously: true,
+    }
+
+    const markdown = stringifyTaskMarkdown(task)
+    expect(markdown).toContain("runContinuously: true")
+
+    const parsed = parseTaskMarkdown(markdown)
+    expect(parsed?.runContinuously).toBe(true)
+  })
+
+  it("omits runContinuously when false or missing", () => {
+    const task: LoopConfig = {
+      id: "interval-task",
+      name: "Interval task",
+      prompt: "Run occasionally.",
+      intervalMinutes: 15,
+      enabled: true,
+    }
+
+    const markdown = stringifyTaskMarkdown(task)
+    expect(markdown).not.toContain("runContinuously")
+    expect(parseTaskMarkdown(markdown)?.runContinuously).toBeUndefined()
+  })
+})

--- a/packages/core/src/agents-files/tasks.ts
+++ b/packages/core/src/agents-files/tasks.ts
@@ -133,6 +133,7 @@ export function stringifyTaskMarkdown(task: LoopConfig): string {
   if (task.speakOnTrigger) frontmatter.speakOnTrigger = "true"
   if (task.continueInSession) frontmatter.continueInSession = "true"
   if (task.lastSessionId) frontmatter.lastSessionId = task.lastSessionId
+  if (task.runContinuously) frontmatter.runContinuously = "true"
   if (task.lastRunAt) frontmatter.lastRunAt = String(task.lastRunAt)
   if (task.schedule) frontmatter.schedule = stringifySchedule(task.schedule)
 
@@ -169,6 +170,7 @@ export function parseTaskMarkdown(
     speakOnTrigger: parseBoolean(fm.speakOnTrigger, false) || undefined,
     continueInSession: parseBoolean(fm.continueInSession, false) || undefined,
     lastSessionId: (fm.lastSessionId ?? "").trim() || undefined,
+    runContinuously: parseBoolean(fm.runContinuously, false) || undefined,
     lastRunAt: fm.lastRunAt ? parseNumber(fm.lastRunAt, 0) || undefined : undefined,
     schedule,
   }

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -63,7 +63,7 @@ describe("config", () => {
 
   describe("resolveWorkspaceAgentsFolder", () => {
     const originalWorkspaceDir = process.env.DOTAGENTS_WORKSPACE_DIR
-    let cwdSpy: ReturnType<typeof vi.spyOn> | undefined
+    let cwdSpy: { mockRestore: () => void } | undefined
 
     afterEach(() => {
       cwdSpy?.mockRestore()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -99,6 +99,8 @@ export interface LoopConfig {
    * (rather than cleared).
    */
   lastSessionId?: string
+  /** Start the next run immediately after the previous run finishes. */
+  runContinuously?: boolean
   /** Wall-clock schedule. When present, supersedes `intervalMinutes`. */
   schedule?: LoopSchedule
 }

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -730,6 +730,7 @@ export interface Loop {
   speakOnTrigger?: boolean;
   continueInSession?: boolean;
   lastSessionId?: string;
+  runContinuously?: boolean;
   lastRunAt?: number;
   isRunning: boolean;
   nextRunAt?: number;


### PR DESCRIPTION
## Summary
- add a `runContinuously` repeat-task mode that starts the next run immediately after the previous run finishes
- surface Continuous schedule mode in desktop and mobile repeat task UIs
- persist/expose the flag through `.agents/tasks`, shared API types, remote server responses, and bundle import/export
- add focused coverage for scheduler behavior and task frontmatter roundtripping

## Validation
- `pnpm build:shared`
- `pnpm --filter @dotagents/desktop typecheck`
- `pnpm --filter @dotagents/shared typecheck`
- `pnpm --filter @dotagents/core typecheck`
- `pnpm --filter @dotagents/core test`
- `pnpm --filter @dotagents/desktop exec vitest run --dir . src/main/loop-service.continuous.test.ts src/renderer/src/pages/settings-loops.list-layout.test.tsx src/renderer/src/pages/settings-loops.save-loop-result.test.tsx --reporter dot`

Note: mobile `tsc --noEmit` was attempted and failed on existing unrelated errors in `src/lib/voice/useSpeechRecognizer.ts` and `src/screens/AgentEditScreen.tsx`; no errors were from this change.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author