### PR TITLE
fix: Normalize icon alignment across panels and zoom levels

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -145,7 +145,7 @@ function SessionOverflowMenu({
           onClick={(event) => event.stopPropagation()}
           onMouseDown={(event) => event.stopPropagation()}
           onPointerDown={(event) => event.stopPropagation()}
-          className="hover:bg-accent focus-visible:ring-ring shrink-0 rounded p-0.5 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+          className="flex h-5 w-5 items-center justify-center hover:bg-accent focus-visible:ring-ring shrink-0 rounded transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
           aria-label={`Session actions for ${sessionTitle}`}
           title="Session actions"
         >
@@ -1114,7 +1114,7 @@ export function ActiveAgentsSidebar({
                   )}
                   <button
                     onClick={(e) => handleStopSession(session.id, e)}
-                    className="hover:bg-destructive/20 hover:text-destructive shrink-0 rounded p-0.5 transition-all"
+                    className="flex h-5 w-5 items-center justify-center hover:bg-destructive/20 hover:text-destructive shrink-0 rounded transition-all"
                     title="Stop this agent session"
                   >
                     <X className="h-3 w-3" />

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -3999,18 +3999,18 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   const getStatusIndicator = () => {
     const isSnoozed = progress.isSnoozed
     if (conversationState === "needs_input") {
-      return <Shield className="h-4 w-4 text-amber-500 animate-pulse" />
+      return <Shield className="h-3.5 w-3.5 text-amber-500 animate-pulse" />
     }
     if (conversationState === "running") {
-      return <LoadingSpinner size="sm" className="[&>div]:gap-0 [&_img]:h-4 [&_img]:w-4" />
+      return <LoadingSpinner size="sm" className="[&>div]:gap-0 [&_img]:h-3.5 [&_img]:w-3.5" />
     }
     if (isSnoozed) {
-      return <Moon className="h-4 w-4 text-muted-foreground" />
+      return <Moon className="h-3.5 w-3.5 text-muted-foreground" />
     }
     if (conversationState === "blocked") {
-      return <XCircle className="h-4 w-4 text-red-500" />
+      return <XCircle className="h-3.5 w-3.5 text-red-500" />
     }
-    return <Check className="h-4 w-4 text-green-500" />
+    return <Check className="h-3.5 w-3.5 text-green-500" />
   }
 
   // Get title for tile variant
@@ -4081,7 +4081,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           }}
         >
           <div className="flex min-w-0 flex-1 items-center gap-1.5">
-            <div className="shrink-0">
+            <div className="flex h-6 w-6 shrink-0 items-center justify-center">
               {getStatusIndicator()}
             </div>
             <span className={cn("pointer-events-none truncate font-medium min-w-0", isCollapsed ? "text-xs" : "text-sm")}>
