### PR TITLE
Improve collapsed tool call previews

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -116,6 +116,12 @@ describe("agent progress tile layout", () => {
     expect(agentProgressSource).toContain('flex-1 truncate whitespace-nowrap font-mono')
   })
 
+  it("keeps tool group expansion state separate from child rows", () => {
+    expect(agentProgressSource).toContain('const groupId = `tool-activity-group:${runItems[0]?.id ?? runStart}`')
+    expect(agentProgressSource).toContain('getToolActivityGroupDefaultExpanded')
+    expect(agentProgressSource).toContain('next[item.id] = true')
+  })
+
   it("stops delegated tool rows from showing a loading spinner after terminal completion", () => {
     expect(agentProgressSource).toContain('function isDelegationActiveStatus(status: ACPDelegationProgress["status"]): boolean {')
     expect(agentProgressSource).toContain('const isPending = isToolUseMessage && !resultMessage && isDelegationActive')

--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -96,14 +96,13 @@ describe("agent progress tile layout", () => {
 
   it("keeps tile message-stream tool execution rows readable at narrow widths and zoom", () => {
     expect(agentProgressSource).toContain(
-      '"flex min-w-0 items-center gap-1.5 rounded text-[11px] cursor-pointer hover:bg-muted/30"'
+      '"flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded text-[11px] cursor-pointer hover:bg-muted/30"'
     )
     expect(agentProgressSource).toContain(
       'rowClassName = "px-1.5 py-0.5"'
     )
     expect(agentProgressSource).toContain('rowClassName="px-1 py-0.5"')
-    expect(agentProgressSource).toContain('className="min-w-0 shrink truncate font-mono font-medium"')
-    expect(agentProgressSource).toContain('className="min-w-0 flex-1 truncate text-[10px] font-mono opacity-50"')
+    expect(agentProgressSource).toContain('className="min-w-0 flex-1 truncate whitespace-nowrap font-mono font-medium"')
     expect(agentProgressSource).toContain('className="mb-1 flex flex-wrap items-center gap-2"')
     expect(agentProgressSource).toContain('className="ml-auto flex shrink-0 flex-wrap items-center gap-2"')
     expect(agentProgressSource).toContain('className="shrink-0 whitespace-nowrap opacity-50 text-[10px]"')
@@ -111,9 +110,10 @@ describe("agent progress tile layout", () => {
     expect(agentProgressSource).toContain('<ToolExecutionBubble')
   })
 
-  it("only shows collapsed tool previews for the latest pending tool run", () => {
-    expect(agentProgressSource).toContain('const shouldShowPreviewLines = runEnd === sortedItems.length - 1')
-    expect(agentProgressSource).toContain('!isExpanded && group.previewLines.length > 0')
+  it("renders collapsed tool previews inline with the group title", () => {
+    expect(agentProgressSource).toContain('const collapsedPreviewLine = group.previewLines.join')
+    expect(agentProgressSource).toContain('!isExpanded && collapsedPreviewLine')
+    expect(agentProgressSource).toContain('flex-1 truncate whitespace-nowrap font-mono')
   })
 
   it("stops delegated tool rows from showing a loading spinner after terminal completion", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -154,11 +154,38 @@ const getPayloadValueType = (value: unknown): string => {
 const StructuredToolPayload: React.FC<{
   payload: unknown
   variant?: "default" | "approval"
+  tone?: "neutral" | "success" | "error"
   maxHeightClassName?: string
-}> = ({ payload, variant = "default", maxHeightClassName = "max-h-48" }) => {
+}> = ({ payload, variant = "default", tone = "neutral", maxHeightClassName = "max-h-48" }) => {
   const entries = getToolArgumentEntries(payload)
   const formattedFallback = entries.length === 0 ? formatToolArguments(payload) : ""
   const isApproval = variant === "approval"
+  const fallbackToneClass = isApproval
+    ? "bg-amber-100/70 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100"
+    : tone === "success"
+      ? "bg-green-50/50 text-foreground dark:bg-green-950/30"
+      : tone === "error"
+        ? "bg-red-50/50 text-red-700 dark:bg-red-950/30 dark:text-red-300"
+        : "bg-muted/40 text-foreground"
+  const entryToneClass = isApproval
+    ? "border-amber-200/70 bg-amber-100/30 dark:border-amber-800/60 dark:bg-amber-900/15"
+    : tone === "success"
+      ? "border-green-200/70 bg-green-50/50 dark:border-green-900/60 dark:bg-green-950/30"
+      : tone === "error"
+        ? "border-red-200/70 bg-red-50/50 dark:border-red-900/60 dark:bg-red-950/30"
+        : "border-border/40 bg-background/40 dark:bg-muted/20"
+  const entryHeaderBorderClass = isApproval
+    ? "border-amber-200/60 dark:border-amber-800/50"
+    : tone === "success"
+      ? "border-green-200/60 dark:border-green-900/50"
+      : tone === "error"
+        ? "border-red-200/60 dark:border-red-900/50"
+        : "border-border/30"
+  const entryTextClass = isApproval
+    ? "text-amber-950 dark:text-amber-100"
+    : tone === "error"
+      ? "text-red-700 dark:text-red-300"
+      : "text-foreground"
 
   if (entries.length === 0) {
     if (!formattedFallback) return null
@@ -166,9 +193,7 @@ const StructuredToolPayload: React.FC<{
       <pre className={cn(
         "max-w-full overflow-x-auto overflow-y-auto rounded p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-words scrollbar-thin",
         maxHeightClassName,
-        isApproval
-          ? "bg-amber-100/70 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100"
-          : "bg-muted/40 text-foreground",
+        fallbackToneClass,
       )}>
         {formattedFallback}
       </pre>
@@ -185,14 +210,12 @@ const StructuredToolPayload: React.FC<{
             key={key}
             className={cn(
               "overflow-hidden rounded-md border",
-              isApproval
-                ? "border-amber-200/70 bg-amber-100/30 dark:border-amber-800/60 dark:bg-amber-900/15"
-                : "border-border/40 bg-background/40 dark:bg-muted/20",
+              entryToneClass,
             )}
           >
             <div className={cn(
               "flex items-center justify-between gap-2 border-b px-2 py-1",
-              isApproval ? "border-amber-200/60 dark:border-amber-800/50" : "border-border/30",
+              entryHeaderBorderClass,
             )}>
               <span className="min-w-0 truncate font-mono text-[10px] font-semibold">{key}</span>
               <span className="shrink-0 text-[9px] uppercase tracking-wide opacity-50">{getPayloadValueType(value)}</span>
@@ -201,12 +224,12 @@ const StructuredToolPayload: React.FC<{
               <pre className={cn(
                 "max-w-full overflow-x-auto overflow-y-auto p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap break-words scrollbar-thin",
                 maxHeightClassName,
-                isApproval ? "text-amber-950 dark:text-amber-100" : "text-foreground",
+                entryTextClass,
               )}>
                 {text}
               </pre>
             ) : (
-              <div className="px-2 py-1.5 font-mono text-[10px] leading-relaxed break-words text-foreground/90">
+              <div className={cn("px-2 py-1.5 font-mono text-[10px] leading-relaxed break-words", entryTextClass)}>
                 {text}
               </div>
             )}
@@ -977,7 +1000,7 @@ const CompactToolExecutionList: React.FC<{
                       </pre>
                     )}
                     {result.content && (
-                      <StructuredToolPayload payload={result.content} maxHeightClassName="max-h-52" />
+                      <StructuredToolPayload payload={result.content} tone={result.success ? "success" : "error"} maxHeightClassName="max-h-52" />
                     )}
                     {!result.error && !result.content && (
                       <pre className="rounded p-1.5 overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words max-w-full max-h-32 scrollbar-thin text-[10px] bg-muted/40">

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -22,7 +22,11 @@ import { useResizable, TILE_DIMENSIONS } from "@renderer/hooks/use-resizable"
 import {
   type AgentUserResponseEvent,
   extractRespondToUserResponseEvents,
+  formatArgumentsPreview,
+  formatToolArguments,
   getAgentConversationStateLabel,
+  getToolArgumentEntries,
+  getToolCallPreview,
   getToolResultsSummary,
   normalizeAgentConversationState,
   TOOL_GROUP_PREVIEW_COUNT,
@@ -126,9 +130,92 @@ type DisplayItem =
   | { kind: "tool_activity_group"; id: string; data: {
       /** The original DisplayItems that were collapsed into this group. */
       items: DisplayItem[]
-      /** Short single-line preview strings for the trailing pending tool group only. */
+      /** Short single-line preview strings for the collapsed tool group. */
       previewLines: string[]
     } }
+
+const formatStructuredPayloadValue = (value: unknown): string => {
+  if (typeof value === "string") return value
+  if (value === undefined) return "undefined"
+  try {
+    const formatted = JSON.stringify(value, null, 2)
+    return formatted ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+const getPayloadValueType = (value: unknown): string => {
+  if (Array.isArray(value)) return `array · ${value.length}`
+  if (value === null) return "null"
+  return typeof value
+}
+
+const StructuredToolPayload: React.FC<{
+  payload: unknown
+  variant?: "default" | "approval"
+  maxHeightClassName?: string
+}> = ({ payload, variant = "default", maxHeightClassName = "max-h-48" }) => {
+  const entries = getToolArgumentEntries(payload)
+  const formattedFallback = entries.length === 0 ? formatToolArguments(payload) : ""
+  const isApproval = variant === "approval"
+
+  if (entries.length === 0) {
+    if (!formattedFallback) return null
+    return (
+      <pre className={cn(
+        "max-w-full overflow-x-auto overflow-y-auto rounded p-2 text-[10px] leading-relaxed whitespace-pre-wrap break-words scrollbar-thin",
+        maxHeightClassName,
+        isApproval
+          ? "bg-amber-100/70 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100"
+          : "bg-muted/40 text-foreground",
+      )}>
+        {formattedFallback}
+      </pre>
+    )
+  }
+
+  return (
+    <div className="space-y-1.5">
+      {entries.map(({ key, value }) => {
+        const text = formatStructuredPayloadValue(value)
+        const isBlock = typeof value === "object" || text.includes("\n") || text.length > 96
+        return (
+          <div
+            key={key}
+            className={cn(
+              "overflow-hidden rounded-md border",
+              isApproval
+                ? "border-amber-200/70 bg-amber-100/30 dark:border-amber-800/60 dark:bg-amber-900/15"
+                : "border-border/40 bg-background/40 dark:bg-muted/20",
+            )}
+          >
+            <div className={cn(
+              "flex items-center justify-between gap-2 border-b px-2 py-1",
+              isApproval ? "border-amber-200/60 dark:border-amber-800/50" : "border-border/30",
+            )}>
+              <span className="min-w-0 truncate font-mono text-[10px] font-semibold">{key}</span>
+              <span className="shrink-0 text-[9px] uppercase tracking-wide opacity-50">{getPayloadValueType(value)}</span>
+            </div>
+            {isBlock ? (
+              <pre className={cn(
+                "max-w-full overflow-x-auto overflow-y-auto p-2 font-mono text-[10px] leading-relaxed whitespace-pre-wrap break-words scrollbar-thin",
+                maxHeightClassName,
+                isApproval ? "text-amber-950 dark:text-amber-100" : "text-foreground",
+              )}>
+                {text}
+              </pre>
+            ) : (
+              <div className="px-2 py-1.5 font-mono text-[10px] leading-relaxed break-words text-foreground/90">
+                {text}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
 
 function isCompletionControlTool(toolName: string): boolean {
   return toolName === RESPOND_TO_USER_TOOL || toolName === MARK_WORK_COMPLETE_TOOL
@@ -572,9 +659,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
                           <div className="mb-1 text-xs font-medium opacity-70">
                             Parameters:
                           </div>
-                          <pre className="rounded bg-muted/50 p-2 overflow-auto text-xs whitespace-pre-wrap max-h-80 scrollbar-thin">
-                            {JSON.stringify(toolCall.arguments, null, 2)}
-                          </pre>
+                          <StructuredToolPayload payload={toolCall.arguments} maxHeightClassName="max-h-80" />
                         </div>
                       )}
                     </div>
@@ -773,38 +858,6 @@ const CompactMessage = React.memo(CompactMessageBase, (prev, next) => (
   prev.branchMessageIndex === next.branchMessageIndex
 ))
 
-// Helper to extract execute_command display info
-function getExecuteCommandDisplay(call: { name: string; arguments: any }, result?: { success: boolean; content: string; error?: string }) {
-  if (call.name !== "execute_command") return null
-
-  const command = typeof call.arguments?.command === "string" ? call.arguments.command : null
-  if (!command) return null
-
-  let outputPreview: string | null = null
-  if (result?.content) {
-    try {
-      const parsed = JSON.parse(result.content)
-      const stdout = parsed.stdout || ""
-      const stderr = parsed.stderr || ""
-      const output = stdout || stderr || parsed.error || ""
-      if (output) {
-        // Take first meaningful line, trim whitespace
-        const firstLine = output.split("\n").map((l: string) => l.trim()).filter(Boolean)[0] || ""
-        outputPreview = firstLine.length > 60 ? firstLine.slice(0, 57) + "…" : firstLine
-      }
-    } catch {
-      // not JSON, use raw content
-      const firstLine = result.content.split("\n").map((l: string) => l.trim()).filter(Boolean)[0] || ""
-      outputPreview = firstLine.length > 60 ? firstLine.slice(0, 57) + "…" : firstLine
-    }
-  }
-
-  // Truncate command for display
-  const displayCommand = command.length > 60 ? command.slice(0, 57) + "…" : command
-
-  return { displayCommand, outputPreview }
-}
-
 type CompactToolExecutionCall = { name: string; arguments: any }
 type CompactToolExecutionResult = { success: boolean; content: string; error?: string } | undefined
 
@@ -851,8 +904,7 @@ const CompactToolExecutionList: React.FC<{
         {toolCallEntries.map(({ call, result }, idx) => {
           const callIsPending = !result
           const callSuccess = result?.success
-          const callResultSummary = result ? getToolResultsSummary([result]) : null
-          const execCmdDisplay = getExecuteCommandDisplay(call, result)
+          const toolPreview = getToolCallPreview({ name: call.name, arguments: call.arguments ?? {} })
 
           return (
             <div key={idx}>
@@ -868,39 +920,18 @@ const CompactToolExecutionList: React.FC<{
                 )}
                 onClick={onToggleDetails}
               >
-                {execCmdDisplay ? (
-                  <>
-                    <span className="min-w-0 shrink truncate font-mono font-medium" title={call.arguments?.command}>{execCmdDisplay.displayCommand}</span>
-                    <span className="shrink-0 text-[10px] opacity-60">
-                      {callIsPending ? (
-                        <Loader2 className="h-2.5 w-2.5 animate-spin" />
-                      ) : callSuccess ? (
-                        <Check className="h-2.5 w-2.5" />
-                      ) : (
-                        <XCircle className="h-2.5 w-2.5" />
-                      )}
-                    </span>
-                    {!detailsExpanded && execCmdDisplay.outputPreview && (
-                      <span className="min-w-0 flex-1 truncate text-[10px] font-mono opacity-50">→ {execCmdDisplay.outputPreview}</span>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <span className="min-w-0 shrink truncate font-mono font-medium" title={call.name}>{call.name}</span>
-                    <span className="shrink-0 text-[10px] opacity-60">
-                      {callIsPending ? (
-                        <Loader2 className="h-2.5 w-2.5 animate-spin" />
-                      ) : callSuccess ? (
-                        <Check className="h-2.5 w-2.5" />
-                      ) : (
-                        <XCircle className="h-2.5 w-2.5" />
-                      )}
-                    </span>
-                    {!detailsExpanded && callResultSummary && (
-                      <span className="min-w-0 flex-1 truncate text-[10px] opacity-50">{callResultSummary}</span>
-                    )}
-                  </>
-                )}
+                <span className="min-w-0 shrink truncate font-mono font-medium" title={call.name}>
+                  {toolPreview}
+                </span>
+                <span className="shrink-0 text-[10px] opacity-60">
+                  {callIsPending ? (
+                    <Loader2 className="h-2.5 w-2.5 animate-spin" />
+                  ) : callSuccess ? (
+                    <Check className="h-2.5 w-2.5" />
+                  ) : (
+                    <XCircle className="h-2.5 w-2.5" />
+                  )}
+                </span>
                 <ChevronRight className={cn(
                   "h-2.5 w-2.5 opacity-40 flex-shrink-0 transition-transform",
                   detailsExpanded && "rotate-90"
@@ -915,19 +946,18 @@ const CompactToolExecutionList: React.FC<{
         <div className={detailsClassName}>
           {toolCallEntries.map(({ call, result }, idx) => {
             const callIsPending = !result
+            const formattedArguments = formatToolArguments(call.arguments)
             return (
               <div key={idx} className="text-[10px] space-y-1">
-                {call.arguments && (
+                {formattedArguments && (
                   <>
                     <div className="flex flex-wrap items-center justify-between gap-1.5">
                       <span className="min-w-0 font-medium opacity-70">Parameters</span>
-                      <Button size="sm" variant="ghost" className="h-5 shrink-0 px-1.5 text-[10px]" onClick={(e) => handleCopy(e, JSON.stringify(call.arguments, null, 2))}>
+                      <Button size="sm" variant="ghost" className="h-5 shrink-0 px-1.5 text-[10px]" onClick={(e) => handleCopy(e, formattedArguments)}>
                         <Copy className="h-2 w-2 mr-0.5" /> Copy
                       </Button>
                     </div>
-                    <pre className="rounded bg-muted/40 p-1.5 overflow-x-auto overflow-y-auto whitespace-pre-wrap max-w-full max-h-32 scrollbar-thin text-[10px]">
-                      {JSON.stringify(call.arguments, null, 2)}
-                    </pre>
+                    <StructuredToolPayload payload={call.arguments} maxHeightClassName="max-h-52" />
                   </>
                 )}
                 {result && (
@@ -947,12 +977,7 @@ const CompactToolExecutionList: React.FC<{
                       </pre>
                     )}
                     {result.content && (
-                      <pre className={cn(
-                        "rounded p-1.5 overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words max-w-full max-h-32 scrollbar-thin text-[10px]",
-                        result.success ? "bg-green-50/50 dark:bg-green-950/30" : "bg-muted/40"
-                      )}>
-                        {result.content}
-                      </pre>
+                      <StructuredToolPayload payload={result.content} maxHeightClassName="max-h-52" />
                     )}
                     {!result.error && !result.content && (
                       <pre className="rounded p-1.5 overflow-x-auto overflow-y-auto whitespace-pre-wrap break-words max-w-full max-h-32 scrollbar-thin text-[10px] bg-muted/40">
@@ -1100,34 +1125,9 @@ const AssistantWithToolsBubble: React.FC<{
   )
 }
 
-// Helper function to format tool arguments for preview
-const formatArgumentsPreview = (args: any): string => {
-  if (!args || typeof args !== 'object') return ''
-  const entries = Object.entries(args)
-  if (entries.length === 0) return ''
-
-  // Take first 3 key parameters
-  const preview = entries.slice(0, 3).map(([key, value]) => {
-    let displayValue: string
-    if (typeof value === 'string') {
-      displayValue = value.length > 30 ? value.slice(0, 30) + '...' : value
-    } else if (typeof value === 'object') {
-      displayValue = Array.isArray(value) ? `[${value.length} items]` : '{...}'
-    } else {
-      displayValue = String(value)
-    }
-    return `${key}: ${displayValue}`
-  }).join(', ')
-
-  if (entries.length > 3) {
-    return preview + ` (+${entries.length - 3} more)`
-  }
-  return preview
-}
-
 // Collapsed group of consecutive tool-call activity.
-// Only the trailing in-flight group shows tool preview lines; historical
-// groups collapse to a count-only header.
+// Each collapsed group shows compact tool preview lines so historical session
+// views still communicate which tools were called without expansion.
 const ToolActivityGroupBubble: React.FC<{
   group: {
     items: DisplayItem[]
@@ -1290,9 +1290,9 @@ const ToolApprovalBubble: React.FC<{
             {showArgs ? "Hide" : "View"} full arguments
           </button>
           {showArgs && (
-            <pre className="mt-1.5 max-h-32 max-w-full overflow-x-auto rounded bg-amber-100/70 p-2 text-xs text-amber-900 whitespace-pre-wrap break-words dark:bg-amber-900/40 dark:text-amber-100">
-              {JSON.stringify(approval.arguments, null, 2)}
-            </pre>
+            <div className="mt-1.5">
+              <StructuredToolPayload payload={approval.arguments} variant="approval" maxHeightClassName="max-h-48" />
+            </div>
           )}
         </div>
 
@@ -3191,7 +3191,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   const displayItems = useMemo<DisplayItem[]>(() => {
     const generateToolExecutionId = (calls: Array<{ name: string; arguments: any }>, timestamp: number) => {
       const signature = calls
-        .map((call) => `${call.name}:${call.arguments ? JSON.stringify(call.arguments).substring(0, 50) : ""}`)
+        .map((call) => `${call.name}:${formatToolArguments(call.arguments).substring(0, 50)}`)
         .join("|") + `@${timestamp}`
       let hash = 0
       for (let i = 0; i < signature.length; i++) {
@@ -3390,23 +3390,21 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       }
       const runItems = sortedItems.slice(runStart, runEnd + 1)
       const previewLines: string[] = []
-      const shouldShowPreviewLines = runEnd === sortedItems.length - 1
-
-      if (shouldShowPreviewLines) {
-        const previewStart = Math.max(0, runItems.length - TOOL_GROUP_PREVIEW_COUNT)
-        for (let j = previewStart; j < runItems.length; j++) {
-          const it = runItems[j]
-          if (it.kind === "assistant_with_tools") {
-            previewLines.push(getToolActivitySummaryLine({
-              role: "assistant",
-              toolCalls: it.data.calls,
-            }))
-          } else if (it.kind === "tool_execution") {
-            previewLines.push(getToolActivitySummaryLine({
-              role: "tool",
-              toolResults: it.data.results,
-            }))
-          }
+      const previewStart = Math.max(0, runItems.length - TOOL_GROUP_PREVIEW_COUNT)
+      for (let j = previewStart; j < runItems.length; j++) {
+        const it = runItems[j]
+        if (it.kind === "assistant_with_tools") {
+          const line = getToolActivitySummaryLine({
+            role: "assistant",
+            toolCalls: it.data.calls,
+          })
+          if (line) previewLines.push(line)
+        } else if (it.kind === "tool_execution") {
+          const line = getToolActivitySummaryLine({
+            role: "tool",
+            toolResults: it.data.results,
+          })
+          if (line) previewLines.push(line)
         }
       }
       grouped.push({

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -3227,8 +3227,10 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         const next = enrichedMessages[i + 1]
         const results = next && next.role === "tool" && next.toolResults ? next.toolResults : []
         const assistantIndex = ++roleCounters.assistant
-        const execTimestamp = next?.timestamp ?? message.timestamp
-        const toolExecId = generateToolExecutionId(message.toolCalls, execTimestamp)
+        // Keep the display item ID tied to the assistant tool-call message, not
+        // the eventual result timestamp. Otherwise an expanded pending tool row
+        // collapses when its result arrives because the key changes.
+        const toolExecId = generateToolExecutionId(message.toolCalls, message.timestamp)
         const toolCallNames = message.toolCalls.map((call) => call.name)
         const visibleToolCalls = message.toolCalls
           .map((call, index) => ({ call, result: results[index] }))
@@ -3407,9 +3409,13 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           if (line) previewLines.push(line)
         }
       }
+      // Use the first child item's ID as the group expansion key. That stays
+      // stable as more tools/skills append to the same run, and also preserves
+      // expansion if a single expanded tool row grows into a grouped run.
+      const groupId = runItems[0]?.id ?? `tool-group-${runStart}`
       grouped.push({
         kind: "tool_activity_group",
-        id: `tool-group-${runStart}-${runEnd}`,
+        id: groupId,
         data: { items: runItems, previewLines },
       })
       runStart = null

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -910,7 +910,7 @@ const CompactToolExecutionList: React.FC<{
             <div key={idx}>
               <div
                 className={cn(
-                  "flex min-w-0 items-center gap-1.5 rounded text-[11px] cursor-pointer hover:bg-muted/30",
+                  "flex min-w-0 items-center gap-1.5 overflow-hidden whitespace-nowrap rounded text-[11px] cursor-pointer hover:bg-muted/30",
                   rowClassName,
                   callIsPending
                     ? "text-blue-600 dark:text-blue-400"
@@ -920,7 +920,7 @@ const CompactToolExecutionList: React.FC<{
                 )}
                 onClick={onToggleDetails}
               >
-                <span className="min-w-0 shrink truncate font-mono font-medium" title={call.name}>
+                <span className="min-w-0 flex-1 truncate whitespace-nowrap font-mono font-medium" title={call.name}>
                   {toolPreview}
                 </span>
                 <span className="shrink-0 text-[10px] opacity-60">
@@ -1139,6 +1139,7 @@ const ToolActivityGroupBubble: React.FC<{
   renderItem: (item: DisplayItem, index: number) => React.ReactNode
 }> = ({ group, isExpanded, onToggleExpand, renderItem }) => {
   const totalCount = group.items.length
+  const collapsedPreviewLine = group.previewLines.join(', ')
 
   return (
     <div className={cn(
@@ -1148,16 +1149,21 @@ const ToolActivityGroupBubble: React.FC<{
     )}>
       {/* Collapsed header */}
       <div
-        className="flex items-center gap-1.5 px-2.5 py-1.5"
+        className="flex min-w-0 items-center gap-1.5 px-2.5 py-1.5"
         onClick={() => !isExpanded && onToggleExpand()}
       >
         <Wrench className="h-3 w-3 shrink-0 text-muted-foreground/70" aria-hidden="true" />
-        <span className="text-[11px] font-medium text-muted-foreground">
+        <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
           {totalCount} tool step{totalCount === 1 ? "" : "s"}
         </span>
+        {!isExpanded && collapsedPreviewLine && (
+          <span className="min-w-0 flex-1 truncate whitespace-nowrap font-mono text-[10px] text-muted-foreground/70">
+            {collapsedPreviewLine}
+          </span>
+        )}
         <button
           onClick={(e) => { e.stopPropagation(); onToggleExpand() }}
-          className="ml-auto p-0.5 rounded hover:bg-muted/30 transition-colors"
+          className="ml-auto shrink-0 p-0.5 rounded hover:bg-muted/30 transition-colors"
           aria-label={isExpanded ? "Collapse tool group" : "Expand tool group"}
         >
           {isExpanded ? (
@@ -1167,23 +1173,6 @@ const ToolActivityGroupBubble: React.FC<{
           )}
         </button>
       </div>
-
-      {/* Preview lines (collapsed) */}
-      {!isExpanded && group.previewLines.length > 0 && (
-        <div
-          className="px-2.5 pb-1.5 space-y-0.5 cursor-pointer"
-          onClick={onToggleExpand}
-        >
-          {group.previewLines.map((line, idx) => (
-            <div
-              key={idx}
-              className="truncate text-[10px] text-muted-foreground/70 font-mono"
-            >
-              {line}
-            </div>
-          ))}
-        </div>
-      )}
 
       {/* Expanded: render all child items */}
       {isExpanded && (
@@ -3416,7 +3405,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       grouped.push({
         kind: "tool_activity_group",
         id: groupId,
-        data: { items: runItems, previewLines },
+        data: { items: runItems, previewLines: previewLines.length > 0 ? [previewLines.join(', ')] : [] },
       })
       runStart = null
     }

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -3421,10 +3421,9 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           if (line) previewLines.push(line)
         }
       }
-      // Use the first child item's ID as the group expansion key. That stays
-      // stable as more tools/skills append to the same run, and also preserves
-      // expansion if a single expanded tool row grows into a grouped run.
-      const groupId = runItems[0]?.id ?? `tool-group-${runStart}`
+      // Prefix the first child ID so the group stays stable as the run grows
+      // without sharing expansion state with any child row.
+      const groupId = `tool-activity-group:${runItems[0]?.id ?? runStart}`
       grouped.push({
         kind: "tool_activity_group",
         id: groupId,
@@ -3447,6 +3446,25 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   }, [enrichedMessages, effectiveUserResponse, progress.retryInfo, progress.steps, progress.streamingContent, toolCallSteps])
 
   const visibleDisplayItems = displayItems
+
+  const getToolActivityGroupDefaultExpanded = useCallback((item: Extract<DisplayItem, { kind: "tool_activity_group" }>) => {
+    const firstChildId = item.data.items[0]?.id
+    return !!firstChildId && expandedItems[firstChildId] === true
+  }, [expandedItems])
+
+  useEffect(() => {
+    setExpandedItems(prev => {
+      let next = prev
+      for (const item of displayItems) {
+        if (item.kind !== "tool_activity_group" || item.id in prev) continue
+        const firstChildId = item.data.items[0]?.id
+        if (!firstChildId || prev[firstChildId] !== true) continue
+        if (next === prev) next = { ...prev }
+        next[item.id] = true
+      }
+      return next
+    })
+  }, [displayItems])
 
   const delegationSummaryEntries = useMemo<DelegationSummaryEntry[]>(() => {
     const latestByRunId = new Map<string, { delegation: ACPDelegationProgress; timestamp: number }>()
@@ -3908,12 +3926,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                           />
                         )
                       } else if (item.kind === "tool_activity_group") {
+                        const groupExpanded = itemKey in expandedItems
+                          ? expandedItems[itemKey]
+                          : getToolActivityGroupDefaultExpanded(item)
                         return (
                           <ToolActivityGroupBubble
                             key={itemKey}
                             group={item.data}
-                            isExpanded={isExpanded}
-                            onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
+                            isExpanded={groupExpanded}
+                            onToggleExpand={() => toggleItemExpansion(itemKey, groupExpanded)}
                             renderItem={(child, childIdx) => {
                               const childKey = child.id || `group-child-${childIdx}`
                               const childExpanded = expandedItems[childKey] ?? false
@@ -4324,12 +4345,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     />
                   )
                 } else if (item.kind === "tool_activity_group") {
+                  const groupExpanded = itemKey in expandedItems
+                    ? expandedItems[itemKey]
+                    : getToolActivityGroupDefaultExpanded(item)
                   return (
                     <ToolActivityGroupBubble
                       key={itemKey}
                       group={item.data}
-                      isExpanded={isExpanded}
-                      onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
+                      isExpanded={groupExpanded}
+                      onToggleExpand={() => toggleItemExpansion(itemKey, groupExpanded)}
                       renderItem={(child, childIdx) => {
                         const childKey = child.id || `group-child-${childIdx}`
                         const childExpanded = expandedItems[childKey] ?? false

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -48,7 +48,7 @@ import {
   preprocessTextForTTS,
   shouldCollapseMessage,
   formatToolArguments,
-  formatArgumentsPreview,
+  getToolCallPreview,
   getToolResultsSummary,
   getAgentConversationStateLabel,
   extractRespondToUserContentFromArgs,
@@ -3392,7 +3392,7 @@ export default function ChatScreen({ route, navigation }: any) {
                               const tcPending = !tcResult && origIdx >= toolResultCount;
                               const tcSuccess = tcResult?.success === true;
                               const tcError = tcResult?.success === false;
-                              const argPreview = formatArgumentsPreview(toolCall.arguments);
+                              const toolPreview = getToolCallPreview(toolCall);
                               return (
                                 <View key={tcIdx} style={styles.toolCallCompactLine}>
                                   <Text style={[
@@ -3412,7 +3412,7 @@ export default function ChatScreen({ route, navigation }: any) {
                                     ]}
                                     numberOfLines={1}
                                   >
-                                    {toolCall.name}{argPreview ? ` · ${argPreview}` : ''}
+                                    {toolPreview}
                                   </Text>
                                 </View>
                               );

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -3154,18 +3154,20 @@ export default function ChatScreen({ route, navigation }: any) {
                       pressed && styles.toolActivityGroupPressed,
                     ]}
                   >
-                    <Text style={styles.toolActivityGroupHeader}>
-                      ▶ {group.count} tool {group.count === 1 ? 'activity' : 'activities'}
-                    </Text>
-                    {group.previewLines.map((line, lineIdx) => (
-                      <Text
-                        key={lineIdx}
-                        style={styles.toolActivityGroupPreviewLine}
-                        numberOfLines={1}
-                      >
-                        {line}
+                    <View style={styles.toolActivityGroupHeaderRow}>
+                      <Text style={styles.toolActivityGroupHeader}>
+                        ▶ {group.count} tool {group.count === 1 ? 'activity' : 'activities'}
                       </Text>
-                    ))}
+                      {group.previewLines.length > 0 && (
+                        <Text
+                          style={styles.toolActivityGroupPreviewLine}
+                          numberOfLines={1}
+                          ellipsizeMode="tail"
+                        >
+                          {group.previewLines.join(', ')}
+                        </Text>
+                      )}
+                    </View>
                   </Pressable>
                 );
               }
@@ -3416,6 +3418,7 @@ export default function ChatScreen({ route, navigation }: any) {
                                       tcError && styles.toolCallCompactNameError,
                                     ]}
                                     numberOfLines={1}
+                                    ellipsizeMode="tail"
                                   >
                                     {toolPreview}
                                   </Text>
@@ -4627,6 +4630,7 @@ function createStyles(theme: Theme, screenHeight: number) {
       alignItems: 'center',
       gap: 4,
       paddingVertical: 1,
+      overflow: 'hidden',
     },
     toolCallCompactPressed: {
       opacity: 0.7,
@@ -4636,6 +4640,7 @@ function createStyles(theme: Theme, screenHeight: number) {
       fontSize: 10,
       fontWeight: '500',
       flexShrink: 1,
+      minWidth: 0,
       color: theme.colors.mutedForeground,
     },
     toolCallCompactNamePending: {
@@ -4671,18 +4676,25 @@ function createStyles(theme: Theme, screenHeight: number) {
     toolActivityGroupPressed: {
       opacity: 0.7,
     },
+    toolActivityGroupHeaderRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      overflow: 'hidden',
+    },
     toolActivityGroupHeader: {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
       fontSize: 10,
       fontWeight: '600',
       color: theme.colors.mutedForeground,
-      marginBottom: 2,
+      flexShrink: 0,
     },
     toolActivityGroupPreviewLine: {
       fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
       fontSize: 10,
       color: theme.colors.mutedForeground,
-      paddingLeft: 8,
+      flexShrink: 1,
+      minWidth: 0,
     },
     toolParamsSection: {
       paddingHorizontal: spacing.xs,

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -923,7 +923,8 @@ export default function ChatScreen({ route, navigation }: any) {
   // Track which individual tool calls are fully expanded to show all input/output details
   // Key format: "messageId-toolCallIndex" (messageId falls back to message array index if undefined)
   const [expandedToolCalls, setExpandedToolCalls] = useState<Record<string, boolean>>({});
-  // Track which tool-activity groups are expanded (keyed by "startIndex-endIndex")
+  // Track which tool-activity groups are expanded (keyed by startIndex so the
+  // state survives when new tool/skill messages append to the same group)
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   // Track the last failed message for retry functionality
   const [lastFailedMessage, setLastFailedMessage] = useState<string | null>(null);
@@ -1728,11 +1729,13 @@ export default function ChatScreen({ route, navigation }: any) {
   // Compute tool-activity groups for consecutive connected tool-call messages
   const toolActivityGroups = useMemo(() => groupToolActivity(messages), [messages]);
 
-  // Toggle expansion of a tool-activity group (keyed by "startIndex-endIndex")
+  const getToolActivityGroupKey = useCallback((group: ToolActivityGroup) => `${group.startIndex}`, []);
+
+  // Toggle expansion of a tool-activity group using a stable key for the run.
   const toggleGroupExpansion = useCallback((group: ToolActivityGroup) => {
-    const key = `${group.startIndex}-${group.endIndex}`;
+    const key = getToolActivityGroupKey(group);
     setExpandedGroups(prev => ({ ...prev, [key]: !prev[key] }));
-  }, []);
+  }, [getToolActivityGroupKey]);
 
   // Auto-expand logic matching desktop behavior (#32, #33):
   // - Tool-only messages (toolCalls/toolResults with no visible user-facing content) collapse by default
@@ -3128,8 +3131,8 @@ export default function ChatScreen({ route, navigation }: any) {
             // --- Tool-activity group handling ---
             const group = toolActivityGroups.groupByIndex.get(i);
             if (group) {
-              const groupKey = `${group.startIndex}-${group.endIndex}`;
-              const isGroupExpanded = expandedGroups[groupKey] ?? false;
+              const groupKey = getToolActivityGroupKey(group);
+              const isGroupExpanded = expandedGroups[groupKey] ?? expandedMessages[group.startIndex] ?? false;
 
               // Non-first message in a collapsed group: skip rendering
               if (i !== group.startIndex && !isGroupExpanded) {
@@ -3250,8 +3253,10 @@ export default function ChatScreen({ route, navigation }: any) {
             }
 
             // Determine if this message needs group expand/collapse chrome
-            const isFirstInExpandedGroup = group && i === group.startIndex && (expandedGroups[`${group.startIndex}-${group.endIndex}`] ?? false);
-            const isLastInExpandedGroup = group && i === group.endIndex && (expandedGroups[`${group.startIndex}-${group.endIndex}`] ?? false);
+            const groupKey = group ? getToolActivityGroupKey(group) : '';
+            const isExpandedGroup = group ? (expandedGroups[groupKey] ?? expandedMessages[group.startIndex] ?? false) : false;
+            const isFirstInExpandedGroup = group && i === group.startIndex && isExpandedGroup;
+            const isLastInExpandedGroup = group && i === group.endIndex && isExpandedGroup;
 
             return (
               <View key={i}>

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -174,6 +174,11 @@ describe('formatArgumentsPreview', () => {
     expect(preview).toContain('...')
   })
 
+  it('keeps multiline string values on one preview line', () => {
+    const args = { command: "python3 - <<'PY'\nprint('hello')\nPY" }
+    expect(formatArgumentsPreview(args)).toBe("command: python3 - <<'PY' print('hel...")
+  })
+
   it('shows +N more for many args', () => {
     const args = { a: '1', b: '2', c: '3', d: '4' }
     expect(formatArgumentsPreview(args)).toContain('+1 more')

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -4,6 +4,7 @@ import {
   getToolCallsSummary,
   getToolCallPreview,
   getToolResultsSummary,
+  getToolArgumentEntries,
   formatToolArguments,
   formatArgumentsPreview,
   RESPOND_TO_USER_TOOL,
@@ -67,27 +68,27 @@ describe('getToolCallsSummary', () => {
     expect(getToolCallsSummary([])).toBe('')
   })
 
-  it('returns human-readable previews', () => {
+  it('returns tool-name-only previews', () => {
     const calls = [
       { name: 'execute_command', arguments: { command: 'pnpm test' } },
       { name: 'read_file', arguments: { path: 'apps/desktop/src/main.ts' } },
     ]
-    expect(getToolCallsSummary(calls)).toBe('🔧 pnpm test, Read apps/desktop/src/main.ts')
+    expect(getToolCallsSummary(calls)).toBe('🔧 execute_command, read_file')
   })
 })
 
 describe('getToolCallPreview', () => {
-  it('prefers the shell command for execute_command', () => {
-    expect(getToolCallPreview({ name: 'execute_command', arguments: { command: 'git status --short' } })).toBe('git status --short')
+  it('returns only the tool name for execute_command', () => {
+    expect(getToolCallPreview({ name: 'execute_command', arguments: { command: 'git status --short' } })).toBe('execute_command')
   })
 
-  it('formats common structured tool arguments', () => {
-    expect(getToolCallPreview({ name: 'write_file', arguments: { path: 'README.md', content: 'hello' } })).toBe('Write README.md')
-    expect(getToolCallPreview({ name: 'web_search', arguments: { query: 'DotAgents skills' } })).toBe('Search “DotAgents skills”')
+  it('omits common structured tool arguments', () => {
+    expect(getToolCallPreview({ name: 'write_file', arguments: { path: 'README.md', content: 'hello' } })).toBe('write_file')
+    expect(getToolCallPreview({ name: 'web_search', arguments: { query: 'DotAgents skills' } })).toBe('web_search')
   })
 
-  it('falls back to a cleaned-up tool name and compact key arguments', () => {
-    expect(getToolCallPreview({ name: 'custom_tool', arguments: { foo: 'bar', nested: { value: true } } })).toBe('Custom tool — foo: bar, nested: {...}')
+  it('falls back to the raw tool name only', () => {
+    expect(getToolCallPreview({ name: 'custom_tool', arguments: { foo: 'bar', nested: { value: true } } })).toBe('custom_tool')
   })
 })
 
@@ -132,6 +133,24 @@ describe('formatToolArguments', () => {
     const args = { path: '/test' }
     expect(formatToolArguments(args)).toBe('{\n  "path": "/test"\n}')
   })
+
+  it('pretty-prints JSON string arguments', () => {
+    expect(formatToolArguments('{"path":"/test","count":2}')).toBe('{\n  "path": "/test",\n  "count": 2\n}')
+  })
+})
+
+describe('getToolArgumentEntries', () => {
+  it('returns normalized entries for objects', () => {
+    expect(getToolArgumentEntries({ command: 'echo hi' })).toEqual([
+      { key: 'command', value: 'echo hi' },
+    ])
+  })
+
+  it('returns normalized entries for JSON string arguments', () => {
+    expect(getToolArgumentEntries('{"command":"echo hi"}')).toEqual([
+      { key: 'command', value: 'echo hi' },
+    ])
+  })
 })
 
 describe('formatArgumentsPreview', () => {
@@ -143,6 +162,10 @@ describe('formatArgumentsPreview', () => {
   it('returns compact key-value preview', () => {
     const args = { path: '/foo', content: 'Hello' }
     expect(formatArgumentsPreview(args)).toBe('path: /foo, content: Hello')
+  })
+
+  it('returns compact key-value preview for JSON string arguments', () => {
+    expect(formatArgumentsPreview('{"path":"/foo","content":"Hello"}')).toBe('path: /foo, content: Hello')
   })
 
   it('truncates long values', () => {

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -73,7 +73,7 @@ describe('getToolCallsSummary', () => {
       { name: 'execute_command', arguments: { command: 'pnpm test' } },
       { name: 'read_file', arguments: { path: 'apps/desktop/src/main.ts' } },
     ]
-    expect(getToolCallsSummary(calls)).toBe('🔧 execute_command, read_file')
+    expect(getToolCallsSummary(calls)).toBe('execute_command, read_file')
   })
 })
 
@@ -89,6 +89,10 @@ describe('getToolCallPreview', () => {
 
   it('falls back to the raw tool name only', () => {
     expect(getToolCallPreview({ name: 'custom_tool', arguments: { foo: 'bar', nested: { value: true } } })).toBe('custom_tool')
+  })
+
+  it('sanitizes whitespace so collapsed labels stay one word', () => {
+    expect(getToolCallPreview({ name: 'custom tool\nname', arguments: {} })).toBe('custom_tool_name')
   })
 })
 

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   shouldCollapseMessage,
   getToolCallsSummary,
+  getToolCallPreview,
   getToolResultsSummary,
   formatToolArguments,
   formatArgumentsPreview,
@@ -66,12 +67,27 @@ describe('getToolCallsSummary', () => {
     expect(getToolCallsSummary([])).toBe('')
   })
 
-  it('returns formatted tool names', () => {
+  it('returns human-readable previews', () => {
     const calls = [
-      { name: 'search', arguments: {} },
-      { name: 'read_file', arguments: {} },
+      { name: 'execute_command', arguments: { command: 'pnpm test' } },
+      { name: 'read_file', arguments: { path: 'apps/desktop/src/main.ts' } },
     ]
-    expect(getToolCallsSummary(calls)).toBe('🔧 search, read_file')
+    expect(getToolCallsSummary(calls)).toBe('🔧 pnpm test, Read apps/desktop/src/main.ts')
+  })
+})
+
+describe('getToolCallPreview', () => {
+  it('prefers the shell command for execute_command', () => {
+    expect(getToolCallPreview({ name: 'execute_command', arguments: { command: 'git status --short' } })).toBe('git status --short')
+  })
+
+  it('formats common structured tool arguments', () => {
+    expect(getToolCallPreview({ name: 'write_file', arguments: { path: 'README.md', content: 'hello' } })).toBe('Write README.md')
+    expect(getToolCallPreview({ name: 'web_search', arguments: { query: 'DotAgents skills' } })).toBe('Search “DotAgents skills”')
+  })
+
+  it('falls back to a cleaned-up tool name and compact key arguments', () => {
+    expect(getToolCallPreview({ name: 'custom_tool', arguments: { foo: 'bar', nested: { value: true } } })).toBe('Custom tool — foo: bar, nested: {...}')
   })
 })
 

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -40,7 +40,7 @@ export function shouldCollapseMessage(
  */
 export function getToolCallsSummary(toolCalls: ToolCall[]): string {
   if (!toolCalls || toolCalls.length === 0) return '';
-  return `🔧 ${toolCalls.map(tc => getToolCallPreview(tc)).join(', ')}`;
+  return toolCalls.map(tc => getToolCallPreview(tc)).join(', ');
 }
 
 /**
@@ -48,7 +48,7 @@ export function getToolCallsSummary(toolCalls: ToolCall[]): string {
  * Details belong in expanded tool views, not collapsed rows.
  */
 export function getToolCallPreview(toolCall: ToolCall): string {
-  return toolCall.name?.trim() || 'tool';
+  return toolCall.name?.trim().replace(/\s+/g, '_') || 'tool';
 }
 
 /**

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -252,10 +252,6 @@ function parseJsonStringIfPossible(value: unknown): unknown {
   }
 }
 
-function normalizeArgumentsRecord(args: unknown): Record<string, unknown> {
-  return normalizeToolArguments(args) ?? {};
-}
-
 /**
  * Normalize tool arguments into an object suitable for field-by-field rendering.
  * Accepts either an object or a JSON string containing an object.

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -8,6 +8,11 @@
 import type { AgentUserResponseEvent } from './agent-progress';
 import { ToolCall, ToolResult } from './types';
 
+export type ToolArgumentEntry = {
+  key: string;
+  value: unknown;
+};
+
 const COLLAPSE_THRESHOLD = 200;
 const MARKDOWN_IMAGE_PAYLOAD_REGEX = /!\[[^\]]*\]\((?:data:image\/|https?:\/\/|assets:\/\/conversation-image\/)[^)]*\)/gi;
 
@@ -31,7 +36,7 @@ export function shouldCollapseMessage(
 /**
  * Generate a summary of tool calls for collapsed view
  * @param toolCalls Array of tool calls
- * @returns A formatted string showing human-readable tool call previews
+ * @returns A formatted string showing only tool names
  */
 export function getToolCallsSummary(toolCalls: ToolCall[]): string {
   if (!toolCalls || toolCalls.length === 0) return '';
@@ -39,73 +44,11 @@ export function getToolCallsSummary(toolCalls: ToolCall[]): string {
 }
 
 /**
- * Generate a compact preview for a single collapsed tool call.
+ * Generate a compact single-token label for a collapsed tool call.
+ * Details belong in expanded tool views, not collapsed rows.
  */
 export function getToolCallPreview(toolCall: ToolCall): string {
-  const args = toolCall.arguments || {};
-  const customPreview = getCustomToolCallPreview(toolCall.name, args);
-  if (customPreview) return customPreview;
-
-  const argsPreview = formatArgumentsPreview(args);
-  const toolName = humanizeToolName(toolCall.name);
-  return argsPreview ? `${toolName} — ${argsPreview}` : toolName;
-}
-
-function getCustomToolCallPreview(toolName: string, args: Record<string, unknown>): string {
-  const normalizedName = toolName.toLowerCase();
-
-  if (normalizedName === 'execute_command' || normalizedName === 'shell' || normalizedName === 'terminal') {
-    return truncatePreview(getStringArg(args, ['command', 'cmd']) || '', 90);
-  }
-
-  if (normalizedName === 'read_file' || normalizedName === 'read') {
-    return formatPathAction('Read', args);
-  }
-
-  if (normalizedName === 'write_file' || normalizedName === 'create_file') {
-    return formatPathAction('Write', args);
-  }
-
-  if (normalizedName === 'edit_file' || normalizedName === 'str_replace' || normalizedName === 'patch_file') {
-    return formatPathAction('Edit', args);
-  }
-
-  if (normalizedName === 'list_directory' || normalizedName === 'list_files') {
-    return formatPathAction('List', args);
-  }
-
-  if (normalizedName.includes('search') || normalizedName === 'grep') {
-    const query = getStringArg(args, ['query', 'pattern', 'text']);
-    if (query) return `Search “${truncatePreview(query, 70)}”`;
-  }
-
-  const url = getStringArg(args, ['url', 'uri']);
-  if (url && (normalizedName.includes('fetch') || normalizedName.includes('web') || normalizedName.includes('browser'))) {
-    return truncatePreview(url, 90);
-  }
-
-  return '';
-}
-
-function formatPathAction(action: string, args: Record<string, unknown>): string {
-  const pathValue = getStringArg(args, ['path', 'file', 'filename', 'filePath', 'targetPath']);
-  return pathValue ? `${action} ${truncatePreview(pathValue, 80)}` : '';
-}
-
-function getStringArg(args: Record<string, unknown>, keys: string[]): string | undefined {
-  for (const key of keys) {
-    const value = args[key];
-    if (typeof value === 'string' && value.trim()) return value.trim();
-  }
-  return undefined;
-}
-
-function humanizeToolName(name: string): string {
-  return name
-    .replace(/[:_.-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/^./, char => char.toUpperCase()) || 'Tool';
+  return toolCall.name?.trim() || 'tool';
 }
 
 /**
@@ -286,12 +229,51 @@ function truncatePreview(text: string, maxLength: number): string {
  * @returns Formatted JSON string with 2-space indentation
  */
 export function formatToolArguments(args: unknown): string {
-  if (!args) return '';
+  if (args === null || args === undefined) return '';
+  const normalizedArgs = parseJsonStringIfPossible(args);
   try {
-    return JSON.stringify(args, null, 2);
+    if (typeof normalizedArgs === 'string') return normalizedArgs;
+    return JSON.stringify(normalizedArgs, null, 2);
   } catch {
     return String(args);
   }
+}
+
+function parseJsonStringIfPossible(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+
+  const trimmed = value.trim();
+  if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return value;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeArgumentsRecord(args: unknown): Record<string, unknown> {
+  return normalizeToolArguments(args) ?? {};
+}
+
+/**
+ * Normalize tool arguments into an object suitable for field-by-field rendering.
+ * Accepts either an object or a JSON string containing an object.
+ */
+export function normalizeToolArguments(args: unknown): Record<string, unknown> | null {
+  const normalizedArgs = parseJsonStringIfPossible(args);
+  if (!normalizedArgs || typeof normalizedArgs !== 'object' || Array.isArray(normalizedArgs)) {
+    return null;
+  }
+  return normalizedArgs as Record<string, unknown>;
+}
+
+/**
+ * Return normalized tool argument entries in insertion order for UI renderers.
+ */
+export function getToolArgumentEntries(args: unknown): ToolArgumentEntry[] {
+  const normalizedArgs = normalizeToolArguments(args);
+  return normalizedArgs ? Object.entries(normalizedArgs).map(([key, value]) => ({ key, value })) : [];
 }
 
 /**
@@ -301,8 +283,9 @@ export function formatToolArguments(args: unknown): string {
  * @returns A compact preview string like "path: /foo/bar, content: Hello..."
  */
 export function formatArgumentsPreview(args: unknown): string {
-  if (!args || typeof args !== 'object') return '';
-  const entries = Object.entries(args as Record<string, unknown>);
+  const normalizedArgs = normalizeToolArguments(args);
+  if (!normalizedArgs) return '';
+  const entries = Object.entries(normalizedArgs);
   if (entries.length === 0) return '';
 
   const preview = entries.slice(0, 3).map(([key, value]) => {
@@ -310,7 +293,7 @@ export function formatArgumentsPreview(args: unknown): string {
     if (typeof value === 'string') {
       displayValue = value.length > 30 ? value.slice(0, 30) + '...' : value;
     } else if (typeof value === 'object') {
-      displayValue = Array.isArray(value) ? `[${value.length} items]` : '{...}';
+      displayValue = value === null ? 'null' : Array.isArray(value) ? `[${value.length} items]` : '{...}';
     } else {
       displayValue = String(value);
     }

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -31,11 +31,81 @@ export function shouldCollapseMessage(
 /**
  * Generate a summary of tool calls for collapsed view
  * @param toolCalls Array of tool calls
- * @returns A formatted string showing tool names
+ * @returns A formatted string showing human-readable tool call previews
  */
 export function getToolCallsSummary(toolCalls: ToolCall[]): string {
   if (!toolCalls || toolCalls.length === 0) return '';
-  return `🔧 ${toolCalls.map(tc => tc.name).join(', ')}`;
+  return `🔧 ${toolCalls.map(tc => getToolCallPreview(tc)).join(', ')}`;
+}
+
+/**
+ * Generate a compact preview for a single collapsed tool call.
+ */
+export function getToolCallPreview(toolCall: ToolCall): string {
+  const args = toolCall.arguments || {};
+  const customPreview = getCustomToolCallPreview(toolCall.name, args);
+  if (customPreview) return customPreview;
+
+  const argsPreview = formatArgumentsPreview(args);
+  const toolName = humanizeToolName(toolCall.name);
+  return argsPreview ? `${toolName} — ${argsPreview}` : toolName;
+}
+
+function getCustomToolCallPreview(toolName: string, args: Record<string, unknown>): string {
+  const normalizedName = toolName.toLowerCase();
+
+  if (normalizedName === 'execute_command' || normalizedName === 'shell' || normalizedName === 'terminal') {
+    return truncatePreview(getStringArg(args, ['command', 'cmd']) || '', 90);
+  }
+
+  if (normalizedName === 'read_file' || normalizedName === 'read') {
+    return formatPathAction('Read', args);
+  }
+
+  if (normalizedName === 'write_file' || normalizedName === 'create_file') {
+    return formatPathAction('Write', args);
+  }
+
+  if (normalizedName === 'edit_file' || normalizedName === 'str_replace' || normalizedName === 'patch_file') {
+    return formatPathAction('Edit', args);
+  }
+
+  if (normalizedName === 'list_directory' || normalizedName === 'list_files') {
+    return formatPathAction('List', args);
+  }
+
+  if (normalizedName.includes('search') || normalizedName === 'grep') {
+    const query = getStringArg(args, ['query', 'pattern', 'text']);
+    if (query) return `Search “${truncatePreview(query, 70)}”`;
+  }
+
+  const url = getStringArg(args, ['url', 'uri']);
+  if (url && (normalizedName.includes('fetch') || normalizedName.includes('web') || normalizedName.includes('browser'))) {
+    return truncatePreview(url, 90);
+  }
+
+  return '';
+}
+
+function formatPathAction(action: string, args: Record<string, unknown>): string {
+  const pathValue = getStringArg(args, ['path', 'file', 'filename', 'filePath', 'targetPath']);
+  return pathValue ? `${action} ${truncatePreview(pathValue, 80)}` : '';
+}
+
+function getStringArg(args: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function humanizeToolName(name: string): string {
+  return name
+    .replace(/[:_.-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^./, char => char.toUpperCase()) || 'Tool';
 }
 
 /**

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -291,7 +291,7 @@ export function formatArgumentsPreview(args: unknown): string {
   const preview = entries.slice(0, 3).map(([key, value]) => {
     let displayValue: string;
     if (typeof value === 'string') {
-      displayValue = value.length > 30 ? value.slice(0, 30) + '...' : value;
+      displayValue = truncatePreview(value, 30);
     } else if (typeof value === 'object') {
       displayValue = value === null ? 'null' : Array.isArray(value) ? `[${value.length} items]` : '{...}';
     } else {

--- a/packages/shared/src/tool-activity-grouping.test.ts
+++ b/packages/shared/src/tool-activity-grouping.test.ts
@@ -33,7 +33,7 @@ const respondToUserMsg = (): GroupableMessage => ({
 describe('getToolActivitySummaryLine', () => {
   it('summarises tool calls', () => {
     expect(getToolActivitySummaryLine(toolOnlyAssistant(['read_file', 'write_file'])))
-      .toBe('🔧 read_file, write_file')
+      .toBe('read_file, write_file')
   })
 
   it('omits successful tool results from collapsed tool-name previews', () => {
@@ -104,7 +104,7 @@ describe('groupToolActivity', () => {
     ]
     const { groups } = groupToolActivity(msgs)
     expect(groups).toHaveLength(1)
-    expect(groups[0].previewLines).toEqual(['🔧 step2', '🔧 step3'])
+    expect(groups[0].previewLines).toEqual(['step2, step3'])
   })
 
   it('keeps preview lines once a later assistant response exists', () => {
@@ -117,7 +117,7 @@ describe('groupToolActivity', () => {
     const { groups } = groupToolActivity(msgs)
 
     expect(groups).toHaveLength(1)
-    expect(groups[0].previewLines).toEqual(['🔧 read_file'])
+    expect(groups[0].previewLines).toEqual(['read_file'])
   })
 
   it('previews every collapsed tool run when multiple groups exist', () => {
@@ -133,8 +133,8 @@ describe('groupToolActivity', () => {
     const { groups } = groupToolActivity(msgs)
 
     expect(groups).toHaveLength(2)
-    expect(groups[0].previewLines).toEqual(['🔧 first'])
-    expect(groups[1].previewLines).toEqual(['🔧 second-1', '🔧 second-2'])
+    expect(groups[0].previewLines).toEqual(['first'])
+    expect(groups[1].previewLines).toEqual(['second-1, second-2'])
   })
 
   it('does not group assistant messages with real content', () => {

--- a/packages/shared/src/tool-activity-grouping.test.ts
+++ b/packages/shared/src/tool-activity-grouping.test.ts
@@ -36,12 +36,12 @@ describe('getToolActivitySummaryLine', () => {
       .toBe('🔧 read_file, write_file')
   })
 
-  it('summarises successful tool results', () => {
-    expect(getToolActivitySummaryLine(toolResultMsg(true))).toBe('✅ 1 result')
+  it('omits successful tool results from collapsed tool-name previews', () => {
+    expect(getToolActivitySummaryLine(toolResultMsg(true))).toBe('')
   })
 
-  it('summarises failed tool results', () => {
-    expect(getToolActivitySummaryLine(toolResultMsg(false))).toBe('⚠️ 1 result')
+  it('omits failed tool results from collapsed tool-name previews', () => {
+    expect(getToolActivitySummaryLine(toolResultMsg(false))).toBe('')
   })
 })
 
@@ -94,7 +94,7 @@ describe('groupToolActivity', () => {
     expect(groups[1].startIndex).toBe(3)
   })
 
-  it('preview shows last N entries for the trailing tool group only', () => {
+  it('preview shows the last N entries for a collapsed tool group', () => {
     const msgs: GroupableMessage[] = [
       toolOnlyAssistant(['step1']),
       toolResultMsg(),
@@ -104,13 +104,10 @@ describe('groupToolActivity', () => {
     ]
     const { groups } = groupToolActivity(msgs)
     expect(groups).toHaveLength(1)
-    expect(groups[0].previewLines).toHaveLength(TOOL_GROUP_PREVIEW_COUNT)
-    // Should be the LAST 3 entries
-    expect(groups[0].previewLines[0]).toContain('step2')
-    expect(groups[0].previewLines[2]).toContain('step3')
+    expect(groups[0].previewLines).toEqual(['🔧 step2', '🔧 step3'])
   })
 
-  it('does not show preview lines once a later assistant response exists', () => {
+  it('keeps preview lines once a later assistant response exists', () => {
     const msgs: GroupableMessage[] = [
       toolOnlyAssistant(['read_file']),
       toolResultMsg(),
@@ -120,10 +117,10 @@ describe('groupToolActivity', () => {
     const { groups } = groupToolActivity(msgs)
 
     expect(groups).toHaveLength(1)
-    expect(groups[0].previewLines).toEqual([])
+    expect(groups[0].previewLines).toEqual(['🔧 read_file'])
   })
 
-  it('only previews the most recent pending tool run when multiple groups exist', () => {
+  it('previews every collapsed tool run when multiple groups exist', () => {
     const msgs: GroupableMessage[] = [
       toolOnlyAssistant(['first']),
       toolResultMsg(),
@@ -136,10 +133,8 @@ describe('groupToolActivity', () => {
     const { groups } = groupToolActivity(msgs)
 
     expect(groups).toHaveLength(2)
-    expect(groups[0].previewLines).toEqual([])
-    expect(groups[1].previewLines).toHaveLength(TOOL_GROUP_PREVIEW_COUNT)
-    expect(groups[1].previewLines[0]).toContain('second-1')
-    expect(groups[1].previewLines[2]).toContain('second-2')
+    expect(groups[0].previewLines).toEqual(['🔧 first'])
+    expect(groups[1].previewLines).toEqual(['🔧 second-1', '🔧 second-2'])
   })
 
   it('does not group assistant messages with real content', () => {

--- a/packages/shared/src/tool-activity-grouping.ts
+++ b/packages/shared/src/tool-activity-grouping.ts
@@ -11,9 +11,8 @@
  * - User messages are NEVER grouped.
  * - User-visible final assistant responses (including respond_to_user output)
  *   are NEVER grouped — they stay rendered normally.
- * - Only the trailing tool-activity group (while waiting for a follow-up
- *   response) gets collapsed preview lines. Historical groups collapse to a
- *   count-only header.
+ * - Collapsed tool-activity groups include compact preview lines so users can
+ *   see which tools were called without expanding the group.
  */
 
 import { RESPOND_TO_USER_TOOL, isToolOnlyMessage, getToolCallsSummary } from './chat-utils'
@@ -41,8 +40,8 @@ export interface ToolActivityGroup {
   /**
    * Collapsed preview lines — at most {@link TOOL_GROUP_PREVIEW_COUNT} entries,
    * taken from the *end* of the group (most recent activity).
-   * Present only for the trailing tool-activity group while a follow-up
-   * response has not been received yet.
+   * Present for every collapsed group so historical session views still show
+   * which tools were called without expanding the group.
    */
   previewLines: string[]
 }
@@ -110,10 +109,7 @@ export function getToolActivitySummaryLine(message: GroupableMessage): string {
   }
 
   if (message.toolResults?.length) {
-    const allOk = message.toolResults.every((r) => r.success)
-    return allOk
-      ? `✅ ${message.toolResults.length} result${message.toolResults.length === 1 ? '' : 's'}`
-      : `⚠️ ${message.toolResults.length} result${message.toolResults.length === 1 ? '' : 's'}`
+    return ''
   }
 
   // Fallback: role label
@@ -152,16 +148,10 @@ export function groupToolActivity(messages: GroupableMessage[]): {
       return
     }
     const previewLines: string[] = []
-    const shouldPreviewTrailingRun = runEnd === messages.length - 1
-
-    // Only preview the latest tool run while we're still waiting for whatever
-    // comes after it. Once a later response is present, historical groups stay
-    // collapsed but do not show tool-call preview lines.
-    if (shouldPreviewTrailingRun) {
-      const previewStartIdx = Math.max(runStart, runEnd - TOOL_GROUP_PREVIEW_COUNT + 1)
-      for (let i = previewStartIdx; i <= runEnd; i++) {
-        previewLines.push(getToolActivitySummaryLine(messages[i]))
-      }
+    const previewStartIdx = Math.max(runStart, runEnd - TOOL_GROUP_PREVIEW_COUNT + 1)
+    for (let i = previewStartIdx; i <= runEnd; i++) {
+      const line = getToolActivitySummaryLine(messages[i])
+      if (line) previewLines.push(line)
     }
     const group: ToolActivityGroup = {
       startIndex: runStart,

--- a/packages/shared/src/tool-activity-grouping.ts
+++ b/packages/shared/src/tool-activity-grouping.ts
@@ -157,7 +157,7 @@ export function groupToolActivity(messages: GroupableMessage[]): {
       startIndex: runStart,
       endIndex: runEnd,
       count,
-      previewLines,
+      previewLines: previewLines.length > 0 ? [previewLines.join(', ')] : [],
     }
     groups.push(group)
     for (let i = runStart; i <= runEnd; i++) {


### PR DESCRIPTION
## Problem Spec

Closes #364. Collapsed tool call rows showed raw tool names and generic argument blobs, making command executions and common file/search operations hard to scan.

## Solution Spec

- **Shared preview formatter** (`packages/shared/src/chat-utils.ts`): add `getToolCallPreview` with per-tool formatters for commands, file reads/writes/edits, directory listings, search, and URL fetch/browser tools.
- **Collapsed summary behavior** (`packages/shared/src/chat-utils.ts`): update `getToolCallsSummary` to use human-readable previews instead of raw tool names.
- **Mobile compact rows** (`apps/mobile/src/screens/ChatScreen.tsx`): render the shared tool-call preview directly in compact/collapsed mobile tool rows.
- **Regression coverage** (`packages/shared/src/chat-utils.test.ts`): add coverage for execute-command previews, common structured tool summaries, and generic fallback formatting.

## Validation

- `git diff --check` passed.
- `pnpm --filter @dotagents/shared test` could not run because `node_modules` is not installed and `vitest` is unavailable in this checkout.

## Notes

Per repository instructions, `pnpm build:shared` should be run after dependency installation before app-level validation.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://app.staging.augmentcode.com/app/session?agentId=01KPKHVHFQF1VB9K1VEEQPPNS1&panel=chat)