### PR TITLE
Add Codex-authenticated STT provider

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const tempDirs: string[] = []
 
-async function setupChatGptWebProviderTest() {
+async function setupChatGptWebProviderTest(options: {
+  accessToken?: string
+  accountId?: string
+} = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-chatgpt-web-images-"))
   tempDirs.push(tempDir)
 
@@ -13,6 +16,8 @@ async function setupChatGptWebProviderTest() {
     configStore: {
       get: vi.fn(() => ({
         chatgptWebBaseUrl: "https://chatgpt.test",
+        chatgptWebAccessToken: options.accessToken || "",
+        chatgptWebAccountId: options.accountId || "",
         mcpToolsChatgptWebModel: "gpt-test",
       })),
       save: vi.fn(),
@@ -21,7 +26,7 @@ async function setupChatGptWebProviderTest() {
 
   vi.doMock("./oauth-storage", () => ({
     oauthStorage: {
-      getTokens: vi.fn(),
+      getTokens: vi.fn(() => options.accessToken ? ({ access_token: options.accessToken }) : null),
       storeTokens: vi.fn(),
       clearTokens: vi.fn(),
     },
@@ -38,9 +43,47 @@ async function setupChatGptWebProviderTest() {
 }
 
 afterEach(async () => {
+  vi.unstubAllGlobals()
   vi.resetModules()
   vi.clearAllMocks()
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe("chatgpt-web provider transcription", () => {
+  it("posts audio to the ChatGPT transcription endpoint with Codex auth", async () => {
+    await setupChatGptWebProviderTest({ accessToken: "token-123", accountId: "acct_123" })
+    const fetchMock = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) => (
+      new Response(JSON.stringify({ text: "hello codex" }), { status: 200 })
+    ))
+    vi.stubGlobal("fetch", fetchMock)
+    const { transcribeWithChatGptWeb } = await import("./chatgpt-web-provider")
+
+    const text = await transcribeWithChatGptWeb(new ArrayBuffer(2), { durationMs: 1234.56 })
+
+    expect(text).toBe("hello codex")
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://chatgpt.test/backend-api/transcribe",
+      expect.objectContaining({ method: "POST" }),
+    )
+    const init = fetchMock.mock.calls[0]![1]! as RequestInit & { body: FormData; headers: Record<string, string> }
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer token-123",
+      "chatgpt-account-id": "acct_123",
+      originator: "dotagents",
+    })
+    expect(init.body.get("duration_ms")).toBe("1235")
+    const file = init.body.get("file")
+    expect(file).toBeInstanceOf(File)
+    expect((file as File).name).toBe("recording.webm")
+  })
+
+  it("throws when ChatGPT transcription returns no text", async () => {
+    await setupChatGptWebProviderTest({ accessToken: "token-123" })
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({}), { status: 200 })))
+    const { transcribeWithChatGptWeb } = await import("./chatgpt-web-provider")
+
+    await expect(transcribeWithChatGptWeb(new ArrayBuffer(2))).rejects.toThrow("returned no text")
+  })
 })
 
 describe("chatgpt-web provider image input", () => {

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -42,6 +42,11 @@ export interface ChatGptWebCompletionOptions {
   tools?: ChatGptWebTool[]
 }
 
+export interface ChatGptWebTranscriptionOptions {
+  durationMs?: number
+  signal?: AbortSignal
+}
+
 export interface ChatGptWebToolCall {
   name: string
   arguments: Record<string, unknown>
@@ -449,6 +454,47 @@ async function resolveChatGptWebAuth(signal?: AbortSignal): Promise<ResolvedChat
     accountId: configuredAccountId || extractChatGptAccountId(accessToken),
     baseUrl,
   }
+}
+
+export async function transcribeWithChatGptWeb(
+  recording: ArrayBuffer,
+  options: ChatGptWebTranscriptionOptions = {},
+): Promise<string> {
+  const auth = await resolveChatGptWebAuth(options.signal)
+  const form = new FormData()
+  form.append("file", new File([recording], "recording.webm", { type: "audio/webm" }))
+
+  if (typeof options.durationMs === "number" && Number.isFinite(options.durationMs) && options.durationMs > 0) {
+    form.append("duration_ms", String(Math.round(options.durationMs)))
+  }
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${auth.accessToken}`,
+    originator: "dotagents",
+  }
+
+  if (auth.accountId) {
+    headers["chatgpt-account-id"] = auth.accountId
+  }
+
+  const response = await fetch(`${auth.baseUrl}/backend-api/transcribe`, {
+    method: "POST",
+    headers,
+    body: form,
+    signal: options.signal,
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "")
+    throw new Error(`ChatGPT Codex transcription failed (${response.status}): ${errorText || response.statusText}`)
+  }
+
+  const json = await response.json() as { text?: unknown }
+  if (typeof json.text !== "string") {
+    throw new Error("ChatGPT Codex transcription returned no text")
+  }
+
+  return json.text
 }
 
 function getConfiguredChatGptWebModel(modelContext: ChatGptWebModelContext): string {

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -3389,9 +3389,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         updates.langfuseBaseUrl = body.langfuseBaseUrl
       }
       // STT Provider
-      const validSttProviders = ["openai", "groq", "parakeet"]
+      const validSttProviders = ["openai", "groq", "chatgpt-web", "parakeet"]
       if (typeof body.sttProviderId === "string" && validSttProviders.includes(body.sttProviderId)) {
-        updates.sttProviderId = body.sttProviderId as "openai" | "groq" | "parakeet"
+        updates.sttProviderId = body.sttProviderId as "openai" | "groq" | "chatgpt-web" | "parakeet"
       }
       if (typeof body.openaiSttModel === "string") {
         updates.openaiSttModel = body.openaiSttModel

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -166,6 +166,58 @@ function getRemoteSttModel(config: Config): string {
   return getConfiguredSttModel(config) || DEFAULT_STT_MODELS.openai
 }
 
+async function transcribeWithConfiguredRemoteStt(
+  config: Config,
+  recording: ArrayBuffer,
+  durationSeconds?: number,
+): Promise<string> {
+  if (config.sttProviderId === "chatgpt-web") {
+    const { transcribeWithChatGptWeb } = await import("./chatgpt-web-provider")
+    return transcribeWithChatGptWeb(recording, {
+      durationMs: typeof durationSeconds === "number" ? durationSeconds * 1000 : undefined,
+    })
+  }
+
+  const form = new FormData()
+  form.append("file", new File([recording], "recording.webm", { type: "audio/webm" }))
+  form.append("model", getRemoteSttModel(config))
+  form.append("response_format", "json")
+
+  const isGroq = config.sttProviderId === "groq"
+  if (isGroq && config.groqSttPrompt?.trim()) {
+    form.append("prompt", config.groqSttPrompt.trim())
+  }
+
+  const languageCode = isGroq
+    ? config.groqSttLanguage || config.sttLanguage
+    : config.openaiSttLanguage || config.sttLanguage
+
+  if (languageCode && languageCode !== "auto") {
+    form.append("language", languageCode)
+  }
+
+  const groqBaseUrl = config.groqBaseUrl || "https://api.groq.com/openai/v1"
+  const openaiBaseUrl = config.openaiBaseUrl || "https://api.openai.com/v1"
+  const transcriptResponse = await fetch(
+    isGroq ? `${groqBaseUrl}/audio/transcriptions` : `${openaiBaseUrl}/audio/transcriptions`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${isGroq ? config.groqApiKey : config.openaiApiKey}`,
+      },
+      body: form,
+    },
+  )
+
+  if (!transcriptResponse.ok) {
+    const message = `${transcriptResponse.statusText} ${(await transcriptResponse.text()).slice(0, 300)}`
+    throw new Error(message)
+  }
+
+  const json: { text: string } = await transcriptResponse.json()
+  return json.text || ""
+}
+
 async function initializeMcpWithProgress(config: Config, sessionId: string, runId?: number): Promise<void> {
   const shouldStop = () => agentSessionStateManager.shouldStopSession(sessionId)
   const effectiveMaxIterations = config.mcpUnlimitedIterations ? Infinity : (config.mcpMaxIterations ?? 10)
@@ -1649,56 +1701,8 @@ export const router = {
         transcript = await parakeetStt.transcribe(input.pcmRecording, 16000)
         transcript = await postProcessTranscriptSafely(transcript, "createRecording")
       } else {
-        // Use OpenAI or Groq for transcription
-        const form = new FormData()
-        form.append(
-          "file",
-          new File([input.recording], "recording.webm", { type: "audio/webm" }),
-        )
-        form.append(
-          "model",
-          getRemoteSttModel(config),
-        )
-        form.append("response_format", "json")
-
-        // Add prompt parameter for Groq if provided
-        if (config.sttProviderId === "groq" && config.groqSttPrompt?.trim()) {
-          form.append("prompt", config.groqSttPrompt.trim())
-        }
-
-        // Add language parameter if specified
-        const languageCode = config.sttProviderId === "groq"
-          ? config.groqSttLanguage || config.sttLanguage
-          : config.openaiSttLanguage || config.sttLanguage;
-
-        if (languageCode && languageCode !== "auto") {
-          form.append("language", languageCode)
-        }
-
-        const groqBaseUrl = config.groqBaseUrl || "https://api.groq.com/openai/v1"
-        const openaiBaseUrl = config.openaiBaseUrl || "https://api.openai.com/v1"
-
-        const transcriptResponse = await fetch(
-          config.sttProviderId === "groq"
-            ? `${groqBaseUrl}/audio/transcriptions`
-            : `${openaiBaseUrl}/audio/transcriptions`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${config.sttProviderId === "groq" ? config.groqApiKey : config.openaiApiKey}`,
-            },
-            body: form,
-          },
-        )
-
-        if (!transcriptResponse.ok) {
-          const message = `${transcriptResponse.statusText} ${(await transcriptResponse.text()).slice(0, 300)}`
-
-          throw new Error(message)
-        }
-
-        const json: { text: string } = await transcriptResponse.json()
-        transcript = await postProcessTranscriptSafely(json.text, "createRecording")
+        transcript = await transcribeWithConfiguredRemoteStt(config, input.recording, input.duration)
+        transcript = await postProcessTranscriptSafely(transcript, "createRecording")
       }
 
       const history = getRecordingHistory()
@@ -1766,55 +1770,12 @@ export const router = {
         }
         transcript = await parakeetStt.transcribe(input.pcmRecording, 16000)
       } else {
-        const form = new FormData()
-        form.append(
-          "file",
-          new File([input.recording], "recording.webm", { type: "audio/webm" }),
-        )
-        form.append(
-          "model",
-          getRemoteSttModel(config),
-        )
-        form.append("response_format", "json")
-
-        if (config.sttProviderId === "groq" && config.groqSttPrompt?.trim()) {
-          form.append("prompt", config.groqSttPrompt.trim())
-        }
-
-        const languageCode = config.sttProviderId === "groq"
-          ? config.groqSttLanguage || config.sttLanguage
-          : config.openaiSttLanguage || config.sttLanguage;
-
-        if (languageCode && languageCode !== "auto") {
-          form.append("language", languageCode)
-        }
-
-        const groqBaseUrl = config.groqBaseUrl || "https://api.groq.com/openai/v1"
-        const openaiBaseUrl = config.openaiBaseUrl || "https://api.openai.com/v1"
-
-        const transcriptResponse = await fetch(
-          config.sttProviderId === "groq"
-            ? `${groqBaseUrl}/audio/transcriptions`
-            : `${openaiBaseUrl}/audio/transcriptions`,
-          {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${config.sttProviderId === "groq" ? config.groqApiKey : config.openaiApiKey}`,
-            },
-            body: form,
-          },
-        )
-
-        if (!transcriptResponse.ok) {
-          const errBody = await transcriptResponse.text().catch(() => "<unreadable>")
-          console.error(
-            `[transcribeChunk] API error ${transcriptResponse.status} ${transcriptResponse.statusText}: ${errBody}`,
-          )
+        try {
+          transcript = await transcribeWithConfiguredRemoteStt(config, input.recording)
+        } catch (error) {
+          console.error(`[transcribeChunk] API error: ${getErrorMessage(error)}`)
           return { text: "" }
         }
-
-        const json: { text: string } = await transcriptResponse.json()
-        transcript = json.text || ""
       }
 
       return { text: transcript }
