### PR TITLE
Fix Skills page Open Folder action

### DIFF
--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -868,6 +868,27 @@ type OpenFileResult = {
   path?: string
 }
 
+async function openDirectoryInFileManager(directoryPath: string): Promise<OpenFileResult> {
+  const resolvedPath = path.resolve(directoryPath)
+  fs.mkdirSync(resolvedPath, { recursive: true })
+
+  const openPathError = await shell.openPath(resolvedPath)
+  if (!openPathError) {
+    return { success: true, path: resolvedPath }
+  }
+
+  try {
+    shell.showItemInFolder(resolvedPath)
+    return { success: true, path: resolvedPath }
+  } catch (error) {
+    return {
+      success: false,
+      path: resolvedPath,
+      error: error instanceof Error ? error.message : openPathError,
+    }
+  }
+}
+
 function revealFileInFolder(filePath: string): OpenFileResult {
   if (!fs.existsSync(filePath)) {
     return { success: false, path: filePath, error: "File does not exist" }
@@ -4460,9 +4481,7 @@ export const router = {
     const layer = getAgentsLayerPaths(globalAgentsFolder)
     const skillsDir = getAgentsSkillsDir(layer)
 
-    fs.mkdirSync(skillsDir, { recursive: true })
-    const error = await shell.openPath(skillsDir)
-    return { success: !error, error: error || undefined }
+    return openDirectoryInFileManager(skillsDir)
   }),
 
   openWorkspaceSkillsFolder: t.procedure.action(async () => {
@@ -4476,9 +4495,7 @@ export const router = {
     const layer = getAgentsLayerPaths(workspaceAgentsFolder)
     const skillsDir = getAgentsSkillsDir(layer)
 
-    fs.mkdirSync(skillsDir, { recursive: true })
-    const error = await shell.openPath(skillsDir)
-    return { success: !error, error: error || undefined }
+    return openDirectoryInFileManager(skillsDir)
   }),
 
   openSkillFile: t.procedure

--- a/apps/desktop/tests/settings-skills-open-folder.test.mjs
+++ b/apps/desktop/tests/settings-skills-open-folder.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const tipcSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/main/tipc.ts'),
+  'utf8',
+)
+
+test('skills folder open action uses the resilient file-manager helper', () => {
+  assert.match(tipcSource, /async function openDirectoryInFileManager\(directoryPath: string\)/)
+  assert.match(tipcSource, /const openPathError = await shell\.openPath\(resolvedPath\)/)
+  assert.match(tipcSource, /shell\.showItemInFolder\(resolvedPath\)/)
+  assert.match(
+    tipcSource,
+    /openSkillsFolder:[\s\S]*?const skillsDir = getAgentsSkillsDir\(layer\)[\s\S]*?return openDirectoryInFileManager\(skillsDir\)/,
+  )
+  assert.match(
+    tipcSource,
+    /openWorkspaceSkillsFolder:[\s\S]*?const skillsDir = getAgentsSkillsDir\(layer\)[\s\S]*?return openDirectoryInFileManager\(skillsDir\)/,
+  )
+})


### PR DESCRIPTION
## Problem Spec

Closes #359. The Skills page Open Folder actions could fail silently if Electron's `shell.openPath` does not launch the platform file manager for the skills directory.

## Solution Spec

- **Resilient file-manager opening** (`apps/desktop/src/main/tipc.ts`): add a shared main-process helper that creates and resolves the target directory, tries `shell.openPath`, and falls back to `shell.showItemInFolder`.
- **Skills folder actions** (`apps/desktop/src/main/tipc.ts`): route both global and workspace Skills folder buttons through the resilient helper.
- **Regression coverage** (`apps/desktop/tests/settings-skills-open-folder.test.mjs`): add a static Node test that verifies both TIPC actions use the helper and fallback path.

## Validation

- `node --test apps/desktop/tests/settings-skills-open-folder.test.mjs` passed.
- `git diff --check` passed.

## Notes

Full app typecheck/test was not run because this checkout has no `node_modules` installed.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://app.staging.augmentcode.com/app/session?agentId=01KPKHVHFQF1VB9K1VEEQPPNS1&panel=chat)