### PR TITLE
Add voice screenshot input shortcut

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -91,4 +91,21 @@ describe("chatgpt-web provider image input", () => {
       },
     ])
   })
+
+  it("leaves oversized conversation image assets as text instead of inlining them", async () => {
+    const { tempDir } = await setupChatGptWebProviderTest()
+    await fs.writeFile(path.join(tempDir, "large.png"), Buffer.alloc(8 * 1024 * 1024 + 1))
+    const { buildCodexInput } = await import("./chatgpt-web-provider")
+
+    const content = "Read this\n\n![Screen selection](assets://conversation-image/conv_123/large.png)"
+    const input = buildCodexInput([{ role: "user", content }])
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content,
+      },
+    ])
+  })
 })

--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -1,0 +1,94 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const tempDirs: string[] = []
+
+async function setupChatGptWebProviderTest() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-chatgpt-web-images-"))
+  tempDirs.push(tempDir)
+
+  vi.doMock("./config", () => ({
+    configStore: {
+      get: vi.fn(() => ({
+        chatgptWebBaseUrl: "https://chatgpt.test",
+        mcpToolsChatgptWebModel: "gpt-test",
+      })),
+      save: vi.fn(),
+    },
+  }))
+
+  vi.doMock("./oauth-storage", () => ({
+    oauthStorage: {
+      getTokens: vi.fn(),
+      storeTokens: vi.fn(),
+      clearTokens: vi.fn(),
+    },
+  }))
+
+  vi.doMock("./conversation-image-assets", () => ({
+    CONVERSATION_IMAGE_ASSET_HOST: "conversation-image",
+    getConversationImageAssetPath: vi.fn((_conversationId: string, fileName: string) => (
+      path.join(tempDir, fileName)
+    )),
+  }))
+
+  return { tempDir }
+}
+
+afterEach(async () => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe("chatgpt-web provider image input", () => {
+  it("converts data-image markdown into Codex multimodal input parts", async () => {
+    await setupChatGptWebProviderTest()
+    const { buildCodexInput } = await import("./chatgpt-web-provider")
+
+    const input = buildCodexInput([
+      { role: "system", content: "System prompt" },
+      { role: "user", content: "What do you see?\n\n![Screen selection](data:image/png;base64,abc123)" },
+    ])
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "What do you see?\n\n" },
+          { type: "input_image", image_url: "data:image/png;base64,abc123" },
+        ],
+      },
+    ])
+  })
+
+  it("resolves conversation image asset markdown into data-image Codex input parts", async () => {
+    const { tempDir } = await setupChatGptWebProviderTest()
+    await fs.writeFile(path.join(tempDir, "image.png"), Buffer.from("hello-image"))
+    const { buildCodexInput } = await import("./chatgpt-web-provider")
+
+    const input = buildCodexInput([
+      {
+        role: "user",
+        content: "Read this\n\n![Screen selection](assets://conversation-image/conv_123/image.png)",
+      },
+    ])
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: "Read this\n\n" },
+          {
+            type: "input_image",
+            image_url: `data:image/png;base64,${Buffer.from("hello-image").toString("base64")}`,
+          },
+        ],
+      },
+    ])
+  })
+})

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "crypto"
+import fs from "fs"
 import { configStore } from "./config"
 import { oauthStorage } from "./oauth-storage"
+import { CONVERSATION_IMAGE_ASSET_HOST, getConversationImageAssetPath } from "./conversation-image-assets"
 
 const DEFAULT_CHATGPT_WEB_BASE_URL = "https://chatgpt.com"
 const DEFAULT_CHATGPT_WEB_MODEL = "gpt-5.4-mini"
@@ -19,6 +21,11 @@ export interface ChatGptWebMessage {
   role: string
   content: string
 }