@@ -2083,52 +2044,7 @@ export const router = {
               }
               transcript = await parakeetStt.transcribe(input.pcmRecording, 16000)
             } else {
-              const form = new FormData()
-              form.append(
-                "file",
-                new File([input.recording], "recording.webm", { type: "audio/webm" }),
-              )
-              form.append(
-                "model",
-                getRemoteSttModel(config),
-              )
-              form.append("response_format", "json")
-
-              if (config.sttProviderId === "groq" && config.groqSttPrompt?.trim()) {
-                form.append("prompt", config.groqSttPrompt.trim())
-              }
-
-              const languageCode = config.sttProviderId === "groq"
-                ? config.groqSttLanguage || config.sttLanguage
-                : config.openaiSttLanguage || config.sttLanguage
-
-              if (languageCode && languageCode !== "auto") {
-                form.append("language", languageCode)
-              }
-
-              const groqBaseUrl = config.groqBaseUrl || "https://api.groq.com/openai/v1"
-              const openaiBaseUrl = config.openaiBaseUrl || "https://api.openai.com/v1"
-
-              const transcriptResponse = await fetch(
-                config.sttProviderId === "groq"
-                  ? `${groqBaseUrl}/audio/transcriptions`
-                  : `${openaiBaseUrl}/audio/transcriptions`,
-                {
-                  method: "POST",
-                  headers: {
-                    Authorization: `Bearer ${config.sttProviderId === "groq" ? config.groqApiKey : config.openaiApiKey}`,
-                  },
-                  body: form,
-                },
-              )
-
-              if (!transcriptResponse.ok) {
-                const message = `${transcriptResponse.statusText} ${(await transcriptResponse.text()).slice(0, 300)}`
-                throw new Error(message)
-              }
-
-              const json: { text: string } = await transcriptResponse.json()
-              transcript = json.text
+              transcript = await transcribeWithConfiguredRemoteStt(config, input.recording, input.duration)
             }
 
             // Save the recording file
