### PR TITLE
Add session switch autoresearch performance loop

### DIFF
--- a/apps/desktop/DEBUGGING.md
+++ b/apps/desktop/DEBUGGING.md
@@ -117,6 +117,96 @@ Recommended workflow:
 4. Run a short `--trace-seconds 20` capture during the janky window.
 5. Compare heap, node count, `TaskDuration`, `ScriptDuration`, `LayoutDuration`, and the trace flame chart.
 
+## Session switching autoresearch loop
+
+For repeatable optimization of switching between many large sessions, use the
+synthetic session-switch benchmark. It drives the renderer through CDP and a
+dev-only harness instead of starting real agents, so runs are deterministic and
+safe to repeat.
+
+```bash
+# Terminal 1: run the desktop app with renderer CDP enabled
+REMOTE_DEBUGGING_PORT=9333 pnpm dev -- -dui -dapp
+
+# Terminal 2: run a fixed benchmark scenario
+pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario large --switches 30
+
+# Optional: include a Chrome trace for Perfetto/DevTools inspection
+pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario huge --switches 20 --trace
+
+# Single large fake session presets for 500/1000-message manual stress tests
+pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario single-500 --switches 5
+pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario single-1000 --switches 5
+
+# Compare a candidate run against a saved baseline and get keep/discard guidance
+pnpm --filter @dotagents/desktop perf:session-switch:compare -- \
+  --baseline tmp/perf/session-switch/baseline.results.json \
+  --candidate tmp/perf/session-switch/candidate.results.json
+```
+
+Artifacts are written under `apps/desktop/tmp/perf/session-switch/`:
+
+- `*.results.json` → summary metrics and CDP metric deltas
+- `*.events.jsonl` → one row per session switch
+- `*.trace.json` → Chrome trace when `--trace` is passed
+- `results.tsv` → autoresearch-style ledger for baseline/variant comparison
+
+Key metrics to compare before keeping an optimization:
+
+- `switchLatencyP50Ms`, `switchLatencyP95Ms`, `maxSwitchLatencyMs`
+- long-task count and total duration
+- JS heap delta and DOM node count
+- CDP deltas: `TaskDuration`, `ScriptDuration`, `LayoutDuration`, `RecalcStyleDuration`
+
+Recommended feedback loop:
+
+1. Run a baseline and save the generated `*.results.json` path.
+2. Make one targeted optimization hypothesis.
+3. Re-run the exact same scenario.
+4. Run `perf:session-switch:compare` against the baseline and candidate.
+5. Keep the change only if the comparator says `keep`, or if the result is
+   `inconclusive` but the code is simpler and the metrics are neutral.
+6. Discard/rework if the comparator says `discard`.
+
+Default comparator thresholds:
+
+- `keep`: p95 improves by at least 10%.
+- `discard`: p95 regresses by more than 5%.
+- `discard`: heap delta regresses by more than 50 MB.
+- `discard`: DOM node count regresses by more than 10%.
+- otherwise: `inconclusive`.
+
+Comparator artifacts:
+
+- `*.comparison.json` → full baseline/candidate diff and decision
+- `comparisons.tsv` → autoresearch-style keep/discard ledger
+
+The harness is gated behind `localStorage.dotagents.sessionSwitchPerfHarness =
+"true"` and is only initialized in dev/test renderer builds. The benchmark
+script enables that flag automatically over CDP and reloads the renderer target
+if needed.
+
+To manually preseed a fake large session in the app UI, enable both harness keys
+from the renderer DevTools console and reload:
+
+```javascript
+localStorage.setItem("dotagents.sessionSwitchPerfHarness", "true")
+localStorage.setItem("dotagents.sessionSwitchPerfPreseed", "1000") // or "500"
+location.reload()
+```
+
+For custom preseed fixtures, store JSON instead:
+
+```javascript
+localStorage.setItem("dotagents.sessionSwitchPerfPreseed", JSON.stringify({
+  sessionCount: 2,
+  messagesPerSession: 1000,
+  messageChars: 800,
+  stepsPerSession: 120,
+}))
+location.reload()
+```
+
 ---
 
 ## IPC Methods (Testing from DevTools Console)

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -24,6 +24,8 @@
     "dev": "npx tsx scripts/dev-with-sherpa.ts",
     "dev:no-sherpa": "electron-vite dev --watch --",
     "perf:renderer:record": "npx tsx scripts/renderer-perf-recorder.ts",
+    "perf:session-switch": "npx tsx scripts/session-switch-perf-loop.ts",
+    "perf:session-switch:compare": "npx tsx scripts/session-switch-perf-compare.ts",
     "prebuild": "npx tsx scripts/ensure-build-dirs.ts",
     "build": "pnpm run typecheck && pnpm run test:run && electron-vite build && pnpm run build-rs",
     "postinstall": "node scripts/postinstall.cjs",