@@ -4090,16 +4090,16 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           </div>
           <div className="ml-auto flex max-w-full flex-wrap items-center justify-end gap-1 app-no-drag-region">
             {canCollapseTile && (
-              <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={handleToggleCollapse} title={isCollapsed ? "Expand panel" : "Collapse panel"}>
-                {isCollapsed ? <ChevronDown className="h-3 w-3" /> : <ChevronUp className="h-3 w-3" />}
+              <Button variant="ghost" size="sm-icon" className="shrink-0" onClick={handleToggleCollapse} title={isCollapsed ? "Expand panel" : "Collapse panel"}>
+                {isCollapsed ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronUp className="h-3.5 w-3.5" />}
               </Button>
             )}
 
             {conversationId && (
               <Button
                 variant="ghost"
-                size="icon"
-                className="h-6 w-6 shrink-0"
+                size="sm-icon"
+                className="shrink-0"
                 onClick={(e) => {
                   e.stopPropagation()
                   togglePinSession(conversationId)
@@ -4108,17 +4108,17 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                 aria-label={isPinned ? "Unpin session" : "Pin session"}
                 aria-pressed={isPinned}
               >
-                <Pin className={cn("h-3 w-3", isPinned && "fill-current text-foreground")} />
+                <Pin className={cn("h-3.5 w-3.5", isPinned && "fill-current text-foreground")} />
               </Button>
             )}
             {/* Combined close button: stops agent if running, dismisses if complete */}
             {!isComplete ? (
-              <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0 hover:bg-destructive/20 hover:text-destructive" onClick={(e) => { e.stopPropagation(); handleKillConfirmation(); }} title="Stop agent">
-                <OctagonX className="h-3 w-3" />
+              <Button variant="ghost" size="sm-icon" className="shrink-0 hover:bg-destructive/20 hover:text-destructive" onClick={(e) => { e.stopPropagation(); handleKillConfirmation(); }} title="Stop agent">
+                <OctagonX className="h-3.5 w-3.5" />
               </Button>
             ) : onDismiss ? (
-              <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0" onClick={(e) => { e.stopPropagation(); onDismiss(); }} title="Dismiss">
-                <X className="h-3 w-3" />
+              <Button variant="ghost" size="sm-icon" className="shrink-0" onClick={(e) => { e.stopPropagation(); onDismiss(); }} title="Dismiss">
+                <X className="h-3.5 w-3.5" />
               </Button>
             ) : null}
           </div>

--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -4,6 +4,7 @@ import { cn } from "@renderer/lib/utils"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { NavLink, Outlet, useNavigate, useLocation } from "react-router-dom"
 import { LoadingSpinner } from "@renderer/components/ui/loading-spinner"
+import { Button } from "@renderer/components/ui/button"
 import { ActiveAgentsSidebar } from "@renderer/components/active-agents-sidebar"
 import { SandboxSlotIndicator } from "@renderer/components/sandbox-slot-switcher"
 import { SessionActionDialog, type SessionActionDialogMode } from "@renderer/components/session-action-dialog"
@@ -485,13 +486,12 @@ export const Component = () => {
           >
             {!isCollapsed && (
               <div className="flex items-center gap-1">
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm-icon"
                   onClick={handleToggleGlobalTTS}
                   disabled={!configQuery.data || saveConfigMutation.isPending}
-                  className={cn(
-                    "app-no-drag-region text-muted-foreground hover:bg-accent/50 hover:text-foreground shrink-0 rounded p-1 transition-colors disabled:opacity-50",
-                  )}
+                  className="app-no-drag-region text-muted-foreground hover:bg-accent/50 hover:text-foreground shrink-0 disabled:opacity-50"
                   title={
                     isGlobalTTSEnabled
                       ? "Disable global TTS"
@@ -510,13 +510,14 @@ export const Component = () => {
                   ) : (
                     <VolumeX className="h-3.5 w-3.5" />
                   )}
-                </button>
+                </Button>
 
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="sm-icon"
                   onClick={handleEmergencyStopAll}
                   disabled={isEmergencyStopping}
-                  className="app-no-drag-region text-destructive hover:bg-destructive/10 shrink-0 rounded p-1 transition-colors disabled:opacity-50"
+                  className="app-no-drag-region text-destructive hover:bg-destructive/10 shrink-0 disabled:opacity-50"
                   title="Emergency stop all agent sessions"
                   aria-label="Emergency stop all agent sessions"
                 >
@@ -525,25 +526,27 @@ export const Component = () => {
                   ) : (
                     <OctagonX className="h-3.5 w-3.5" />
                   )}
-                </button>
+                </Button>
               </div>
             )}
 
-            <button
+            <Button
+              variant="ghost"
+              size="sm-icon"
               onClick={toggleCollapse}
               className={cn(
-                "app-no-drag-region flex h-6 w-6 items-center justify-center rounded-md transition-colors",
+                "app-no-drag-region shrink-0",
                 "text-muted-foreground hover:bg-accent hover:text-foreground",
               )}
               title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
             >
               {isCollapsed ? (
-                <PanelLeft className="h-4 w-4" />
+                <PanelLeft className="h-3.5 w-3.5" />
               ) : (
-                <PanelLeftClose className="h-4 w-4" />
+                <PanelLeftClose className="h-3.5 w-3.5" />
               )}
-            </button>
+            </Button>
           </header>
 
           {/* Scrollable area: Settings + Sessions scroll together */}

--- a/apps/desktop/src/renderer/src/components/message-queue-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/message-queue-panel.tsx
@@ -200,8 +200,8 @@ function QueuedMessageItem({
                 {isFailed && (
                   <Button
                     variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-primary hover:bg-primary/10 hover:text-primary"
+                    size="sm-icon"
+                    className="text-primary hover:bg-primary/10 hover:text-primary"
                     onClick={() => retryMutation.mutate()}
                     disabled={retryMutation.isPending}
                     title="Retry message"
@@ -213,8 +213,7 @@ function QueuedMessageItem({
                 {!isAddedToHistory && (
                   <Button
                     variant="ghost"
-                    size="icon"
-                    className="h-6 w-6"
+                    size="sm-icon"
                     onClick={() => setIsEditing(true)}
                     title="Edit message"
                     aria-label="Edit message"
@@ -224,8 +223,8 @@ function QueuedMessageItem({
                 )}
                 <Button
                   variant="ghost"
-                  size="icon"
-                  className="h-6 w-6 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  size="sm-icon"
+                  className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                   onClick={() => removeMutation.mutate()}
                   disabled={removeMutation.isPending}
                   title="Remove from queue"
@@ -313,8 +312,8 @@ export function MessageQueuePanel({
           {isPaused ? (
             <Button
               variant="ghost"
-              size="icon"
-              className="h-6 w-6 text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-200 hover:bg-green-100 dark:hover:bg-green-900/30"
+              size="sm-icon"
+              className="text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-200 hover:bg-green-100 dark:hover:bg-green-900/30"
               onClick={() => resumeMutation.mutate()}
               disabled={resumeMutation.isPending}
               title="Resume queue execution"
@@ -324,8 +323,8 @@ export function MessageQueuePanel({
           ) : (
             <Button
               variant="ghost"
-              size="icon"
-              className="h-6 w-6 text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/30"
+              size="sm-icon"
+              className="text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200 hover:bg-amber-100 dark:hover:bg-amber-900/30"
               onClick={() => pauseMutation.mutate()}
               disabled={pauseMutation.isPending || hasProcessingMessage}
               title="Pause queue"
@@ -335,9 +334,8 @@ export function MessageQueuePanel({
           )}
           <Button
             variant="ghost"
-            size="icon"
+            size="sm-icon"
             className={cn(
-              "h-6 w-6",
               isPaused
                 ? "text-orange-600 dark:text-orange-400 hover:text-orange-800 dark:hover:text-orange-200"
                 : "text-amber-600 dark:text-amber-400 hover:text-amber-800 dark:hover:text-amber-200"
@@ -429,9 +427,8 @@ export function MessageQueuePanel({
           )}
           <Button
             variant="ghost"
-            size="icon"
+            size="sm-icon"
             className={cn(
-              "h-6 w-6",
               isPaused
                 ? "text-orange-700 dark:text-orange-300 hover:text-orange-900 dark:hover:text-orange-100 hover:bg-orange-200/50 dark:hover:bg-orange-800/50"
                 : "text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-100 hover:bg-amber-200/50 dark:hover:bg-amber-800/50"
@@ -443,9 +440,9 @@ export function MessageQueuePanel({
             title={isListCollapsed ? "Expand queue" : "Collapse queue"}
           >
             {isListCollapsed ? (
-              <ChevronDown className="h-3 w-3" />
+              <ChevronDown className="h-3.5 w-3.5" />
             ) : (
-              <ChevronUp className="h-3 w-3" />
+              <ChevronUp className="h-3.5 w-3.5" />
             )}
           </Button>
         </div>

--- a/apps/desktop/src/renderer/src/components/overlay-follow-up-input.tsx
+++ b/apps/desktop/src/renderer/src/components/overlay-follow-up-input.tsx
@@ -354,9 +354,9 @@ export function OverlayFollowUpInput({
           />
           <Button
             type="button"
-            size="icon"
+            size="md-icon"
             variant="ghost"
-            className="h-7 w-7 flex-shrink-0"
+            className="flex-shrink-0"
             disabled={isDisabled || imageAttachments.length >= MAX_IMAGE_ATTACHMENTS}
             onMouseDown={handleInputInteraction}
             onClick={handleImageButtonClick}
@@ -366,9 +366,9 @@ export function OverlayFollowUpInput({
           </Button>
           <Button
             type="submit"
-            size="icon"
+            size="md-icon"
             variant="ghost"
-            className="h-7 w-7 flex-shrink-0"
+            className="flex-shrink-0"
             disabled={!hasMessageContent || isDisabled}
             onMouseDown={handleInputInteraction}
             title={isSessionActive && isQueueEnabled ? "Queue message" : "Send message"}
@@ -380,10 +380,10 @@ export function OverlayFollowUpInput({
           </Button>
           <Button
             type="button"
-            size="icon"
+            size="md-icon"
             variant="ghost"
             className={cn(
-              "h-7 w-7 flex-shrink-0",
+              "flex-shrink-0",
               "hover:bg-red-100 dark:hover:bg-red-900/30",
               "hover:text-red-600 dark:hover:text-red-400"
             )}
@@ -398,10 +398,10 @@ export function OverlayFollowUpInput({
           {isSessionActive && sessionId && !sessionId.startsWith('pending-') && (
             <Button
               type="button"
-              size="icon"
+              size="md-icon"
               variant="ghost"
               className={cn(
-                "h-7 w-7 flex-shrink-0",
+                "flex-shrink-0",
                 "text-red-500 hover:text-red-600",
                 "hover:bg-red-100 dark:hover:bg-red-950/30"
               )}

--- a/apps/desktop/src/renderer/src/components/predefined-prompts-menu.tsx
+++ b/apps/desktop/src/renderer/src/components/predefined-prompts-menu.tsx
@@ -31,7 +31,7 @@ interface PredefinedPromptsMenuProps {
   onSelectPrompt: (content: string) => void
   className?: string
   disabled?: boolean
-  buttonSize?: "default" | "sm" | "icon"
+  buttonSize?: "default" | "sm" | "icon" | "sm-icon" | "md-icon"
 }
 
 export function PredefinedPromptsMenu({
@@ -40,8 +40,8 @@ export function PredefinedPromptsMenu({
   disabled = false,
   buttonSize = "icon",
 }: PredefinedPromptsMenuProps) {
-  // Map buttonSize prop to actual Button size - always use "icon" variant for icon-only buttons
-  const actualButtonSize = "icon" as const
+  // Map buttonSize prop to actual Button size
+  const actualButtonSize = (buttonSize === "sm-icon" ? "sm-icon" : buttonSize === "md-icon" ? "md-icon" : "icon") as "icon" | "sm-icon" | "md-icon"
   const configQuery = useConfigQuery()
   const saveConfig = useSaveConfigMutation()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -65,10 +65,12 @@ export function PredefinedPromptsMenu({
   const availableTasks = loopsQuery.data ?? []
   const triggerButtonClassName = buttonSize === "default"
     ? "h-9 w-9"
-    : buttonSize === "sm"
+    : buttonSize === "sm" || buttonSize === "md-icon"
       ? "h-7 w-7"
-      : "h-8 w-8"
-  const triggerIconClassName = buttonSize === "sm" ? "h-3.5 w-3.5 shrink-0" : "h-4 w-4 shrink-0"
+      : buttonSize === "sm-icon"
+        ? "h-6 w-6"
+        : "h-8 w-8"
+  const triggerIconClassName = (buttonSize === "sm" || buttonSize === "sm-icon" || buttonSize === "md-icon") ? "h-3.5 w-3.5 shrink-0" : "h-4 w-4 shrink-0"
   const sectionLabelClassName = "px-2 pb-1 pt-2 text-xs font-medium uppercase tracking-wide text-muted-foreground"
   const menuContentClassName = "w-[min(26rem,calc(100vw-2rem))] max-w-[calc(100vw-2rem)] max-h-[min(32rem,calc(100vh-2rem))] overflow-y-auto"
   const entryClassName = "flex min-w-0 items-start gap-2.5 py-2 cursor-pointer"
@@ -227,24 +229,23 @@ export function PredefinedPromptsMenu({
                   <Button
                     type="button"
                     variant="ghost"
-                    size="icon"
-                    className="h-7 w-7"
+                    size="md-icon"
                     onClick={(e) => handleEdit(e, prompt)}
                     title="Edit"
                     aria-label={`Edit predefined prompt ${prompt.name}`}
                   >
-                    <Pencil className="h-3 w-3" />
+                    <Pencil className="h-3.5 w-3.5" />
                   </Button>
                   <Button
                     type="button"
                     variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 text-destructive hover:text-destructive"
+                    size="md-icon"
+                    className="text-destructive hover:text-destructive"
                     onClick={(e) => handleDelete(e, prompt)}
                     title="Delete"
                     aria-label={`Delete predefined prompt ${prompt.name}`}
                   >
-                    <Trash2 className="h-3 w-3" />
+                    <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
               </DropdownMenuItem>

--- a/apps/desktop/src/renderer/src/components/text-input-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/text-input-panel.tsx
@@ -246,13 +246,12 @@ export const TextInputPanel = forwardRef<TextInputPanelRef, TextInputPanelProps>
               <PredefinedPromptsMenu
                 onSelectPrompt={(content) => setText(content)}
                 disabled={isBusy}
-                className="h-6 w-6"
+                buttonSize="sm-icon"
               />
               <Button
                 type="button"
-                size="icon"
+                size="sm-icon"
                 variant="ghost"
-                className="h-6 w-6"
                 disabled={isBusy || imageAttachments.length >= MAX_IMAGE_ATTACHMENTS}
                 onClick={handleImageButtonClick}
                 title="Attach image"

--- a/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
+++ b/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
@@ -372,43 +372,43 @@ export function TileFollowUpInput({
         <PredefinedPromptsMenu
           onSelectPrompt={(content) => setText(content)}
           disabled={isDisabled}
-          className="h-6 w-6"
+          buttonSize="sm-icon"
         />
         <Button
           type="button"
-          size="icon"
+          size="sm-icon"
           variant="ghost"
-          className="h-6 w-6 flex-shrink-0"
+          className="flex-shrink-0"
           disabled={isDisabled || imageAttachments.length >= MAX_IMAGE_ATTACHMENTS}
           onClick={() => fileInputRef.current?.click()}
           title="Attach image"
         >
-          <ImagePlus className="h-3 w-3" />
+          <ImagePlus className="h-3.5 w-3.5" />
         </Button>
         <Button
           type="submit"
-          size="icon"
+          size="sm-icon"
           variant="ghost"
-          className="h-6 w-6 flex-shrink-0"
+          className="flex-shrink-0"
           disabled={!hasMessageContent || isDisabled}
           title={isInitializingSession ? "Starting follow-up" : isSessionActive && isQueueEnabled ? "Queue message" : "Send follow-up message"}
           aria-label={isInitializingSession ? "Starting follow-up" : isSessionActive && isQueueEnabled ? "Queue message" : "Send follow-up message"}
         >
           {isInitializingSession ? (
-            <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
           ) : (
             <Send className={cn(
-              "h-3 w-3",
+              "h-3.5 w-3.5",
               sendMutation.isPending && "animate-pulse"
             )} aria-hidden="true" />
           )}
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm-icon"
           variant="ghost"
           className={cn(
-            "h-6 w-6 flex-shrink-0",
+            "flex-shrink-0",
             "hover:bg-red-100 dark:hover:bg-red-900/30",
             "hover:text-red-600 dark:hover:text-red-400"
           )}
@@ -416,16 +416,16 @@ export function TileFollowUpInput({
           onClick={handleVoiceClick}
           title={isInitializingSession ? "Voice unavailable while session starts" : isSessionActive && isQueueEnabled ? "Record voice message (will be queued)" : isSessionActive ? "Voice unavailable while agent is processing" : "Continue with voice"}
         >
-          <Mic className="h-3 w-3" />
+          <Mic className="h-3.5 w-3.5" />
         </Button>
         {/* Kill switch - stop agent button (only show when session is active) */}
         {isSessionActive && sessionId && !sessionId.startsWith('pending-') && (
         <Button
           type="button"
-          size="icon"
+          size="sm-icon"
           variant="ghost"
           className={cn(
-            "h-6 w-6 flex-shrink-0",
+            "flex-shrink-0",
             "text-red-500 hover:text-red-600",
             "hover:bg-red-100 dark:hover:bg-red-950/30"
           )}
@@ -434,7 +434,7 @@ export function TileFollowUpInput({
           title="Stop agent execution"
         >
           <OctagonX className={cn(
-            "h-3 w-3",
+            "h-3.5 w-3.5",
             isStoppingSession && "animate-pulse"
           )} />
         </Button>

--- a/apps/desktop/src/renderer/src/components/ui/button.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/button.tsx
@@ -23,6 +23,8 @@ const buttonVariants = tv({
       sm: "h-8 rounded-md px-3 text-xs",
       lg: "h-10 rounded-md px-8",
       icon: "h-8 w-8",
+      "sm-icon": "h-6 w-6",
+      "md-icon": "h-7 w-7",
     },
   },
   defaultVariants: {


### PR DESCRIPTION
## Summary

Fixes #356 — inconsistent vertical alignment of icons across the UI so icons line up on the same visual baseline in all components and at all zoom levels.

## Problem

Several UI components rendered icons slightly misaligned relative to adjacent icons and controls:
- **Tile header**: Status indicator (h-4 w-4) didn't align with action buttons (h-3 w-3 inside h-6 w-6) because different icon sizes and the status wrapper lacked a consistent bounding box
- **Sidebar header**: TTS button, emergency stop, and collapse toggle used inconsistent sizing patterns (raw `<button>` with `p-1` vs `flex h-6 w-6` container)
- **Sidebar session items**: Overflow menu and stop buttons used padding-based sizing without explicit dimensions
- **Ad-hoc icon button sizing**: All compact icon buttons used `size="icon" className="h-6 w-6"` or `h-7 w-7` overrides instead of proper variants

## Changes

### 1. Add `sm-icon` and `md-icon` size variants to Button component
- `sm-icon`: `h-6 w-6` (24px) — for tile headers, compact controls, panel UI
- `md-icon`: `h-7 w-7` (28px) — for overlay follow-up input, predefined prompt edit/delete
- `icon`: `h-8 w-8` (32px) — existing, for default icon buttons

### 2. Fix tile header alignment (agent-progress.tsx)
- Wrap `getStatusIndicator()` in `flex h-6 w-6 items-center justify-center` bounding box
- Standardize all status icons from `h-4 w-4` → `h-3.5 w-3.5` to match other row icons
- Convert action buttons to `size="sm-icon"`, icons from `h-3 w-3` → `h-3.5 w-3.5`

### 3. Fix sidebar header alignment (app-layout.tsx)
- Convert 3 raw `<button>` elements → `<Button variant="ghost" size="sm-icon">`
- Standardize collapse toggle icons from `h-4 w-4` → `h-3.5 w-3.5` to match TTS/emergency buttons

### 4. Fix sidebar session item buttons (active-agents-sidebar.tsx)
- Add `flex h-5 w-5 items-center justify-center` to overflow menu trigger and stop button

### 5. Standardize across remaining components
- **message-queue-panel.tsx**: Convert all `h-6 w-6` overrides → `sm-icon` variant
- **overlay-follow-up-input.tsx**: Convert all `h-7 w-7` overrides → `md-icon` variant  
- **tile-follow-up-input.tsx**: Convert to `sm-icon`, icons `h-3` → `h-3.5`
- **text-input-panel.tsx**: Convert to `sm-icon`
- **predefined-prompts-menu.tsx**: Support `sm-icon`/`md-icon` in buttonSize prop

## Verification

- ✅ `pnpm typecheck` passes
- ✅ App launches with `REMOTE_DEBUGGING_PORT=9333 pnpm dev -- -dui`
- ✅ CDP verification confirms all sidebar header buttons are uniformly 24×24px with `display: flex; align-items: center; justify-content: center`
- ✅ No ad-hoc `size="icon" className="h-6 w-6"` or `h-7 w-7` overrides remain

## Files Changed

| File | Change |
|------|--------|
| `ui/button.tsx` | +2 size variants |
| `agent-progress.tsx` | Status indicator bounding box + icon sizes |
| `app-layout.tsx` | Raw buttons → Button sm-icon |
| `active-agents-sidebar.tsx` | Fixed-dimension overlay buttons |
| `message-queue-panel.tsx` | sm-icon variant |
| `overlay-follow-up-input.tsx` | md-icon variant |
| `tile-follow-up-input.tsx` | sm-icon variant + icon sizes |
| `text-input-panel.tsx` | sm-icon variant |
| `predefined-prompts-menu.tsx` | sm-icon/md-icon support |

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author