### PR TITLE
Fix context summarization progress churn

### DIFF
--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -85,6 +85,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearArchiveFrontier('session-actual-scale')
     clearArchiveFrontier('session-bracket-log')
     clearArchiveFrontier('session-no-microcompact')
+    clearArchiveFrontier('session-archive-reapply')
     clearContextRefs('session-truncate')
     clearContextRefs('session-batch')
     clearContextRefs('session-archive')
@@ -93,6 +94,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearContextRefs('session-actual-scale')
     clearContextRefs('session-bracket-log')
     clearContextRefs('session-no-microcompact')
+    clearContextRefs('session-archive-reapply')
     clearActualTokenUsage('session-truncate')
     clearActualTokenUsage('session-batch')
     clearActualTokenUsage('session-archive')
@@ -101,10 +103,12 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearActualTokenUsage('session-actual-scale')
     clearActualTokenUsage('session-bracket-log')
     clearActualTokenUsage('session-no-microcompact')
+    clearActualTokenUsage('session-archive-reapply')
     clearIterativeSummary('session-archive')
     clearIterativeSummary('session-live-tail')
     clearIterativeSummary('session-protected-tail')
     clearIterativeSummary('session-no-microcompact')
+    clearIterativeSummary('session-archive-reapply')
     Object.assign(mockConfig, {
       mcpContextReductionEnabled: true,
       mcpContextTargetRatio: 0.5,
@@ -342,6 +346,31 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(Number(readResult.matchCount)).toBeGreaterThan(0)
   })
 
+  it('does not batch-summarize generated context summary messages again', async () => {
+    makeTextCompletionWithFetchMock.mockResolvedValue('new condensed finding')
+    Object.assign(mockConfig, {
+      mcpMaxContextTokensOverride: 2000,
+    })
+
+    const existingSummary = `[Earlier Context Summary: 8 messages]\n${'s'.repeat(2200)}`
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-batch',
+      lastNMessages: 1,
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'Original user request' },
+        { role: 'assistant', content: existingSummary },
+        { role: 'assistant', content: 'a'.repeat(2300) },
+        { role: 'user', content: 'latest follow up' },
+      ],
+    })
+
+    expect(makeTextCompletionWithFetchMock).toHaveBeenCalledTimes(1)
+    expect(makeTextCompletionWithFetchMock.mock.calls[0]?.[0]).not.toContain('Earlier Context Summary: 8 messages')
+    expect(result.messages.some((msg) => msg.content === existingSummary)).toBe(true)
+    expect(result.messages.some((msg) => msg.content.includes('[Earlier Context Summary: 1 message]'))).toBe(true)
+  })
+
   it('archives older raw history behind a rolling summary frontier', async () => {
     makeTextCompletionWithFetchMock.mockResolvedValue('archived work summary')
     Object.assign(mockConfig, {
@@ -381,6 +410,48 @@ describe('shrinkMessagesForLLM replacement policy', () => {
       kind: 'archived_history',
     }))
     expect(Number(readResult.messageCount)).toBeGreaterThan(0)
+  })
+
+  it('reapplies an existing archive frontier even when too few new messages arrived to advance it', async () => {
+    makeTextCompletionWithFetchMock.mockResolvedValue('archived work summary')
+    Object.assign(mockConfig, {
+      mcpContextTargetRatio: 0.95,
+      mcpMaxContextTokensOverride: 10000,
+    })
+
+    const baseMessages = [
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: 'Original task request' },
+      ...Array.from({ length: 48 }, (_, index) => ({
+        role: index % 2 === 0 ? 'assistant' : 'user',
+        content: `message-${index} ${'z'.repeat(80)}`,
+      })),
+    ]
+
+    const first = await shrinkMessagesForLLM({
+      sessionId: 'session-archive-reapply',
+      messages: baseMessages,
+      lastNMessages: 3,
+    })
+    expect(first.appliedStrategies).toContain('archive_frontier')
+    expect(first.messages.length).toBeLessThan(baseMessages.length)
+
+    const followUpMessages = [
+      ...baseMessages,
+      { role: 'assistant', content: 'new but not enough to advance archive' },
+      { role: 'user', content: 'latest follow up' },
+    ]
+
+    const second = await shrinkMessagesForLLM({
+      sessionId: 'session-archive-reapply',
+      messages: followUpMessages,
+      lastNMessages: 3,
+    })
+
+    expect(makeTextCompletionWithFetchMock).toHaveBeenCalledTimes(1)
+    expect(second.appliedStrategies).toContain('archive_frontier')
+    expect(second.messages.length).toBeLessThan(followUpMessages.length)
+    expect(second.messages.some((msg) => msg.content.startsWith('[Session Progress Summary]'))).toBe(true)
   })
 
   it('keeps search-mode excerpts within maxChars even for long queries', async () => {
@@ -484,7 +555,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(firstMatch.excerpt.length).toBeLessThanOrEqual(4000)
   })
 
