### PR TITLE
Add cross-platform session video rendering

### DIFF
--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -73,4 +73,19 @@ describe("conversation image assets", () => {
     expect(second).toContain(" Z")
     expect(`${first}${second}`).not.toContain("data:image")
   })
+
+  it("stores local videos as conversation asset URLs", async () => {
+    const { service, conversationsFolder } = await setupConversationImageAssetTest()
+    const sourcePath = path.join(conversationsFolder, "source.mp4")
+    await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]))
+
+    const assetUrl = await service.storeVideoPathAsConversationAsset("conv_video_test", sourcePath)
+
+    expect(assetUrl).toContain("assets://conversation-video/conv_video_test/")
+    const fileName = assetUrl.match(/conv_video_test\/([a-f0-9]{64}\.mp4)$/)?.[1]
+    expect(fileName).toBeTruthy()
+
+    const storedVideo = await fs.readFile(path.join(conversationsFolder, "_videos", "conv_video_test", fileName!))
+    expect([...storedVideo]).toEqual([0, 1, 2, 3])
+  })
 })

--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -79,13 +79,29 @@ describe("conversation image assets", () => {
     const sourcePath = path.join(conversationsFolder, "source.mp4")
     await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]))
 
+    const readFileSpy = vi.spyOn(fs, "readFile")
     const assetUrl = await service.storeVideoPathAsConversationAsset("conv_video_test", sourcePath)
+    const duplicateAssetUrl = await service.storeVideoPathAsConversationAsset("conv_video_test", sourcePath)
 
     expect(assetUrl).toContain("assets://conversation-video/conv_video_test/")
+    expect(duplicateAssetUrl).toBe(assetUrl)
+    expect(readFileSpy).not.toHaveBeenCalled()
+    readFileSpy.mockRestore()
+
     const fileName = assetUrl.match(/conv_video_test\/([a-f0-9]{64}\.mp4)$/)?.[1]
     expect(fileName).toBeTruthy()
 
     const storedVideo = await fs.readFile(path.join(conversationsFolder, "_videos", "conv_video_test", fileName!))
     expect([...storedVideo]).toEqual([0, 1, 2, 3])
+  })
+
+  it("rejects unsupported local video extensions", async () => {
+    const { service, conversationsFolder } = await setupConversationImageAssetTest()
+    const sourcePath = path.join(conversationsFolder, "source.txt")
+    await fs.writeFile(sourcePath, Buffer.from([0, 1, 2, 3]))
+
+    await expect(service.storeVideoPathAsConversationAsset("conv_video_test", sourcePath)).rejects.toThrow(
+      "Unsupported video extension",
+    )
   })
 })

--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -104,4 +104,14 @@ describe("conversation image assets", () => {
       "Unsupported video extension",
     )
   })
+
+  it("rejects directory paths passed as video sources", async () => {
+    const { service, conversationsFolder } = await setupConversationImageAssetTest()
+    const dirPath = path.join(conversationsFolder, "videos_dir.mp4")
+    await fs.mkdir(dirPath, { recursive: true })
+
+    await expect(service.storeVideoPathAsConversationAsset("conv_video_test", dirPath)).rejects.toThrow(
+      "Video path is not a regular file",
+    )
+  })
 })

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -20,6 +20,11 @@ import {
   getConversationImageAssetDir,
   getConversationImageAssetPath,
 } from "./conversation-image-assets"
+import {
+  buildConversationVideoAssetUrl,
+  getConversationVideoAssetDir,
+  getConversationVideoAssetPath,
+} from "./conversation-video-assets"
 
 // Threshold for compacting conversations on load
 // When a conversation exceeds this many messages, older ones are summarized
@@ -59,6 +64,20 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   ".webp": "image/webp",
   ".bmp": "image/bmp",
   ".avif": "image/avif",