--- a/apps/desktop/scripts/session-switch-perf-compare.ts
+++ b/apps/desktop/scripts/session-switch-perf-compare.ts
@@ -1,0 +1,178 @@
+import fs from "fs"
+import path from "path"
+
+type Summary = {
+  runId?: string
+  options?: { scenario?: string; label?: string; switches?: number; messagesPerSession?: number }
+  eventCount?: number
+  switchLatencyP50Ms: number
+  switchLatencyP95Ms: number
+  maxSwitchLatencyMs: number
+  avgSwitchLatencyMs?: number
+  longTaskCount?: number
+  longTaskTotalMs?: number
+  domNodes?: number
+  jsHeapUsedSizeDeltaMb?: number | null
+  cdpMetricDeltas?: Record<string, number>
+  artifacts?: { summaryPath?: string; resultsTsvPath?: string }
+}
+
+type Options = {
+  baselinePath: string
+  candidatePath: string
+  outputPath?: string
+  ledgerPath?: string
+  minP95ImprovementPercent: number
+  maxP95RegressionPercent: number
+  maxHeapRegressionMb: number
+  maxDomRegressionPercent: number
+  failOnDiscard: boolean
+}
+
+type Decision = "keep" | "discard" | "inconclusive"
+
+function parseOptions(argv: string[]): Options {
+  const args = argv[0] === "--" ? argv.slice(1) : argv
+  const get = (name: string, fallback?: string) => {
+    const index = args.indexOf(name)
+    return index >= 0 ? args[index + 1] : fallback
+  }
+  const baselinePath = get("--baseline")
+  const candidatePath = get("--candidate")
+  if (!baselinePath || !candidatePath) {
+    throw new Error("Usage: pnpm perf:session-switch:compare -- --baseline baseline.results.json --candidate candidate.results.json")
+  }
+  return {
+    baselinePath,
+    candidatePath,
+    outputPath: get("--output"),
+    ledgerPath: get("--ledger"),
+    minP95ImprovementPercent: Number(get("--min-p95-improvement-percent", "10")),
+    maxP95RegressionPercent: Number(get("--max-p95-regression-percent", "5")),
+    maxHeapRegressionMb: Number(get("--max-heap-regression-mb", "50")),
+    maxDomRegressionPercent: Number(get("--max-dom-regression-percent", "10")),
+    failOnDiscard: args.includes("--fail-on-discard"),
+  }
+}
+
+function readSummary(filePath: string): Summary {
+  return JSON.parse(fs.readFileSync(resolveInputPath(filePath), "utf8")) as Summary
+}
+
+function resolveInputPath(filePath: string): string {
+  if (path.isAbsolute(filePath)) return filePath
+  const packageRelative = path.resolve(process.cwd(), filePath)
+  if (fs.existsSync(packageRelative)) return packageRelative
+  const repoRelative = path.resolve(process.cwd(), "../..", filePath)
+  if (fs.existsSync(repoRelative)) return repoRelative
+  return packageRelative
+}
+
+function pctDelta(baseline: number, candidate: number): number {
+  if (!Number.isFinite(baseline) || baseline === 0) return 0
+  return ((candidate - baseline) / baseline) * 100
+}
+
+function numberDelta(baseline?: number | null, candidate?: number | null): number | null {
+  if (baseline === null || candidate === null || baseline === undefined || candidate === undefined) return null
+  return candidate - baseline
+}
+
+function appendTsv(filePath: string, row: Record<string, string | number>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  const headers = Object.keys(row)
+  if (!fs.existsSync(filePath)) fs.writeFileSync(filePath, `${headers.join("\t")}\n`)
+  fs.appendFileSync(filePath, `${headers.map((header) => row[header]).join("\t")}\n`)
+}
+
+function decide(options: Options, deltas: Record<string, number | null>): { decision: Decision; reasons: string[] } {
+  const reasons: string[] = []
+  const p95Delta = deltas.p95Percent ?? 0
+  const heapDelta = deltas.heapDeltaMb
+  const domDeltaPercent = deltas.domPercent ?? 0
+
+  if (p95Delta > options.maxP95RegressionPercent) {
+    reasons.push(`p95 regressed by ${p95Delta.toFixed(1)}%`)
+    return { decision: "discard", reasons }
+  }
+  if (heapDelta !== null && heapDelta > options.maxHeapRegressionMb) {
+    reasons.push(`heap delta regressed by ${heapDelta.toFixed(1)} MB`)
+    return { decision: "discard", reasons }
+  }
+  if (domDeltaPercent > options.maxDomRegressionPercent) {
+    reasons.push(`DOM node count regressed by ${domDeltaPercent.toFixed(1)}%`)
+    return { decision: "discard", reasons }
+  }
+  if (p95Delta <= -options.minP95ImprovementPercent) {
+    reasons.push(`p95 improved by ${Math.abs(p95Delta).toFixed(1)}%`)
+    return { decision: "keep", reasons }
+  }
+  reasons.push(`p95 delta ${p95Delta.toFixed(1)}% is within threshold`)
+  return { decision: "inconclusive", reasons }
+}
+
+function main(): void {
+  const options = parseOptions(process.argv.slice(2))
+  const baseline = readSummary(options.baselinePath)
+  const candidate = readSummary(options.candidatePath)
+  const deltas = {
+    p50Ms: candidate.switchLatencyP50Ms - baseline.switchLatencyP50Ms,
+    p50Percent: pctDelta(baseline.switchLatencyP50Ms, candidate.switchLatencyP50Ms),
+    p95Ms: candidate.switchLatencyP95Ms - baseline.switchLatencyP95Ms,
+    p95Percent: pctDelta(baseline.switchLatencyP95Ms, candidate.switchLatencyP95Ms),
+    maxMs: candidate.maxSwitchLatencyMs - baseline.maxSwitchLatencyMs,
+    maxPercent: pctDelta(baseline.maxSwitchLatencyMs, candidate.maxSwitchLatencyMs),
+    longTaskCount: (candidate.longTaskCount ?? 0) - (baseline.longTaskCount ?? 0),
+    longTaskTotalMs: (candidate.longTaskTotalMs ?? 0) - (baseline.longTaskTotalMs ?? 0),
+    heapDeltaMb: numberDelta(baseline.jsHeapUsedSizeDeltaMb, candidate.jsHeapUsedSizeDeltaMb),
+    domNodes: (candidate.domNodes ?? 0) - (baseline.domNodes ?? 0),
+    domPercent: pctDelta(baseline.domNodes ?? 0, candidate.domNodes ?? 0),
+  }
+  const verdict = decide(options, deltas)
+  const comparison = {
+    comparedAt: new Date().toISOString(),
+    baselinePath: resolveInputPath(options.baselinePath),
+    candidatePath: resolveInputPath(options.candidatePath),
+    thresholds: {
+      minP95ImprovementPercent: options.minP95ImprovementPercent,
+      maxP95RegressionPercent: options.maxP95RegressionPercent,
+      maxHeapRegressionMb: options.maxHeapRegressionMb,
+      maxDomRegressionPercent: options.maxDomRegressionPercent,
+    },
+    baseline,
+    candidate,
+    deltas,
+    ...verdict,
+  }
+  const defaultOutput = path.join(path.dirname(comparison.candidatePath), `${candidate.runId ?? "candidate"}.comparison.json`)
+  const outputPath = path.resolve(process.cwd(), options.outputPath ?? defaultOutput)
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, JSON.stringify(comparison, null, 2))
+  const ledgerPath = path.resolve(process.cwd(), options.ledgerPath ?? path.join(path.dirname(outputPath), "comparisons.tsv"))
+  appendTsv(ledgerPath, {
+    timestamp: comparison.comparedAt,
+    decision: verdict.decision,
+    scenario: candidate.options?.scenario ?? "unknown",
+    baseline: path.basename(options.baselinePath),
+    candidate: path.basename(options.candidatePath),
+    p95_delta_percent: deltas.p95Percent.toFixed(2),
+    p95_delta_ms: deltas.p95Ms.toFixed(2),
+    max_delta_percent: deltas.maxPercent.toFixed(2),
+    heap_delta_mb: deltas.heapDeltaMb === null ? "n/a" : deltas.heapDeltaMb.toFixed(2),
+    dom_delta_percent: deltas.domPercent.toFixed(2),
+    reasons: verdict.reasons.join("; "),
+  })
+  console.log(`[session-switch-compare] decision=${verdict.decision}`)
+  console.log(`[session-switch-compare] p95 delta=${deltas.p95Ms.toFixed(1)}ms (${deltas.p95Percent.toFixed(1)}%)`)
+  console.log(`[session-switch-compare] max delta=${deltas.maxMs.toFixed(1)}ms (${deltas.maxPercent.toFixed(1)}%)`)
+  console.log(`[session-switch-compare] ${verdict.reasons.join("; ")}`)
+  console.log(`[session-switch-compare] Wrote ${outputPath}`)
+  if (options.failOnDiscard && verdict.decision === "discard") process.exit(2)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error("[session-switch-compare] Failed:", error)
+  process.exit(1)
+}