+
+type CodexInputContent = string | Array<
+  | { type: "input_text"; text: string }
+  | { type: "input_image"; image_url: string }
+>
 
 export interface ChatGptWebTool {
   name: string
@@ -56,6 +63,19 @@ export interface ChatGptWebResponse {
 interface PreparedCodexTools {
   tools: Array<Record<string, unknown>>
   nameMap: Map<string, string>
+}
+
+const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\((data:image\/[a-z0-9.+-]+;base64,[^)]+|assets:\/\/conversation-image\/[^)]+)\)/gi
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  apng: "image/apng",
+  gif: "image/gif",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  avif: "image/avif",
 }
 
 interface ResolvedChatGptWebAuth {
@@ -470,14 +490,72 @@ function buildCodexInstructions(messages: ChatGptWebMessage[]): string {
   return instructions || DEFAULT_CHATGPT_WEB_INSTRUCTIONS
 }
 
-function buildCodexInput(messages: ChatGptWebMessage[]): Array<Record<string, unknown>> {
+function resolveConversationAssetImageUrl(imageUrl: string): string | null {
+  try {
+    const parsed = new URL(imageUrl)
+    if (parsed.protocol !== "assets:" || parsed.hostname !== CONVERSATION_IMAGE_ASSET_HOST) {
+      return null
+    }
+
+    const [, encodedConversationId, encodedFileName] = parsed.pathname.split("/")
+    if (!encodedConversationId || !encodedFileName) return null
+
+    const conversationId = decodeURIComponent(encodedConversationId)
+    const fileName = decodeURIComponent(encodedFileName)
+    const assetPath = getConversationImageAssetPath(conversationId, fileName)
+    const extension = fileName.split(".").pop()?.toLowerCase() || "png"
+    const mimeType = IMAGE_MIME_BY_EXTENSION[extension] || "image/png"
+    const buffer = fs.readFileSync(assetPath)
+    return `data:${mimeType};base64,${buffer.toString("base64")}`
+  } catch {
+    return null
+  }
+}
+
+function resolveMarkdownImageUrlForCodex(imageUrl: string): string | null {
+  if (imageUrl.startsWith("data:image/")) return imageUrl
+  if (imageUrl.startsWith("assets://")) return resolveConversationAssetImageUrl(imageUrl)
+  return null
+}
+
+function buildCodexMessageContent(content: string): CodexInputContent {
+  const parts: Exclude<CodexInputContent, string> = []
+  let lastIndex = 0
+  let hasResolvedImage = false
+
+  MARKDOWN_IMAGE_REGEX.lastIndex = 0
+  for (let match = MARKDOWN_IMAGE_REGEX.exec(content); match; match = MARKDOWN_IMAGE_REGEX.exec(content)) {
+    const before = content.slice(lastIndex, match.index)
+    if (before) parts.push({ type: "input_text", text: before })
+
+    const imageUrl = resolveMarkdownImageUrlForCodex(match[1])
+    if (imageUrl) {
+      parts.push({ type: "input_image", image_url: imageUrl })
+      hasResolvedImage = true
+    } else {
+      parts.push({ type: "input_text", text: match[0] })
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  const after = content.slice(lastIndex)
+  if (after) parts.push({ type: "input_text", text: after })
+
+  return hasResolvedImage && parts.length > 0 ? parts : content
+}
+
+export function buildCodexInput(messages: ChatGptWebMessage[]): Array<Record<string, unknown>> {
   return messages
     .filter((message) => message.role !== "system")
-    .map((message) => ({
-      type: "message",
-      role: message.role === "assistant" ? "assistant" : "user",
-      content: message.content,
-    }))
+    .map((message) => {
+      const role = message.role === "assistant" ? "assistant" : "user"
+      return {
+        type: "message",
+        role,
+        content: role === "user" ? buildCodexMessageContent(message.content) : message.content,
+      }
+    })
 }
 
 function buildCodexTools(tools: ChatGptWebTool[] | undefined): PreparedCodexTools | undefined {

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -78,6 +78,8 @@ const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   avif: "image/avif",
 }
 
+const MAX_CONVERSATION_IMAGE_ASSET_SIZE_BYTES = 8 * 1024 * 1024
+
 interface ResolvedChatGptWebAuth {
   accessToken: string
   accountId?: string
@@ -506,6 +508,9 @@ function resolveConversationAssetImageUrl(imageUrl: string): string | null {
     const extension = fileName.split(".").pop()?.toLowerCase() || "png"
     const mimeType = IMAGE_MIME_BY_EXTENSION[extension] || "image/png"
     const buffer = fs.readFileSync(assetPath)
+    if (buffer.length > MAX_CONVERSATION_IMAGE_ASSET_SIZE_BYTES) {
+      return null
+    }
     return `data:${mimeType};base64,${buffer.toString("base64")}`
   } catch {
     return null

--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -65,6 +65,19 @@ describe("conversation image assets", () => {
     expect(conversation.messages[0].content).not.toContain("data:image")
   })
 
+  it("uses a non-empty title for image-only first messages without alt text", async () => {
+    const { service } = await setupConversationImageAssetTest()
+    const base64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")
+
+    const conversation = await service.createConversationWithId(
+      "conv_empty_alt_image_title_test",
+      `![](data:image/png;base64,${base64})`,
+      "user",
+    )
+
+    expect(conversation.title).toBe("Image")
+  })
+
   it("uses independent inline image matching for concurrent materialization calls", async () => {
     const { service } = await setupConversationImageAssetTest()
     const pngBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")

--- a/apps/desktop/src/main/conversation-image-assets.test.ts
+++ b/apps/desktop/src/main/conversation-image-assets.test.ts
@@ -49,6 +49,22 @@ describe("conversation image assets", () => {
     expect([...storedImage]).toEqual([0x89, 0x50, 0x4e, 0x47])
   })
 
+  it("materializes inline data images in the first conversation message", async () => {
+    const { service } = await setupConversationImageAssetTest()
+    const base64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")
+
+    const conversation = await service.createConversationWithId(
+      "conv_first_image_test",
+      `What is this?\n\n![Screen selection](data:image/png;base64,${base64})`,
+      "user",
+    )
+
+    expect(conversation.messages[0].content).toContain(
+      "![Screen selection](assets://conversation-image/conv_first_image_test/",
+    )
+    expect(conversation.messages[0].content).not.toContain("data:image")
+  })
+
   it("uses independent inline image matching for concurrent materialization calls", async () => {
     const { service } = await setupConversationImageAssetTest()
     const pngBase64 = Buffer.from([0x89, 0x50, 0x4e, 0x47]).toString("base64")

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -937,17 +937,18 @@ export class ConversationService {
     const validatedId = this.validateConversationId(conversationId)
     const messageId = this.generateMessageId()
     const now = Date.now()
+    const storedFirstMessage = await this.materializeInlineDataImagesInContent(validatedId, firstMessage)
 
     const message: ConversationMessage = {
       id: messageId,
       role,
-      content: firstMessage,
+      content: storedFirstMessage,
       timestamp: now,
     }
 
     const conversation: Conversation = {
       id: validatedId,
-      title: this.generateConversationTitle(firstMessage),
+      title: this.generateConversationTitle(storedFirstMessage),
       createdAt: now,
       updatedAt: now,
       messages: [message],

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -226,8 +226,10 @@ export class ConversationService {
   }
 
   private generateConversationTitle(firstMessage: string): string {
-    const cleanedMessage = sanitizeMessageContentForDisplay(firstMessage).trim()
-    const source = cleanedMessage || firstMessage.trim()
+    let cleanedMessage = sanitizeMessageContentForDisplay(firstMessage)
+      .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
+      .trim()
+    const source = cleanedMessage || firstMessage.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1").trim()
     // Generate a title from the first message (first 50 characters)
     const title = source.slice(0, 50)
     return title.length < source.length ? `${title}...` : title

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -229,7 +229,7 @@ export class ConversationService {
     let cleanedMessage = sanitizeMessageContentForDisplay(firstMessage)
       .replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1")
       .trim()
-    const source = cleanedMessage || firstMessage.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1").trim()
+    const source = cleanedMessage || firstMessage.replace(/!\[([^\]]*)\]\([^)]+\)/g, "$1").trim() || "Image"
     // Generate a title from the first message (first 50 characters)
     const title = source.slice(0, 50)
     return title.length < source.length ? `${title}...` : title

--- a/apps/desktop/src/main/keyboard.ts
+++ b/apps/desktop/src/main/keyboard.ts
@@ -18,6 +18,7 @@ import { spawn, ChildProcess } from "child_process"
 import path from "path"
 import { matchesKeyCombo, getEffectiveShortcut } from "../shared/key-utils"
 import { isDebugKeybinds, logKeybinds } from "./debug"
+import { captureSelectedScreenRegion } from "./screenshot-capture"
 
 const rdevPath = path
   .join(
@@ -31,6 +32,7 @@ const KEYBOARD_LISTENER_FORCE_KILL_WAIT_MS = 250
 
 let keyboardListenerChild: ChildProcess | null = null
 let keyboardListenerStopState: { child: ChildProcess; promise: Promise<void> } | null = null
+let isVoiceScreenshotCaptureInProgress = false
 
 type RdevEvent = {
   event_type: "KeyPress" | "KeyRelease"
@@ -347,6 +349,37 @@ export function listenToKeyboardEvents() {
     if (startCustomMcpTimer) {
       clearTimeout(startCustomMcpTimer)
       startCustomMcpTimer = undefined
+    }
+  }
+
+  const startVoiceScreenshotRecording = async () => {
+    if (isVoiceScreenshotCaptureInProgress || state.isRecording) return
+
+    isVoiceScreenshotCaptureInProgress = true
+    cancelRecordingTimer()
+    cancelMcpRecordingTimer()
+    cancelCustomRecordingTimer()
+    cancelCustomMcpTimer()
+
+    try {
+      const screenshot = await captureSelectedScreenRegion()
+      if (!screenshot) return
+
+      await showPanelWindowAndStartMcpRecording(
+        undefined,
+        undefined,
+        undefined,
+        true,
+        undefined,
+        undefined,
+        screenshot,
+      )
+    } catch (error) {
+      if (isDebugKeybinds()) {
+        logKeybinds("Voice screenshot capture failed:", error)
+      }
+    } finally {
+      isVoiceScreenshotCaptureInProgress = false
     }
   }
 
@@ -834,6 +867,32 @@ export function listenToKeyboardEvents() {
             showMainWindow()
             return
           }
+        }
+      }
+
+      if (config.voiceScreenshotShortcutEnabled !== false) {
+        const effectiveVoiceScreenshotShortcut = getEffectiveShortcut(
+          config.voiceScreenshotShortcut || "ctrl-shift-x",
+          config.customVoiceScreenshotShortcut,
+        ) || "ctrl-shift-x"
+
+        const matchesVoiceScreenshotShortcut = matchesKeyCombo(
+          e.data,
+          {
+            ctrl: isPressedCtrlKey,
+            shift: isPressedShiftKey,
+            alt: isPressedAltKey,
+            meta: isPressedMetaKey,
+          },
+          effectiveVoiceScreenshotShortcut,
+        )
+
+        if (matchesVoiceScreenshotShortcut) {
+          if (isDebugKeybinds()) {
+            logKeybinds("Voice screenshot recording triggered:", effectiveVoiceScreenshotShortcut)
+          }
+          void startVoiceScreenshotRecording()
+          return
         }
       }
 

--- a/apps/desktop/src/main/keyboard.ts
+++ b/apps/desktop/src/main/keyboard.ts
@@ -870,7 +870,7 @@ export function listenToKeyboardEvents() {
         }
       }
 
-      if (config.voiceScreenshotShortcutEnabled !== false) {
+      if (process.platform === "darwin" && config.voiceScreenshotShortcutEnabled !== false) {
         const effectiveVoiceScreenshotShortcut = getEffectiveShortcut(
           config.voiceScreenshotShortcut || "ctrl-shift-x",
           config.customVoiceScreenshotShortcut,

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -99,6 +99,7 @@ vi.mock('./langfuse-service', () => ({
 
 vi.mock('./chatgpt-web-provider', () => ({
   isChatGptWebProvider: vi.fn((providerId: string) => providerId === 'chatgpt-web'),
+  getCurrentChatGptWebModelName: vi.fn(() => 'chatgpt-web-test-model'),
   makeChatGptWebCompletion: makeChatGptWebCompletionMock,
   makeChatGptWebResponse: makeChatGptWebResponseMock,
 }))
@@ -223,6 +224,34 @@ describe('LLM Fetch with AI SDK', () => {
     )
 
     expect(result.content).toBe('Hello, world!')
+  })
+
+  it('converts markdown data-image attachments into multimodal model content', async () => {
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+
+    generateTextMock.mockResolvedValue({
+      text: '{"content":"I can see it"}',
+      finishReason: 'stop',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    } as any)
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    await makeLLMCallWithFetch(
+      [{ role: 'user', content: 'What is this?\n\n![Screen selection](data:image/png;base64,abc123)' }],
+      'openai'
+    )
+
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is this?\n\n' },
+          { type: 'image', image: 'abc123', mediaType: 'image/png' },
+        ],
+      }],
+    }))
   })
 
   it('should return plain text when JSON parsing fails', async () => {

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -254,6 +254,60 @@ describe('LLM Fetch with AI SDK', () => {
     }))
   })
 
+  it('leaves remote https markdown images as plain text to avoid provider-side fetching', async () => {
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+
+    generateTextMock.mockResolvedValue({
+      text: '{"content":"ok"}',
+      finishReason: 'stop',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    } as any)
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    await makeLLMCallWithFetch(
+      [{ role: 'user', content: 'See ![photo](https://example.com/pic.png) here' }],
+      'openai'
+    )
+
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [{
+        role: 'user',
+        content: 'See ![photo](https://example.com/pic.png) here',
+      }],
+    }))
+  })
+
+  it('preserves whitespace-only text segments around images', async () => {
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+
+    generateTextMock.mockResolvedValue({
+      text: '{"content":"ok"}',
+      finishReason: 'stop',
+      usage: { promptTokens: 10, completionTokens: 20 },
+    } as any)
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    await makeLLMCallWithFetch(
+      [{ role: 'user', content: 'A\n\n![img](data:image/png;base64,abc123)\n\nB' }],
+      'openai'
+    )
+
+    expect(generateTextMock).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'A\n\n' },
+          { type: 'image', image: 'abc123', mediaType: 'image/png' },
+          { type: 'text', text: '\n\nB' },
+        ],
+      }],
+    }))
+  })
+
   it('should return plain text when JSON parsing fails', async () => {
     const { generateText } = await import('ai')
     const generateTextMock = vi.mocked(generateText)

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -646,7 +646,7 @@ async function withRetry<T>(
  */
 type MarkdownImageForModel = { image: string | URL; mediaType?: string }
 
-const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\((data:image\/[a-z0-9.+-]+;base64,[^)]+|assets:\/\/conversation-image\/[^)]+|https?:\/\/[^)\s]+)\)/gi
+const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\((data:image\/[a-z0-9.+-]+;base64,[^)]+|assets:\/\/conversation-image\/[^)]+)\)/gi
 
 const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
   png: "image/png",