+}
+const VIDEO_EXTENSION_BY_MIME_SUBTYPE: Record<string, string> = {
+  mp4: "mp4",
+  m4v: "m4v",
+  webm: "webm",
+  quicktime: "mov",
+  ogg: "ogv",
+}
+const VIDEO_MIME_BY_EXTENSION: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".ogv": "video/ogg",
 }
 
 export class ConversationService {
@@ -116,6 +135,15 @@ export class ConversationService {
     return IMAGE_MIME_BY_EXTENSION[path.extname(imagePath).toLowerCase()] ?? null
   }
 
+  private getVideoExtensionForMimeType(mimeType: string): string | null {
+    const normalized = mimeType.toLowerCase().replace(/^video\//u, "")
+    return VIDEO_EXTENSION_BY_MIME_SUBTYPE[normalized] ?? null
+  }
+
+  private getVideoMimeTypeFromPath(videoPath: string): string | null {
+    return VIDEO_MIME_BY_EXTENSION[path.extname(videoPath).toLowerCase()] ?? null
+  }
+
   private async storeConversationImageBuffer(
     conversationId: string,
     buffer: Buffer,
@@ -161,6 +189,42 @@ export class ConversationService {
     const [, subtype, rawBase64] = match
     const buffer = Buffer.from(rawBase64.replace(/\s+/g, ""), "base64")
     return this.storeConversationImageBuffer(conversationId, buffer, `image/${subtype.toLowerCase()}`)
+  }
+
+  private async storeConversationVideoBuffer(
+    conversationId: string,
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<string> {
+    const extension = this.getVideoExtensionForMimeType(mimeType)
+    if (!extension || buffer.length <= 0) {
+      throw new Error(`Unsupported or empty conversation video: ${mimeType}`)
+    }
+
+    const hash = createHash("sha256").update(buffer).digest("hex")
+    const fileName = `${hash}.${extension}`
+    const assetPath = getConversationVideoAssetPath(conversationId, fileName)
+
+    await fsPromises.mkdir(getConversationVideoAssetDir(conversationId), { recursive: true })
+    try {
+      await fsPromises.writeFile(assetPath, buffer, { flag: "wx" })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error
+      }
+    }
+
+    return buildConversationVideoAssetUrl(conversationId, fileName)
+  }
+
+  async storeVideoPathAsConversationAsset(conversationId: string, videoPath: string): Promise<string> {
+    const mimeType = this.getVideoMimeTypeFromPath(videoPath)
+    if (!mimeType) {
+      throw new Error(`Unsupported video extension for path: ${videoPath}`)
+    }
+
+    const buffer = await fsPromises.readFile(videoPath)
+    return this.storeConversationVideoBuffer(conversationId, buffer, mimeType)
   }
 
   async materializeInlineDataImagesInContent(conversationId: string, content: string): Promise<string> {

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -215,6 +215,9 @@ export class ConversationService {
 
     const extension = this.getVideoExtensionForMimeType(mimeType)
     const sourceStat = await fsPromises.stat(videoPath)
+    if (!sourceStat.isFile()) {
+      throw new Error(`Video path is not a regular file: ${videoPath}`)
+    }
     if (!extension || sourceStat.size <= 0) {
       throw new Error(`Unsupported or empty conversation video: ${mimeType}`)
     }

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -2,6 +2,8 @@ import fs from "fs"
 import fsPromises from "fs/promises"
 import path from "path"
 import { createHash } from "crypto"
+import { Writable } from "stream"
+import { pipeline } from "stream/promises"
 import { conversationsFolder } from "./config"
 import { logApp } from "./debug"
 import {
@@ -191,30 +193,18 @@ export class ConversationService {
     return this.storeConversationImageBuffer(conversationId, buffer, `image/${subtype.toLowerCase()}`)
   }
 
-  private async storeConversationVideoBuffer(
-    conversationId: string,
-    buffer: Buffer,
-    mimeType: string,
-  ): Promise<string> {
-    const extension = this.getVideoExtensionForMimeType(mimeType)
-    if (!extension || buffer.length <= 0) {
-      throw new Error(`Unsupported or empty conversation video: ${mimeType}`)
-    }
-
-    const hash = createHash("sha256").update(buffer).digest("hex")
-    const fileName = `${hash}.${extension}`
-    const assetPath = getConversationVideoAssetPath(conversationId, fileName)
-
-    await fsPromises.mkdir(getConversationVideoAssetDir(conversationId), { recursive: true })
-    try {
-      await fsPromises.writeFile(assetPath, buffer, { flag: "wx" })
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-        throw error
-      }
-    }
-
-    return buildConversationVideoAssetUrl(conversationId, fileName)
+  private async computeFileSha256(filePath: string): Promise<string> {
+    const hash = createHash("sha256")
+    await pipeline(
+      fs.createReadStream(filePath),
+      new Writable({
+        write(chunk: Buffer, _encoding, callback) {
+          hash.update(chunk)
+          callback()
+        },
+      }),
+    )
+    return hash.digest("hex")
   }
 
   async storeVideoPathAsConversationAsset(conversationId: string, videoPath: string): Promise<string> {
@@ -223,8 +213,31 @@ export class ConversationService {
       throw new Error(`Unsupported video extension for path: ${videoPath}`)
     }
 
-    const buffer = await fsPromises.readFile(videoPath)
-    return this.storeConversationVideoBuffer(conversationId, buffer, mimeType)
+    const extension = this.getVideoExtensionForMimeType(mimeType)
+    const sourceStat = await fsPromises.stat(videoPath)
+    if (!extension || sourceStat.size <= 0) {
+      throw new Error(`Unsupported or empty conversation video: ${mimeType}`)
+    }
+
+    const hash = await this.computeFileSha256(videoPath)
+    const fileName = `${hash}.${extension}`
+    const assetPath = getConversationVideoAssetPath(conversationId, fileName)
+
+    await fsPromises.mkdir(getConversationVideoAssetDir(conversationId), { recursive: true })
+    try {
+      await pipeline(fs.createReadStream(videoPath), fs.createWriteStream(assetPath, { flags: "wx" }))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        try {
+          await fsPromises.unlink(assetPath)
+        } catch {
+          // Best-effort cleanup for partially copied files.
+        }
+        throw error
+      }
+    }
+
+    return buildConversationVideoAssetUrl(conversationId, fileName)
   }
 
   async materializeInlineDataImagesInContent(conversationId: string, content: string): Promise<string> {

--- a/apps/desktop/src/main/conversation-video-assets.ts
+++ b/apps/desktop/src/main/conversation-video-assets.ts
@@ -1,0 +1,52 @@
+import path from "path"
+import { conversationsFolder } from "./config"
+import { assertSafeConversationId } from "./conversation-id"
+
+export const CONVERSATION_VIDEO_ASSET_HOST = "conversation-video"
+export const CONVERSATION_VIDEO_ASSETS_DIR_NAME = "_videos"
+
+const SAFE_VIDEO_ASSET_FILE_REGEX = /^[a-f0-9]{16,64}\.(?:mp4|m4v|webm|mov|ogv)$/u
+
+const VIDEO_MIME_BY_EXTENSION: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".ogv": "video/ogg",
+}
+
+export function getConversationVideoAssetsRoot(): string {
+  return path.join(conversationsFolder, CONVERSATION_VIDEO_ASSETS_DIR_NAME)
+}
+
+export function getConversationVideoAssetDir(conversationId: string): string {
+  assertSafeConversationId(conversationId)
+  const root = path.resolve(getConversationVideoAssetsRoot())
+  const resolved = path.resolve(root, conversationId)
+  if (!resolved.startsWith(root + path.sep)) {
+    throw new Error("Invalid conversation video asset directory")
+  }
+  return resolved
+}
+
+export function getConversationVideoAssetPath(conversationId: string, fileName: string): string {
+  assertSafeConversationId(conversationId)
+  if (path.basename(fileName) !== fileName || !SAFE_VIDEO_ASSET_FILE_REGEX.test(fileName)) {
+    throw new Error("Invalid conversation video asset filename")
+  }
+
+  const dir = getConversationVideoAssetDir(conversationId)
+  const resolved = path.resolve(dir, fileName)
+  if (!resolved.startsWith(dir + path.sep)) {
+    throw new Error("Invalid conversation video asset path")
+  }
+  return resolved
+}
+
+export function getConversationVideoMimeTypeFromFileName(fileName: string): string {
+  return VIDEO_MIME_BY_EXTENSION[path.extname(fileName).toLowerCase()] ?? "application/octet-stream"
+}
+
+export function buildConversationVideoAssetUrl(conversationId: string, fileName: string): string {
+  return `assets://${CONVERSATION_VIDEO_ASSET_HOST}/${encodeURIComponent(conversationId)}/${encodeURIComponent(fileName)}`
+}

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -35,6 +35,10 @@ import { processTranscriptWithACPAgent } from "./acp-main-agent"
 import { resolveMainAcpAgentSelection } from "./main-agent-selection"
 import { state, agentProcessManager, agentSessionStateManager } from "./state"
 import { conversationService } from "./conversation-service"
+import {
+  getConversationVideoAssetPath,
+  getConversationVideoMimeTypeFromFileName,
+} from "./conversation-video-assets"
 import { AgentProgressUpdate, SessionProfileSnapshot, LoopConfig, Config, normalizeAgentProfileRole } from "../shared/types"
 import { getBranchMessageIndexMap } from "@shared/conversation-progress"
 import { agentSessionTracker } from "./agent-session-tracker"
@@ -3589,6 +3593,75 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
     } catch (error: any) {
       diagnosticsService.logError("remote-server", "Failed to fetch conversation", error)
       return reply.code(500).send({ error: error?.message || "Failed to fetch conversation" })
+    }
+  })
+
+  // GET /v1/conversations/:id/assets/videos/:fileName - Stream conversation video asset for mobile
+  fastify.get("/v1/conversations/:id/assets/videos/:fileName", async (req, reply) => {
+    try {
+      const params = req.params as { id: string; fileName: string }
+      const conversationId = params.id
+      const fileName = params.fileName
+
+      const conversationIdError = getConversationIdValidationError(conversationId)
+      if (conversationIdError) {
+        return reply.code(400).send({ error: conversationIdError })
+      }
+
+      let assetPath: string
+      try {
+        assetPath = getConversationVideoAssetPath(conversationId, fileName)
+      } catch (error) {
+        return reply.code(400).send({ error: error instanceof Error ? error.message : "Invalid video asset" })
+      }
+
+      const stat = await fs.promises.stat(assetPath)
+      if (!stat.isFile() || stat.size <= 0) {
+        return reply.code(404).send({ error: "Video asset not found" })
+      }
+
+      const contentType = getConversationVideoMimeTypeFromFileName(fileName)
+      const range = req.headers.range
+      reply.header("Accept-Ranges", "bytes")
+      reply.header("Content-Type", contentType)
+
+      if (range) {
+        const match = range.match(/^bytes=(\d*)-(\d*)$/)
+        if (!match) {
+          return reply.code(416).header("Content-Range", `bytes */${stat.size}`).send()
+        }
+
+        if (!match[1] && !match[2]) {
+          return reply.code(416).header("Content-Range", `bytes */${stat.size}`).send()
+        }
+
+        const suffixLength = !match[1] && match[2] ? Number.parseInt(match[2], 10) : null
+        const start = suffixLength !== null
+          ? Math.max(stat.size - suffixLength, 0)
+          : Number.parseInt(match[1], 10)
+        const end = suffixLength !== null
+          ? stat.size - 1
+          : match[2] ? Number.parseInt(match[2], 10) : stat.size - 1
+        if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start || start >= stat.size) {
+          return reply.code(416).header("Content-Range", `bytes */${stat.size}`).send()
+        }
+
+        const boundedEnd = Math.min(end, stat.size - 1)
+        const chunkSize = boundedEnd - start + 1
+        reply.code(206)
+        reply.header("Content-Range", `bytes ${start}-${boundedEnd}/${stat.size}`)
+        reply.header("Content-Length", String(chunkSize))
+        return reply.send(fs.createReadStream(assetPath, { start, end: boundedEnd }))
+      }
+
+      reply.header("Content-Length", String(stat.size))
+      return reply.send(fs.createReadStream(assetPath))
+    } catch (error: any) {
+      if (error?.code === "ENOENT") {
+        return reply.code(404).send({ error: "Video asset not found" })
+      }
+      diagnosticsService.logError("remote-server", "Failed to stream conversation video asset", error)
+      return reply.code(500).send({ error: error?.message || "Failed to stream video asset" })
     }
   })
 

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -76,7 +76,7 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
   {
     name: "respond_to_user",
     description:
-      "Send a response directly to the user. On voice interfaces this will be spoken aloud via TTS; on messaging channels (mobile, WhatsApp, etc.) it will be sent as a message. Regular assistant text is internal and not guaranteed to reach the user; use this tool to explicitly communicate with them. Provide at least one of: non-empty text or one/more images.",
+      "Send a response directly to the user. On voice interfaces this will be spoken aloud via TTS; on messaging channels (mobile, WhatsApp, etc.) it will be sent as a message. Regular assistant text is internal and not guaranteed to reach the user; use this tool to explicitly communicate with them. Provide at least one of: non-empty text, one/more images, or one/more videos.",
     inputSchema: {
       type: "object",
       properties: {
@@ -103,6 +103,29 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
               alt: {
                 type: "string",
                 description: "Optional alt text shown with markdown image syntax.",
+              },
+            },
+            required: [],
+          },
+        },
+        videos: {
+          type: "array",
+          description:
+            "Optional videos to include in the message. Each video can be provided as an HTTP(S) URL or as a local file path that will be stored as a conversation asset and streamed lazily by desktop/mobile.",
+          items: {
+            type: "object",
+            properties: {
+              url: {
+                type: "string",
+                description: "HTTP(S) URL for the video.",
+              },
+              path: {
+                type: "string",
+                description: "Local video file path (absolute, or relative to the current working directory). Supported extensions: mp4, m4v, webm, mov, ogv.",
+              },
+              label: {
+                type: "string",
+                description: "Optional label shown on the video card.",
               },
             },
             required: [],

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -326,10 +326,18 @@ const isAllowedRespondToUserImageUrl = (url: string): boolean => {
 
 const isAllowedRespondToUserVideoUrl = (url: string): boolean => {
   const normalized = url.trim().toLowerCase()
-  return (
-    normalized.startsWith("https://") ||
-    normalized.startsWith("http://")
-  )
+  if (normalized.startsWith("assets://conversation-video/")) return true
+  if (!normalized.startsWith("https://") && !normalized.startsWith("http://")) return false
+  // Only allow http(s) URLs that actually look like video files so tool output
+  // matches what the UI can render as a video card.
+  try {
+    const ext = normalized.lastIndexOf(".")
+    if (ext < 0) return false
+    const extension = normalized.slice(ext).replace(/[?#].*$/, "")
+    return extension in VIDEO_MIME_BY_EXTENSION
+  } catch {
+    return false
+  }
 }
 
 const getDecodedBase64ByteLength = (rawBase64: string): number => {
@@ -827,7 +835,7 @@ const toolHandlers: Record<string, ToolHandler> = {
       if (url) {
         if (!isAllowedRespondToUserVideoUrl(url)) {
           return {
-            content: [{ type: "text", text: JSON.stringify({ success: false, error: `videos[${index}].url must be http(s)` }) }],
+            content: [{ type: "text", text: JSON.stringify({ success: false, error: `videos[${index}].url must be a valid http(s) video URL (recognized extension: mp4, m4v, webm, mov, ogv) or an assets://conversation-video/ URL` }) }],
             isError: true,
           }
         }

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -282,8 +282,11 @@ async function normalizeExecuteCommandWorkspacePaths(
 }
 
 const MAX_RESPOND_TO_USER_IMAGES = 4
+const MAX_RESPOND_TO_USER_VIDEOS = 2
 const MAX_RESPOND_TO_USER_IMAGE_FILE_BYTES = 8 * 1024 * 1024
 const MAX_RESPOND_TO_USER_TOTAL_EMBEDDED_IMAGE_BYTES = 12 * 1024 * 1024
+const MAX_RESPOND_TO_USER_VIDEO_FILE_BYTES = 250 * 1024 * 1024
+const MAX_RESPOND_TO_USER_TOTAL_VIDEO_BYTES = 500 * 1024 * 1024
 const MAX_RESPOND_TO_USER_RESPONSE_CONTENT_BYTES = 12 * 1024 * 1024
 const DATA_IMAGE_BASE64_PREFIX_REGEX = /^data:image\/[a-z0-9.+-]+;base64,/i
 
@@ -296,10 +299,21 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   ".bmp": "image/bmp",
 }
 
+const VIDEO_MIME_BY_EXTENSION: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".ogv": "video/ogg",
+}
+
 const escapeMarkdownAltText = (value: string) => value.replace(/[\[\]\\]/g, "").trim()
 
 const getImageMimeTypeFromPath = (imagePath: string): string | undefined =>
   IMAGE_MIME_BY_EXTENSION[path.extname(imagePath).toLowerCase()]
+
+const getVideoMimeTypeFromPath = (videoPath: string): string | undefined =>
+  VIDEO_MIME_BY_EXTENSION[path.extname(videoPath).toLowerCase()]
 
 const isAllowedRespondToUserImageUrl = (url: string): boolean => {
   const normalized = url.trim().toLowerCase()
@@ -307,6 +321,14 @@ const isAllowedRespondToUserImageUrl = (url: string): boolean => {
     normalized.startsWith("https://") ||
     normalized.startsWith("http://") ||
     DATA_IMAGE_BASE64_PREFIX_REGEX.test(normalized)
+  )
+}
+
+const isAllowedRespondToUserVideoUrl = (url: string): boolean => {
+  const normalized = url.trim().toLowerCase()
+  return (
+    normalized.startsWith("https://") ||
+    normalized.startsWith("http://")
   )
 }
 
@@ -363,6 +385,31 @@ async function resolveValidImagePath(rawPath: string): Promise<{ resolvedPath: s
   const mimeType = getImageMimeTypeFromPath(resolvedPath)
   if (!mimeType) {
     throw new Error(`Unsupported image extension for path: ${rawPath}`)
+  }
+
+  return { resolvedPath, fileBytes: stat.size }
+}
+
+async function resolveValidVideoPath(rawPath: string): Promise<{ resolvedPath: string; fileBytes: number }> {
+  const resolvedPath = path.isAbsolute(rawPath)
+    ? rawPath
+    : path.resolve(process.cwd(), rawPath)
+
+  const stat = await fs.stat(resolvedPath)
+  if (!stat.isFile()) {
+    throw new Error(`Video path is not a file: ${rawPath}`)
+  }
+  if (stat.size <= 0) {
+    throw new Error(`Video file is empty: ${rawPath}`)
+  }
+  if (stat.size > MAX_RESPOND_TO_USER_VIDEO_FILE_BYTES) {
+    const maxMb = Math.round(MAX_RESPOND_TO_USER_VIDEO_FILE_BYTES / (1024 * 1024))
+    throw new Error(`Video file is larger than ${maxMb}MB: ${rawPath}`)
+  }
+
+  const mimeType = getVideoMimeTypeFromPath(resolvedPath)
+  if (!mimeType) {
+    throw new Error(`Unsupported video extension for path: ${rawPath}`)
   }
 
   return { resolvedPath, fileBytes: stat.size }
@@ -575,13 +622,30 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
+    if (args.videos !== undefined && !Array.isArray(args.videos)) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "videos must be an array if provided" }) }],
+        isError: true,
+      }
+    }
+
     const imageInputs = Array.isArray(args.images)
       ? args.images
+      : []
+    const videoInputs = Array.isArray(args.videos)
+      ? args.videos
       : []
 
     if (imageInputs.length > MAX_RESPOND_TO_USER_IMAGES) {
       return {
         content: [{ type: "text", text: JSON.stringify({ success: false, error: `You can include up to ${MAX_RESPOND_TO_USER_IMAGES} images.` }) }],
+        isError: true,
+      }
+    }
+
+    if (videoInputs.length > MAX_RESPOND_TO_USER_VIDEOS) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: `You can include up to ${MAX_RESPOND_TO_USER_VIDEOS} videos.` }) }],
         isError: true,
       }
     }