--- a/apps/desktop/scripts/session-switch-perf-loop.ts
+++ b/apps/desktop/scripts/session-switch-perf-loop.ts
@@ -1,0 +1,341 @@
+import fs from "fs"
+import path from "path"
+
+type CdpTarget = {
+  id: string
+  type: string
+  title: string
+  url: string
+  webSocketDebuggerUrl?: string
+}
+
+type Options = {
+  port: number
+  outputDir: string
+  label: string
+  scenario: string
+  targetUrlFragment?: string
+  sessionCount: number
+  messagesPerSession: number
+  messageChars: number
+  stepsPerSession: number
+  toolCallsEvery: number
+  switches: number
+  warmupSwitches: number
+  framesToWait: number
+  maxFrameWaitMs: number
+  trace: boolean
+}
+
+type CdpMetricMap = Record<string, number>
+
+type SwitchEvent = {
+  index: number
+  warmup: boolean
+  sessionId: string
+  durationMs: number
+  longTaskTotalMs: number
+  longTaskCount: number
+  domNodes: number
+  jsHeapUsedSize?: number
+  cdpMetrics: CdpMetricMap
+}
+
+type RuntimeEvaluateResult<T> = {
+  result?: { value?: T; description?: string }
+  exceptionDetails?: { text?: string; exception?: { description?: string } }
+}
+
+const HARNESS_KEY = "dotagents.sessionSwitchPerfHarness"
+const TRACE_CATEGORIES = [
+  "devtools.timeline",
+  "v8",
+  "blink.user_timing",
+  "disabled-by-default-devtools.timeline",
+].join(",")
+
+function parseOptions(argv: string[]): Options {
+  const args = argv[0] === "--" ? argv.slice(1) : argv
+  const get = (name: string, fallback?: string) => {
+    const index = args.indexOf(name)
+    return index >= 0 ? args[index + 1] : fallback
+  }
+  const has = (name: string) => args.includes(name)
+  const scenario = get("--scenario", "large")!
+  const scenarioDefaults = scenario === "single-1000"
+    ? { sessionCount: 1, messagesPerSession: 1000, messageChars: 800, stepsPerSession: 120 }
+    : scenario === "single-500"
+      ? { sessionCount: 1, messagesPerSession: 500, messageChars: 800, stepsPerSession: 80 }
+      : scenario === "huge"
+    ? { sessionCount: 8, messagesPerSession: 250, messageChars: 1000, stepsPerSession: 120 }
+    : scenario === "medium"
+      ? { sessionCount: 4, messagesPerSession: 80, messageChars: 500, stepsPerSession: 40 }
+      : { sessionCount: 5, messagesPerSession: 150, messageChars: 800, stepsPerSession: 80 }
+
+  return {
+    port: Number(get("--port", "9333")),
+    outputDir: get("--output-dir", "tmp/perf/session-switch")!,
+    label: get("--label", "session-switch")!,
+    scenario,
+    targetUrlFragment: get("--target-url-fragment"),
+    sessionCount: Number(get("--session-count", String(scenarioDefaults.sessionCount))),
+    messagesPerSession: Number(get("--messages-per-session", String(scenarioDefaults.messagesPerSession))),
+    messageChars: Number(get("--message-chars", String(scenarioDefaults.messageChars))),
+    stepsPerSession: Number(get("--steps-per-session", String(scenarioDefaults.stepsPerSession))),
+    toolCallsEvery: Number(get("--tool-calls-every", "8")),
+    switches: Number(get("--switches", "30")),
+    warmupSwitches: Number(get("--warmup-switches", "5")),
+    framesToWait: Number(get("--frames-to-wait", "2")),
+    maxFrameWaitMs: Number(get("--max-frame-wait-ms", "250")),
+    trace: has("--trace"),
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
+  return response.json() as Promise<T>
+}
+
+function pickTarget(targets: CdpTarget[], fragment?: string): CdpTarget {
+  const pages = targets.filter((target) => target.type === "page" && target.webSocketDebuggerUrl)
+  const exact = fragment
+    ? pages.find((target) => target.url.includes(fragment))
+    : pages.find((target) => {
+        try {
+          return new URL(target.url).pathname === "/"
+        } catch {
+          return target.url === "/"
+        }
+      })
+  const fallback = pages.find((target) => !target.url.includes("/panel")) ?? pages[0]
+  if (!exact && !fallback) throw new Error("No renderer page targets found on the CDP endpoint")
+  return exact ?? fallback
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1)
+  return sorted[index]
+}
+
+function metricValue(metrics: CdpMetricMap, name: string): number {
+  return Number(metrics[name] ?? 0)
+}
+
+function appendResultsTsv(filePath: string, row: Record<string, string | number>): void {
+  const headers = Object.keys(row)
+  if (!fs.existsSync(filePath)) fs.writeFileSync(filePath, `${headers.join("\t")}\n`)
+  fs.appendFileSync(filePath, `${headers.map((header) => row[header]).join("\t")}\n`)
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2))
+  const outputDir = path.resolve(process.cwd(), options.outputDir)
+  fs.mkdirSync(outputDir, { recursive: true })
+
+  const runId = new Date().toISOString().replace(/[:.]/g, "-")
+  const baseName = `${options.label}-${options.scenario}-${runId}`
+  const eventsPath = path.join(outputDir, `${baseName}.events.jsonl`)
+  const summaryPath = path.join(outputDir, `${baseName}.results.json`)
+  const tracePath = path.join(outputDir, `${baseName}.trace.json`)
+  const resultsTsvPath = path.join(outputDir, "results.tsv")
+
+  const targets = await fetchJson<CdpTarget[]>(`http://127.0.0.1:${options.port}/json/list`)
+  const target = pickTarget(targets, options.targetUrlFragment)
+  const websocket = new WebSocket(target.webSocketDebuggerUrl!)
+  const pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>()
+  const traceEvents: unknown[] = []
+  let nextId = 1
+  let traceComplete: (() => void) | null = null
+
+  await new Promise<void>((resolve, reject) => {
+    websocket.addEventListener("open", () => resolve(), { once: true })
+    websocket.addEventListener("error", () => reject(new Error("Failed to connect to renderer CDP websocket")), { once: true })
+  })
+
+  const send = <T>(method: string, params?: Record<string, unknown>) => {
+    const id = nextId++
+    websocket.send(JSON.stringify({ id, method, params }))
+    return new Promise<T>((resolve, reject) => pending.set(id, { resolve, reject }))
+  }
+
+  websocket.addEventListener("message", async (event) => {
+    const raw = typeof event.data === "string" ? event.data : await new Response(event.data).text()
+    const payload = JSON.parse(raw)
+    if (payload.id) {
+      const request = pending.get(payload.id)
+      if (!request) return
+      pending.delete(payload.id)
+      if (payload.error) request.reject(new Error(payload.error.message || "Unknown CDP error"))
+      else request.resolve(payload.result)
+      return
+    }
+    if (payload.method === "Tracing.dataCollected") traceEvents.push(...(payload.params?.value ?? []))
+    if (payload.method === "Tracing.tracingComplete") traceComplete?.()
+  })
+
+  const evaluate = async <T>(expression: string): Promise<T> => {
+    const response = await send<RuntimeEvaluateResult<T>>("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    })
+    if (response.exceptionDetails) {
+      throw new Error(response.exceptionDetails.exception?.description || response.exceptionDetails.text || "Runtime.evaluate failed")
+    }
+    return response.result?.value as T
+  }
+
+  const getMetrics = async (): Promise<CdpMetricMap> => {
+    const result = await send<{ metrics: Array<{ name: string; value: number }> }>("Performance.getMetrics")
+    return Object.fromEntries(result.metrics.map((metric) => [metric.name, metric.value]))
+  }
+
+  const waitForHarness = async (): Promise<void> => {
+    await evaluate<void>(`localStorage.setItem(${JSON.stringify(HARNESS_KEY)}, "true")`)
+    const alreadyReady = await evaluate<boolean>(`typeof window.__DOTAGENTS_SESSION_SWITCH_PERF__ !== "undefined"`)
+    if (alreadyReady) return
+
+    await send("Page.reload", { ignoreCache: true })
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const ready = await evaluate<boolean>(`typeof window.__DOTAGENTS_SESSION_SWITCH_PERF__ !== "undefined"`).catch(() => false)
+      if (ready) return
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+    throw new Error("Timed out waiting for session-switch perf harness. Start the app in dev mode with CDP enabled.")
+  }
+
+  try {
+    await send("Runtime.enable")
+    await send("Performance.enable")
+    await send("Page.enable")
+    await waitForHarness()
+
+    if (options.trace) {
+      await send("Tracing.start", { categories: TRACE_CATEGORIES, transferMode: "ReportEvents" })
+    }
+
+    const seedSnapshot = await evaluate<{ sessionIds: string[] }>(`
+      window.__DOTAGENTS_SESSION_SWITCH_PERF__.seed(${JSON.stringify({
+        sessionCount: options.sessionCount,
+        messagesPerSession: options.messagesPerSession,
+        messageChars: options.messageChars,
+        stepsPerSession: options.stepsPerSession,
+        toolCallsEvery: options.toolCallsEvery,
+        titlePrefix: `Perf ${options.scenario}`,
+      })})
+    `)
+    const sessionIds = seedSnapshot.sessionIds
+    if (sessionIds.length === 0) throw new Error("Harness seeded zero sessions")
+
+    const totalSwitches = options.warmupSwitches + options.switches
+    const eventsStream = fs.createWriteStream(eventsPath, { flags: "a" })
+    const baselineMetrics = await getMetrics()
+    const events: SwitchEvent[] = []
+
+    for (let index = 0; index < totalSwitches; index++) {
+      const sessionId = sessionIds[index % sessionIds.length]
+      const sample = await evaluate<{
+        sessionId: string
+        durationMs: number
+        longTaskTotalMs: number
+        longTaskCount: number
+        domNodes: number
+        jsHeapUsedSize?: number
+      }>(`
+        window.__DOTAGENTS_SESSION_SWITCH_PERF__.switchTo(${JSON.stringify(sessionId)}, ${JSON.stringify({ framesToWait: options.framesToWait, maxFrameWaitMs: options.maxFrameWaitMs })})
+      `)
+      const eventRecord: SwitchEvent = {
+        index,
+        warmup: index < options.warmupSwitches,
+        sessionId: sample.sessionId,
+        durationMs: sample.durationMs,
+        longTaskTotalMs: sample.longTaskTotalMs,
+        longTaskCount: sample.longTaskCount,
+        domNodes: sample.domNodes,
+        jsHeapUsedSize: sample.jsHeapUsedSize,
+        cdpMetrics: await getMetrics(),
+      }
+      events.push(eventRecord)
+      eventsStream.write(`${JSON.stringify(eventRecord)}\n`)
+      console.log(`[session-switch-perf] ${index + 1}/${totalSwitches} ${eventRecord.warmup ? "warmup" : "sample"} ${eventRecord.durationMs.toFixed(1)}ms`)
+    }
+
+    await new Promise<void>((resolve) => eventsStream.end(() => resolve()))
+    const finalMetrics = await getMetrics()
+    const measured = events.filter((event) => !event.warmup)
+    const durations = measured.map((event) => event.durationMs)
+    const firstHeap = measured.find((event) => event.jsHeapUsedSize !== undefined)?.jsHeapUsedSize
+    const lastHeap = [...measured].reverse().find((event) => event.jsHeapUsedSize !== undefined)?.jsHeapUsedSize
+    const summary = {
+      runId,
+      options,
+      target: { id: target.id, title: target.title, url: target.url },
+      eventCount: measured.length,
+      switchLatencyP50Ms: percentile(durations, 50),
+      switchLatencyP95Ms: percentile(durations, 95),
+      maxSwitchLatencyMs: durations.length ? Math.max(...durations) : 0,
+      avgSwitchLatencyMs: durations.reduce((sum, value) => sum + value, 0) / Math.max(1, durations.length),
+      longTaskCount: measured.reduce((sum, event) => sum + event.longTaskCount, 0),
+      longTaskTotalMs: measured.reduce((sum, event) => sum + event.longTaskTotalMs, 0),
+      domNodes: measured[measured.length - 1]?.domNodes ?? 0,
+      jsHeapUsedSizeDeltaMb: firstHeap !== undefined && lastHeap !== undefined
+        ? (lastHeap - firstHeap) / 1024 / 1024
+        : null,
+      cdpMetricDeltas: {
+        TaskDuration: metricValue(finalMetrics, "TaskDuration") - metricValue(baselineMetrics, "TaskDuration"),
+        ScriptDuration: metricValue(finalMetrics, "ScriptDuration") - metricValue(baselineMetrics, "ScriptDuration"),
+        LayoutDuration: metricValue(finalMetrics, "LayoutDuration") - metricValue(baselineMetrics, "LayoutDuration"),
+        RecalcStyleDuration: metricValue(finalMetrics, "RecalcStyleDuration") - metricValue(baselineMetrics, "RecalcStyleDuration"),
+      },
+      artifacts: { eventsPath, summaryPath, tracePath: options.trace ? tracePath : null, resultsTsvPath },
+    }
+
+    if (options.trace) {
+      const complete = new Promise<void>((resolve) => { traceComplete = resolve })
+      await send("Tracing.end")
+      await complete
+      fs.writeFileSync(tracePath, JSON.stringify({ traceEvents }, null, 2))
+    }
+
+    fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2))
+    appendResultsTsv(resultsTsvPath, {
+      timestamp: new Date().toISOString(),
+      label: options.label,
+      scenario: options.scenario,
+      session_count: options.sessionCount,
+      messages_per_session: options.messagesPerSession,
+      switches: options.switches,
+      p50_ms: summary.switchLatencyP50Ms.toFixed(2),
+      p95_ms: summary.switchLatencyP95Ms.toFixed(2),
+      max_ms: summary.maxSwitchLatencyMs.toFixed(2),
+      long_tasks: summary.longTaskCount,
+      heap_delta_mb: summary.jsHeapUsedSizeDeltaMb === null ? "n/a" : summary.jsHeapUsedSizeDeltaMb.toFixed(2),
+      dom_nodes: summary.domNodes,
+      status: "baseline",
+      notes: "session-switch-cdp-run",
+    })
+
+    console.log(`[session-switch-perf] Summary saved to ${summaryPath}`)
+    console.log(`[session-switch-perf] p50=${summary.switchLatencyP50Ms.toFixed(1)}ms p95=${summary.switchLatencyP95Ms.toFixed(1)}ms max=${summary.maxSwitchLatencyMs.toFixed(1)}ms`)
+  } finally {
+    if (websocket.readyState === WebSocket.OPEN) {
+      await new Promise<void>((resolve) => {
+        websocket.addEventListener("close", () => resolve(), { once: true })
+        websocket.close()
+        setTimeout(resolve, 250)
+      })
+    } else {
+      websocket.close()
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("[session-switch-perf] Failed:", error)
+  process.exit(1)
+})

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,10 +1,11 @@
 import { RouterProvider } from "react-router-dom"
 import { router } from "./router"
