### PR TITLE
Store secrets outside shareable agents config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,6 +38,9 @@ docker-compose.yml
 .env.*
 !.env.example
 
+# Local-only DotAgents secret material
+**/.agents/secrets.local.json*
+
 # Logs
 *.log
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ tmp/
 
 # Local .agents backup snapshots
 .agents/.backups/
+**/.agents/secrets.local.json*
 
 # Local factory/agent scaffolding
 .factory/

--- a/apps/desktop/src/main/agents-files/modular-config.test.ts
+++ b/apps/desktop/src/main/agents-files/modular-config.test.ts
@@ -11,6 +11,7 @@ import {
   writeAgentsLayerFromConfig,
   writeAgentsPrompts,
 } from "./modular-config"
+import { AGENTS_SECRETS_LOCAL_JSON, SECRET_REF_PREFIX } from "../../../../../packages/core/src/agents-files/secrets"
 
 const DEFAULT_PROMPT = "DEFAULT PROMPT\nLine2"
 
@@ -96,8 +97,15 @@ describe("modular-config", () => {
 
     expect(settings.textInputEnabled).toBe(false)
     expect(mcp.mcpMaxIterations).toBe(99)
-    expect(models.openaiApiKey).toBe("sk-test")
+    expect(models.openaiApiKey).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
     expect(layout.themePreference).toBe("dark")
+
+    const secrets = JSON.parse(fs.readFileSync(path.join(agentsDir, AGENTS_SECRETS_LOCAL_JSON), "utf8"))
+    expect(Object.values(secrets.secrets)).toContain("sk-test")
+    expect(fs.readFileSync(path.join(agentsDir, ".gitignore"), "utf8")).toContain(`/${AGENTS_SECRETS_LOCAL_JSON}*`)
+
+    const loaded = loadAgentsLayerConfig(layer)
+    expect(loaded.openaiApiKey).toBe("sk-test")
   })
 
   it("finds .agents directory upward", () => {

--- a/apps/desktop/src/main/agents-files/modular-config.test.ts
+++ b/apps/desktop/src/main/agents-files/modular-config.test.ts
@@ -102,7 +102,7 @@ describe("modular-config", () => {
 
     const secrets = JSON.parse(fs.readFileSync(path.join(agentsDir, AGENTS_SECRETS_LOCAL_JSON), "utf8"))
     expect(Object.values(secrets.secrets)).toContain("sk-test")
-    expect(fs.readFileSync(path.join(agentsDir, ".gitignore"), "utf8")).toContain(`/${AGENTS_SECRETS_LOCAL_JSON}*`)
+    expect(fs.readFileSync(path.join(agentsDir, ".gitignore"), "utf8")).toContain(`**/${AGENTS_SECRETS_LOCAL_JSON}*`)
 
     const loaded = loadAgentsLayerConfig(layer)
     expect(loaded.openaiApiKey).toBe("sk-test")

--- a/apps/desktop/src/main/agents-files/modular-config.test.ts
+++ b/apps/desktop/src/main/agents-files/modular-config.test.ts
@@ -11,7 +11,7 @@ import {
   writeAgentsLayerFromConfig,
   writeAgentsPrompts,
 } from "./modular-config"
-import { AGENTS_SECRETS_LOCAL_JSON, SECRET_REF_PREFIX } from "../../../../../packages/core/src/agents-files/secrets"
+import { AGENTS_SECRETS_LOCAL_JSON, SECRET_REF_PREFIX } from "./secrets"
 
 const DEFAULT_PROMPT = "DEFAULT PROMPT\nLine2"
 

--- a/apps/desktop/src/main/agents-files/secrets.ts
+++ b/apps/desktop/src/main/agents-files/secrets.ts
@@ -1,0 +1,11 @@
+// Explicit bindings keep Electron main-process bundling from emitting
+// side-effect-only imports with undefined re-export references.
+import {
+  AGENTS_SECRETS_LOCAL_JSON,
+  SECRET_REF_PREFIX,
+} from "../../../../../packages/core/src/agents-files/secrets"
+
+export {
+  AGENTS_SECRETS_LOCAL_JSON,
+  SECRET_REF_PREFIX,
+}

--- a/apps/desktop/src/main/agents-files/secrets.ts
+++ b/apps/desktop/src/main/agents-files/secrets.ts
@@ -3,7 +3,7 @@
 import {
   AGENTS_SECRETS_LOCAL_JSON,
   SECRET_REF_PREFIX,
-} from "../../../../../packages/core/src/agents-files/secrets"
+} from "@dotagents/core"
 
 export {
   AGENTS_SECRETS_LOCAL_JSON,

--- a/apps/desktop/src/main/sandbox-service.test.ts
+++ b/apps/desktop/src/main/sandbox-service.test.ts
@@ -97,6 +97,7 @@ describe("sandbox-service", () => {
         JSON.stringify({ secrets: { apiKey: "sk-secret" } }),
       )
       fs.writeFileSync(path.join(agentsDir, "secrets.local.json.tmp-123"), "sk-secret")
+      fs.writeFileSync(path.join(agentsDir, "secrets.local.json~"), "sk-secret")
 
       const nestedSkillDir = path.join(agentsDir, "skills", "local-secret-test")
       fs.mkdirSync(nestedSkillDir, { recursive: true })
@@ -108,6 +109,7 @@ describe("sandbox-service", () => {
       const slotDir = path.join(agentsDir, ".sandboxes", "default")
       expect(fs.existsSync(path.join(slotDir, "secrets.local.json"))).toBe(false)
       expect(fs.existsSync(path.join(slotDir, "secrets.local.json.tmp-123"))).toBe(false)
+      expect(fs.existsSync(path.join(slotDir, "secrets.local.json~"))).toBe(false)
       expect(fs.existsSync(path.join(slotDir, "skills", "local-secret-test", "skill.md"))).toBe(true)
       expect(
         fs.existsSync(path.join(slotDir, "skills", "local-secret-test", "secrets.local.json")),

--- a/apps/desktop/src/main/sandbox-service.test.ts
+++ b/apps/desktop/src/main/sandbox-service.test.ts
@@ -90,6 +90,29 @@ describe("sandbox-service", () => {
       const content = JSON.parse(fs.readFileSync(slotSettingsPath, "utf-8"))
       expect(content.theme).toBe("dark")
     })
+
+    it("does not copy local secret store files into sandbox snapshots", () => {
+      fs.writeFileSync(
+        path.join(agentsDir, "secrets.local.json"),
+        JSON.stringify({ secrets: { apiKey: "sk-secret" } }),
+      )
+      fs.writeFileSync(path.join(agentsDir, "secrets.local.json.tmp-123"), "sk-secret")
+
+      const nestedSkillDir = path.join(agentsDir, "skills", "local-secret-test")
+      fs.mkdirSync(nestedSkillDir, { recursive: true })
+      fs.writeFileSync(path.join(nestedSkillDir, "skill.md"), "# Test")
+      fs.writeFileSync(path.join(nestedSkillDir, "secrets.local.json"), "sk-nested")
+
+      saveBaseline(agentsDir)
+
+      const slotDir = path.join(agentsDir, ".sandboxes", "default")
+      expect(fs.existsSync(path.join(slotDir, "secrets.local.json"))).toBe(false)
+      expect(fs.existsSync(path.join(slotDir, "secrets.local.json.tmp-123"))).toBe(false)
+      expect(fs.existsSync(path.join(slotDir, "skills", "local-secret-test", "skill.md"))).toBe(true)
+      expect(
+        fs.existsSync(path.join(slotDir, "skills", "local-secret-test", "secrets.local.json")),
+      ).toBe(false)
+    })
   })
 
   describe("saveCurrentAsSlot", () => {

--- a/apps/desktop/src/main/sandbox-service.ts
+++ b/apps/desktop/src/main/sandbox-service.ts
@@ -11,6 +11,7 @@
 import fs from "fs"
 import path from "path"
 import { logApp } from "./debug"
+import { AGENTS_SECRETS_LOCAL_JSON } from "./agents-files/secrets"
 
 // ============================================================================
 // Types
@@ -64,7 +65,6 @@ const SANDBOXES_DIR = ".sandboxes"
 const SLOT_MANIFEST_FILE = "slot-manifest.json"
 const ACTIVE_SLOT_FILE = "active-slot.json"
 const DEFAULT_SLOT_NAME = "default"
-const AGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"
 
 // Files/dirs from .agents that belong to a slot snapshot
 const SNAPSHOT_ITEMS = [
@@ -136,7 +136,7 @@ function copyDirRecursiveSync(src: string, dest: string): void {
   if (stats.isDirectory() && EXCLUDED_DIRS.has(entryName)) return
   if (
     stats.isFile() &&
-    EXCLUDED_FILE_PREFIXES.some((prefix) => entryName === prefix || entryName.startsWith(`${prefix}.`))
+    EXCLUDED_FILE_PREFIXES.some((prefix) => entryName.startsWith(prefix))
   ) return
   if (stats.isSymbolicLink()) return // skip symlinks for safety
   if (stats.isFile()) {

--- a/apps/desktop/src/main/sandbox-service.ts
+++ b/apps/desktop/src/main/sandbox-service.ts
@@ -64,6 +64,7 @@ const SANDBOXES_DIR = ".sandboxes"
 const SLOT_MANIFEST_FILE = "slot-manifest.json"
 const ACTIVE_SLOT_FILE = "active-slot.json"
 const DEFAULT_SLOT_NAME = "default"
+const AGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"
 
 // Files/dirs from .agents that belong to a slot snapshot
 const SNAPSHOT_ITEMS = [
@@ -81,6 +82,9 @@ const SNAPSHOT_ITEMS = [
 
 // Directories that should not be included in snapshots
 const EXCLUDED_DIRS = new Set([SANDBOXES_DIR, ".backups", ".restore-staging"])
+
+// Local secret store files should never be copied into sandbox snapshots.
+const EXCLUDED_FILE_PREFIXES = [`${AGENTS_SECRETS_LOCAL_JSON}`]
 
 // ============================================================================
 // Helpers
@@ -128,6 +132,12 @@ function copyDirRecursiveSync(src: string, dest: string): void {
   if (!fs.existsSync(src)) return
   // Use lstatSync to avoid following symlinks — prevents traversing outside .agents
   const stats = fs.lstatSync(src)
+  const entryName = path.basename(src)
+  if (stats.isDirectory() && EXCLUDED_DIRS.has(entryName)) return
+  if (
+    stats.isFile() &&
+    EXCLUDED_FILE_PREFIXES.some((prefix) => entryName === prefix || entryName.startsWith(`${prefix}.`))
+  ) return
   if (stats.isSymbolicLink()) return // skip symlinks for safety
   if (stats.isFile()) {
     fs.mkdirSync(path.dirname(dest), { recursive: true })

--- a/apps/desktop/src/renderer/src/components/model-preset-manager.tsx
+++ b/apps/desktop/src/renderer/src/components/model-preset-manager.tsx
@@ -391,6 +391,9 @@ export function ModelPresetManager({
                 onChange={(e) => setNewPreset({ ...newPreset, apiKey: e.target.value })}
                 placeholder="sk-..."
               />
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Stored in local secret storage; shareable .agents config keeps only a secret reference.
+              </p>
             </div>
 
             {/* Model Preferences Section */}
@@ -504,6 +507,9 @@ export function ModelPresetManager({
                   }
                   placeholder="sk-..."
                 />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Stored in local secret storage; shareable .agents config keeps only a secret reference.
+                </p>
               </div>
 
               {/* Model Preferences Section */}

--- a/apps/desktop/src/renderer/src/pages/settings-discord.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-discord.tsx
@@ -189,7 +189,8 @@ export function Component() {
           </Control>
 
           <div className="px-3 py-1 text-sm text-muted-foreground">
-            Discord needs the bot token plus the Message Content intent enabled in the Discord developer portal.
+            Discord needs the bot token plus the Message Content intent enabled in the Discord developer portal. The token is
+            stored in local secret storage; shareable .agents config keeps only a secret reference.
           </div>
 
           <div className="px-3 pb-3">

--- a/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
@@ -159,6 +159,7 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
     Control: (props: any) => ({ type: "Control", props }),
     ControlGroup: (props: any) => props.children,
     ControlLabel: (props: any) => props.label,
+    SettingsSearchContext: { Provider: PassThrough },
   }
   const inputMock = { Input: (props: any) => ({ type: "Input", props }) }
   const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
@@ -195,7 +196,7 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   vi.doMock("@renderer/lib/tipc-client", () => tipcClientMock)
   vi.doMock("../lib/tipc-client", () => tipcClientMock)
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null }))
+  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null, Search: Null, X: Null }))
   vi.doMock("@dotagents/shared", () => ({ __esModule: true, STT_PROVIDER_ID: {}, SUPPORTED_LANGUAGES: [] }))
   vi.doMock("@shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))
   vi.doMock("../shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -1398,6 +1398,9 @@ export function Component() {
                   placeholder="sk-lf-..."
                   className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
                 />
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Stored in local secret storage; shareable .agents config keeps only a secret reference.
+                </p>
               </Control>
 
               <Control label={<ControlLabel label="Base URL" tooltip="Langfuse API endpoint. Leave empty for Langfuse Cloud (cloud.langfuse.com)" />} className="px-3">

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -840,17 +840,24 @@ export function Component() {
     },
   ) => (
     <Control label={label} className="px-3">
-      <Input
-        type={type}
-        placeholder={placeholder}
-        value={providerDrafts[key]}
-        onChange={(e) => {
-          updateProviderDraft(key, e.currentTarget.value)
-        }}
-        onBlur={(e) => {
-          flushProviderSave(key, e.currentTarget.value)
-        }}
-      />
+      <div className="space-y-1">
+        <Input
+          type={type}
+          placeholder={placeholder}
+          value={providerDrafts[key]}
+          onChange={(e) => {
+            updateProviderDraft(key, e.currentTarget.value)
+          }}
+          onBlur={(e) => {
+            flushProviderSave(key, e.currentTarget.value)
+          }}
+        />
+        {type === "password" && (
+          <p className="text-[11px] text-muted-foreground">
+            Stored in local secret storage; shareable .agents config files keep only a secret reference.
+          </p>
+        )}
+      </div>
     </Control>
   )
 

--- a/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
@@ -308,6 +308,9 @@ export function RemoteServerSettingsGroups({
                     Copy disabled in Streamer Mode
                   </div>
                 )}
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  Stored in local secret storage; shareable .agents config keeps only a secret reference.
+                </p>
               </Control>
 
               <Control label={<ControlLabel label="Log Level" tooltip="Fastify logger level" />} className="px-3">

--- a/packages/core/src/agents-files/modular-config.test.ts
+++ b/packages/core/src/agents-files/modular-config.test.ts
@@ -108,6 +108,23 @@ describe("modular-config", () => {
     expect(loaded.openaiApiKey).toBe("sk-test")
   })
 
+  it("does not re-import stale plaintext secrets from disk while saving current config", () => {
+    const dir = mkTempDir("dotagents-modular-stale-secrets-")
+    const agentsDir = path.join(dir, ".agents")
+    const layer = getAgentsLayerPaths(agentsDir)
+
+    writeJson(layer.modelsJsonPath, { openaiApiKey: "sk-stale" })
+
+    writeAgentsLayerFromConfig(layer, { openaiApiKey: "sk-current" } as Config)
+
+    const loaded = loadAgentsLayerConfig(layer)
+    const secrets = JSON.parse(fs.readFileSync(path.join(agentsDir, AGENTS_SECRETS_LOCAL_JSON), "utf8"))
+
+    expect(loaded.openaiApiKey).toBe("sk-current")
+    expect(Object.values(secrets.secrets)).toContain("sk-current")
+    expect(Object.values(secrets.secrets)).not.toContain("sk-stale")
+  })
+
   it("stores nested MCP and provider credentials as local secret refs", () => {
     const dir = mkTempDir("dotagents-modular-secrets-")
     const agentsDir = path.join(dir, ".agents")

--- a/packages/core/src/agents-files/modular-config.test.ts
+++ b/packages/core/src/agents-files/modular-config.test.ts
@@ -11,6 +11,7 @@ import {
   writeAgentsLayerFromConfig,
   writeAgentsPrompts,
 } from "./modular-config"
+import { AGENTS_SECRETS_LOCAL_JSON, SECRET_REF_PREFIX } from "./secrets"
 
 const DEFAULT_PROMPT = "DEFAULT PROMPT\nLine2"
 
@@ -96,8 +97,60 @@ describe("modular-config", () => {
 
     expect(settings.textInputEnabled).toBe(false)
     expect(mcp.mcpMaxIterations).toBe(99)
-    expect(models.openaiApiKey).toBe("sk-test")
+    expect(models.openaiApiKey).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
     expect(layout.themePreference).toBe("dark")
+
+    const secrets = JSON.parse(fs.readFileSync(path.join(agentsDir, AGENTS_SECRETS_LOCAL_JSON), "utf8"))
+    expect(Object.values(secrets.secrets)).toContain("sk-test")
+    expect(fs.readFileSync(path.join(agentsDir, ".gitignore"), "utf8")).toContain(`/${AGENTS_SECRETS_LOCAL_JSON}*`)
+
+    const loaded = loadAgentsLayerConfig(layer)
+    expect(loaded.openaiApiKey).toBe("sk-test")
+  })
+
+  it("stores nested MCP and provider credentials as local secret refs", () => {
+    const dir = mkTempDir("dotagents-modular-secrets-")
+    const agentsDir = path.join(dir, ".agents")
+    const layer = getAgentsLayerPaths(agentsDir)
+
+    const config = {
+      langfusePublicKey: "pk-lf-public",
+      langfuseSecretKey: "sk-lf-secret",
+      modelPresets: [{ id: "openrouter", name: "OpenRouter", baseUrl: "https://openrouter.ai/api/v1", apiKey: "sk-model" }],
+      mcpConfig: {
+        mcpServers: {
+          github: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-github"],
+            env: { GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_secret", SAFE_FLAG: "1" },
+            headers: { Authorization: "Bearer server-secret", Accept: "application/json" },
+            oauth: { clientSecret: "oauth-secret", serverMetadata: { token_endpoint: "https://example.com/token" } },
+          },
+        },
+      },
+    } as unknown as Config
+
+    writeAgentsLayerFromConfig(layer, config)
+
+    const settings = JSON.parse(fs.readFileSync(layer.settingsJsonPath, "utf8"))
+    const models = JSON.parse(fs.readFileSync(layer.modelsJsonPath, "utf8"))
+    const mcp = JSON.parse(fs.readFileSync(layer.mcpJsonPath, "utf8"))
+
+    expect(settings.langfusePublicKey).toBe("pk-lf-public")
+    expect(settings.langfuseSecretKey).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(models.modelPresets[0].apiKey).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(mcp.mcpConfig.mcpServers.github.env.GITHUB_PERSONAL_ACCESS_TOKEN).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(mcp.mcpConfig.mcpServers.github.headers.Authorization).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(mcp.mcpConfig.mcpServers.github.headers.Accept).toBe("application/json")
+    expect(mcp.mcpConfig.mcpServers.github.oauth.clientSecret).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(mcp.mcpConfig.mcpServers.github.oauth.serverMetadata.token_endpoint).toBe("https://example.com/token")
+
+    const loaded = loadAgentsLayerConfig(layer)
+    expect(loaded.langfuseSecretKey).toBe("sk-lf-secret")
+    expect(loaded.modelPresets[0].apiKey).toBe("sk-model")
+    expect(loaded.mcpConfig.mcpServers.github.env.GITHUB_PERSONAL_ACCESS_TOKEN).toBe("ghp_secret")
+    expect(loaded.mcpConfig.mcpServers.github.headers.Authorization).toBe("Bearer server-secret")
+    expect(loaded.mcpConfig.mcpServers.github.oauth.clientSecret).toBe("oauth-secret")
   })
 
   it("does not rewrite layer JSON files when the in-memory value is unchanged", () => {

--- a/packages/core/src/agents-files/modular-config.test.ts
+++ b/packages/core/src/agents-files/modular-config.test.ts
@@ -102,7 +102,7 @@ describe("modular-config", () => {
 
     const secrets = JSON.parse(fs.readFileSync(path.join(agentsDir, AGENTS_SECRETS_LOCAL_JSON), "utf8"))
     expect(Object.values(secrets.secrets)).toContain("sk-test")
-    expect(fs.readFileSync(path.join(agentsDir, ".gitignore"), "utf8")).toContain(`/${AGENTS_SECRETS_LOCAL_JSON}*`)
+    expect(fs.readFileSync(path.join(agentsDir, ".gitignore"), "utf8")).toContain(`**/${AGENTS_SECRETS_LOCAL_JSON}*`)
 
     const loaded = loadAgentsLayerConfig(layer)
     expect(loaded.openaiApiKey).toBe("sk-test")

--- a/packages/core/src/agents-files/modular-config.ts
+++ b/packages/core/src/agents-files/modular-config.ts
@@ -8,6 +8,12 @@ import {
   safeWriteJsonFileSync,
 } from "./safe-file"
 import { parseFrontmatterOrBody, stringifyFrontmatterDocument } from "./frontmatter"
+import {
+  getAgentsSecretsLocalPath,
+  migrateJsonFileSecretsToLocalStore,
+  prepareConfigForPersistence,
+  resolveSecretRefs,
+} from "./secrets"
 
 export const AGENTS_DIR_NAME = ".agents"
 export const AGENTS_BACKUPS_DIR_NAME = ".backups"
@@ -98,7 +104,10 @@ export function loadAgentsLayerConfig(layer: AgentsLayerPaths): Partial<Config> 
     defaultValue: {},
   })
 
-  return { ...settings, ...models, ...mcp, ...layout }
+  return resolveSecretRefs(
+    { ...settings, ...models, ...mcp, ...layout },
+    getAgentsSecretsLocalPath(layer.agentsDir),
+  )
 }
 
 export function loadAgentsPrompts(layer: AgentsLayerPaths): { systemPrompt: string | null, agentsGuidelines: string | null } {
@@ -264,10 +273,16 @@ export function writeAgentsLayerFromConfig(
   ensureDirSync(layer.agentsDir)
   ensureDirSync(layer.layoutsDir)
 
-  const split = splitConfigIntoAgentsFiles(config)
+  const secretsFilePath = getAgentsSecretsLocalPath(layer.agentsDir)
+  const configForDisk = prepareConfigForPersistence(
+    config,
+    secretsFilePath,
+  )
+  const split = splitConfigIntoAgentsFiles(configForDisk)
 
   const writeJsonIfNeeded = (filePath: string, value: unknown) => {
     if (onlyIfMissing && fileExists(filePath)) return
+    migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true)
     safeWriteJsonFileSync(filePath, value, {
       backupDir: layer.backupsDir,
       maxBackups,

--- a/packages/core/src/agents-files/modular-config.ts
+++ b/packages/core/src/agents-files/modular-config.ts
@@ -282,7 +282,10 @@ export function writeAgentsLayerFromConfig(
 
   const writeJsonIfNeeded = (filePath: string, value: unknown) => {
     if (onlyIfMissing && fileExists(filePath)) return
-    migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true)
+    migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true, {
+      backupDir: layer.backupsDir,
+      maxBackups,
+    })
     safeWriteJsonFileSync(filePath, value, {
       backupDir: layer.backupsDir,
       maxBackups,

--- a/packages/core/src/agents-files/modular-config.ts
+++ b/packages/core/src/agents-files/modular-config.ts
@@ -10,7 +10,6 @@ import {
 import { parseFrontmatterOrBody, stringifyFrontmatterDocument } from "./frontmatter"
 import {
   getAgentsSecretsLocalPath,
-  migrateJsonFileSecretsToLocalStore,
   prepareConfigForPersistence,
   resolveSecretRefs,
 } from "./secrets"
@@ -282,10 +281,6 @@ export function writeAgentsLayerFromConfig(
 
   const writeJsonIfNeeded = (filePath: string, value: unknown) => {
     if (onlyIfMissing && fileExists(filePath)) return
-    migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true, {
-      backupDir: layer.backupsDir,
-      maxBackups,
-    })
     safeWriteJsonFileSync(filePath, value, {
       backupDir: layer.backupsDir,
       maxBackups,

--- a/packages/core/src/agents-files/secrets.test.ts
+++ b/packages/core/src/agents-files/secrets.test.ts
@@ -4,6 +4,7 @@ import os from "os"
 import path from "path"
 import {
   AGENTS_SECRETS_LOCAL_JSON,
+  extractSecretsForPersistence,
   migrateJsonFileSecretsToLocalStore,
   resolveSecretRefs,
   SECRET_REF_PREFIX,
@@ -14,6 +15,22 @@ function mkTempDir(prefix: string): string {
 }
 
 describe("agents-files secrets", () => {
+  it("generates distinct secret refs for paths that only differ by dot placement", () => {
+    const extracted = extractSecretsForPersistence({
+      "service.prod": { apiKey: "sk-dot-segment" },
+      service: { prod: { apiKey: "sk-nested" } },
+    })
+
+    const dotSegmentRef = extracted.value["service.prod"].apiKey
+    const nestedRef = extracted.value.service.prod.apiKey
+
+    expect(dotSegmentRef).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(nestedRef).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(dotSegmentRef).not.toBe(nestedRef)
+    expect(Object.keys(extracted.secrets)).toHaveLength(2)
+    expect(Object.values(extracted.secrets).sort()).toEqual(["sk-dot-segment", "sk-nested"])
+  })
+
   it("preserves unresolved secret refs instead of replacing them with empty strings", () => {
     const dir = mkTempDir("dotagents-secret-refs-")
     const secretsFilePath = path.join(dir, AGENTS_SECRETS_LOCAL_JSON)

--- a/packages/core/src/agents-files/secrets.test.ts
+++ b/packages/core/src/agents-files/secrets.test.ts
@@ -4,6 +4,7 @@ import os from "os"
 import path from "path"
 import {
   AGENTS_SECRETS_LOCAL_JSON,
+  ensureAgentsSecretsGitignore,
   extractSecretsForPersistence,
   migrateJsonFileSecretsToLocalStore,
   resolveSecretRefs,
@@ -29,6 +30,19 @@ describe("agents-files secrets", () => {
     expect(dotSegmentRef).not.toBe(nestedRef)
     expect(Object.keys(extracted.secrets)).toHaveLength(2)
     expect(Object.values(extracted.secrets).sort()).toEqual(["sk-dot-segment", "sk-nested"])
+  })
+
+  it("writes a recursive idempotent gitignore pattern for local secret store files", () => {
+    const dir = mkTempDir("dotagents-secret-gitignore-")
+    const agentsDir = path.join(dir, ".agents")
+    const gitignorePath = path.join(agentsDir, ".gitignore")
+
+    ensureAgentsSecretsGitignore(agentsDir)
+    ensureAgentsSecretsGitignore(agentsDir)
+
+    const lines = fs.readFileSync(gitignorePath, "utf8").split(/\r?\n/)
+    const secretIgnoreLines = lines.filter((line) => line.trim() === `**/${AGENTS_SECRETS_LOCAL_JSON}*`)
+    expect(secretIgnoreLines).toHaveLength(1)
   })
 
   it("preserves unresolved secret refs instead of replacing them with empty strings", () => {

--- a/packages/core/src/agents-files/secrets.test.ts
+++ b/packages/core/src/agents-files/secrets.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import {
+  AGENTS_SECRETS_LOCAL_JSON,
+  migrateJsonFileSecretsToLocalStore,
+  resolveSecretRefs,
+  SECRET_REF_PREFIX,
+} from "./secrets"
+
+function mkTempDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+describe("agents-files secrets", () => {
+  it("preserves unresolved secret refs instead of replacing them with empty strings", () => {
+    const dir = mkTempDir("dotagents-secret-refs-")
+    const secretsFilePath = path.join(dir, AGENTS_SECRETS_LOCAL_JSON)
+    const missingRef = `${SECRET_REF_PREFIX}openaiApiKey`
+
+    fs.writeFileSync(secretsFilePath, JSON.stringify({ version: 1, secrets: {} }), "utf8")
+
+    const resolved = resolveSecretRefs({ openaiApiKey: missingRef }, secretsFilePath)
+
+    expect(resolved.openaiApiKey).toBe(missingRef)
+  })
+
+  it("migrates plaintext secrets with safe backup writes", () => {
+    const dir = mkTempDir("dotagents-secret-migration-")
+    const configFilePath = path.join(dir, "models.json")
+    const secretsFilePath = path.join(dir, AGENTS_SECRETS_LOCAL_JSON)
+    const backupDir = path.join(dir, ".backups")
+
+    fs.writeFileSync(
+      configFilePath,
+      JSON.stringify({ openaiApiKey: "sk-test", themePreference: "dark" }, null, 2),
+      "utf8",
+    )
+
+    migrateJsonFileSecretsToLocalStore(configFilePath, secretsFilePath, true, { backupDir })
+
+    const migrated = JSON.parse(fs.readFileSync(configFilePath, "utf8"))
+    expect(migrated.openaiApiKey).toMatch(new RegExp(`^${SECRET_REF_PREFIX}`))
+    expect(migrated.themePreference).toBe("dark")
+
+    const secrets = JSON.parse(fs.readFileSync(secretsFilePath, "utf8"))
+    expect(Object.values(secrets.secrets)).toContain("sk-test")
+
+    const backups = fs.readdirSync(backupDir).filter((file) => file.endsWith(".bak"))
+    expect(backups.length).toBe(1)
+    expect(JSON.parse(fs.readFileSync(path.join(backupDir, backups[0]), "utf8"))).toEqual({
+      openaiApiKey: "sk-test",
+      themePreference: "dark",
+    })
+  })
+})

--- a/packages/core/src/agents-files/secrets.ts
+++ b/packages/core/src/agents-files/secrets.ts
@@ -54,10 +54,12 @@ function stablePathSegment(index: number, value: unknown): string {
   return `index:${index}`
 }
 
+function encodeSecretIdSegment(segment: string): string {
+  return encodeURIComponent(segment).replace(/\./g, "%2E")
+}
+
 function secretIdForPath(pathSegments: string[]): string {
-  return pathSegments
-    .map((segment) => segment.replace(/[^a-zA-Z0-9._:-]/g, "_"))
-    .join(".")
+  return pathSegments.map(encodeSecretIdSegment).join(".")
 }
 
 export function getAgentsSecretsLocalPath(agentsDir: string): string {

--- a/packages/core/src/agents-files/secrets.ts
+++ b/packages/core/src/agents-files/secrets.ts
@@ -127,7 +127,7 @@ export function mergeSecretsIntoLocalStore(
 
 export function ensureAgentsSecretsGitignore(agentsDir: string): void {
   const gitignorePath = path.join(agentsDir, ".gitignore")
-  const ignoreLine = `/${AGENTS_SECRETS_LOCAL_JSON}*`
+  const ignoreLine = `**/${AGENTS_SECRETS_LOCAL_JSON}*`
   try {
     fs.mkdirSync(agentsDir, { recursive: true })
     const existing = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : ""

--- a/packages/core/src/agents-files/secrets.ts
+++ b/packages/core/src/agents-files/secrets.ts
@@ -1,5 +1,6 @@
 import fs from "fs"
 import path from "path"
+import { safeWriteJsonFileSync } from "./safe-file"
 
 export const AGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"
 export const SECRET_REF_PREFIX = "dotagents-secret://"
@@ -202,6 +203,7 @@ export function migrateJsonFileSecretsToLocalStore(
   filePath: string,
   secretsFilePath: string,
   pretty: boolean,
+  options: { backupDir?: string; maxBackups?: number } = {},
 ): void {
   try {
     if (!fs.existsSync(filePath)) return
@@ -211,11 +213,12 @@ export function migrateJsonFileSecretsToLocalStore(
 
     if (JSON.stringify(parsed) === JSON.stringify(sanitized)) return
 
-    fs.writeFileSync(
-      filePath,
-      `${JSON.stringify(sanitized, null, pretty ? 2 : 0)}\n`,
-      { encoding: "utf8" },
-    )
+    safeWriteJsonFileSync(filePath, sanitized, {
+      backupDir: options.backupDir,
+      maxBackups: options.maxBackups,
+      pretty,
+      skipIfUnchanged: true,
+    })
   } catch {
     // Best effort: never block config writes on local secret migration.
   }
@@ -231,7 +234,7 @@ export function resolveSecretRefs<T>(value: T, secretsFilePath: string): T {
     }
     if (isSecretRef(current)) {
       const id = secretIdFromRef(current)
-      return id ? store.secrets[id] ?? "" : ""
+      return id ? (store.secrets[id] ?? current) : current
     }
     return current
   }

--- a/packages/core/src/agents-files/secrets.ts
+++ b/packages/core/src/agents-files/secrets.ts
@@ -1,0 +1,240 @@
+import fs from "fs"
+import path from "path"
+
+export const AGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"
+export const SECRET_REF_PREFIX = "dotagents-secret://"
+
+type SecretStoreFile = {
+  version: 1
+  secrets: Record<string, string>
+}
+
+type ExtractResult<T> = {
+  value: T
+  secrets: Record<string, string>
+  clearedSecretIds: string[]
+  changed: boolean
+}
+
+const NON_SECRET_KEY_NAMES = new Set([
+  "publickey",
+  "langfusepublickey",
+  "tokenendpoint",
+  "tokenendpointauthmethod",
+  "tokenendpointauthmethodssupported",
+  "tokentype",
+  "tokencount",
+  "tokenconfigured",
+  "maxtokens",
+])
+
+function normalizeKeyName(key: string): string {
+  return key.replace(/[^a-zA-Z0-9]/g, "").toLowerCase()
+}
+
+function isSecretBearingKey(key: string): boolean {
+  const normalized = normalizeKeyName(key)
+  if (!normalized || NON_SECRET_KEY_NAMES.has(normalized)) return false
+  if (normalized === "authorization" || normalized === "proxyauthorization") return true
+  if (normalized === "apikey" || normalized.endsWith("apikey") || normalized.includes("xapikey")) return true
+  if (normalized.includes("secret") || normalized.includes("password") || normalized.includes("credential")) return true
+  if (normalized === "accesstoken" || normalized === "refreshtoken" || normalized.endsWith("authtoken")) return true
+  if (normalized.includes("bearer")) return true
+  if (normalized.includes("token") && !normalized.includes("endpoint")) return true
+  if (normalized === "codeverifier") return true
+  return false
+}
+
+function stablePathSegment(index: number, value: unknown): string {
+  if (value && typeof value === "object") {
+    const id = (value as Record<string, unknown>).id
+    if (typeof id === "string" && id.trim()) return `id:${id.trim()}`
+  }
+  return `index:${index}`
+}
+
+function secretIdForPath(pathSegments: string[]): string {
+  return pathSegments
+    .map((segment) => segment.replace(/[^a-zA-Z0-9._:-]/g, "_"))
+    .join(".")
+}
+
+export function getAgentsSecretsLocalPath(agentsDir: string): string {
+  return path.join(agentsDir, AGENTS_SECRETS_LOCAL_JSON)
+}
+
+export function isSecretRef(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(SECRET_REF_PREFIX)
+}
+
+export function makeSecretRef(secretId: string): string {
+  return `${SECRET_REF_PREFIX}${encodeURIComponent(secretId)}`
+}
+
+function secretIdFromRef(ref: string): string | null {
+  if (!isSecretRef(ref)) return null
+  try {
+    return decodeURIComponent(ref.slice(SECRET_REF_PREFIX.length))
+  } catch {
+    return null
+  }
+}
+
+function readSecretStore(filePath: string): SecretStoreFile {
+  try {
+    if (!fs.existsSync(filePath)) return { version: 1, secrets: {} }
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8")) as Partial<SecretStoreFile>
+    if (!parsed || typeof parsed !== "object" || typeof parsed.secrets !== "object" || !parsed.secrets) {
+      return { version: 1, secrets: {} }
+    }
+    return {
+      version: 1,
+      secrets: Object.fromEntries(
+        Object.entries(parsed.secrets).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+      ),
+    }
+  } catch {
+    return { version: 1, secrets: {} }
+  }
+}
+
+function writeSecretStore(filePath: string, store: SecretStoreFile): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`
+  fs.writeFileSync(tmpPath, `${JSON.stringify(store, null, 2)}\n`, { encoding: "utf8", mode: 0o600 })
+  fs.renameSync(tmpPath, filePath)
+  try {
+    fs.chmodSync(filePath, 0o600)
+  } catch {
+    // Best effort: Windows and some filesystems may ignore POSIX permissions.
+  }
+}
+
+export function mergeSecretsIntoLocalStore(
+  filePath: string,
+  secrets: Record<string, string>,
+  clearedSecretIds: string[] = [],
+): void {
+  const store = readSecretStore(filePath)
+  for (const id of clearedSecretIds) delete store.secrets[id]
+  for (const [id, value] of Object.entries(secrets)) store.secrets[id] = value
+  if (Object.keys(secrets).length === 0 && clearedSecretIds.length === 0) return
+  writeSecretStore(filePath, store)
+}
+
+export function ensureAgentsSecretsGitignore(agentsDir: string): void {
+  const gitignorePath = path.join(agentsDir, ".gitignore")
+  const ignoreLine = `/${AGENTS_SECRETS_LOCAL_JSON}*`
+  try {
+    fs.mkdirSync(agentsDir, { recursive: true })
+    const existing = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : ""
+    if (existing.split(/\r?\n/).some((line) => line.trim() === ignoreLine)) return
+    const prefix = existing.length > 0 && !existing.endsWith("\n") ? "\n" : ""
+    fs.writeFileSync(
+      gitignorePath,
+      `${existing}${prefix}# DotAgents local secret material\n${ignoreLine}\n`,
+      "utf8",
+    )
+  } catch {
+    // Best effort only; repository-level .gitignore also excludes this filename.
+  }
+}
+
+export function extractSecretsForPersistence<T>(value: T, pathSegments: string[] = []): ExtractResult<T> {
+  const secrets: Record<string, string> = {}
+  const clearedSecretIds: string[] = []
+
+  const visit = (current: unknown, currentPath: string[], currentKey?: string): { value: unknown; changed: boolean } => {
+    if (Array.isArray(current)) {
+      let changed = false
+      const next = current.map((item, index) => {
+        const result = visit(item, [...currentPath, stablePathSegment(index, item)])
+        changed ||= result.changed
+        return result.value
+      })
+      return { value: changed ? next : current, changed }
+    }
+
+    if (current && typeof current === "object") {
+      let changed = false
+      const next: Record<string, unknown> = {}
+      for (const [key, child] of Object.entries(current as Record<string, unknown>)) {
+        const result = visit(child, [...currentPath, key], key)
+        next[key] = result.value
+        changed ||= result.changed
+      }
+      return { value: changed ? next : current, changed }
+    }
+
+    if (currentKey && isSecretBearingKey(currentKey) && typeof current === "string") {
+      const secretId = secretIdForPath(currentPath)
+      if (current.trim().length === 0) {
+        clearedSecretIds.push(secretId)
+        return { value: current, changed: false }
+      }
+      if (isSecretRef(current)) return { value: current, changed: false }
+      secrets[secretId] = current
+      return { value: makeSecretRef(secretId), changed: true }
+    }
+
+    return { value: current, changed: false }
+  }
+
+  const result = visit(value, pathSegments)
+  return {
+    value: result.value as T,
+    secrets,
+    clearedSecretIds,
+    changed: result.changed,
+  }
+}
+
+export function prepareConfigForPersistence<T>(value: T, secretsFilePath: string): T {
+  const extracted = extractSecretsForPersistence(value)
+  if (extracted.changed || extracted.clearedSecretIds.length > 0) {
+    mergeSecretsIntoLocalStore(secretsFilePath, extracted.secrets, extracted.clearedSecretIds)
+    ensureAgentsSecretsGitignore(path.dirname(secretsFilePath))
+  }
+  return extracted.value
+}
+
+export function migrateJsonFileSecretsToLocalStore(
+  filePath: string,
+  secretsFilePath: string,
+  pretty: boolean,
+): void {
+  try {
+    if (!fs.existsSync(filePath)) return
+    const raw = fs.readFileSync(filePath, "utf8")
+    const parsed = JSON.parse(raw)
+    const sanitized = prepareConfigForPersistence(parsed, secretsFilePath)
+
+    if (JSON.stringify(parsed) === JSON.stringify(sanitized)) return
+
+    fs.writeFileSync(
+      filePath,
+      `${JSON.stringify(sanitized, null, pretty ? 2 : 0)}\n`,
+      { encoding: "utf8" },
+    )
+  } catch {
+    // Best effort: never block config writes on local secret migration.
+  }
+}
+
+export function resolveSecretRefs<T>(value: T, secretsFilePath: string): T {
+  const store = readSecretStore(secretsFilePath)
+
+  const visit = (current: unknown): unknown => {
+    if (Array.isArray(current)) return current.map(visit)
+    if (current && typeof current === "object") {
+      return Object.fromEntries(Object.entries(current as Record<string, unknown>).map(([key, child]) => [key, visit(child)]))
+    }
+    if (isSecretRef(current)) {
+      const id = secretIdFromRef(current)
+      return id ? store.secrets[id] ?? "" : ""
+    }
+    return current
+  }
+
+  return visit(value) as T
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -182,7 +182,9 @@ function migratePlaintextSecretsToLocalStore(): void {
       layer.modelsJsonPath,
       layer.layoutJsonPath,
     ]) {
-      migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true)
+      migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true, {
+        backupDir: layer.backupsDir,
+      })
     }
   }
 
@@ -194,6 +196,7 @@ function migratePlaintextSecretsToLocalStore(): void {
     getConfigPath(),
     getAgentsSecretsLocalPath(globalAgentsFolder),
     false,
+    { backupDir: path.join(getDataFolder(), ".backups") },
   )
 }
 
@@ -646,6 +649,7 @@ export function persistConfigToDisk(
       legacyConfigFilePath,
       getAgentsSecretsLocalPath(agentsDir),
       false,
+      { backupDir, maxBackups },
     )
     safeWriteJsonFileSync(legacyConfigFilePath, configForLegacyDisk, {
       backupDir,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -645,12 +645,6 @@ export function persistConfigToDisk(
       config,
       getAgentsSecretsLocalPath(agentsDir),
     )
-    migrateJsonFileSecretsToLocalStore(
-      legacyConfigFilePath,
-      getAgentsSecretsLocalPath(agentsDir),
-      false,
-      { backupDir, maxBackups },
-    )
     safeWriteJsonFileSync(legacyConfigFilePath, configForLegacyDisk, {
       backupDir,
       maxBackups,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -12,6 +12,12 @@ import {
   writeAgentsLayerFromConfig,
 } from "./agents-files/modular-config"
 import { safeReadJsonFileSync, safeWriteJsonFileSync } from "./agents-files/safe-file"
+import {
+  getAgentsSecretsLocalPath,
+  migrateJsonFileSecretsToLocalStore,
+  prepareConfigForPersistence,
+  resolveSecretRefs,
+} from "./agents-files/secrets"
 import { getErrorMessage, normalizeError } from "./error-utils"
 
 const DEFAULT_APP_ID = "app.dotagents"
@@ -164,6 +170,31 @@ function migrateAgentsFolderToHome(dataFolder: string): void {
     path.join(globalAgentsFolder, "layouts", "ui.json"),
   )
 
+}
+
+function migratePlaintextSecretsToLocalStore(): void {
+  const migrateAgentsDir = (agentsDir: string) => {
+    const layer = getAgentsLayerPaths(agentsDir)
+    const secretsFilePath = getAgentsSecretsLocalPath(agentsDir)
+    for (const filePath of [
+      layer.settingsJsonPath,
+      layer.mcpJsonPath,
+      layer.modelsJsonPath,
+      layer.layoutJsonPath,
+    ]) {
+      migrateJsonFileSecretsToLocalStore(filePath, secretsFilePath, true)
+    }
+  }
+
+  migrateAgentsDir(globalAgentsFolder)
+  const workspaceAgentsFolder = resolveWorkspaceAgentsFolder()
+  if (workspaceAgentsFolder) migrateAgentsDir(workspaceAgentsFolder)
+
+  migrateJsonFileSecretsToLocalStore(
+    getConfigPath(),
+    getAgentsSecretsLocalPath(globalAgentsFolder),
+    false,
+  )
 }
 
 type LoadedConfig = {
@@ -377,10 +408,14 @@ const getConfig = (): LoadedConfig => {
   )
 
   // 2) Always load legacy config.json as the base layer (it holds API keys, preferences, etc.)
-  const savedConfig = safeReadJsonFileSync<Partial<Config>>(configFilePath, {
+  const savedConfigRaw = safeReadJsonFileSync<Partial<Config>>(configFilePath, {
     backupDir: legacyBackupsFolder,
     defaultValue: {},
   })
+  const savedConfig = resolveSecretRefs(
+    savedConfigRaw,
+    getAgentsSecretsLocalPath(globalAgentsFolder),
+  )
 
   // Merge order: defaults ← config.json ← .agents (if present)
   // This ensures existing settings (API keys etc.) from config.json are always preserved,
@@ -493,6 +528,7 @@ export class ConfigStore {
     // One-time migration: move files from old app-data/.agents → ~/.agents
     try {
       migrateAgentsFolderToHome(dataFolder)
+      migratePlaintextSecretsToLocalStore()
     } catch {
       // best-effort
     }
@@ -602,7 +638,16 @@ export function persistConfigToDisk(
   }
 
   try {
-    safeWriteJsonFileSync(legacyConfigFilePath, config, {
+    const configForLegacyDisk = prepareConfigForPersistence(
+      config,
+      getAgentsSecretsLocalPath(agentsDir),
+    )
+    migrateJsonFileSecretsToLocalStore(
+      legacyConfigFilePath,
+      getAgentsSecretsLocalPath(agentsDir),
+      false,
+    )
+    safeWriteJsonFileSync(legacyConfigFilePath, configForLegacyDisk, {
       backupDir,
       maxBackups,
       pretty: false,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,6 +159,19 @@ export {
 } from './agents-files/modular-config';
 export type { AgentsLayerPaths, SplitAgentsConfig } from './agents-files/modular-config';
 
+// Agents files — local secrets
+export {
+  AGENTS_SECRETS_LOCAL_JSON,
+  SECRET_REF_PREFIX,
+  getAgentsSecretsLocalPath,
+  isSecretRef,
+  makeSecretRef,
+  extractSecretsForPersistence,
+  prepareConfigForPersistence,
+  migrateJsonFileSecretsToLocalStore,
+  resolveSecretRefs,
+} from './agents-files/secrets';
+
 // Agents files — knowledge notes
 export {
   AGENTS_KNOWLEDGE_DIR,


### PR DESCRIPTION
## Summary

Closes #155.

- Adds a local .agents/secrets.local.json secret store and writes dotagents-secret:// references into shareable .agents JSON files.
- Resolves secret references at runtime and migrates existing plaintext secrets from global/workspace .agents files plus legacy config.json.
- Adds accidental-sharing safeguards via .gitignore, generated .agents/.gitignore, .dockerignore, bundle/export sanitization, and sandbox snapshot exclusions.
- Updates settings UI copy to explain local secret storage and updates regression tests for core and desktop flows.

## Validation

- pnpm build:core
- pnpm --filter @dotagents/core test
- pnpm --filter @dotagents/core typecheck
- pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/pages/settings-providers.draft.test.tsx src/renderer/src/pages/settings-general.langfuse-draft.test.tsx src/main/agents-files/modular-config.test.ts src/main/sandbox-service.test.ts
- pnpm --filter @dotagents/desktop typecheck
- git check-ignore verified secrets.local.json and temp variants are ignored

## Notes

This is Phase 1: secret values are still stored locally in plaintext, but they are separated from portable/shareable .agents config and protected against common accidental sharing paths. OS keychain-backed storage can be layered in later behind the same reference API.