@@ -600,16 +664,19 @@ const toolHandlers: Record<string, ToolHandler> = {
     }
 
     const conversationId = activeSession.conversationId
-    if (imageInputs.length > 0 && !conversationId) {
+    if ((imageInputs.length > 0 || videoInputs.length > 0) && !conversationId) {
       return {
-        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Images require an active conversation" }) }],
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "Media assets require an active conversation" }) }],
         isError: true,
       }
     }
 
     const imageMarkdownBlocks: string[] = []
+    const videoMarkdownBlocks: string[] = []
     let localImageCount = 0
+    let localVideoCount = 0
     let embeddedImageBytes = 0
+    let localVideoBytes = 0
 
     for (let index = 0; index < imageInputs.length; index++) {
       const rawItem = imageInputs[index]
@@ -726,13 +793,85 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
+    for (let index = 0; index < videoInputs.length; index++) {
+      const rawItem = videoInputs[index]
+      if (!rawItem || typeof rawItem !== "object" || Array.isArray(rawItem)) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: `videos[${index}] must be an object` }) }],
+          isError: true,
+        }
+      }
+
+      const videoItem = rawItem as Record<string, unknown>
+      const url = typeof videoItem.url === "string" ? videoItem.url.trim() : ""
+      const videoPath = typeof videoItem.path === "string" ? videoItem.path.trim() : ""
+      const preferredLabel = typeof videoItem.label === "string" ? videoItem.label.trim() : ""
+
+      if (!url && !videoPath) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: `videos[${index}] must include either url or path` }) }],
+          isError: true,
+        }
+      }
+
+      if (url && videoPath) {
+        return {
+          content: [{ type: "text", text: JSON.stringify({ success: false, error: `videos[${index}] cannot include both url and path` }) }],
+          isError: true,
+        }
+      }
+
+      const fallbackLabel = videoPath ? path.basename(videoPath) : `Video ${index + 1}`
+      const safeLabel = escapeMarkdownAltText(preferredLabel || fallbackLabel) || `Video ${index + 1}`
+
+      if (url) {
+        if (!isAllowedRespondToUserVideoUrl(url)) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ success: false, error: `videos[${index}].url must be http(s)` }) }],
+            isError: true,
+          }
+        }
+        videoMarkdownBlocks.push(`[${safeLabel}](${url})`)
+        continue
+      }
+
+      try {
+        const { resolvedPath, fileBytes } = await resolveValidVideoPath(videoPath)
+        if (localVideoBytes + fileBytes > MAX_RESPOND_TO_USER_TOTAL_VIDEO_BYTES) {
+          const maxMb = Math.round(MAX_RESPOND_TO_USER_TOTAL_VIDEO_BYTES / (1024 * 1024))
+          return {
+            content: [{ type: "text", text: JSON.stringify({ success: false, error: `Total local video payload exceeds the ${maxMb}MB limit` }) }],
+            isError: true,
+          }
+        }
+        localVideoBytes += fileBytes
+        const assetUrl = await conversationService.storeVideoPathAsConversationAsset(conversationId!, resolvedPath)
+        videoMarkdownBlocks.push(`[${safeLabel}](${assetUrl})`)
+        localVideoCount++
+      } catch (error) {
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              success: false,
+              error: error instanceof Error
+                ? `Failed to load videos[${index}].path: ${error.message}`
+                : `Failed to load videos[${index}].path`,
+            }),
+          }],
+          isError: true,
+        }
+      }
+    }
+
     const imageMarkdown = imageMarkdownBlocks.join("\n\n")