-import { lazy, Suspense } from "react"
+import { lazy, Suspense, useEffect } from "react"
 import { Toaster } from "sonner"
 import { ThemeProvider } from "./contexts/theme-context"
 import { useStoreSync } from "./hooks/use-store-sync"
 import { useAudioInputDeviceFallback } from "./hooks/use-audio-input-device-fallback"
+import { initializeSessionSwitchPerfHarness } from "./lib/session-switch-perf-harness"
 
 const McpElicitationDialog = lazy(() => import("./components/mcp-elicitation-dialog"))
 const McpSamplingDialog = lazy(() => import("./components/mcp-sampling-dialog"))
@@ -12,6 +13,10 @@ const McpSamplingDialog = lazy(() => import("./components/mcp-sampling-dialog"))
 function StoreInitializer({ children }: { children: React.ReactNode }) {
   useStoreSync()
   useAudioInputDeviceFallback()
+  useEffect(() => {
+    if (!import.meta.env.DEV && import.meta.env.MODE !== "test") return undefined
+    return initializeSessionSwitchPerfHarness()
+  }, [])
   return <>{children}</>
 }
 

--- a/apps/desktop/src/renderer/src/lib/session-switch-perf-harness.ts
+++ b/apps/desktop/src/renderer/src/lib/session-switch-perf-harness.ts
@@ -1,0 +1,289 @@
+import type { AgentProgressStep, AgentProgressUpdate, ConversationHistoryMessage } from "@shared/types"
+import { useAgentStore } from "@renderer/stores"
+
+export const DOTAGENTS_SESSION_SWITCH_PERF_HARNESS_KEY =
+  "dotagents.sessionSwitchPerfHarness"
+export const DOTAGENTS_SESSION_SWITCH_PERF_PRESEED_KEY =
+  "dotagents.sessionSwitchPerfPreseed"
+
+type SeedOptions = {
+  sessionCount?: number
+  messagesPerSession?: number
+  messageChars?: number
+  stepsPerSession?: number
+  toolCallsEvery?: number
+  titlePrefix?: string
+}
+
+type SwitchOptions = {
+  framesToWait?: number
+  maxFrameWaitMs?: number
+}
+
+type HarnessSnapshot = {
+  sessionIds: string[]
+  focusedSessionId: string | null
+  expandedSessionId: string | null
+  domNodes: number
+  jsHeapUsedSize?: number
+  jsHeapTotalSize?: number
+  longTaskCount: number
+}
+
+type SwitchSample = HarnessSnapshot & {
+  sessionId: string
+  durationMs: number
+  longTaskTotalMs: number
+}
+
+export type SessionSwitchPerfHarness = {
+  seed: (options?: SeedOptions) => HarnessSnapshot
+  clear: () => HarnessSnapshot
+  snapshot: () => HarnessSnapshot
+  switchTo: (sessionId: string, options?: SwitchOptions) => Promise<SwitchSample>
+  getSessionIds: () => string[]
+  drainLongTasks: () => Array<{ name: string; startTime: number; duration: number }>
+}
+
+declare global {
+  interface Window {
+    __DOTAGENTS_SESSION_SWITCH_PERF__?: SessionSwitchPerfHarness
+  }
+}
+
+let installed = false
+let longTasks: Array<{ name: string; startTime: number; duration: number }> = []
+let longTaskObserver: PerformanceObserver | null = null
+
+function isEnabled(): boolean {
+  try {
+    const params = new URLSearchParams(window.location.search)
+    return (
+      params.get("sessionSwitchPerfHarness") === "1" ||
+      localStorage.getItem(DOTAGENTS_SESSION_SWITCH_PERF_HARNESS_KEY) === "true"
+    )
+  } catch {
+    return false
+  }
+}
+
+function parsePositiveInt(value: string | null | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : undefined
+}
+
+function parsePreseedOptions(): SeedOptions | null {
+  try {
+    const params = new URLSearchParams(window.location.search)
+    const rawPreseed =
+      params.get("sessionSwitchPerfPreseed") ??
+      localStorage.getItem(DOTAGENTS_SESSION_SWITCH_PERF_PRESEED_KEY)
+    if (!rawPreseed || rawPreseed === "false" || rawPreseed === "0") return null
+
+    const fromJson = rawPreseed.trim().startsWith("{")
+      ? JSON.parse(rawPreseed) as SeedOptions
+      : {}
+    const requestedMessages = parsePositiveInt(rawPreseed)
+    const messagesPerSession =
+      parsePositiveInt(params.get("sessionSwitchPerfMessages")) ??
+      requestedMessages ??
+      fromJson.messagesPerSession ??
+      1000
+
+    return {
+      sessionCount: parsePositiveInt(params.get("sessionSwitchPerfSessions")) ?? fromJson.sessionCount ?? 1,
+      messagesPerSession,
+      messageChars: parsePositiveInt(params.get("sessionSwitchPerfMessageChars")) ?? fromJson.messageChars ?? 800,
+      stepsPerSession: parsePositiveInt(params.get("sessionSwitchPerfSteps")) ?? fromJson.stepsPerSession ?? 80,
+      toolCallsEvery: parsePositiveInt(params.get("sessionSwitchPerfToolCallsEvery")) ?? fromJson.toolCallsEvery ?? 8,
+      titlePrefix: fromJson.titlePrefix ?? `Preseeded ${messagesPerSession}-message Session`,
+    }
+  } catch (error) {
+    console.warn("[session-switch-perf] Ignoring invalid preseed options", error)
+    return null
+  }
+}
+
+function heapSnapshot(): Pick<HarnessSnapshot, "jsHeapUsedSize" | "jsHeapTotalSize"> {
+  const memory = (performance as Performance & {
+    memory?: { usedJSHeapSize?: number; totalJSHeapSize?: number }
+  }).memory
+  return {
+    jsHeapUsedSize: memory?.usedJSHeapSize,
+    jsHeapTotalSize: memory?.totalJSHeapSize,
+  }
+}
+
+function snapshot(): HarnessSnapshot {
+  const state = useAgentStore.getState()
+  return {
+    sessionIds: Array.from(state.agentProgressById.keys()),
+    focusedSessionId: state.focusedSessionId,
+    expandedSessionId: state.expandedSessionId,
+    domNodes: document.getElementsByTagName("*").length,
+    longTaskCount: longTasks.length,
+    ...heapSnapshot(),
+  }
+}
+
+function makeText(label: string, targetLength: number): string {
+  const chunk = `${label} lorem ipsum performance fixture with markdown **bold** and \`code\`. `
+  return chunk.repeat(Math.max(1, Math.ceil(targetLength / chunk.length))).slice(0, targetLength)
+}
+
+function makeProgress(sessionIndex: number, options: Required<SeedOptions>): AgentProgressUpdate {
+  const now = Date.now()
+  const sessionId = `perf_session_${sessionIndex}_${now}`
+  const conversationId = `perf_conversation_${sessionIndex}_${now}`
+  const conversationHistory: ConversationHistoryMessage[] = Array.from({ length: options.messagesPerSession }, (_, messageIndex) => {
+    const role: ConversationHistoryMessage["role"] = messageIndex % 2 === 0 ? "user" : "assistant"
+    const hasToolCall = role === "assistant" && options.toolCallsEvery > 0 && messageIndex % options.toolCallsEvery === 1
+    return {
+      role,
+      content: makeText(`${role} ${sessionIndex}.${messageIndex}`, options.messageChars),
+      timestamp: now + messageIndex,
+      branchMessageIndex: messageIndex,
+      ...(hasToolCall
+        ? {
+            toolCalls: [{ name: "read_more_context", arguments: { query: `fixture ${messageIndex}` } }],
+            toolResults: [{ success: true, content: makeText("tool result", Math.floor(options.messageChars / 2)) }],
+          }
+        : {}),
+    }
+  })
+  const steps: AgentProgressStep[] = Array.from({ length: options.stepsPerSession }, (_, stepIndex) => ({
+    id: `${sessionId}_step_${stepIndex}`,
+    type: stepIndex % 5 === 0 ? "tool_call" : "thinking",
+    title: stepIndex % 5 === 0 ? `Tool call ${stepIndex}` : `Thinking ${stepIndex}`,
+    description: makeText(`step ${stepIndex}`, Math.min(240, options.messageChars)),
+    status: stepIndex === options.stepsPerSession - 1 ? "in_progress" : "completed",
+    timestamp: now + stepIndex,
+  }))
+
+  return {
+    sessionId,
+    conversationId,
+    conversationTitle: `${options.titlePrefix} ${sessionIndex + 1}`,
+    currentIteration: Math.max(1, options.stepsPerSession),
+    maxIterations: Math.max(1, options.stepsPerSession + 10),
+    steps,
+    isComplete: false,
+    conversationHistory,
+    conversationHistoryTotalCount: conversationHistory.length,
+    profileName: "Perf Harness",
+    modelInfo: { provider: "fixture", model: "synthetic" },
+    streamingContent: { text: makeText("streaming", Math.floor(options.messageChars / 3)), isStreaming: true },
+  }
+}
+
+async function waitFrames(count: number, maxFrameWaitMs: number): Promise<void> {
+  for (let index = 0; index < count; index++) {
+    await new Promise<void>((resolve) => {
+      let settled = false
+      const finish = () => {
+        if (settled) return
+        settled = true
+        resolve()
+      }
+      requestAnimationFrame(finish)
+      setTimeout(finish, maxFrameWaitMs)
+    })
+  }
+}
+
+function installLongTaskObserver(): void {
+  if (longTaskObserver || typeof PerformanceObserver === "undefined") return
+  try {
+    longTaskObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        longTasks.push({ name: entry.name, startTime: entry.startTime, duration: entry.duration })
+      }
+    })
+    longTaskObserver.observe({ entryTypes: ["longtask"] })
+  } catch {
+    longTaskObserver = null
+  }
+}
+
+export function initializeSessionSwitchPerfHarness(): () => void {
+  if (installed || typeof window === "undefined" || !isEnabled()) return () => {}
+  installed = true
+  installLongTaskObserver()
+
+  const harness: SessionSwitchPerfHarness = {
+    seed: (rawOptions = {}) => {
+      const options: Required<SeedOptions> = {
+        sessionCount: rawOptions.sessionCount ?? 5,
+        messagesPerSession: rawOptions.messagesPerSession ?? 100,
+        messageChars: rawOptions.messageChars ?? 600,
+        stepsPerSession: rawOptions.stepsPerSession ?? 50,
+        toolCallsEvery: rawOptions.toolCallsEvery ?? 8,
+        titlePrefix: rawOptions.titlePrefix ?? "Perf Session",
+      }
+      const state = useAgentStore.getState()
+      state.clearAllProgress()
+      longTasks = []
+      const updates = Array.from({ length: options.sessionCount }, (_, index) => makeProgress(index, options))
+      for (const update of updates) state.updateSessionProgress(update)
+      const firstSessionId = updates[0]?.sessionId ?? null
+      state.setFocusedSessionId(firstSessionId)
+      state.setExpandedSessionId(firstSessionId)
+      state.setViewedConversationId(updates[0]?.conversationId ?? null)
+      return snapshot()
+    },
+    clear: () => {
+      useAgentStore.getState().clearAllProgress()
+      useAgentStore.getState().setViewedConversationId(null)
+      longTasks = []
+      return snapshot()
+    },
+    snapshot,
+    switchTo: async (sessionId, options = {}) => {
+      const beforeLongTaskCount = longTasks.length
+      const start = performance.now()
+      const state = useAgentStore.getState()
+      const progress = state.agentProgressById.get(sessionId)
+      if (!progress) throw new Error(`Unknown perf session: ${sessionId}`)
+      state.setViewedConversationId(null)
+      state.setFocusedSessionId(sessionId)
+      state.setExpandedSessionId(sessionId)
+      state.setViewedConversationId(progress.conversationId ?? null)
+      await waitFrames(options.framesToWait ?? 2, options.maxFrameWaitMs ?? 250)
+      const durationMs = performance.now() - start
+      const newLongTasks = longTasks.slice(beforeLongTaskCount)
+      return {
+        ...snapshot(),
+        sessionId,
+        durationMs,
+        longTaskTotalMs: newLongTasks.reduce((sum, entry) => sum + entry.duration, 0),
+      }
+    },
+    getSessionIds: () => Array.from(useAgentStore.getState().agentProgressById.keys()),
+    drainLongTasks: () => {
+      const drained = longTasks
+      longTasks = []
+      return drained
+    },
+  }
+
+  window.__DOTAGENTS_SESSION_SWITCH_PERF__ = harness
+  console.info("[session-switch-perf] Harness installed")
+  const preseedOptions = parsePreseedOptions()
+  if (preseedOptions) {
+    const seeded = harness.seed(preseedOptions)
+    console.info("[session-switch-perf] Preseeded synthetic sessions", {
+      sessionCount: seeded.sessionIds.length,
+      messagesPerSession: preseedOptions.messagesPerSession,
+    })
+  }
+
+  return () => {
+    if (window.__DOTAGENTS_SESSION_SWITCH_PERF__ === harness) {
+      delete window.__DOTAGENTS_SESSION_SWITCH_PERF__
+    }
+    longTaskObserver?.disconnect()
+    longTaskObserver = null
+    installed = false
+  }
+}

