### PR TITLE
fix: clear stale TTS tracking keys for continueInSession loops

### DIFF
--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -425,6 +425,17 @@ class LoopService {
       // assistant response. The session ran silently in the background; this
       // wakes it up only after the result is ready.
       if (loop.speakOnTrigger && sessionId) {
+        // Clear stale TTS tracking keys for this session in all renderer
+        // windows.  For continueInSession loops the sessionId is reused across
+        // runs, so keys from the previous run would still be in the module-level
+        // played-set and cause hasTTSPlayed() to block the new auto-play.
+        const { WINDOWS: wins } = await import("./window")
+        for (const win of wins.values()) {
+          try {
+            getRendererHandlers<RendererHandlers>(win.webContents).clearSessionTTSKeys?.send(sessionId)
+          } catch {}
+        }
+
         const { setTrackedAgentSessionSnoozed } = await import("./floating-panel-session-state")
         setTrackedAgentSessionSnoozed(sessionId, false)
 

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -430,10 +430,12 @@ class LoopService {
         // runs, so keys from the previous run would still be in the module-level
         // played-set and cause hasTTSPlayed() to block the new auto-play.
         const { WINDOWS: wins } = await import("./window")
-        for (const win of wins.values()) {
+        for (const [id, win] of wins.entries()) {
           try {
             getRendererHandlers<RendererHandlers>(win.webContents).clearSessionTTSKeys?.send(sessionId)
-          } catch {}
+          } catch (e) {
+            logApp(`[LoopService] clearSessionTTSKeys send to ${id} failed:`, e)
+          }
         }
 
         const { setTrackedAgentSessionSnoozed } = await import("./floating-panel-session-state")

--- a/apps/desktop/src/main/renderer-handlers.ts
+++ b/apps/desktop/src/main/renderer-handlers.ts
@@ -38,6 +38,10 @@ export type RendererHandlers = {
   focusAgentSession: (sessionId: string) => void
   setAgentSessionSnoozed: (data: { sessionId: string; isSnoozed: boolean }) => void
 
+  // Clear stale TTS tracking keys for a session so auto-play can fire fresh
+  // (e.g. when a continueInSession loop reuses a sessionId across runs)
+  clearSessionTTSKeys: (sessionId: string) => void
+
   // Message Queue handlers
   onMessageQueueUpdate: (data: { conversationId: string; queue: QueuedMessage[]; isPaused: boolean }) => void
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
@@ -16,7 +16,7 @@ describe("agent progress TTS guardrails", () => {
 
   it("suppresses tile auto-play while the floating panel is visible so the same session is not spoken twice", () => {
     expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
-    expect(agentProgressSource).toContain('shouldAutoPlayTTSForVariant(variant, isSnoozed, isFocused, isFloatingPanelVisible)')
+    expect(agentProgressSource).toContain('shouldAutoPlayTTSForVariant(messageVariant, isSnoozed, isFocused, isFloatingPanelVisible)')
     expect(agentProgressSource).toContain('const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)')
   })
 

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -5,6 +5,7 @@ import { useAgentStore, useConversationStore } from '@renderer/stores'
 import { AgentProgressUpdate, QueuedMessage } from '@shared/types'
 import { queryClient } from '@renderer/lib/queries'
 import { ttsManager } from '@renderer/lib/tts-manager'
+import { clearSessionTTSTracking } from '@renderer/lib/tts-tracking'
 import { logUI } from '@renderer/lib/debug'
 
 const areStringArraysEqual = (left: string[], right: string[]): boolean => {
@@ -136,6 +137,16 @@ export function useStoreSync() {
     )
     return unlisten
   }, [setSessionSnoozed])
+
+  // Clear stale TTS tracking keys for a session (sent before speakOnTrigger unsnooze)
+  useEffect(() => {
+    const unlisten = rendererHandlers.clearSessionTTSKeys.listen(
+      (sessionId: string) => {
+        clearSessionTTSTracking(sessionId)
+      }
+    )
+    return unlisten
+  }, [])
 
   // Listen for message queue updates
   useEffect(() => {


### PR DESCRIPTION
## Problem

For `continueInSession` loops (like `good-morning`), the sessionId is reused across daily runs via `reviveSession()`. The TTS tracking set (`sessionsWithTTSPlayed`) retains entries from previous runs because the key format includes `sessionId`. When the new run completes and we unsnooze via `speakOnTrigger`, `hasTTSPlayed()` returns true for the stale keys, causing the auto-play effect to bail.

This is a **second root cause** on top of PR #371 (which fixed snoozed sessions never unsnoozing). PR #371 correctly unsnoozes the session after completion, but the TTS tracking collision still blocks auto-play.

## Fix

Add a `clearSessionTTSKeys` IPC handler that clears all TTS tracking keys for a given session. Send it from `loop-service.ts` to all renderer windows **before** the `speakOnTrigger` unsnooze, so the auto-play gate fires fresh.

### Flow (after both fixes)

1. Loop task starts → session runs snoozed in background (PR #371)
2. Loop completes → `speakOnTrigger` fires
3. **NEW:** Clear stale TTS tracking keys for the session across all renderers
4. Unsnooze the session → renderer updates `isSnoozed=false`
5. Show panel + focus session → `CompactMessageBase` re-renders
6. TTS auto-play effect fires → `hasTTSPlayed()` returns false → TTS generates and plays ✅

## Files changed

- **`renderer-handlers.ts`** — Added `clearSessionTTSKeys` renderer handler type
- **`loop-service.ts`** — Send `clearSessionTTSKeys` to all windows before speakOnTrigger unsnooze
- **`use-store-sync.ts`** — Listen for `clearSessionTTSKeys` and call `clearSessionTTSTracking(sessionId)`
- **`agent-progress.snoozed-tts.test.ts`** — Fix param name `variant` → `messageVariant` (from PR #371)