-    const responseContent = [text, imageMarkdown].filter(Boolean).join("\n\n")
+    const videoMarkdown = videoMarkdownBlocks.join("\n\n")
+    const responseContent = [text, imageMarkdown, videoMarkdown].filter(Boolean).join("\n\n")
     const responseContentBytes = getUtf8ByteLength(responseContent)
 
     if (!responseContent.trim()) {
       return {
-        content: [{ type: "text", text: JSON.stringify({ success: false, error: "respond_to_user requires text and/or images" }) }],
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "respond_to_user requires text, images, and/or videos" }) }],
         isError: true,
       }
     }
@@ -762,8 +901,11 @@ const toolHandlers: Record<string, ToolHandler> = {
             responseContentLength: responseContent.length,
             responseContentBytes,
             imageCount: imageMarkdownBlocks.length,
+            videoCount: videoMarkdownBlocks.length,
             localImageCount,
+            localVideoCount,
             embeddedImageBytes,
+            localVideoBytes,
           }, null, 2),
         },
       ],

--- a/apps/desktop/src/main/serve.test.ts
+++ b/apps/desktop/src/main/serve.test.ts
@@ -4,6 +4,9 @@ const mocks = vi.hoisted(() => ({
   getConversationImageAssetPath: vi.fn(
     (conversationId: string, fileName: string) => `/images/${conversationId}/${fileName}`,
   ),
+  getConversationVideoAssetPath: vi.fn(
+    (conversationId: string, fileName: string) => `/videos/${conversationId}/${fileName}`,
+  ),
   registerFileProtocol: vi.fn(),
   registerSchemesAsPrivileged: vi.fn(),
 }))
@@ -24,6 +27,11 @@ vi.mock("./conversation-image-assets", () => ({
   getConversationImageAssetPath: mocks.getConversationImageAssetPath,
 }))
 
+vi.mock("./conversation-video-assets", () => ({
+  CONVERSATION_VIDEO_ASSET_HOST: "conversation-video",
+  getConversationVideoAssetPath: mocks.getConversationVideoAssetPath,
+}))
+
 describe("serve protocol", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -40,5 +48,17 @@ describe("serve protocol", () => {
 
     expect(callback).toHaveBeenCalledWith({ error: -6 })
     expect(mocks.getConversationImageAssetPath).not.toHaveBeenCalled()
+  })
+
+  it("resolves conversation video asset paths", async () => {
+    const { registerServeProtocol } = await import("./serve")
+    registerServeProtocol()
+
+    const handler = mocks.registerFileProtocol.mock.calls[0][1]
+    const callback = vi.fn()
+
+    handler({ url: "assets://conversation-video/conv_1/abcdef1234567890.mp4" }, callback)
+
+    expect(callback).toHaveBeenCalledWith({ path: "/videos/conv_1/abcdef1234567890.mp4" })
   })
 })

--- a/apps/desktop/src/main/serve.ts
+++ b/apps/desktop/src/main/serve.ts
@@ -6,6 +6,10 @@ import {
   CONVERSATION_IMAGE_ASSET_HOST,
   getConversationImageAssetPath,
 } from "./conversation-image-assets"
+import {
+  CONVERSATION_VIDEO_ASSET_HOST,
+  getConversationVideoAssetPath,
+} from "./conversation-video-assets"
 
 const rendererDir = path.join(__dirname, "../renderer")
 
@@ -89,7 +93,7 @@ export function registerServeProtocol() {
       return handleApp(request, callback)
     }
 
