### PR TITLE
Remove unrecoverable tool error note

### DIFF
--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -118,6 +118,7 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       "session-resume",
       "session-resume-followup",
       "session-command",
+      "session-permission-error",
       "session-tool-error",
       "session-blank-response",
       "session-review-loop",
@@ -357,6 +358,48 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
     expect(secondPrompt).toContain("Invalid execute_command.skillId: aj47/dotagents-mono")
     expect(secondPrompt).toContain("Retry the same command without skillId")
     expect(secondPrompt).toContain("Do not use repo names, file paths, URLs, or GitHub slugs as skillId")
+  })
+
+  it("does not inject unrecoverable permissions notes for failed tools", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+
+    mocks.makeLLMCallWithStreamingAndTools
+      .mockResolvedValueOnce({ content: "", toolCalls: [
+        { name: "execute_command", arguments: { command: "cat /private/file" } },
+      ] })
+      .mockResolvedValueOnce({ content: "", toolCalls: [
+        { name: "respond_to_user", arguments: { text: "The command failed with access denied." } },
+        { name: "mark_work_complete", arguments: { summary: "Explained command failure" } },
+      ] })
+
+    await processTranscriptWithAgentMode(
+      "Read that file if possible",
+      availableTools as any,
+      makeExecuteToolCall("session-permission-error", 1, {
+        execute_command: {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ success: false, error: "access denied", stderr: "Permission denied" }, null, 2),
+          }],
+          isError: true,
+        },
+      }),
+      4,
+      [],
+      "conv-permission-error",
+      "session-permission-error",
+      undefined,
+      undefined,
+      1,
+    )
+
+    const retryPrompt = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[1]?.[0] ?? [])
+      .map((message: any) => message.content)
+      .join("\n")
+    expect(retryPrompt).toContain("TOOL FAILED: execute_command")
+    expect(retryPrompt).toContain("access denied")
+    expect(retryPrompt).not.toContain("Some tools (execute_command) have unrecoverable errors")
+    expect(retryPrompt).not.toContain("Please complete what you can or explain what cannot be done")
   })
 
   it("routes failed communication-only tool batches through error recovery before retrying", async () => {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -179,38 +179,6 @@ function extractSkillsIndexForMinimalPrompt(skillsInstructions?: string): string
 const NON_AGENT_WORKING_NOTES_LIMIT = 3
 const AGENT_WORKING_NOTES_LIMIT = 4
 
-/**
- * Analyze tool errors and categorize them
- */
-function analyzeToolErrors(toolResults: MCPToolResult[]): {
-  errorTypes: string[]
-} {
-  const errorTypes: string[] = []
-  const errorMessages = toolResults
-    .filter((r) => r.isError)
-    .map((r) => r.content.map((c) => c.text).join(" ").toLowerCase())
-    .join(" ")
-
-  // Categorize error types
-  if (errorMessages.includes("timeout")) {
-    errorTypes.push("timeout")
-  }
-  if (errorMessages.includes("connection") || errorMessages.includes("network")) {
-    errorTypes.push("connectivity")
-  }
-  if (errorMessages.includes("permission") || errorMessages.includes("access") || errorMessages.includes("denied")) {
-    errorTypes.push("permissions")
-  }
-  if (errorMessages.includes("not found") || errorMessages.includes("does not exist") || errorMessages.includes("missing")) {
-    errorTypes.push("not_found")
-  }
-  if (errorMessages.includes("invalid") || errorMessages.includes("expected")) {
-    errorTypes.push("invalid_params")
-  }
-
-  return { errorTypes }
-}
-
 function isInvalidExecuteCommandSkillIdFailure(toolName: string | undefined, result: MCPToolResult): boolean {
   if (toolName !== "execute_command" || !result.isError) return false
 
@@ -2728,9 +2696,6 @@ export async function processTranscriptWithAgentMode(
     const completionSignalConfirmed = completionToolCalled && allToolsSuccessful
 
     if (hasErrors) {
-      // Enhanced error analysis and recovery suggestions
-      const errorAnalysis = analyzeToolErrors(toolResults)
-
       const hasInvalidExecuteCommandSkillIdError = toolResults.some((result, index) =>
         isInvalidExecuteCommandSkillIdFailure(toolCallsArray[index]?.name, result)
       )
@@ -2753,39 +2718,6 @@ export async function processTranscriptWithAgentMode(
           if (currentCount + 1 >= MAX_TOOL_FAILURES) {
             logLLM(`⚠️ Tool "${toolName}" has failed ${MAX_TOOL_FAILURES} times - will be excluded`)
           }
-        }
-      }
-
-      // Check for unrecoverable errors that should trigger early completion
-      const hasUnrecoverableError = errorAnalysis.errorTypes?.some(
-        type => type === "permissions" || type === "authentication"
-      )
-      if (hasUnrecoverableError) {
-        // Build list of tools that failed with unrecoverable errors in THIS batch only
-        // (not all historical failures from toolFailureCount, which could mislead the model)
-        const currentUnrecoverableTools: string[] = []
-        for (let i = 0; i < toolResults.length; i++) {
-          const result = toolResults[i]
-          if (result.isError) {
-            const errorText = result.content.map((c) => c.text).join(" ").toLowerCase()
-            if (errorText.includes("permission") || errorText.includes("access") ||
-                errorText.includes("denied") || errorText.includes("authentication") ||
-                errorText.includes("unauthorized") || errorText.includes("forbidden")) {
-              const toolName = toolCallsArray[i]?.name || "unknown"
-              currentUnrecoverableTools.push(toolName)
-            }
-          }
-        }
-
-        if (currentUnrecoverableTools.length > 0) {
-          const failedToolNames = currentUnrecoverableTools.join(", ")
-          logLLM(`⚠️ Unrecoverable errors detected for tools: ${failedToolNames}`)
-          // Add note to conversation so LLM knows to wrap up
-          conversationHistory.push({
-            role: "user",
-            content: `Note: Some tools (${failedToolNames}) have unrecoverable errors (permissions/authentication). Please complete what you can or explain what cannot be done.`,
-            timestamp: Date.now()
-          })
         }
       }
 


### PR DESCRIPTION
## Summary
- remove the synthetic unrecoverable permissions/authentication note injected after failed tool calls
- rely on the existing failed-tool summary that already includes the actual error text
- add regression coverage to ensure permission-style command failures do not inject the removed note

## Tests
- `pnpm vitest run apps/desktop/src/main/llm.respond-to-user-history.test.ts`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author