### PR TITLE
Lazy load long session history

### DIFF
--- a/apps/desktop/src/main/conversation-service.lazy-load.test.ts
+++ b/apps/desktop/src/main/conversation-service.lazy-load.test.ts
@@ -1,0 +1,63 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const tempDirs: string[] = []
+
+async function setupConversationServiceTest() {
+  const conversationsFolder = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-conv-lazy-"))
+  tempDirs.push(conversationsFolder)
+
+  vi.doMock("./config", () => ({
+    appId: "app.dotagents.test",
+    dataFolder: conversationsFolder,
+    recordingsFolder: path.join(conversationsFolder, "recordings"),
+    conversationsFolder,
+    configPath: path.join(conversationsFolder, "config.json"),
+    configStore: { get: vi.fn(), save: vi.fn(), reload: vi.fn(), config: undefined },
+  }))
+  vi.doMock("./context-budget", () => ({ summarizeContent: vi.fn((content: string) => content) }))
+  vi.doMock("./llm-fetch", () => ({ makeTextCompletionWithFetch: vi.fn() }))
+
+  const { ConversationService } = await import("./conversation-service")
+  return ConversationService.getInstance()
+}
+
+afterEach(async () => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
+})
+
+describe("conversation lazy loading", () => {
+  it("returns a tail message window without raw history payloads", async () => {
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_lazy_window",
+      title: "Lazy window",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: [
+        { id: "m1", role: "assistant", content: "Summary", timestamp: 1, isSummary: true, summarizedMessageCount: 2 },
+        { id: "m2", role: "user", content: "Middle", timestamp: 2 },
+        { id: "m3", role: "assistant", content: "Answer", timestamp: 3 },
+        { id: "m4", role: "user", content: "Follow up", timestamp: 4 },
+      ],
+      rawMessages: [
+        { id: "r1", role: "user", content: "Raw 1", timestamp: 1 },
+        { id: "r2", role: "assistant", content: "Raw 2", timestamp: 2 },
+        { id: "r3", role: "user", content: "Raw 3", timestamp: 3 },
+        { id: "r4", role: "assistant", content: "Raw 4", timestamp: 4 },
+      ],
+    }, true)
+
+    const loaded = await service.loadConversation("conv_lazy_window", { messageLimit: 2 })
+
+    expect(loaded?.messages.map((message) => message.content)).toEqual(["Answer", "Follow up"])
+    expect(loaded?.messageOffset).toBe(2)
+    expect(loaded?.totalMessageCount).toBe(4)
+    expect(loaded?.branchMessageIndexOffset).toBe(3)
+    expect(loaded).not.toHaveProperty("rawMessages")
+  })
+})

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -12,6 +12,7 @@ import {
   ConversationCompactionMetadata,
   ConversationMessage,
   ConversationHistoryItem,
+  LoadedConversation,
 } from "../shared/types"
 import { summarizeContent } from "./context-budget"
 import { assertSafeConversationId, validateAndSanitizeConversationId } from "./conversation-id"
@@ -826,6 +827,43 @@ export class ConversationService {
     return summarizedMessageCount + messages.filter((message) => !message.isSummary).length
   }
 
+  private getRepresentedCountForMessages(messages: ConversationMessage[]): number {
+    return messages.reduce((total, message) => {
+      if (message.isSummary) {
+        return total + Math.max(message.summarizedMessageCount ?? 0, 1)
+      }
+      return total + 1
+    }, 0)
+  }
+
+  private applyConversationMessageLimit(
+    conversation: Conversation,
+    messageLimit?: number,
+  ): LoadedConversation {
+    const normalizedLimit = typeof messageLimit === "number" && Number.isFinite(messageLimit)
+      ? Math.max(0, Math.floor(messageLimit ?? 0))
+      : 0
+
+    if (normalizedLimit <= 0) {
+      return conversation
+    }
+
+    const totalMessageCount = conversation.messages.length
+    const messageOffset = Math.max(0, totalMessageCount - normalizedLimit)
+    const branchMessageIndexOffset = this.getRepresentedCountForMessages(
+      conversation.messages.slice(0, messageOffset),
+    )
+    const { rawMessages: _rawMessages, ...conversationWithoutRawMessages } = conversation
+
+    return {
+      ...conversationWithoutRawMessages,
+      messages: conversation.messages.slice(messageOffset),
+      messageOffset,
+      totalMessageCount,
+      branchMessageIndexOffset,
+    }
+  }
+
   private getStoredRawMessages(conversation: Conversation): ConversationMessage[] {
     if (Array.isArray(conversation.rawMessages) && conversation.rawMessages.length > 0) {
       return conversation.rawMessages
@@ -904,11 +942,17 @@ export class ConversationService {
     })
   }
 