-    if (host === CONVERSATION_IMAGE_ASSET_HOST) {
+    if (host === CONVERSATION_IMAGE_ASSET_HOST || host === CONVERSATION_VIDEO_ASSET_HOST) {
       let pathSegments: string[] = []
 
       try {
@@ -105,7 +109,10 @@ export function registerServeProtocol() {
 
       if (conversationId && fileName) {
         try {
-          return callback({ path: getConversationImageAssetPath(conversationId, fileName) })
+          const assetPath = host === CONVERSATION_IMAGE_ASSET_HOST
+            ? getConversationImageAssetPath(conversationId, fileName)
+            : getConversationVideoAssetPath(conversationId, fileName)
+          return callback({ path: assetPath })
         } catch {
           return callback({ error: FILE_NOT_FOUND })
         }

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -135,13 +135,17 @@ function isCompletionControlTool(toolName: string): boolean {
 }
 
 const MARKDOWN_IMAGE_PAYLOAD_REGEX = /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/gi
+const MARKDOWN_VIDEO_PAYLOAD_REGEX = /(^|[^!])\[[^\]]*\]\((?:https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?|assets:\/\/(?:conversation-video|recording)\/[^)]+)\)/gi
 
-function stripMarkdownImagePayloads(content: string): string {
-  return content.replace(MARKDOWN_IMAGE_PAYLOAD_REGEX, "")
+function stripMarkdownMediaPayloads(content: string): string {
+  return content
+    .replace(MARKDOWN_IMAGE_PAYLOAD_REGEX, "")
+    .replace(MARKDOWN_VIDEO_PAYLOAD_REGEX, "$1")
 }
 
-function hasMarkdownImagePayload(content: string): boolean {
-  return /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/i.test(content)
+function hasMarkdownMediaPayload(content: string): boolean {
+  return /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/i.test(content) ||
+    /(^|[^!])\[[^\]]*\]\((?:https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?|assets:\/\/(?:conversation-video|recording)\/[^)]+)\)/i.test(content)
 }
 
 function extractRespondToUserResponsesFromMessages(
@@ -315,8 +319,8 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const hasExtras =
     (message.toolCalls?.length ?? 0) > 0 ||
     displayResults.length > 0
-  const effectiveTextContentLength = stripMarkdownImagePayloads(effectiveContent).length
-  const collapseLengthLimit = hasMarkdownImagePayload(effectiveContent) ? 500 : 100
+  const effectiveTextContentLength = stripMarkdownMediaPayloads(effectiveContent).length
+  const collapseLengthLimit = hasMarkdownMediaPayload(effectiveContent) ? 500 : 100
   const shouldCollapse = effectiveTextContentLength > collapseLengthLimit || hasExtras
 
   // Track the computed ttsSource (ttsText || effectiveContent) since that's what determines the
@@ -3103,8 +3107,10 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       )
       .map(({ i }) => i)
 
-    const stripImageMarkdown = (text: string) =>
-      text.replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    const stripMediaMarkdown = (text: string) =>
+      text
+        .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+        .replace(/(^|[^!])\[[^\]]*\]\((?:https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?|assets:\/\/(?:conversation-video|recording)\/[^)]+)\)/gi, "$1")
 
     const attachEvent = (event: AgentUserResponseEvent, normalizedEventText: string) => {
       if (!normalizedEventText) return false
@@ -3141,7 +3147,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     // can still bind to the text-only streamed prose that carries the same words.
     for (const event of effectiveResponseEvents) {
       if (usedEventIds.has(event.id)) continue
-      attachEvent(event, normalizeAssistantResponseForDedupe(stripImageMarkdown(event.text)))
+      attachEvent(event, normalizeAssistantResponseForDedupe(stripMediaMarkdown(event.text)))
     }
 
     // Pass 4: synthesize standalone assistant messages for unmatched events.

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
@@ -61,6 +61,12 @@ export const isAllowedMarkdownLinkUrl = (rawUrl?: string) => {
   return false
 }
 
+const isDesktopRenderableVideoUrl = (rawUrl?: string) => {
+  if (!rawUrl) return false
+  const url = rawUrl.trim().toLowerCase()
+  return isRenderableVideoUrl(rawUrl) || ALLOWED_RECORDING_ASSET_URL_REGEX.test(url)
+}
+
 const VideoAttachmentCard = ({
   src,
   label,
@@ -134,7 +140,7 @@ const markdownLinkComponent = ({
   children?: React.ReactNode
   href?: string
 }) => {
-  if (href && isRenderableVideoUrl(href)) {
+  if (href && isDesktopRenderableVideoUrl(href)) {
     return <VideoAttachmentCard src={href} label={extractTextContent(children)} />
   }
 

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
@@ -2,7 +2,8 @@ import React, { useState, useId, useCallback, useRef } from "react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 import rehypeHighlight from "rehype-highlight"
-import { ChevronDown, ChevronRight, Brain, Copy, CheckCheck } from "lucide-react"
+import { ChevronDown, ChevronRight, Brain, Copy, CheckCheck, PlayCircle } from "lucide-react"
+import { getVideoAssetLabel, isRenderableVideoUrl } from "@dotagents/shared"
 import { cn } from "@renderer/lib/utils"
 import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import "highlight.js/styles/github.css"
@@ -36,6 +37,9 @@ const ALLOWED_MARKDOWN_DATA_IMAGE_URL_REGEX =
   /^data:image\/(?:png|apng|gif|jpe?g|webp|bmp|avif)(?:;|,)/
 const ALLOWED_CONVERSATION_IMAGE_ASSET_URL_REGEX =
   /^assets:\/\/conversation-image\//
+const ALLOWED_CONVERSATION_VIDEO_ASSET_URL_REGEX =
+  /^assets:\/\/conversation-video\//
+const ALLOWED_RECORDING_ASSET_URL_REGEX = /^assets:\/\/recording\//
 
 export const isAllowedMarkdownLinkUrl = (rawUrl?: string) => {
   if (!rawUrl) return false
@@ -47,12 +51,60 @@ export const isAllowedMarkdownLinkUrl = (rawUrl?: string) => {
     url.startsWith("#") ||
     url.startsWith("http://") ||
     url.startsWith("https://") ||
+    ALLOWED_CONVERSATION_VIDEO_ASSET_URL_REGEX.test(url) ||
+    ALLOWED_RECORDING_ASSET_URL_REGEX.test(url) ||
     url.startsWith("mailto:")
   ) {
     return true
   }
 
   return false
+}
+
+const VideoAttachmentCard = ({
+  src,
+  label,
+}: {
+  src: string
+  label?: string
+}) => {
+  const [loaded, setLoaded] = useState(false)
+  const displayLabel = getVideoAssetLabel(label, src)
+
+  return (
+    <span className="not-prose my-3 block overflow-hidden rounded-lg border border-border bg-muted/20">
+      {loaded ? (
+        <video
+          src={src}
+          controls
+          playsInline
+          preload="metadata"
+          className="block max-h-[30rem] w-full bg-black"
+          onError={() => {
+            logUI("[MarkdownRenderer] video failed to render", {
+              label: displayLabel,
+              srcPreview: src.slice(0, 64),
+            })
+          }}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setLoaded(true)}
+          className="flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-muted/40"
+          aria-label={`Load video ${displayLabel}`}
+        >
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <PlayCircle className="h-5 w-5" />
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm font-medium text-foreground">{displayLabel}</span>
+            <span className="block text-xs text-muted-foreground">Loads only when you click play</span>
+          </span>
+        </button>
+      )}
+    </span>
+  )
 }
 
 export const isAllowedMarkdownImageUrl = (rawUrl?: string) => {
@@ -82,6 +134,10 @@ const markdownLinkComponent = ({
   children?: React.ReactNode
   href?: string
 }) => {
+  if (href && isRenderableVideoUrl(href)) {
+    return <VideoAttachmentCard src={href} label={extractTextContent(children)} />
+  }
+
   if (isAllowedMarkdownLinkUrl(href)) {
     return (
       <a

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -31,6 +31,7 @@
     "expo-speech": "~14.0.7",
     "expo-speech-recognition": "^2.1.2",
     "expo-status-bar": "~3.0.8",
+    "expo-video": "^55.0.15",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -308,6 +308,7 @@ const mergeVoiceText = (base?: string, live?: string) => {
 const getCollapsedMessagePreview = (content: string) =>
   content
     .replace(/!\[[^\]]*\]\((?:data:image\/[^)]+|[^)]+)\)/gi, '[Image]')
+    .replace(/(^|[^!])\[[^\]]*\]\((?:assets:\/\/conversation-video\/[^)]+|https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?)\)/gi, '$1[Video]')
     .replace(/\s+/g, ' ')
     .trim();
 
@@ -3321,7 +3322,11 @@ export default function ChatScreen({ route, navigation }: any) {
                     {shouldShowExpandedContent ? (
                       <View style={m.role === 'assistant' ? styles.assistantMessageRow : undefined}>
                         <View style={m.role === 'assistant' ? styles.assistantMessageBody : undefined}>
-                          <MarkdownRenderer content={visibleMessageContent} />
+                          <MarkdownRenderer
+                            content={visibleMessageContent}
+                            assetBaseUrl={config.baseUrl}
+                            assetAuthToken={config.apiKey}
+                          />
                         </View>
                         {canSpeakVisibleContent && (
                           <TouchableOpacity

--- a/apps/mobile/src/ui/MarkdownRenderer.tsx
+++ b/apps/mobile/src/ui/MarkdownRenderer.tsx
@@ -12,14 +12,17 @@ interface MarkdownRendererProps {
   assetAuthToken?: string;
 }
 
-const MARKDOWN_VIDEO_LINK_REGEX = /(^|[^!])\[([^\]]+)\]\(([^)]+)\)/g;
-
+// NOTE: Splitting markdown around video links may break contiguous constructs (lists, fenced code blocks)
+// when a video link appears inline. This is an accepted trade-off for now; video links in agent messages
+// rarely appear mid-structure.
 function splitVideoLinks(content: string) {
+  // Create a new regex instance per call to avoid /g lastIndex state leaking between invocations.
+  const videoLinkRegex = /(^|[^!])\[([^\]]+)\]\(([^)]+)\)/g;
   const parts: Array<{ type: 'markdown' | 'video'; content?: string; label?: string; url?: string }> = [];
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
-  while ((match = MARKDOWN_VIDEO_LINK_REGEX.exec(content)) !== null) {
+  while ((match = videoLinkRegex.exec(content)) !== null) {
     const [fullMatch, prefix, label, url] = match;
     if (!isRenderableVideoUrl(url)) continue;
 

--- a/apps/mobile/src/ui/MarkdownRenderer.tsx
+++ b/apps/mobile/src/ui/MarkdownRenderer.tsx
@@ -1,15 +1,47 @@
 import React from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
+import { isRenderableVideoUrl } from '@dotagents/shared';
 import { useTheme } from './ThemeProvider';
 import { spacing, radius } from './theme';
+import { VideoAttachmentCard } from './VideoAttachmentCard';
 
 interface MarkdownRendererProps {
   content: string;
+  assetBaseUrl?: string;
+  assetAuthToken?: string;
+}
+
+const MARKDOWN_VIDEO_LINK_REGEX = /(^|[^!])\[([^\]]+)\]\(([^)]+)\)/g;
+
+function splitVideoLinks(content: string) {
+  const parts: Array<{ type: 'markdown' | 'video'; content?: string; label?: string; url?: string }> = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = MARKDOWN_VIDEO_LINK_REGEX.exec(content)) !== null) {
+    const [fullMatch, prefix, label, url] = match;
+    if (!isRenderableVideoUrl(url)) continue;
+
+    const matchStart = (match.index ?? 0) + prefix.length;
+    if (matchStart > lastIndex) {
+      parts.push({ type: 'markdown', content: content.slice(lastIndex, matchStart) });
+    }
+    parts.push({ type: 'video', label, url });
+    lastIndex = (match.index ?? 0) + fullMatch.length;
+  }
+
+  if (lastIndex < content.length) {
+    parts.push({ type: 'markdown', content: content.slice(lastIndex) });
+  }
+
+  return parts.length > 0 ? parts : [{ type: 'markdown' as const, content }];
 }
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
+  assetBaseUrl,
+  assetAuthToken,
 }) => {
   const { theme, isDark } = useTheme();
 
@@ -152,10 +184,31 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     },
   });
 
+  const parts = splitVideoLinks(content);
+
   return (
-    <Markdown style={markdownStyles}>
-      {content}
-    </Markdown>
+    <View>
+      {parts.map((part, index) => {
+        if (part.type === 'video' && part.url) {
+          return (
+            <VideoAttachmentCard
+              key={`video-${index}-${part.url}`}
+              sourceUrl={part.url}
+              label={part.label}
+              assetBaseUrl={assetBaseUrl}
+              authToken={assetAuthToken}
+            />
+          );
+        }
+
+        if (!part.content?.trim()) return null;
+        return (
+          <Markdown key={`markdown-${index}`} style={markdownStyles}>
+            {part.content}
+          </Markdown>
+        );
+      })}
+    </View>
   );
 };
 