@@ -665,6 +665,8 @@ function parseDataImageUrl(imageUrl: string): MarkdownImageForModel | null {
   return { image: match[2], mediaType: match[1] }
 }
 
+const MAX_CONVERSATION_IMAGE_ASSET_SIZE_BYTES = 8 * 1024 * 1024
+
 function resolveAssetsImageUrlForModel(imageUrl: string): MarkdownImageForModel | null {
   try {
     const parsed = new URL(imageUrl)
@@ -681,6 +683,12 @@ function resolveAssetsImageUrlForModel(imageUrl: string): MarkdownImageForModel 
     const extension = fileName.split(".").pop()?.toLowerCase() || "png"
     const mimeType = IMAGE_MIME_BY_EXTENSION[extension] || "image/png"
     const buffer = fs.readFileSync(assetPath)
+    if (buffer.length > MAX_CONVERSATION_IMAGE_ASSET_SIZE_BYTES) {
+      if (isDebugLLM()) {
+        logLLM("Conversation image asset exceeds size limit for LLM", { imageUrl, size: buffer.length })
+      }
+      return null
+    }
     return { image: buffer.toString("base64"), mediaType: mimeType }
   } catch (error) {
     if (isDebugLLM()) {
@@ -692,7 +700,6 @@ function resolveAssetsImageUrlForModel(imageUrl: string): MarkdownImageForModel 
 
 function resolveMarkdownImageForModel(imageUrl: string): MarkdownImageForModel | null {
   if (imageUrl.startsWith("data:image/")) return parseDataImageUrl(imageUrl)
-  if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) return { image: new URL(imageUrl) }
   if (imageUrl.startsWith("assets://")) return resolveAssetsImageUrlForModel(imageUrl)
   return null
 }
@@ -705,7 +712,7 @@ function convertMarkdownImagesToModelContent(content: string): UserContent {
   MARKDOWN_IMAGE_REGEX.lastIndex = 0
   for (let match = MARKDOWN_IMAGE_REGEX.exec(content); match; match = MARKDOWN_IMAGE_REGEX.exec(content)) {
     const before = content.slice(lastIndex, match.index)
-    if (before.trim()) parts.push({ type: "text", text: before })
+    if (before) parts.push({ type: "text", text: before })
 
     const image = resolveMarkdownImageForModel(match[1])
     if (image) {
@@ -718,7 +725,7 @@ function convertMarkdownImagesToModelContent(content: string): UserContent {
   }
 
   const after = content.slice(lastIndex)
-  if (after.trim()) parts.push({ type: "text", text: after })
+  if (after) parts.push({ type: "text", text: after })
 
   return hasResolvedImage && parts.length > 0 ? parts : content
 }

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -11,8 +11,10 @@
  */
 
 import { generateText, streamText, tool as aiTool } from "ai"
+import type { ModelMessage, UserContent } from "ai"
 import { jsonSchema } from "ai"
 import { randomUUID } from "crypto"
+import fs from "fs"
 import {
   createLanguageModel,
   getCurrentProviderId,
@@ -38,6 +40,7 @@ import {
 } from "./langfuse-service"
 import { recordActualTokenUsage } from "./context-budget"
 import { getCurrentChatGptWebModelName, isChatGptWebProvider, makeChatGptWebCompletion, makeChatGptWebResponse } from "./chatgpt-web-provider"
+import { CONVERSATION_IMAGE_ASSET_HOST, getConversationImageAssetPath } from "./conversation-image-assets"
 
 /**
  * Extended usage type that includes cache token details from AI SDK providers.
@@ -641,21 +644,104 @@ async function withRetry<T>(
  * message prefill" and require the conversation to end with a user message.
  * See: https://github.com/aj47/dotagents-mono/issues/1035
  */
+type MarkdownImageForModel = { image: string | URL; mediaType?: string }
+
+const MARKDOWN_IMAGE_REGEX = /!\[[^\]]*\]\((data:image\/[a-z0-9.+-]+;base64,[^)]+|assets:\/\/conversation-image\/[^)]+|https?:\/\/[^)\s]+)\)/gi
+
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  apng: "image/apng",
+  gif: "image/gif",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+  bmp: "image/bmp",
+  avif: "image/avif",
+}
+
+function parseDataImageUrl(imageUrl: string): MarkdownImageForModel | null {
+  const match = /^data:(image\/[a-z0-9.+-]+);base64,(.+)$/i.exec(imageUrl)
+  if (!match) return null
+  return { image: match[2], mediaType: match[1] }
+}
+
+function resolveAssetsImageUrlForModel(imageUrl: string): MarkdownImageForModel | null {
+  try {
+    const parsed = new URL(imageUrl)
+    if (parsed.protocol !== "assets:" || parsed.hostname !== CONVERSATION_IMAGE_ASSET_HOST) {
+      return null
+    }
+
+    const [, encodedConversationId, encodedFileName] = parsed.pathname.split("/")
+    if (!encodedConversationId || !encodedFileName) return null
+
+    const conversationId = decodeURIComponent(encodedConversationId)
+    const fileName = decodeURIComponent(encodedFileName)
+    const assetPath = getConversationImageAssetPath(conversationId, fileName)
+    const extension = fileName.split(".").pop()?.toLowerCase() || "png"
+    const mimeType = IMAGE_MIME_BY_EXTENSION[extension] || "image/png"
+    const buffer = fs.readFileSync(assetPath)
+    return { image: buffer.toString("base64"), mediaType: mimeType }
+  } catch (error) {
+    if (isDebugLLM()) {
+      logLLM("Failed to resolve conversation image asset for LLM", { imageUrl, error })
+    }
+    return null
+  }
+}
+
+function resolveMarkdownImageForModel(imageUrl: string): MarkdownImageForModel | null {
+  if (imageUrl.startsWith("data:image/")) return parseDataImageUrl(imageUrl)
+  if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) return { image: new URL(imageUrl) }
+  if (imageUrl.startsWith("assets://")) return resolveAssetsImageUrlForModel(imageUrl)
+  return null
+}
+
+function convertMarkdownImagesToModelContent(content: string): UserContent {
+  const parts: Exclude<UserContent, string> = []
+  let lastIndex = 0
+  let hasResolvedImage = false
+
+  MARKDOWN_IMAGE_REGEX.lastIndex = 0
+  for (let match = MARKDOWN_IMAGE_REGEX.exec(content); match; match = MARKDOWN_IMAGE_REGEX.exec(content)) {
+    const before = content.slice(lastIndex, match.index)
+    if (before.trim()) parts.push({ type: "text", text: before })
+
+    const image = resolveMarkdownImageForModel(match[1])
+    if (image) {
+      parts.push({ type: "image", ...image })
+      hasResolvedImage = true
+    } else {
+      parts.push({ type: "text", text: match[0] })
+    }
+    lastIndex = match.index + match[0].length
+  }
+
+  const after = content.slice(lastIndex)
+  if (after.trim()) parts.push({ type: "text", text: after })
+
+  return hasResolvedImage && parts.length > 0 ? parts : content
+}
+
 function convertMessages(messages: Array<{ role: string; content: string }>): {
   system: string | undefined
-  messages: Array<{ role: "user" | "assistant"; content: string }>
+  messages: ModelMessage[]
 } {
   const systemMessages: string[] = []
-  const otherMessages: Array<{ role: "user" | "assistant"; content: string }> =
-    []
+  const otherMessages: ModelMessage[] = []
 
   for (const msg of messages) {
     if (msg.role === "system") {
       systemMessages.push(msg.content)
+    } else if (msg.role === "assistant") {
+      otherMessages.push({
+        role: "assistant",
+        content: msg.content,
+      })
     } else {
       otherMessages.push({
-        role: msg.role as "user" | "assistant",
-        content: msg.content,
+        role: "user",
+        content: convertMarkdownImagesToModelContent(msg.content),
       })
     }
   }

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1725,7 +1725,10 @@ export async function processTranscriptWithAgentMode(
             return null
           }
 
-          const content = sanitizedContent
+          // Preserve user-provided image markdown for the provider adapter; it
+          // converts data/assets image URLs into multimodal message parts. The
+          // sanitized variant above is still used for tool replay and emptiness checks.
+          const content = rawContent
           return {
             role: entry.role as "user" | "assistant",
             content,

--- a/apps/desktop/src/main/renderer-handlers.ts
+++ b/apps/desktop/src/main/renderer-handlers.ts
@@ -9,9 +9,9 @@ export type RendererHandlers = {
   startOrFinishRecording: (data?: { fromButtonClick?: boolean }) => void
   refreshRecordingHistory: () => void
 
-  startMcpRecording: (data?: { conversationId?: string; conversationTitle?: string; sessionId?: string; fromTile?: boolean; fromButtonClick?: boolean }) => void
+  startMcpRecording: (data?: { conversationId?: string; conversationTitle?: string; sessionId?: string; fromTile?: boolean; fromButtonClick?: boolean; screenshot?: { name?: string; dataUrl: string } }) => void
   finishMcpRecording: () => void
-  startOrFinishMcpRecording: (data?: { conversationId?: string; sessionId?: string; fromTile?: boolean; fromButtonClick?: boolean }) => void
+  startOrFinishMcpRecording: (data?: { conversationId?: string; sessionId?: string; fromTile?: boolean; fromButtonClick?: boolean; screenshot?: { name?: string; dataUrl: string } }) => void
 
   showTextInput: (data?: { initialText?: string; conversationId?: string; conversationTitle?: string }) => void
   hideTextInput: () => void

--- a/apps/desktop/src/main/screenshot-capture.test.ts
+++ b/apps/desktop/src/main/screenshot-capture.test.ts
@@ -1,0 +1,60 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const tempDirs: string[] = []
+const originalPlatform = process.platform
+
+async function setupScreenshotCaptureTest(fileContents?: Buffer) {
+  Object.defineProperty(process, "platform", { value: "darwin" })
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-screenshot-capture-"))
+  tempDirs.push(tempDir)
+
+  vi.doMock("electron", () => ({
+    app: {
+      getPath: vi.fn(() => tempDir),
+    },
+  }))
+
+  vi.doMock("child_process", () => ({
+    execFile: vi.fn((_command: string, args: string[], callback: (error: Error | null) => void) => {
+      if (fileContents) {
+        fs.writeFile(args[2], fileContents).then(() => callback(null))
+        return
+      }
+      callback(new Error("cancelled"))
+    }),
+  }))
+
+  return { tempDir }
+}
+
+afterEach(async () => {
+  Object.defineProperty(process, "platform", { value: originalPlatform })
+  vi.resetModules()
+  vi.clearAllMocks()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe("captureSelectedScreenRegion", () => {
+  it("returns null when screencapture is cancelled before creating a file", async () => {
+    await setupScreenshotCaptureTest()
+    const { captureSelectedScreenRegion } = await import("./screenshot-capture")
+
+    await expect(captureSelectedScreenRegion()).resolves.toBeNull()
+  })
+
+  it("rejects oversized captures before building a data URL", async () => {
+    const { MAX_SCREENSHOT_CAPTURE_SIZE_BYTES, captureSelectedScreenRegion } = await importOversizedCapture()
+
+    await expect(captureSelectedScreenRegion()).rejects.toThrow("Screen selection is too large")
+    expect(MAX_SCREENSHOT_CAPTURE_SIZE_BYTES).toBe(8 * 1024 * 1024)
+  })
+})
+
+async function importOversizedCapture() {
+  vi.resetModules()
+  await setupScreenshotCaptureTest(Buffer.alloc(8 * 1024 * 1024 + 1))
+  return import("./screenshot-capture")
+}

--- a/apps/desktop/src/main/screenshot-capture.ts
+++ b/apps/desktop/src/main/screenshot-capture.ts
@@ -32,7 +32,15 @@ export async function captureSelectedScreenRegion(): Promise<ScreenRegionCapture
   try {
     // macOS interactive region capture. The user can drag-select a rectangle;
     // Escape cancels without creating the file.
-    await execFileAsync("screencapture", ["-i", "-x", filePath])
+    try {
+      await execFileAsync("screencapture", ["-i", "-x", filePath])
+    } catch {
+      // screencapture exits non-zero on cancel; if the file wasn't created,
+      // treat it as a user cancellation rather than an error.
+      if (!fs.existsSync(filePath)) {
+        return null
+      }
+    }
 
     if (!fs.existsSync(filePath)) {
       return null

--- a/apps/desktop/src/main/screenshot-capture.ts
+++ b/apps/desktop/src/main/screenshot-capture.ts
@@ -9,6 +9,8 @@ export type ScreenRegionCapture = {
   dataUrl: string
 }
 
+export const MAX_SCREENSHOT_CAPTURE_SIZE_BYTES = 8 * 1024 * 1024
+
 function execFileAsync(command: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     execFile(command, args, (error) => {
@@ -49,6 +51,9 @@ export async function captureSelectedScreenRegion(): Promise<ScreenRegionCapture
     const buffer = await fs.promises.readFile(filePath)
     if (buffer.length === 0) {
       return null
+    }
+    if (buffer.length > MAX_SCREENSHOT_CAPTURE_SIZE_BYTES) {
+      throw new Error(`Screen selection is too large (${buffer.length} bytes). Try selecting a smaller area.`)
     }
 
     return {

--- a/apps/desktop/src/main/screenshot-capture.ts
+++ b/apps/desktop/src/main/screenshot-capture.ts
@@ -1,0 +1,53 @@
+import { app } from "electron"
+import { execFile } from "child_process"
+import { randomUUID } from "crypto"
+import fs from "fs"
+import path from "path"
+
+export type ScreenRegionCapture = {
+  name: string
+  dataUrl: string
+}
+
+function execFileAsync(command: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, (error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+export async function captureSelectedScreenRegion(): Promise<ScreenRegionCapture | null> {
+  if (process.platform !== "darwin") {
+    throw new Error("Screenshot selection is currently only supported on macOS.")
+  }
+
+  const fileName = `dotagents-screen-selection-${randomUUID()}.png`
+  const filePath = path.join(app.getPath("temp"), fileName)
+
+  try {
+    // macOS interactive region capture. The user can drag-select a rectangle;
+    // Escape cancels without creating the file.
+    await execFileAsync("screencapture", ["-i", "-x", filePath])
+
+    if (!fs.existsSync(filePath)) {
+      return null
+    }
+
+    const buffer = await fs.promises.readFile(filePath)
+    if (buffer.length === 0) {
+      return null
+    }
+
+    return {
+      name: "Screen selection",
+      dataUrl: `data:image/png;base64,${buffer.toString("base64")}`,
+    }
+  } finally {
+    fs.promises.unlink(filePath).catch(() => undefined)
+  }
+}

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2333,7 +2333,7 @@ export const router = {
       }
 
       // Update session with actual conversation ID and title after transcription
-      const conversationTitle = transcript || input.screenshot?.name || "Screen selection"
+      const conversationTitle = transcript?.trim() || input.screenshot?.name || "Screen selection"
       agentSessionTracker.updateSession(sessionId, {
         conversationId,
         conversationTitle,

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -572,6 +572,21 @@ import { writeText, writeTextWithFocusRestore } from "./keyboard"
 
 const t = tipc.create()
 
+type ScreenshotAttachmentInput = { name?: string; dataUrl: string }
+
+function escapeMarkdownImageAlt(text: string): string {
+  return text.replace(/[\[\]]/g, "")
+}
+
+function appendScreenshotToTranscript(transcript: string, screenshot?: ScreenshotAttachmentInput): string {
+  if (!screenshot?.dataUrl) return transcript
+
+  const alt = escapeMarkdownImageAlt(screenshot.name || "Screen selection") || "Screen selection"
+  const trimmedTranscript = transcript.trim()
+  const screenshotMarkdown = `![${alt}](${screenshot.dataUrl})`
+  return trimmedTranscript ? `${trimmedTranscript}\n\n${screenshotMarkdown}` : screenshotMarkdown
+}
+
 const getRecordingHistory = () => {
   try {
     const history = JSON.parse(
@@ -2017,6 +2032,7 @@ export const router = {
       duration: number
       conversationId?: string
       sessionId?: string
+      screenshot?: ScreenshotAttachmentInput
       fromTile?: boolean // When true, session runs in background (snoozed) - panel won't show
     }>()
     .action(async ({ input }) => {
@@ -2111,8 +2127,10 @@ export const router = {
               Buffer.from(input.recording),
             )
 
+            const messageText = appendScreenshotToTranscript(transcript, input.screenshot)
+
             // Queue the transcript instead of processing immediately
-            const queuedMessage = messageQueueService.enqueue(input.conversationId, transcript, activeSessionId)
+            const queuedMessage = messageQueueService.enqueue(input.conversationId, messageText, activeSessionId)
             logApp(`[createMcpRecording] Queued voice transcript ${queuedMessage.id} for active session ${activeSessionId}`)
 
             return { conversationId: input.conversationId, queued: true, queuedMessageId: queuedMessage.id }
@@ -2282,6 +2300,8 @@ export const router = {
           transcript = json.text
         }
 
+      const messageText = appendScreenshotToTranscript(transcript, input.screenshot)
+
       // Create or continue conversation
       let conversationId = input.conversationId
       let conversation: Conversation | null = null
@@ -2289,7 +2309,7 @@ export const router = {
       if (!conversationId) {
         // Create new conversation with the transcript
         conversation = await conversationService.createConversation(
-          transcript,
+          messageText,
           "user",
         )
         conversationId = conversation.id
@@ -2300,12 +2320,12 @@ export const router = {
         if (conversation) {
           await conversationService.addMessageToConversation(
             conversationId,
-            transcript,
+            messageText,
             "user",
           )
         } else {
           conversation = await conversationService.createConversation(
-            transcript,
+            messageText,
             "user",
           )
           conversationId = conversation.id
@@ -2313,7 +2333,7 @@ export const router = {
       }
 
       // Update session with actual conversation ID and title after transcription
-      const conversationTitle = transcript
+      const conversationTitle = transcript || input.screenshot?.name || "Screen selection"
       agentSessionTracker.updateSession(sessionId, {
         conversationId,
         conversationTitle,
@@ -2329,7 +2349,7 @@ export const router = {
         // Fire-and-forget: Start agent processing without blocking.
         // Preserve the tile/background snooze state after transcription so
         // voice follow-ups from a session tile do not re-focus the panel.
-        processWithAgentMode(transcript, conversationId, sessionId, startSnoozed)
+        processWithAgentMode(messageText, conversationId, sessionId, startSnoozed)
         .then((finalResponse) => {
           // Save to history after completion
           const history = getRecordingHistory()

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -582,9 +582,8 @@ function appendScreenshotToTranscript(transcript: string, screenshot?: Screensho
   if (!screenshot?.dataUrl) return transcript
 
   const alt = escapeMarkdownImageAlt(screenshot.name || "Screen selection") || "Screen selection"
-  const trimmedTranscript = transcript.trim()
   const screenshotMarkdown = `![${alt}](${screenshot.dataUrl})`
-  return trimmedTranscript ? `${trimmedTranscript}\n\n${screenshotMarkdown}` : screenshotMarkdown
+  return transcript ? `${transcript}\n\n${screenshotMarkdown}` : screenshotMarkdown
 }
 
 const getRecordingHistory = () => {

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -586,6 +586,14 @@ function appendScreenshotToTranscript(transcript: string, screenshot?: Screensho
   return transcript ? `${transcript}\n\n${screenshotMarkdown}` : screenshotMarkdown
 }
 
+function getLatestStoredUserMessageContent(conversation: Conversation | null, fallback: string): string {
+  const latestUserMessage = conversation?.messages
+    ?.slice()
+    .reverse()
+    .find((message) => message.role === "user")
+  return latestUserMessage?.content || fallback
+}
+
 const getRecordingHistory = () => {
   try {
     const history = JSON.parse(
@@ -1893,12 +1901,14 @@ export const router = {
 
       // Create or get conversation ID
       let conversationId = input.conversationId
+      let agentInputText = input.text
       if (!conversationId) {
         const conversation = await conversationService.createConversation(
           input.text,
           "user",
         )
         conversationId = conversation.id
+        agentInputText = getLatestStoredUserMessageContent(conversation, input.text)
       } else {
         // Check if message queuing is enabled and there's an active session
         if (queueEnabled) {
@@ -1906,8 +1916,9 @@ export const router = {
           if (activeSessionId) {
             const session = agentSessionTracker.getSession(activeSessionId)
             if (session && session.status === "active") {
+              const queuedText = await conversationService.materializeInlineDataImagesInContent(conversationId, input.text)
               // Queue the message instead of starting a new session
-              const queuedMessage = messageQueueService.enqueue(conversationId, input.text, activeSessionId)
+              const queuedMessage = messageQueueService.enqueue(conversationId, queuedText, activeSessionId)
               logApp("[createMcpTextInput] Queued message for active session", {
                 conversationId,
                 queuedMessageId: queuedMessage.id,
@@ -1933,11 +1944,12 @@ export const router = {
         }
 
         // Add user message to existing conversation
-        await conversationService.addMessageToConversation(
+        const updatedConversation = await conversationService.addMessageToConversation(
           conversationId,
           input.text,
           "user",
         )
+        agentInputText = getLatestStoredUserMessageContent(updatedConversation, input.text)
       }
 
       // Try to find and revive an existing session for this conversation
@@ -1976,7 +1988,7 @@ export const router = {
       // This allows multiple sessions to run concurrently
       // Pass existingSessionId to reuse the session if found
       // When fromTile=true, start snoozed so the floating panel doesn't appear
-      processWithAgentMode(input.text, conversationId, existingSessionId, input.fromTile ?? false)
+      processWithAgentMode(agentInputText, conversationId, existingSessionId, input.fromTile ?? false)
         .then((finalResponse) => {
           // Save to history after completion
           const history = getRecordingHistory()
@@ -2127,9 +2139,10 @@ export const router = {
             )
 
             const messageText = appendScreenshotToTranscript(transcript, input.screenshot)
+            const queuedText = await conversationService.materializeInlineDataImagesInContent(input.conversationId, messageText)
 
             // Queue the transcript instead of processing immediately
-            const queuedMessage = messageQueueService.enqueue(input.conversationId, messageText, activeSessionId)
+            const queuedMessage = messageQueueService.enqueue(input.conversationId, queuedText, activeSessionId)
             logApp(`[createMcpRecording] Queued voice transcript ${queuedMessage.id} for active session ${activeSessionId}`)
 
             return { conversationId: input.conversationId, queued: true, queuedMessageId: queuedMessage.id }
@@ -2300,6 +2313,7 @@ export const router = {
         }
 
       const messageText = appendScreenshotToTranscript(transcript, input.screenshot)
+      let agentInputText = messageText
 
       // Create or continue conversation
       let conversationId = input.conversationId
@@ -2312,22 +2326,26 @@ export const router = {
           "user",
         )
         conversationId = conversation.id
+        agentInputText = getLatestStoredUserMessageContent(conversation, messageText)
       } else {
         // Load existing conversation and add user message
         conversation =
           await conversationService.loadConversation(conversationId)
         if (conversation) {
-          await conversationService.addMessageToConversation(
+          const updatedConversation = await conversationService.addMessageToConversation(
             conversationId,
             messageText,
             "user",
           )
+          conversation = updatedConversation ?? conversation
+          agentInputText = getLatestStoredUserMessageContent(conversation, messageText)
         } else {
           conversation = await conversationService.createConversation(
             messageText,
             "user",
           )
           conversationId = conversation.id
+          agentInputText = getLatestStoredUserMessageContent(conversation, messageText)
         }
       }
 
@@ -2348,7 +2366,7 @@ export const router = {
         // Fire-and-forget: Start agent processing without blocking.
         // Preserve the tile/background snooze state after transcription so
         // voice follow-ups from a session tile do not re-focus the panel.
-        processWithAgentMode(messageText, conversationId, sessionId, startSnoozed)
+        processWithAgentMode(agentInputText, conversationId, sessionId, startSnoozed)
         .then((finalResponse) => {
           // Save to history after completion
           const history = getRecordingHistory()

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -16,6 +16,7 @@ import { state, agentProcessManager, suppressPanelAutoShow, isHeadlessMode } fro
 import { calculatePanelPosition } from "./panel-position"
 import { setupConsoleLogger } from "./console-logger"
 import { emergencyStopAll } from "./emergency-stop"
+import type { ScreenRegionCapture } from "./screenshot-capture"
 
 type WINDOW_ID = "main" | "panel" | "setup"
 
@@ -1142,7 +1143,7 @@ export async function showPanelWindowAndStartRecording(fromButtonClick?: boolean
   showPanelWindow()
 }
 
-export async function showPanelWindowAndStartMcpRecording(conversationId?: string, sessionId?: string, fromTile?: boolean, fromButtonClick?: boolean, conversationTitle?: string, isStillHeld?: () => boolean) {
+export async function showPanelWindowAndStartMcpRecording(conversationId?: string, sessionId?: string, fromTile?: boolean, fromButtonClick?: boolean, conversationTitle?: string, isStillHeld?: () => boolean, screenshot?: ScreenRegionCapture) {
   // In headless mode, skip all window operations
   if (isHeadlessMode) return
 
@@ -1170,7 +1171,7 @@ export async function showPanelWindowAndStartMcpRecording(conversationId?: strin
   // Pass fromTile and fromButtonClick flags so panel knows how to behave after recording ends
   whenPanelReady(() => {
     if (isStillHeld && !isStillHeld()) return
-    getWindowRendererHandlers("panel")?.startMcpRecording.send({ conversationId, conversationTitle, sessionId, fromTile, fromButtonClick })
+    getWindowRendererHandlers("panel")?.startMcpRecording.send({ conversationId, conversationTitle, sessionId, fromTile, fromButtonClick, screenshot })
   })
   showPanelWindow()
 }

--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -23,6 +23,8 @@ import { Send, Bot } from "lucide-react"
 import { useSelectedAgentId } from "@renderer/components/agent-selector"
 import type { AgentProfile } from "@shared/types"
 
+type PendingScreenshotAttachment = { name?: string; dataUrl: string }
+
 const DEFAULT_VISUALIZER_BAR_COUNT = 70
 const MIN_VISUALIZER_BAR_COUNT = 24
 const MAX_VISUALIZER_BAR_COUNT = 240
@@ -70,6 +72,7 @@ export function Component() {
   const textInputPanelRef = useRef<TextInputPanelRef>(null)
   const mcpConversationIdRef = useRef<string | undefined>(undefined)
   const mcpSessionIdRef = useRef<string | undefined>(undefined)
+  const mcpScreenshotRef = useRef<PendingScreenshotAttachment | undefined>(undefined)
   const fromTileRef = useRef<boolean>(false)
   const [continueConversationTitle, setContinueConversationTitle] = useState<string | null>(null)
   const [fromButtonClick, setFromButtonClick] = useState(false)
@@ -283,11 +286,13 @@ export function Component() {
       // The refs are more reliable for mic button clicks as they avoid timing issues.
       const conversationIdForMcp = mcpConversationIdRef.current ?? currentConversationId
       const sessionIdForMcp = mcpSessionIdRef.current
+      const screenshotForMcp = mcpScreenshotRef.current
       const wasFromTile = fromTileRef.current
 
       // Clear the refs after capturing to avoid reusing stale IDs
       mcpConversationIdRef.current = undefined
       mcpSessionIdRef.current = undefined
+      mcpScreenshotRef.current = undefined
       fromTileRef.current = false
 
       // If recording was from a tile, hide the floating panel immediately
@@ -304,6 +309,7 @@ export function Component() {
         // otherwise undefined to create a fresh conversation/session.
         conversationId: conversationIdForMcp ?? undefined,
         sessionId: sessionIdForMcp,
+        screenshot: screenshotForMcp,
         // Pass fromTile so session starts snoozed when recording was from a tile
         fromTile: wasFromTile,
       })
@@ -432,6 +438,7 @@ export function Component() {
         // Clear context from aborted runs so follow-up recordings start clean.
         mcpConversationIdRef.current = undefined
         mcpSessionIdRef.current = undefined
+        mcpScreenshotRef.current = undefined
         fromTileRef.current = false
         setMcpMode(false)
         mcpModeRef.current = false
@@ -445,6 +452,7 @@ export function Component() {
         console.warn("[Panel] Recording blob is empty, ignoring (likely accidental press)")
         mcpConversationIdRef.current = undefined
         mcpSessionIdRef.current = undefined
+        mcpScreenshotRef.current = undefined
         fromTileRef.current = false
         setMcpMode(false)
         mcpModeRef.current = false
@@ -459,6 +467,7 @@ export function Component() {
         console.warn("[Panel] Recording duration too short:", duration, "ms - ignoring (likely accidental press)")
         mcpConversationIdRef.current = undefined
         mcpSessionIdRef.current = undefined
+        mcpScreenshotRef.current = undefined
         fromTileRef.current = false
         setMcpMode(false)
         mcpModeRef.current = false
@@ -480,6 +489,7 @@ export function Component() {
         // Ensure MCP context does not leak into future MCP submissions.
         mcpConversationIdRef.current = undefined
         mcpSessionIdRef.current = undefined
+        mcpScreenshotRef.current = undefined
         fromTileRef.current = false
         transcribeMutation.mutate({
           blob,
@@ -613,6 +623,7 @@ export function Component() {
       // Ensure we are in normal dictation mode (not MCP/agent)
       setMcpMode(false)
       mcpModeRef.current = false
+      mcpScreenshotRef.current = undefined
       setContinueConversationTitle(null)
       // Track if recording was triggered via UI button click (e.g., tray menu)
       setFromButtonClick(data?.fromButtonClick ?? false)
@@ -665,6 +676,7 @@ export function Component() {
         // Force normal dictation mode - each new recording starts fresh
         setMcpMode(false)
         mcpModeRef.current = false
+        mcpScreenshotRef.current = undefined
         // Track if recording was triggered via UI button click
         setFromButtonClick(data?.fromButtonClick ?? false)
         // Clear any stale "Continuing:" banner from a prior continue session
@@ -782,6 +794,7 @@ export function Component() {
       // Store the conversationId, sessionId, and fromTile flag for use when recording ends
       mcpConversationIdRef.current = data?.conversationId
       mcpSessionIdRef.current = data?.sessionId
+      mcpScreenshotRef.current = data?.screenshot
       fromTileRef.current = data?.fromTile ?? false
       // Track if recording was triggered via UI button click vs keyboard shortcut
       // When true, we show "Enter" as the submit hint instead of "Release keys"
@@ -827,6 +840,7 @@ export function Component() {
         mcpModeRef.current = false
         mcpConversationIdRef.current = undefined
         mcpSessionIdRef.current = undefined
+        mcpScreenshotRef.current = undefined
         fromTileRef.current = false
       })
     })
@@ -854,6 +868,7 @@ export function Component() {
         // Store the conversationId and sessionId for use when recording ends
         mcpConversationIdRef.current = data?.conversationId
         mcpSessionIdRef.current = data?.sessionId
+        mcpScreenshotRef.current = data?.screenshot
         fromTileRef.current = data?.fromTile ?? false
         // Track if recording was triggered via UI button click vs keyboard shortcut
         setFromButtonClick(data?.fromButtonClick ?? false)
@@ -882,6 +897,7 @@ export function Component() {
           mcpModeRef.current = false
           mcpConversationIdRef.current = undefined
           mcpSessionIdRef.current = undefined
+          mcpScreenshotRef.current = undefined
           fromTileRef.current = false
         })
       }

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1013,6 +1013,9 @@ export type Config = {
   shortcut?: "hold-ctrl" | "ctrl-slash" | "custom"
   customShortcut?: string
   customShortcutMode?: "hold" | "toggle" // Mode for custom recording shortcut
+  voiceScreenshotShortcutEnabled?: boolean
+  voiceScreenshotShortcut?: "ctrl-shift-x" | "custom"
+  customVoiceScreenshotShortcut?: string
   hideDockIcon?: boolean
   launchAtLogin?: boolean
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -186,6 +186,9 @@ const getConfig = (): LoadedConfig => {
     // Recording shortcut: On Windows, use Ctrl+/ to avoid conflicts with common shortcuts
     // On macOS, Hold Ctrl is fine since Cmd is used for most shortcuts
     shortcut: isWindows ? "ctrl-slash" : "hold-ctrl",
+    voiceScreenshotShortcutEnabled: true,
+    voiceScreenshotShortcut: "ctrl-shift-x",
+    customVoiceScreenshotShortcut: "",
 
     mcpToolsShortcut: "hold-ctrl-alt",
     // Note: mcpToolsEnabled and mcpAgentModeEnabled are deprecated and always treated as true


### PR DESCRIPTION
## Summary
- add a default `Ctrl+Shift+X` desktop shortcut for voice input with macOS drag-select screenshot capture
- pass the selected screenshot through the panel recording flow and MCP recording submission
- preserve screenshot attachments for LLM calls by converting markdown image URLs into AI SDK multimodal message parts
- send screenshot attachments as ChatGPT-web Codex `input_image` parts instead of raw `assets://...` markdown
- materialize first-message inline data images into conversation assets to avoid storing large base64 blobs

## Validation
- `pnpm --filter @dotagents/desktop typecheck`
- `pnpm --filter @dotagents/desktop test -- run src/main/chatgpt-web-provider.test.ts src/main/llm-fetch.test.ts src/main/conversation-image-assets.test.ts`

## Notes
- Screenshot region selection currently uses macOS `screencapture -i`, so this shortcut is macOS-only for now.
- Left existing untracked local `.agents/`, `apps/desktop/assets/`, and Playwright local folders untouched.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author