@@ -2262,54 +2178,7 @@ export const router = {
           }
           transcript = await parakeetStt.transcribe(input.pcmRecording, 16000)
         } else {
-          // Use OpenAI or Groq for transcription
-          const form = new FormData()
-          form.append(
-            "file",
-            new File([input.recording], "recording.webm", { type: "audio/webm" }),
-          )
-          form.append(
-            "model",
-            getRemoteSttModel(config),
-          )
-          form.append("response_format", "json")
-
-          if (config.sttProviderId === "groq" && config.groqSttPrompt?.trim()) {
-            form.append("prompt", config.groqSttPrompt.trim())
-          }
-
-          // Add language parameter if specified
-          const languageCode = config.sttProviderId === "groq"
-            ? config.groqSttLanguage || config.sttLanguage
-            : config.openaiSttLanguage || config.sttLanguage;
-
-          if (languageCode && languageCode !== "auto") {
-            form.append("language", languageCode)
-          }
-
-          const groqBaseUrl = config.groqBaseUrl || "https://api.groq.com/openai/v1"
-          const openaiBaseUrl = config.openaiBaseUrl || "https://api.openai.com/v1"
-
-          const transcriptResponse = await fetch(
-            config.sttProviderId === "groq"
-              ? `${groqBaseUrl}/audio/transcriptions`
-              : `${openaiBaseUrl}/audio/transcriptions`,
-            {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${config.sttProviderId === "groq" ? config.groqApiKey : config.openaiApiKey}`,
-              },
-              body: form,
-            },
-          )
-
-          if (!transcriptResponse.ok) {
-            const message = `${transcriptResponse.statusText} ${(await transcriptResponse.text()).slice(0, 300)}`
-            throw new Error(message)
-          }
-
-          const json: { text: string } = await transcriptResponse.json()
-          transcript = json.text
+          transcript = await transcribeWithConfiguredRemoteStt(config, input.recording, input.duration)
         }
 
       const messageText = appendScreenshotToTranscript(transcript, input.screenshot)
@@ -3822,7 +3691,7 @@ export const router = {
       mcpToolsChatgptWebModel?: string
       currentModelPresetId?: string
       // STT Provider settings
-      sttProviderId?: "openai" | "groq" | "parakeet"
+      sttProviderId?: "openai" | "groq" | "chatgpt-web" | "parakeet"
       openaiSttModel?: string
       groqSttModel?: string
       // Transcript Post-Processing settings

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -348,6 +348,14 @@ export function Component() {
                   Parakeet uses its local downloaded model bundle. Manage installation and runtime settings on Providers.
                 </p>
               </Control>
+            ) : sttProviderId === "chatgpt-web" ? (
+              <Control
+                label={<ControlLabel label="Speech-to-Text model" tooltip="OpenAI Codex transcription uses the ChatGPT backend transcription endpoint." />}
+              >
+                <p className="text-sm text-muted-foreground">
+                  OpenAI Codex chooses the transcription model server-side. Connect your Codex account on Providers.
+                </p>
+              </Control>
             ) : (
               <ModelSelector
                 providerId={sttProviderId}

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -789,6 +789,7 @@ export function Component() {
         ...(tts === "gemini" ? [{ label: "TTS", icon: Volume2 }] : []),
       ],
       chatgptWeb: [
+        ...(stt === "chatgpt-web" ? [{ label: "STT", icon: Mic }] : []),
         ...(transcript === "chatgpt-web" ? [{ label: "Cleanup", icon: FileText }] : []),
         ...(mcp === "chatgpt-web" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
       ],
@@ -1053,7 +1054,7 @@ export function Component() {
                     <div className="text-xs text-muted-foreground mt-1">
                       {(chatgptWebAuthQuery.data as any)?.planType
                         ? `Plan: ${(chatgptWebAuthQuery.data as any).planType}`
-                        : "Uses your ChatGPT Codex subscription via OAuth."}
+                        : "Uses your ChatGPT Codex subscription via OAuth for agent, cleanup, and transcription requests."}
                     </div>
                     {(chatgptWebAuthQuery.data as any)?.accountId && (
                       <div className="text-xs text-muted-foreground mt-1">
@@ -1086,7 +1087,7 @@ export function Component() {
                 </div>
 
                 <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Browser sign-in should return to `http://localhost:1455/auth/callback`. Use Copy Callback URL if you need to inspect or paste the callback target.
+                  Browser sign-in should return to `http://localhost:1455/auth/callback`. STT uses ChatGPT's `/backend-api/transcribe` endpoint with the same Codex OAuth session.
                 </p>
               </div>
             )}
@@ -1251,7 +1252,7 @@ export function Component() {
                         : "Not connected"}
                     </div>
                     <div className="text-xs text-muted-foreground mt-1">
-                      Uses your ChatGPT Codex subscription via OAuth.
+                      Uses your ChatGPT Codex subscription via OAuth for agent, cleanup, and transcription requests.
                     </div>
                   </div>
 
@@ -1279,7 +1280,7 @@ export function Component() {
                 </div>
 
                 <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Browser sign-in should return to `http://localhost:1455/auth/callback`. This provider now talks to the Codex responses transport, not the legacy conversation endpoint.
+                  Browser sign-in should return to `http://localhost:1455/auth/callback`. This provider talks to Codex responses and ChatGPT transcription transports, not the legacy conversation endpoint.
                 </p>
               </div>
             )}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -281,7 +281,7 @@ export type ProfileModelConfig = {
   mcpToolsChatgptWebModel?: string
   currentModelPresetId?: string
   // STT Provider settings
-  sttProviderId?: "openai" | "groq" | "parakeet"
+  sttProviderId?: "openai" | "groq" | "chatgpt-web" | "parakeet"
   openaiSttModel?: string
   groqSttModel?: string
   // Transcript Post-Processing settings

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -29,6 +29,7 @@ import Slider from '@react-native-community/slider';
 const STT_PROVIDERS = [
   { label: 'OpenAI', value: 'openai' },
   { label: 'Groq', value: 'groq' },
+  { label: 'OpenAI Codex', value: 'chatgpt-web' },
   { label: 'Parakeet (Local)', value: 'parakeet' },
 ] as const;
 

--- a/docs/codex-auth-media.md
+++ b/docs/codex-auth-media.md
@@ -1,0 +1,37 @@
+# Codex-authenticated media support
+
+DotAgents can reuse the existing OpenAI Codex / ChatGPT OAuth session for the
+media endpoints that ChatGPT exposes behind the Codex login.
+
+## Implemented: speech-to-text
+
+- Provider ID: `chatgpt-web` / label `OpenAI Codex`.
+- Endpoint: `POST https://chatgpt.com/backend-api/transcribe`.
+- Auth: the same OAuth access token used by the Codex Responses transport.
+- Request shape: multipart form data with a `file` part and optional
+  `duration_ms` when the desktop recording duration is available.
+- Model selection: ChatGPT chooses the transcription model server-side, so the
+  settings UI intentionally does not expose a Codex STT model selector.
+
+This is wired into the existing desktop transcription paths for recordings,
+preview chunks, and agent-mode voice recordings. The mobile settings screen can
+also select the provider because it updates the desktop app's remote settings.
+
+## Investigated but not implemented yet
+
+### Text-to-speech
+
+OpenAI's public TTS endpoint is `POST /v1/audio/speech`, but that endpoint uses
+API-key auth. Codex's app-server has experimental realtime output-audio events,
+but there is not a stable ChatGPT `/backend-api/...` TTS endpoint equivalent to
+`/backend-api/transcribe` yet. DotAgents should keep using the existing OpenAI,
+Groq, Gemini, Edge, and local TTS providers until a stable Codex-auth TTS path is
+available.
+
+### Image generation
+
+Codex CLI supports image generation behind an experimental feature flag and uses
+the OpenAI Images API flow with GPT Image models such as `gpt-image-1.5`. The
+desktop app does not currently have a first-class image-generation feature
+surface, so this PR does not add one. A future integration should add an explicit
+image-generation UI/tool rather than overloading chat or transcription settings.

--- a/docs/codex-auth-reasoning.md
+++ b/docs/codex-auth-reasoning.md
@@ -3,6 +3,9 @@
 DotAgents' ChatGPT/Codex provider calls the ChatGPT backend Responses API through the
 Codex OAuth credentials stored by the desktop app.
 
+For Codex-authenticated speech-to-text support and notes on investigated TTS and
+image-generation paths, see [`codex-auth-media.md`](./codex-auth-media.md).
+
 ## Request behavior
 
 - Reasoning-capable Codex models receive a `reasoning.effort` request option.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -136,7 +136,7 @@ export type ProfileModelConfig = {
   /** @deprecated Use agentChatgptWebModel instead. */
   mcpToolsChatgptWebModel?: string
   currentModelPresetId?: string
-  sttProviderId?: "openai" | "groq" | "parakeet"
+  sttProviderId?: "openai" | "groq" | "chatgpt-web" | "parakeet"
   openaiSttModel?: string
   groqSttModel?: string
   transcriptPostProcessingProviderId?: "openai" | "groq" | "gemini" | "chatgpt-web"

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -317,7 +317,7 @@ export interface Settings {
   mcpMessageQueueEnabled?: boolean;
 
   // Speech-to-Text Configuration
-  sttProviderId?: 'openai' | 'groq' | 'parakeet';
+  sttProviderId?: 'openai' | 'groq' | 'chatgpt-web' | 'parakeet';
   sttLanguage?: string;
   transcriptionPreviewEnabled?: boolean;
 
@@ -445,7 +445,7 @@ export interface SettingsUpdate {
   mcpMessageQueueEnabled?: boolean;
 
   // Speech-to-Text Configuration
-  sttProviderId?: 'openai' | 'groq' | 'parakeet';
+  sttProviderId?: 'openai' | 'groq' | 'chatgpt-web' | 'parakeet';
   sttLanguage?: string;
   transcriptionPreviewEnabled?: boolean;
 

--- a/packages/shared/src/providers.test.ts
+++ b/packages/shared/src/providers.test.ts
@@ -25,10 +25,11 @@ import type { ModelPreset } from './providers'
 // ── Provider Constants ───────────────────────────────────────────────────────
 
 describe('STT_PROVIDERS', () => {
-  it('includes openai, groq, and parakeet', () => {
+  it('includes openai, groq, OpenAI Codex, and parakeet', () => {
     const values = STT_PROVIDERS.map(p => p.value)
     expect(values).toContain('openai')
     expect(values).toContain('groq')
+    expect(values).toContain('chatgpt-web')
     expect(values).toContain('parakeet')
   })
 

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -23,6 +23,7 @@ export interface ModelPreset {
 export const STT_PROVIDERS = [
   { label: "OpenAI", value: "openai" },
   { label: "Groq", value: "groq" },
+  { label: "OpenAI Codex", value: "chatgpt-web" },
   { label: "Parakeet (Local)", value: "parakeet" },
 ] as const;
 

--- a/packages/shared/src/stt-models.test.ts
+++ b/packages/shared/src/stt-models.test.ts
@@ -62,6 +62,10 @@ describe('getDefaultSttModel', () => {
     expect(getDefaultSttModel('parakeet')).toBeUndefined()
   })
 
+  it('returns undefined for Codex because the backend chooses the model', () => {
+    expect(getDefaultSttModel('chatgpt-web')).toBeUndefined()
+  })
+
   it('returns undefined for undefined', () => {
     expect(getDefaultSttModel(undefined)).toBeUndefined()
   })
@@ -90,6 +94,11 @@ describe('getConfiguredSttModel', () => {
 
   it('returns undefined for unknown provider', () => {
     const config = { sttProviderId: 'parakeet' }
+    expect(getConfiguredSttModel(config)).toBeUndefined()
+  })
+
+  it('returns undefined for Codex because it has no configurable STT model', () => {
+    const config = { sttProviderId: 'chatgpt-web' }
     expect(getConfiguredSttModel(config)).toBeUndefined()
   })
 


### PR DESCRIPTION
## Summary
- add OpenAI Codex (chatgpt-web) as a selectable STT provider across shared constants, desktop settings, remote settings validation, and mobile settings
- route remote transcription through a shared helper and use ChatGPT's /backend-api/transcribe endpoint with the existing Codex OAuth session
- add provider/type coverage and docs for implemented STT plus investigated TTS/image-generation limitations

## Validation
- pnpm build:shared
- pnpm --filter @dotagents/core build
- pnpm --filter @dotagents/core typecheck && pnpm --filter @dotagents/shared typecheck
- pnpm --filter @dotagents/desktop exec vitest run src/main/chatgpt-web-provider.test.ts
- pnpm --filter @dotagents/shared test -- providers.test.ts stt-models.test.ts
- pnpm --filter @dotagents/desktop typecheck
- pnpm --filter @dotagents/mobile exec vitest run src/lib/settingsApi.operator.test.ts src/store/config.test.ts

## Notes
- pnpm --filter @dotagents/mobile test currently fails in pre-existing AgentEditScreen node assertions about ACP/stdio connection-type copy/logic; this PR only changes the mobile STT provider option list.
- Unrelated untracked workspace files were intentionally left out of the commit.
