### PR TITLE
fix: unsnooze session after loop completes when speakOnTrigger is set

### DIFF
--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -346,9 +346,11 @@ class LoopService {
       }
 
       const conversationTitle = `[Repeat] ${loop.name}`
-      // Start the session un-snoozed when `speakOnTrigger` is set so the
-      // renderer's TTS auto-play gate (which skips snoozed sessions) runs.
-      const startSnoozed = !loop.speakOnTrigger
+      // Always start snoozed so the panel stays hidden during execution.
+      // When `speakOnTrigger` is set, we unsnooze *after* the loop completes
+      // so the renderer's TTS auto-play gate fires on the finished response
+      // without popping the panel open for the entire run.
+      const startSnoozed = true
 
       let conversationId: string | undefined
       let sessionId: string | undefined
@@ -417,6 +419,27 @@ class LoopService {
       // Reuse the main agent execution flow.
       const { runAgentLoopSession } = await import("./tipc")
       await runAgentLoopSession(loop.prompt, conversationId, sessionId, startSnoozed)
+
+      // When `speakOnTrigger` is set, unsnooze the now-completed session and
+      // show the panel so the renderer's TTS auto-play gate fires for the
+      // assistant response. The session ran silently in the background; this
+      // wakes it up only after the result is ready.
+      if (loop.speakOnTrigger && sessionId) {
+        const { setTrackedAgentSessionSnoozed } = await import("./floating-panel-session-state")
+        setTrackedAgentSessionSnoozed(sessionId, false)
+
+        // Show the panel and focus the completed session so the renderer
+        // renders the CompactMessage with isSnoozed=false, triggering TTS.
+        const { showPanelWindow, resizePanelForAgentMode, getWindowRendererHandlers } = await import("./window")
+        resizePanelForAgentMode()
+        showPanelWindow({ markOpenedWithMain: false })
+        try {
+          getWindowRendererHandlers("panel")?.focusAgentSession.send(sessionId)
+        } catch (e) {
+          logApp(`[LoopService] Failed to focus session ${sessionId} after speakOnTrigger unsnooze:`, e)
+        }
+        logApp(`[LoopService] Unsnoozed session ${sessionId} for loop "${loop.name}" (speakOnTrigger)`)
+      }
     } catch (error) {
       logApp(`[LoopService] Error executing loop "${loop.name}":`, error)
     } finally {

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1003,7 +1003,7 @@ export interface LoopConfig {
   profileId?: string       // optional profile to use for the agent session
   lastRunAt?: number       // timestamp (ms) of last execution
   runOnStartup?: boolean   // if true, fires immediately on app start before first interval
-  speakOnTrigger?: boolean // if true, spawned session starts un-snoozed so TTS auto-plays
+  speakOnTrigger?: boolean // if true, unsnoozes session on completion so TTS auto-plays
   continueInSession?: boolean // if true, reuses the prior session across iterations
   lastSessionId?: string   // session id to resume on next run when continueInSession is on
   runContinuously?: boolean // if true, starts the next run immediately after the previous run finishes

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,9 +78,11 @@ export interface LoopConfig {
   lastRunAt?: number
   runOnStartup?: boolean
   /**
-   * If true, the session spawned by this task starts un-snoozed so the
-   * renderer auto-plays TTS for the assistant response. Snoozed sessions
-   * intentionally suppress TTS auto-play.
+   * If true, the session is automatically unsnoozed when the loop completes
+   * so the renderer auto-plays TTS for the assistant response. The session
+   * still runs snoozed (quietly in the background) during execution — it only
+   * wakes up after the result is ready, showing the panel and triggering TTS.
+   * Snoozed sessions intentionally suppress TTS auto-play until unsnoozed.
    */
   speakOnTrigger?: boolean
   /**


### PR DESCRIPTION
## Problem

TTS wouldn't play from long routine tasks that run in the background (snoozed). The root cause: snoozed sessions suppress TTS auto-play entirely, and nothing ever unsnoozed them after completion — so the response was silently completed with zero TTS activity.

Previously `speakOnTrigger` started the session **unsnoozed**, which showed the panel for the entire task duration — disruptive for long-running background tasks and still didn't reliably trigger TTS because the auto-play gate timing was wrong.

## Fix

- **All loop sessions now start snoozed** (quiet background execution, panel stays hidden)
- **When `speakOnTrigger` is true**, the session is automatically **unsnoozed after the loop completes**, showing the panel and triggering the renderer's TTS auto-play for the finished response
- Tasks run silently and only announce themselves when the result is ready

## Changes

| File | Change |
|------|--------|
| `loop-service.ts` | `startSnoozed = true` always; added post-completion unsnooze + show panel + focus session when `speakOnTrigger` |
| `packages/core/src/types.ts` | Updated `speakOnTrigger` doc comment (unsnoozes on completion, not starts unsnoozed) |
| `apps/desktop/src/shared/types.ts` | Updated inline comment |

## Testing

- Typecheck passes (`pnpm typecheck`)
- Runtime test: needs `speakOnTrigger: true` added to task frontmatter, then verify panel shows + TTS plays on completion

## Edge cases

- **Error paths**: If the loop errors, the unsnooze is skipped (inside try block after `runAgentLoopSession`) — no TTS for errored sessions ✅
- **Revived sessions**: `reviveSession` also gets `startSnoozed=true`, unsnooze still happens after completion ✅
- **Completed session unsnooze**: `unsnoozeSession()` fails silently for completed sessions (moved to `completedSessions` map), but `broadcastSessionSnoozed()` still reaches the renderer which updates `agentProgressById` → TTS useEffect re-fires ✅