-  it('does not reapply archive frontier when there is no new overflow', async () => {
+  it('reapplies archive frontier even when there is no new overflow', async () => {
     makeTextCompletionWithFetchMock.mockResolvedValue('archived work summary')
     Object.assign(mockConfig, {
       mcpContextSummarizeCharThreshold: 10000,
@@ -513,10 +584,11 @@ describe('shrinkMessagesForLLM replacement policy', () => {
       lastNMessages: 3,
     })
 
-    expect(secondPass.appliedStrategies).not.toContain('archive_frontier')
+    expect(secondPass.appliedStrategies).toContain('archive_frontier')
     expect(makeTextCompletionWithFetchMock).toHaveBeenCalledTimes(1)
+    expect(secondPass.messages.length).toBeLessThan(messages.length)
     expect(secondPass.messages.some((msg) => msg.content.includes('live-marker-43'))).toBe(true)
-    expect(secondPass.messages.some((msg) => msg.content.startsWith('[Session Progress Summary]'))).toBe(false)
+    expect(secondPass.messages.some((msg) => msg.content.startsWith('[Session Progress Summary]'))).toBe(true)
   })
 
   it('skips microcompact when context is comfortably under budget', async () => {

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -1080,6 +1080,11 @@ function buildSummaryMessage(batch: SummaryBatch, summary: string, contextRef?: 
   }
 }
 
+function isGeneratedContextSummaryMessage(content: string): boolean {
+  return content.startsWith("[Earlier Context Summary:")
+    || content.startsWith("[Session Progress Summary]")
+}
+
 function buildBatchSummaryFallback(items: SummaryCandidate[]): string {
   return items
     .map((item) => `${item.role}: ${item.contentForSummary.split("\n")[0].trim().slice(0, 120)}`)
@@ -1195,7 +1200,7 @@ function shouldApplyArchiveFrontier(
   targetTokens: number,
 ): boolean {
   if (!state) return false
-  return shouldAdvanceArchiveFrontier(state, messagesLength, tokens, targetTokens)
+  return state.hasArchiveState || shouldAdvanceArchiveFrontier(state, messagesLength, tokens, targetTokens)
 }
 
 async function updateIterativeSummaryForDroppedMessages(
@@ -1622,6 +1627,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     })
     .filter((x) => x.len > summarizeThreshold && x.role !== "system")
     .filter((x) => x.role !== "tool")
+    .filter((x) => !isGeneratedContextSummaryMessage(x.contentForSummary))
     .filter((x) => !truncationProtectedIndices.has(x.i))
     .filter((x) => x.i !== firstTierOneProtectedUserIdx)
     .filter((x) => !recentTierOneProtectedIndices.has(x.i))

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1717,7 +1717,9 @@ export async function processTranscriptWithAgentMode(
       sessionId: currentSessionId,
       onSummarizationProgress: (current, total, message) => {
         // Update thinking step with summarization progress
-        thinkingStep.description = `Summarizing context (${current}/${total})`
+        thinkingStep.description = current <= 0
+          ? "Updating context summary"
+          : `Summarizing context (${current}/${total})`
         thinkingStep.llmContent = message
         emit({
           currentIteration: iteration,
@@ -1732,6 +1734,20 @@ export async function processTranscriptWithAgentMode(
     contextInfoRef = { estTokens: estTokensAfter, maxTokens: maxContextTokens }
     // Track last context budget for Langfuse trace metadata
     lastContextBudgetInfo = { estTokensAfter, maxTokens: maxContextTokens, appliedStrategies }
+
+    if (thinkingStep.description?.startsWith("Summarizing context") || thinkingStep.description === "Updating context summary") {
+      thinkingStep.description = appliedStrategies.length > 0
+        ? "Generating response with compacted context"
+        : "Generating response"
+      thinkingStep.llmContent = ""
+      emit({
+        currentIteration: iteration,
+        maxIterations,
+        steps: progressSteps.slice(-3),
+        isComplete: false,
+        conversationHistory: formatConversationForProgress(conversationHistory),
+      })
+    }
 
     // If stop was requested during context shrinking, exit now
     if (agentSessionStateManager.shouldStopSession(currentSessionId)) {


### PR DESCRIPTION
## Summary
- Reapply existing archive-frontier state on later context shrink passes so archived raw history stays bounded
- Exclude generated context summary messages from batch summarization candidates to avoid summary-of-summary churn
- Clear stale Summarizing context (x/y) UI progress once context shrinking finishes

## Why
The visible Summarizing context (x/y) progress could appear to keep climbing in long revived sessions. Logs showed archive-frontier compaction being created, but later shrink passes could skip reapplying the existing archive if too few new messages had arrived to advance it. That allowed full raw history to re-enter the prompt and made summarization progress grow unexpectedly.

## Tests
- pnpm --filter @dotagents/desktop exec vitest run src/main/context-budget.test.ts
- pnpm --filter @dotagents/desktop exec vitest run src/main/context-budget.test.ts src/main/llm.respond-to-user-history.test.ts

## Note
- pnpm --filter @dotagents/desktop typecheck:node was attempted but is currently blocked by pre-existing SessionProfileSnapshot type mismatches involving sttProviderId: "chatgpt-web" between packages/core/dist and apps/desktop/src/shared/types.