--- a/apps/desktop/tests/session-switch-perf-harness.test.mjs
+++ b/apps/desktop/tests/session-switch-perf-harness.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const read = (relativePath) => fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+
+test('desktop exposes a gated session-switch performance harness', () => {
+  const appSource = read('apps/desktop/src/renderer/src/App.tsx')
+  const harnessSource = read('apps/desktop/src/renderer/src/lib/session-switch-perf-harness.ts')
+
+  assert.match(appSource, /initializeSessionSwitchPerfHarness/)
+  assert.match(harnessSource, /dotagents\.sessionSwitchPerfHarness/)
+  assert.match(harnessSource, /dotagents\.sessionSwitchPerfPreseed/)
+  assert.match(harnessSource, /__DOTAGENTS_SESSION_SWITCH_PERF__/)
+  assert.match(harnessSource, /updateSessionProgress\(update\)/)
+  assert.match(harnessSource, /setFocusedSessionId\(sessionId\)/)
+  assert.match(harnessSource, /messagesPerSession.*1000/s)
+})
+
+test('desktop package wires the CDP session-switch benchmark script', () => {
+  const packageSource = read('apps/desktop/package.json')
+  const scriptSource = read('apps/desktop/scripts/session-switch-perf-loop.ts')
+  const compareSource = read('apps/desktop/scripts/session-switch-perf-compare.ts')
+
+  assert.match(packageSource, /"perf:session-switch": "npx tsx scripts\/session-switch-perf-loop\.ts"/)
+  assert.match(packageSource, /"perf:session-switch:compare": "npx tsx scripts\/session-switch-perf-compare\.ts"/)
+  assert.match(scriptSource, /Performance\.getMetrics/)
+  assert.match(scriptSource, /Tracing\.start/)
+  assert.match(scriptSource, /single-1000/)
+  assert.match(scriptSource, /single-500/)
+  assert.match(scriptSource, /results\.tsv/)
+  assert.match(compareSource, /min-p95-improvement-percent/)
+  assert.match(compareSource, /decision: "keep"/)
+  assert.match(compareSource, /decision: "discard"/)
+  assert.match(compareSource, /comparisons\.tsv/)
+})