--- a/apps/mobile/src/ui/VideoAttachmentCard.tsx
+++ b/apps/mobile/src/ui/VideoAttachmentCard.tsx
@@ -38,9 +38,10 @@ export const VideoAttachmentCard: React.FC<VideoAttachmentCardProps> = ({
     // Asset URLs (assets://) can't be played directly on mobile — they must be
     // resolved to an HTTP URL via buildConversationVideoAssetHttpUrl (which
     // requires assetBaseUrl). If the source is an asset URL and it wasn't
-    // resolved, don't show the card.
+    // resolved, don't show the card. Auth is also required since the desktop
+    // remote server rejects unauthenticated /v1/* requests.
     if (isConversationVideoAssetUrl(sourceUrl)) {
-      return resolvedUri !== sourceUrl && isRenderableVideoUrl(resolvedUri);
+      return resolvedUri !== sourceUrl && !!authToken && isRenderableVideoUrl(resolvedUri);
     }
     return isRenderableVideoUrl(sourceUrl) || isRenderableVideoUrl(resolvedUri);
   })();
@@ -100,9 +101,29 @@ export const VideoAttachmentCard: React.FC<VideoAttachmentCardProps> = ({
       height: 220,
       backgroundColor: '#000',
     },
+    fallbackLink: {
+      paddingVertical: spacing.xs,
+      marginBottom: spacing.sm,
+    },
+    fallbackLinkText: {
+      color: theme.colors.primary,
+      fontSize: 13,
+      textDecorationLine: 'underline',
+    },
   }), [isDark, theme]);
 