-  async loadConversation(conversationId: string): Promise<Conversation | null> {
+  async loadConversation(
+    conversationId: string,
+    options?: { messageLimit?: number },
+  ): Promise<LoadedConversation | null> {
     // Enqueue as a mutation so that any repair save inside loadConversationFromDisk()
     // is serialized with other writes, preventing lost-update races.
     return this.enqueueConversationMutation(conversationId, async () => {
-      return this.loadConversationFromDisk(conversationId)
+      const conversation = await this.loadConversationFromDisk(conversationId)
+      return conversation
+        ? this.applyConversationMessageLimit(conversation, options?.messageLimit)
+        : null
     })
   }
 

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3412,9 +3412,11 @@ export const router = {
   }),
 
   loadConversation: t.procedure
-    .input<{ conversationId: string }>()
+    .input<{ conversationId: string; messageLimit?: number }>()
     .action(async ({ input }) => {
-      return conversationService.loadConversation(input.conversationId)
+      return conversationService.loadConversation(input.conversationId, {
+        messageLimit: input.messageLimit,
+      })
     }),
 
   saveConversation: t.procedure

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -662,6 +662,39 @@ describe("agent progress response history", () => {
     expect(text).not.toContain("mark_work_complete")
   })
 
+  it("shows a lazy history window control for partial conversation history", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const onLoadEarlierConversationHistory = vi.fn()
+    const progress = {
+      sessionId: "pending-conv-1",
+      conversationId: "conv-1",
+      currentIteration: 0,
+      maxIterations: 2,
+      steps: [],
+      isComplete: true,
+      conversationHistoryTotalCount: 5,
+      conversationHistoryStartIndex: 3,
+      conversationHistory: [
+        { role: "user", content: "Recent question", timestamp: 300 },
+        { role: "assistant", content: "Recent answer", timestamp: 400 },
+      ],
+    }
+
+    const tree = runtime.render(AgentProgress, { progress, onLoadEarlierConversationHistory })
+    const text = getTextContent(tree)
+    const loadButton = findAll(
+      tree,
+      (value) => value?.type === "button" && getTextContent(value).includes("Load 3 earlier"),
+    )[0]
+
+    expect(text).toContain("Showing latest 2 of 5 messages")
+    expect(loadButton).toBeTruthy()
+
+    loadButton.props.onClick({ preventDefault: vi.fn(), stopPropagation: vi.fn() })
+    expect(onLoadEarlierConversationHistory).toHaveBeenCalledTimes(1)
+  })
+
   it("smartly auto-speaks response-linked assistant messages and keeps replay available before completion", async () => {
     const runtime = createHookRuntime()
     const { AgentProgress, tipcMock } = await loadAgentProgress(runtime, { ttsEnabled: true, ttsAutoPlay: true })

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -68,6 +68,10 @@ interface AgentProgressProps {
   onExpand?: () => void
   /** For tile variant: whether this tile is in expanded/full view mode */
   isExpanded?: boolean
+  /** Load the next older chunk when this progress contains a partial history window. */
+  onLoadEarlierConversationHistory?: () => void
+  /** Whether an older history chunk is currently being loaded. */
+  isLoadingEarlierConversationHistory?: boolean
   /** For tile variant: open the in-app voice continuation modal */
   onVoiceContinue?: (options: {
     conversationId?: string
@@ -78,6 +82,8 @@ interface AgentProgressProps {
     onSubmitted?: () => void
   }) => void
 }
+
+const CONVERSATION_HISTORY_PAGE_SIZE = 120
 
 // Enhanced conversation message component
 
@@ -2893,6 +2899,8 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   isFollowUpInputInitializing,
   onExpand,
   isExpanded,
+  onLoadEarlierConversationHistory,
+  isLoadingEarlierConversationHistory = false,
   onVoiceContinue,
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -3761,6 +3769,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   }, [enrichedMessages, effectiveUserResponse, progress.retryInfo, progress.steps, progress.streamingContent, toolCallSteps])
 
   const visibleDisplayItems = displayItems
+  const loadedConversationHistoryCount = conversationHistory?.length ?? 0
+  const conversationHistoryTotalCount = Math.max(
+    progress.conversationHistoryTotalCount ?? loadedConversationHistoryCount,
+    loadedConversationHistoryCount,
+  )
+  const hiddenConversationHistoryCount = Math.max(
+    0,
+    conversationHistoryTotalCount - loadedConversationHistoryCount,
+  )
 
   const getToolActivityGroupDefaultExpanded = useCallback((item: Extract<DisplayItem, { kind: "tool_activity_group" }>) => {
     const firstChildId = item.data.items[0]?.id
@@ -4176,6 +4193,25 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                         Showing latest {visibleDisplayItems.length} updates
                       </div>
                     )}
+                    {hiddenConversationHistoryCount > 0 && (
+                      <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/30 px-2 py-1.5 text-[11px] text-muted-foreground">
+                        <span>Showing latest {loadedConversationHistoryCount} of {conversationHistoryTotalCount} messages</span>
+                        {onLoadEarlierConversationHistory && (
+                          <button
+                            type="button"
+                            disabled={isLoadingEarlierConversationHistory}
+                            onClick={(e) => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              onLoadEarlierConversationHistory()
+                            }}
+                            className="rounded px-1.5 py-0.5 font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                          >
+                            {isLoadingEarlierConversationHistory ? "Loading…" : `Load ${Math.min(hiddenConversationHistoryCount, CONVERSATION_HISTORY_PAGE_SIZE)} earlier`}
+                          </button>
+                        )}
+                      </div>
+                    )}
                     {visibleDisplayItems.map((item, index) => {
                       const itemKey = item.id
                       // Final assistant message should be expanded by default when agent is complete
@@ -4575,6 +4611,25 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               {displayItems.length > visibleDisplayItems.length && (
                 <div className="px-2 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground/70">
                   Showing latest {visibleDisplayItems.length} updates
+                </div>
+              )}
+              {hiddenConversationHistoryCount > 0 && (
+                <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/30 px-2 py-1.5 text-[11px] text-muted-foreground">
+                  <span>Showing latest {loadedConversationHistoryCount} of {conversationHistoryTotalCount} messages</span>
+                  {onLoadEarlierConversationHistory && (
+                    <button
+                      type="button"
+                      disabled={isLoadingEarlierConversationHistory}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        onLoadEarlierConversationHistory()
+                      }}
+                      className="rounded px-1.5 py-0.5 font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isLoadingEarlierConversationHistory ? "Loading…" : `Load ${Math.min(hiddenConversationHistoryCount, CONVERSATION_HISTORY_PAGE_SIZE)} earlier`}
+                    </button>
+                  )}
                 </div>
               )}
               {visibleDisplayItems.map((item, index) => {

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -105,6 +105,8 @@ function formatTimestamp(timestamp: number): string {
 
 const RECENT_SESSIONS_LIMIT = 8
 const PENDING_CONTINUATION_TIMEOUT_MS = 20_000
+const PENDING_RESUME_HISTORY_MESSAGE_LIMIT = 120
+const PENDING_RESUME_HISTORY_PAGE_SIZE = 120
 
 type ActiveSessionTileProps = {
   sessionId: string
@@ -383,6 +385,7 @@ export function Component() {
   // State for resuming a saved conversation before a live session exists.
   const [pendingResumeConversationId, setPendingResumeConversationId] = useState<string | null>(null)
   const [pendingContinuationStartedAt, setPendingContinuationStartedAt] = useState<number | null>(null)
+  const [pendingResumeHistoryMessageLimit, setPendingResumeHistoryMessageLimit] = useState(PENDING_RESUME_HISTORY_MESSAGE_LIMIT)
   const pendingResumeConversationIdRef = useRef<string | null>(pendingResumeConversationId)
   const pendingContinuationStartedAtRef = useRef<number | null>(pendingContinuationStartedAt)
   const navigationState = location.state as SessionsNavigationState | null
@@ -397,6 +400,7 @@ export function Component() {
 
   useEffect(() => {
     setPendingContinuationStartedAt(null)
+    setPendingResumeHistoryMessageLimit(PENDING_RESUME_HISTORY_MESSAGE_LIMIT)
   }, [pendingResumeConversationId])
 
   const activeSessionEntries = React.useMemo<VisibleSessionEntry[]>(() => {
@@ -574,12 +578,16 @@ export function Component() {
 
   // Load the saved conversation that is about to be resumed.
   const pendingResumeConversationQuery = useQuery({
-    queryKey: ["conversation", pendingResumeConversationId],
+    queryKey: ["conversation", pendingResumeConversationId, pendingResumeHistoryMessageLimit],
     queryFn: async () => {
       if (!pendingResumeConversationId) return null
-      return tipcClient.loadConversation({ conversationId: pendingResumeConversationId })
+      return tipcClient.loadConversation({
+        conversationId: pendingResumeConversationId,
+        messageLimit: pendingResumeHistoryMessageLimit,
+      })
     },
     enabled: !!pendingResumeConversationId,
+    placeholderData: (previousData: any) => previousData,
   })
 
   const isPendingResumeConversationMissing =
@@ -612,6 +620,7 @@ export function Component() {
     const isInitializing = pendingContinuationStartedAt !== null
 
     const branchMessageIndexMap = getBranchMessageIndexMap(conv.messages)
+    const branchMessageIndexOffset = conv.branchMessageIndexOffset ?? 0
     return {
       sessionId: `pending-${pendingResumeConversationId}`,
       conversationId: pendingResumeConversationId,
@@ -629,16 +638,22 @@ export function Component() {
           }]
         : [],
       isComplete: !isInitializing,
+      conversationHistoryStartIndex: conv.messageOffset ?? 0,
+      conversationHistoryTotalCount: conv.totalMessageCount ?? conv.messages.length,
       conversationHistory: conv.messages.map((m, index) => ({
         role: m.role,
         content: m.content,
         toolCalls: m.toolCalls,
         toolResults: m.toolResults,
         timestamp: m.timestamp,
-        branchMessageIndex: branchMessageIndexMap[index],
+        branchMessageIndex: branchMessageIndexOffset + branchMessageIndexMap[index],
       })),
     }
   }, [pendingResumeConversationId, pendingResumeConversationQuery.data, pendingContinuationStartedAt])
+
+  const handleLoadEarlierPendingHistory = useCallback(() => {
+    setPendingResumeHistoryMessageLimit((limit) => limit + PENDING_RESUME_HISTORY_PAGE_SIZE)
+  }, [])
 
   // Resume a saved conversation by focusing an existing live session when
   // possible, or by showing a temporary resume tile until a live session starts.
@@ -893,6 +908,8 @@ export function Component() {
                 onDismiss={handleDismissPendingResume}
                 onFollowUpSent={handlePendingContinuationStarted}
                 isFollowUpInputInitializing={pendingContinuationStartedAt !== null}
+                onLoadEarlierConversationHistory={handleLoadEarlierPendingHistory}
+                isLoadingEarlierConversationHistory={pendingResumeConversationQuery.isFetching}
                 onVoiceContinue={handleOpenVoiceContinuation}
               />
             ) : showPendingLoadingTile ? (

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -238,6 +238,15 @@ export interface Conversation {
   branchSource?: ConversationBranchSource
 }
 
+export interface LoadedConversation extends Conversation {
+  /** Start index of `messages` within the persisted conversation when loaded as a window. */
+  messageOffset?: number
+  /** Total number of persisted display messages before windowing. */
+  totalMessageCount?: number
+  /** Raw-history branch index represented before the first loaded display message. */
+  branchMessageIndexOffset?: number
+}
+
 export interface ConversationHistoryItem {
   id: string
   title: string

--- a/packages/shared/src/agent-progress.ts
+++ b/packages/shared/src/agent-progress.ts
@@ -243,6 +243,10 @@ export interface AgentProgressUpdate {
    */
   responseEvents?: AgentUserResponseEvent[]
   conversationHistory?: ConversationHistoryMessage[]
+  /** Total history size when `conversationHistory` is a lazy-loaded display window. */
+  conversationHistoryTotalCount?: number
+  /** Start index of `conversationHistory` within the full persisted history window. */
+  conversationHistoryStartIndex?: number
   streamingContent?: {
     text: string
     isStreaming: boolean


### PR DESCRIPTION
## Summary
- load only the latest 120 messages when opening long saved conversations in the session view
- add a Load earlier control to fetch older history chunks on demand
- preserve branch targets for lazy-loaded history windows and avoid sending raw history payloads for limited loads
- add main-process and renderer tests for the lazy-load path

## Validation
- pnpm build:shared
- pnpm --filter @dotagents/desktop exec vitest run src/main/conversation-service.lazy-load.test.ts src/renderer/src/components/agent-progress.response-history.test.ts

## Notes
- pnpm --filter @dotagents/desktop typecheck is currently blocked by an existing SessionProfileSnapshot / sttProviderId mismatch: @dotagents/core includes chatgpt-web, while apps/desktop/src/shared/types.ts does not.