### PR DESCRIPTION
## Summary

This PR adds a Karpathy-style autoresearch feedback loop for optimizing Electron renderer performance when switching between multiple large DotAgents sessions.

The loop is benchmark-first:

1. Seed deterministic large fake sessions in the renderer.
2. Drive session switching over Electron CDP.
3. Record per-run metrics and artifacts.
4. Compare a candidate run against a baseline.
5. Produce a keep, discard, or inconclusive recommendation using explicit thresholds.

This gives us a repeatable baseline to candidate to compare workflow before making UI optimization changes.

## What changed

### Dev-only renderer performance harness

Adds apps/desktop/src/renderer/src/lib/session-switch-perf-harness.ts and initializes it from App.tsx only in dev/test renderer builds.

The harness is gated by localStorage/query params and exposes a narrow window.__DOTAGENTS_SESSION_SWITCH_PERF__ API with seed, switchTo, snapshot, clear, getSessionIds, and drainLongTasks.

It seeds synthetic AgentProgressUpdate objects through the existing Zustand store path, so it exercises the same renderer session state used by real sessions without starting real agents or making LLM/API calls.

### Fake 500/1000-message large-session fixtures

Adds deterministic large-session stress presets:

- pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario single-500 --switches 5
- pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario single-1000 --switches 5