-  if (!canRender) return null;
+  if (!canRender) {
+    return (
+      <Pressable
+        accessibilityRole="link"
+        accessibilityLabel={`Open video link: ${displayLabel}`}
+        onPress={() => Linking.openURL(sourceUrl)}
+        style={styles.fallbackLink}
+      >
+        <Text style={styles.fallbackLinkText}>🔗 {displayLabel}</Text>
+      </Pressable>
+    );
+  }
 
   return (
     <View style={styles.card}>

--- a/apps/mobile/src/ui/VideoAttachmentCard.tsx
+++ b/apps/mobile/src/ui/VideoAttachmentCard.tsx
@@ -1,0 +1,127 @@
+import React, { useMemo, useState } from 'react';
+import { Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { VideoView, useVideoPlayer, type VideoSource } from 'expo-video';
+import {
+  buildConversationVideoAssetHttpUrl,
+  getVideoAssetLabel,
+  isRenderableVideoUrl,
+} from '@dotagents/shared';
+import { useTheme } from './ThemeProvider';
+import { radius, spacing } from './theme';
+
+interface VideoAttachmentCardProps {
+  sourceUrl: string;
+  label?: string;
+  assetBaseUrl?: string;
+  authToken?: string;
+}
+
+function resolveVideoUri(sourceUrl: string, assetBaseUrl?: string): string {
+  const remoteAssetUrl = assetBaseUrl
+    ? buildConversationVideoAssetHttpUrl(assetBaseUrl, sourceUrl)
+    : null;
+  return remoteAssetUrl ?? sourceUrl;
+}
+
+export const VideoAttachmentCard: React.FC<VideoAttachmentCardProps> = ({
+  sourceUrl,
+  label,
+  assetBaseUrl,
+  authToken,
+}) => {
+  const { theme, isDark } = useTheme();
+  const [loaded, setLoaded] = useState(false);
+  const displayLabel = getVideoAssetLabel(label, sourceUrl);
+  const resolvedUri = resolveVideoUri(sourceUrl, assetBaseUrl);
+  const canRender = isRenderableVideoUrl(sourceUrl) || isRenderableVideoUrl(resolvedUri);
+  const canOpenExternally = !authToken || resolvedUri === sourceUrl;
+
+  const source = useMemo<VideoSource>(() => {
+    if (!loaded || !canRender) return null;
+    const headers = authToken ? { Authorization: `Bearer ${authToken}` } : undefined;
+    return headers ? { uri: resolvedUri, headers } : { uri: resolvedUri };
+  }, [authToken, canRender, loaded, resolvedUri]);
+
+  const player = useVideoPlayer(source, (videoPlayer) => {
+    videoPlayer.loop = false;
+  });
+
+  const styles = useMemo(() => StyleSheet.create({
+    card: {
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      borderRadius: radius.lg,
+      backgroundColor: isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.03)',
+      overflow: 'hidden',
+      marginBottom: spacing.sm,
+    },
+    header: {
+      padding: spacing.sm,
+      gap: 2,
+    },
+    title: {
+      color: theme.colors.foreground,
+      fontWeight: '600',
+      fontSize: 13,
+    },
+    subtitle: {
+      color: theme.colors.mutedForeground,
+      fontSize: 11,
+    },
+    button: {
+      marginTop: spacing.xs,
+      alignSelf: 'flex-start',
+      borderRadius: radius.md,
+      backgroundColor: theme.colors.primary,
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 6,
+    },
+    buttonText: {
+      color: theme.colors.primaryForeground,
+      fontWeight: '700',
+      fontSize: 12,
+    },
+    video: {
+      width: '100%',
+      height: 220,
+      backgroundColor: '#000',
+    },
+  }), [isDark, theme]);
+
+  if (!canRender) return null;
+
+  return (
+    <View style={styles.card}>
+      {loaded ? (
+        <VideoView
+          player={player}
+          style={styles.video}
+          nativeControls
+          contentFit="contain"
+          playsInline
+          surfaceType={Platform.OS === 'android' ? 'surfaceView' : undefined}
+        />
+      ) : (
+        <View style={styles.header}>
+          <Text style={styles.title} numberOfLines={1}>🎬 {displayLabel}</Text>
+          <Text style={styles.subtitle} numberOfLines={1}>Loads only when you tap play</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Play video ${displayLabel}`}
+            onPress={() => setLoaded(true)}
+            style={styles.button}
+          >
+            <Text style={styles.buttonText}>Play video</Text>
+          </Pressable>
+          {canOpenExternally ? (
+            <Pressable onPress={() => Linking.openURL(resolvedUri)}>
+              <Text style={[styles.subtitle, { marginTop: spacing.xs }]}>Open externally</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      )}
+    </View>
+  );
+};
+
+export default VideoAttachmentCard;

--- a/apps/mobile/src/ui/VideoAttachmentCard.tsx
+++ b/apps/mobile/src/ui/VideoAttachmentCard.tsx
@@ -4,6 +4,7 @@ import { VideoView, useVideoPlayer, type VideoSource } from 'expo-video';
 import {
   buildConversationVideoAssetHttpUrl,
   getVideoAssetLabel,
+  isConversationVideoAssetUrl,
   isRenderableVideoUrl,
 } from '@dotagents/shared';
 import { useTheme } from './ThemeProvider';
@@ -33,7 +34,16 @@ export const VideoAttachmentCard: React.FC<VideoAttachmentCardProps> = ({
   const [loaded, setLoaded] = useState(false);
   const displayLabel = getVideoAssetLabel(label, sourceUrl);
   const resolvedUri = resolveVideoUri(sourceUrl, assetBaseUrl);
-  const canRender = isRenderableVideoUrl(sourceUrl) || isRenderableVideoUrl(resolvedUri);
+  const canRender = (() => {
+    // Asset URLs (assets://) can't be played directly on mobile — they must be
+    // resolved to an HTTP URL via buildConversationVideoAssetHttpUrl (which
+    // requires assetBaseUrl). If the source is an asset URL and it wasn't
+    // resolved, don't show the card.
+    if (isConversationVideoAssetUrl(sourceUrl)) {
+      return resolvedUri !== sourceUrl && isRenderableVideoUrl(resolvedUri);
+    }
+    return isRenderableVideoUrl(sourceUrl) || isRenderableVideoUrl(resolvedUri);
+  })();
   const canOpenExternally = !authToken || resolvedUri === sourceUrl;
 
   const source = useMemo<VideoSource>(() => {

--- a/apps/mobile/src/ui/VideoAttachmentCard.tsx
+++ b/apps/mobile/src/ui/VideoAttachmentCard.tsx
@@ -48,9 +48,13 @@ export const VideoAttachmentCard: React.FC<VideoAttachmentCardProps> = ({
 
   const source = useMemo<VideoSource>(() => {
     if (!loaded || !canRender) return null;
-    const headers = authToken ? { Authorization: `Bearer ${authToken}` } : undefined;
+    // Only attach auth headers for conversation video asset URLs to avoid
+    // leaking the desktop API key to third-party hosts.
+    const headers = (authToken && isConversationVideoAssetUrl(sourceUrl))
+      ? { Authorization: `Bearer ${authToken}` }
+      : undefined;
     return headers ? { uri: resolvedUri, headers } : { uri: resolvedUri };
-  }, [authToken, canRender, loaded, resolvedUri]);
+  }, [authToken, canRender, loaded, resolvedUri, sourceUrl]);
 
   const player = useVideoPlayer(source, (videoPlayer) => {
     videoPlayer.loop = false;

--- a/packages/shared/src/conversation-media-assets.test.ts
+++ b/packages/shared/src/conversation-media-assets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildConversationVideoAssetHttpUrl,
   getVideoAssetLabel,
+  isConversationVideoAssetUrl,
   isRenderableVideoUrl,
   parseConversationVideoAssetUrl,
 } from './conversation-media-assets';
@@ -26,6 +27,13 @@ describe('conversation video asset utilities', () => {
       'http://localhost:3210/v1/',
       'assets://conversation-video/conv_1/abcdef1234567890.mp4',
     )).toBe('http://localhost:3210/v1/conversations/conv_1/assets/videos/abcdef1234567890.mp4');
+  });
+
+  it('detects conversation video asset urls', () => {
+    expect(isConversationVideoAssetUrl('assets://conversation-video/conv_1/abcdef1234567890.mp4')).toBe(true);
+    expect(isConversationVideoAssetUrl('assets://recording/recording_1/demo.mp4')).toBe(false);
+    expect(isConversationVideoAssetUrl('https://example.com/demo.mp4')).toBe(false);
+    expect(isConversationVideoAssetUrl(undefined)).toBe(false);
   });
 
   it('uses link text before filename for labels', () => {

--- a/packages/shared/src/conversation-media-assets.test.ts
+++ b/packages/shared/src/conversation-media-assets.test.ts
@@ -16,6 +16,7 @@ describe('conversation video asset utilities', () => {
 
   it('detects renderable video urls', () => {
     expect(isRenderableVideoUrl('assets://conversation-video/conv_1/abcdef1234567890.mp4')).toBe(true);
+    expect(isRenderableVideoUrl('assets://recording/recording_1/demo.mp4')).toBe(false);
     expect(isRenderableVideoUrl('https://example.com/demo.webm?download=1')).toBe(true);
     expect(isRenderableVideoUrl('https://example.com/demo.png')).toBe(false);
   });

--- a/packages/shared/src/conversation-media-assets.test.ts
+++ b/packages/shared/src/conversation-media-assets.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildConversationVideoAssetHttpUrl,
+  getVideoAssetLabel,
+  isRenderableVideoUrl,
+  parseConversationVideoAssetUrl,
+} from './conversation-media-assets';
+
+describe('conversation video asset utilities', () => {
+  it('parses conversation video asset urls', () => {
+    expect(parseConversationVideoAssetUrl('assets://conversation-video/conv_1/abcdef1234567890.mp4')).toEqual({
+      conversationId: 'conv_1',
+      fileName: 'abcdef1234567890.mp4',
+    });
+  });
+
+  it('detects renderable video urls', () => {
+    expect(isRenderableVideoUrl('assets://conversation-video/conv_1/abcdef1234567890.mp4')).toBe(true);
+    expect(isRenderableVideoUrl('https://example.com/demo.webm?download=1')).toBe(true);
+    expect(isRenderableVideoUrl('https://example.com/demo.png')).toBe(false);
+  });
+
+  it('builds authenticated remote asset urls from api base url', () => {
+    expect(buildConversationVideoAssetHttpUrl(
+      'http://localhost:3210/v1/',
+      'assets://conversation-video/conv_1/abcdef1234567890.mp4',
+    )).toBe('http://localhost:3210/v1/conversations/conv_1/assets/videos/abcdef1234567890.mp4');
+  });
+
+  it('uses link text before filename for labels', () => {
+    expect(getVideoAssetLabel('Demo clip', 'assets://conversation-video/conv_1/abcdef1234567890.mp4')).toBe('Demo clip');
+    expect(getVideoAssetLabel('', 'assets://conversation-video/conv_1/abcdef1234567890.mp4')).toBe('abcdef1234567890.mp4');
+  });
+});

--- a/packages/shared/src/conversation-media-assets.ts
+++ b/packages/shared/src/conversation-media-assets.ts
@@ -1,7 +1,6 @@
 export const CONVERSATION_VIDEO_ASSET_HOST = 'conversation-video';
 
 const CONVERSATION_VIDEO_ASSET_URL_REGEX = /^assets:\/\/conversation-video\/([^/]+)\/([^/?#]+)(?:[?#].*)?$/i;
-const RECORDING_ASSET_URL_REGEX = /^assets:\/\/recording\//i;
 const VIDEO_EXTENSION_REGEX = /\.(?:mp4|m4v|webm|mov|ogv)(?:[?#].*)?$/i;
 
 export interface ConversationVideoAssetRef {
@@ -32,7 +31,7 @@ export function isRenderableVideoUrl(rawUrl?: string): boolean {
   const url = rawUrl.trim();
   const lower = url.toLowerCase();
 
-  if (isConversationVideoAssetUrl(url) || RECORDING_ASSET_URL_REGEX.test(lower)) {
+  if (isConversationVideoAssetUrl(url)) {
     return true;
   }
 

--- a/packages/shared/src/conversation-media-assets.ts
+++ b/packages/shared/src/conversation-media-assets.ts
@@ -1,0 +1,75 @@
+export const CONVERSATION_VIDEO_ASSET_HOST = 'conversation-video';
+
+const CONVERSATION_VIDEO_ASSET_URL_REGEX = /^assets:\/\/conversation-video\/([^/]+)\/([^/?#]+)(?:[?#].*)?$/i;
+const RECORDING_ASSET_URL_REGEX = /^assets:\/\/recording\//i;
+const VIDEO_EXTENSION_REGEX = /\.(?:mp4|m4v|webm|mov|ogv)(?:[?#].*)?$/i;
+
+export interface ConversationVideoAssetRef {
+  conversationId: string;
+  fileName: string;
+}
+
+export function parseConversationVideoAssetUrl(rawUrl: string): ConversationVideoAssetRef | null {
+  const match = rawUrl.trim().match(CONVERSATION_VIDEO_ASSET_URL_REGEX);
+  if (!match) return null;
+
+  try {
+    return {
+      conversationId: decodeURIComponent(match[1]),
+      fileName: decodeURIComponent(match[2]),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isConversationVideoAssetUrl(rawUrl?: string): boolean {
+  return !!rawUrl && parseConversationVideoAssetUrl(rawUrl) !== null;
+}
+
+export function isRenderableVideoUrl(rawUrl?: string): boolean {
+  if (!rawUrl) return false;
+  const url = rawUrl.trim();
+  const lower = url.toLowerCase();
+
+  if (isConversationVideoAssetUrl(url) || RECORDING_ASSET_URL_REGEX.test(lower)) {
+    return true;
+  }
+
+  if (!lower.startsWith('http://') && !lower.startsWith('https://')) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return VIDEO_EXTENSION_REGEX.test(`${parsed.pathname}${parsed.search}${parsed.hash}`);
+  } catch {
+    return VIDEO_EXTENSION_REGEX.test(lower);
+  }
+}
+
+export function getVideoAssetLabel(label: string | undefined, rawUrl: string): string {
+  const trimmed = label?.trim();
+  if (trimmed) return trimmed;
+
+  const assetRef = parseConversationVideoAssetUrl(rawUrl);
+  if (assetRef) return assetRef.fileName;
+
+  try {
+    const parsed = new URL(rawUrl);
+    const fileName = parsed.pathname.split('/').filter(Boolean).pop();
+    return decodeURIComponent(fileName || 'Video');
+  } catch {
+    return rawUrl.split('/').filter(Boolean).pop() || 'Video';
+  }
+}
+
+export function buildConversationVideoAssetHttpUrl(apiBaseUrl: string, assetUrl: string): string | null {
+  const assetRef = parseConversationVideoAssetUrl(assetUrl);
+  if (!assetRef) return null;
+
+  const base = apiBaseUrl.trim().replace(/\/+$/, '');
+  if (!base) return null;
+
+  return `${base}/conversations/${encodeURIComponent(assetRef.conversationId)}/assets/videos/${encodeURIComponent(assetRef.fileName)}`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,6 +18,7 @@ export * from './hub';
 export * from './conversation-state';
 export * from './agent-progress';
 export * from './message-display-utils';
+export * from './conversation-media-assets';
 export * from './stt-models';
 export * from './api-key-error-utils';
 export * from './tool-activity-grouping';

--- a/packages/shared/src/message-display-utils.test.ts
+++ b/packages/shared/src/message-display-utils.test.ts
@@ -53,6 +53,11 @@ describe('sanitizeMessageContentForSpeech', () => {
     expect(sanitizeMessageContentForSpeech(content)).toBe('Image')
   })
 
+  it('strips markdown video links', () => {
+    const content = 'Watch [demo](assets://conversation-video/conv_1/abcdef1234567890.mp4) please'
+    expect(sanitizeMessageContentForSpeech(content)).toBe('Watch Video: demo please')
+  })
+
   it('leaves plain text unchanged', () => {
     const content = 'Just regular text with no images'
     expect(sanitizeMessageContentForSpeech(content)).toBe(content)

--- a/packages/shared/src/message-display-utils.ts
+++ b/packages/shared/src/message-display-utils.ts
@@ -3,6 +3,7 @@ import type { AgentProgressUpdate } from "./agent-progress"
 // Inline data URLs can be megabytes long; replace them in display/budget text.
 const INLINE_DATA_IMAGE_REGEX = /!\[([^\]]*)\]\((data:image\/[^)]+)\)/gi
 const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/gi
+const MARKDOWN_VIDEO_LINK_REGEX = /(^|[^!])\[([^\]]*)\]\((assets:\/\/conversation-video\/[^)]+|https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?)\)/gi
 
 function hasInlineDataImage(content: string): boolean {
   return !!content && /data:image\//i.test(content)
@@ -26,10 +27,15 @@ export function sanitizeMessageContentForSpeech(content: string): string {
 
   // Strip markdown image payloads (including inline data URLs) before TTS.
   // This keeps speech requests small and avoids reading non-verbal content.
-  return content.replace(MARKDOWN_IMAGE_REGEX, (_match, altText: string) => {
-    const cleanedAlt = altText?.trim()
-    return cleanedAlt ? `Image: ${cleanedAlt}` : "Image"
-  })
+  return content
+    .replace(MARKDOWN_IMAGE_REGEX, (_match, altText: string) => {
+      const cleanedAlt = altText?.trim()
+      return cleanedAlt ? `Image: ${cleanedAlt}` : "Image"
+    })
+    .replace(MARKDOWN_VIDEO_LINK_REGEX, (_match, prefix: string, label: string) => {
+      const cleanedLabel = label?.trim()
+      return `${prefix}${cleanedLabel ? `Video: ${cleanedLabel}` : "Video"}`
+    })
 }
 
 function sanitizeConversationHistoryForDisplay(

--- a/packages/shared/src/session.test.ts
+++ b/packages/shared/src/session.test.ts
@@ -131,6 +131,10 @@ describe('sanitizeSessionText', () => {
   it('replaces data URL images with [Image]', () => {
     expect(sanitizeSessionText('![](data:image/png;base64,abc)')).toBe('[Image]')
   })
+
+  it('replaces markdown video links with [Video]', () => {
+    expect(sanitizeSessionText('Watch [demo](assets://conversation-video/conv_1/abcdef1234567890.mp4) now')).toBe('Watch [Video] now')
+  })
 })
 
 // ── sessionToListItem ────────────────────────────────────────────────────────

--- a/packages/shared/src/session.ts
+++ b/packages/shared/src/session.ts
@@ -6,10 +6,12 @@ import type { ToolCall, ToolResult } from './types';
 import { filterVisibleChatMessages } from './chat-utils';
 
 const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\((?:data:image\/[^)]+|[^)]+)\)/gi;
+const MARKDOWN_VIDEO_LINK_REGEX = /(^|[^!])\[[^\]]*\]\((?:assets:\/\/conversation-video\/[^)]+|https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?)\)/gi;
 
 export function sanitizeSessionText(content: string): string {
   return content
     .replace(MARKDOWN_IMAGE_REGEX, '[Image]')
+    .replace(MARKDOWN_VIDEO_LINK_REGEX, '$1[Video]')
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       expo-status-bar:
         specifier: ~3.0.8
         version: 3.0.9(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-video:
+        specifier: ^55.0.15
+        version: 55.0.15(expo@54.0.30(@babel/core@7.28.5)(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -3944,6 +3947,13 @@ packages:
   expo-status-bar@3.0.9:
     resolution: {integrity: sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-video@55.0.15:
+    resolution: {integrity: sha512-4GEEiTH5hGsyEt7Chsiv8IS4ioYuEJ4Wc+tjbf8NiGvAw0bQquN41zWmYLnwgzPoU3tCr8SaACgEvJRc3+FcWw==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -11500,6 +11510,12 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.2.1(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-video@55.0.15(expo@54.0.30(@babel/core@7.28.5)(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.30(@babel/core@7.28.5)(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: 0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0)
 
   expo@54.0.30(@babel/core@7.28.5)(react-native@0.81.4(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.9.3))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- add conversation video assets with safe local storage and Electron `assets://conversation-video/...` serving
- add authenticated remote video streaming with byte-range support for mobile playback
- render video links as lazy desktop/mobile video cards and add `respond_to_user.videos` support
- add shared utilities and sanitization so previews/TTS handle videos without reading URLs

## Validation
- `pnpm build:shared`
- `pnpm --filter @dotagents/shared test -- conversation-media-assets.test.ts session.test.ts message-display-utils.test.ts`
- `pnpm --filter @dotagents/shared typecheck`
- `pnpm --filter @dotagents/desktop exec vitest run src/main/conversation-image-assets.test.ts src/main/serve.test.ts`
- `pnpm --filter @dotagents/desktop exec tsc --noEmit`
- `pnpm --filter @dotagents/mobile test:vitest`

## Notes
- Added `expo-video` for native mobile playback.
- `pnpm --filter @dotagents/mobile exec tsc --noEmit --pretty false` still fails on pre-existing unrelated errors in `src/lib/voice/useSpeechRecognizer.ts` and `src/screens/AgentEditScreen.tsx`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author