Also supports manual preseed in the app UI via renderer DevTools:

- localStorage.setItem("dotagents.sessionSwitchPerfHarness", "true")
- localStorage.setItem("dotagents.sessionSwitchPerfPreseed", "1000")
- location.reload()

Custom JSON preseed is also supported for multiple sessions and different message sizes.

### CDP session-switch benchmark runner

Adds apps/desktop/scripts/session-switch-perf-loop.ts, wired as:

- pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario large --switches 30

The runner:

- connects to the Electron renderer CDP endpoint
- enables Runtime, Performance, Page, and optional Tracing
- enables/reloads the dev-only harness if needed
- seeds synthetic sessions
- switches through sessions repeatedly
- records renderer-level switch samples and CDP metrics
- writes artifacts under apps/desktop/tmp/perf/session-switch/

Artifacts:

- *.results.json: summary metrics and CDP deltas
- *.events.jsonl: per-switch samples
- *.trace.json: optional Chrome trace
- results.tsv: run ledger

Key metrics:

- switchLatencyP50Ms
- switchLatencyP95Ms
- maxSwitchLatencyMs
- long task count / total duration
- JS heap delta
- DOM node count
- CDP deltas for TaskDuration, ScriptDuration, LayoutDuration, RecalcStyleDuration

### Keep/discard comparator

Adds apps/desktop/scripts/session-switch-perf-compare.ts, wired as:

- pnpm --filter @dotagents/desktop perf:session-switch:compare -- --baseline tmp/perf/session-switch/baseline.results.json --candidate tmp/perf/session-switch/candidate.results.json

Default decision thresholds:

- keep: p95 improves by at least 10 percent
- discard: p95 regresses by more than 5 percent
- discard: heap delta regresses by more than 50 MB
- discard: DOM node count regresses by more than 10 percent
- otherwise: inconclusive

The comparator writes:

- *.comparison.json
- comparisons.tsv

### Documentation and regression test

Updates apps/desktop/DEBUGGING.md with the full workflow:

- starting Electron with CDP
- running fixed scenarios
- using 500/1000-message presets
- manually preseeding fake large sessions
- comparing candidate runs against baselines
- interpreting keep/discard decisions

Adds apps/desktop/tests/session-switch-perf-harness.test.mjs to ensure the wiring stays in place.

## Validation

Ran successfully:

- node --test apps/desktop/tests/session-switch-perf-harness.test.mjs
- pnpm --filter @dotagents/desktop typecheck

Smoke-tested the CDP loop against a running renderer on port 9333:

- pnpm --filter @dotagents/desktop perf:session-switch -- --port 9333 --scenario single-1000 --switches 1 --warmup-switches 0 --frames-to-wait 1 --max-frame-wait-ms 250 --label smoke-1000

Result:

- exit code 0
- artifact: apps/desktop/tmp/perf/session-switch/smoke-1000-single-1000-2026-04-25T20-25-11-845Z.results.json
- p50/p95/max: 933.4ms

Smoke-tested baseline/candidate/compare loop:

- baseline: loop-baseline-medium-2026-04-25T20-31-18-587Z.results.json
- candidate: loop-candidate-medium-2026-04-25T20-31-22-134Z.results.json
- comparator output: decision=inconclusive
- p95 delta: -72.4ms (-6.8 percent)
- comparison artifact: apps/desktop/tmp/perf/session-switch/2026-04-25T20-31-22-134Z.comparison.json

## Notes

- This PR does not optimize session rendering yet; it finishes the measurement and feedback loop needed to evaluate optimizations safely.
- The harness is dev/test-only and explicitly gated, so it should not expose a production window API.
- Generated benchmark artifacts live under apps/desktop/tmp/, which is already gitignored.
- The benchmark uses synthetic renderer state by design for deterministic repeatability and to avoid depending on private real conversation history.
