### PR TITLE
fix: normalize heading font size in collapsed agent response previews

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -976,7 +976,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
             "leading-relaxed text-left",
             !isExpanded && shouldCollapse && "line-clamp-2"
           )}>
-          <MarkdownRenderer content={effectiveContent.trim()} />
+          <MarkdownRenderer content={effectiveContent.trim()} collapsed={!isExpanded && shouldCollapse} />
           </div>
           {hasExtras && isExpanded && (
             <div className="mt-2 space-y-2 text-left">

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
@@ -13,6 +13,7 @@ import { logExpand, logUI } from "@renderer/lib/debug"
 interface MarkdownRendererProps {
   content: string
   className?: string
+  collapsed?: boolean
   getThinkKey?: (content: string, index: number) => string
   isThinkExpanded?: (key: string) => boolean
   onToggleThink?: (key: string) => void
@@ -407,6 +408,7 @@ const parseThinkSections = (content: string) => {
 const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({
   content,
   className,
+  collapsed,
   getThinkKey,
   isThinkExpanded,
   onToggleThink,
@@ -444,17 +446,17 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({
                   ...sharedMarkdownComponents,
                   // Custom components for better styling
                   h1: ({ children }) => (
-                    <h1 className="mb-3 text-xl font-bold text-foreground">
+                    <h1 className={collapsed ? "text-sm font-normal text-foreground" : "mb-3 text-xl font-bold text-foreground"}>
                       {children}
                     </h1>
                   ),
                   h2: ({ children }) => (
-                    <h2 className="mb-2 text-lg font-semibold text-foreground">
+                    <h2 className={collapsed ? "text-sm font-normal text-foreground" : "mb-2 text-lg font-semibold text-foreground"}>
                       {children}
                     </h2>
                   ),
                   h3: ({ children }) => (
-                    <h3 className="mb-2 text-base font-medium text-foreground">
+                    <h3 className={collapsed ? "text-sm font-normal text-foreground" : "mb-2 text-base font-medium text-foreground"}>
                       {children}
                     </h3>
                   ),
@@ -496,6 +498,7 @@ const MarkdownRendererBase: React.FC<MarkdownRendererProps> = ({
 export const MarkdownRenderer = React.memo(MarkdownRendererBase, (prev, next) => (
   prev.content === next.content &&
   prev.className === next.className &&
+  prev.collapsed === next.collapsed &&
   prev.getThinkKey === next.getThinkKey &&
   prev.isThinkExpanded === next.isThinkExpanded &&
   prev.onToggleThink === next.onToggleThink

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -273,6 +273,7 @@ const getCollapsedMessagePreview = (content: string) =>
   content
     .replace(/!\[[^\]]*\]\((?:data:image\/[^)]+|[^)]+)\)/gi, '[Image]')
     .replace(/(^|[^!])\[[^\]]*\]\((?:assets:\/\/conversation-video\/[^)]+|https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?)\)/gi, '$1[Video]')
+    .replace(/^#{1,6}\s+/gm, '')
     .replace(/\s+/g, ' ')
     .trim();
 


### PR DESCRIPTION
## Summary

- Add `collapsed` prop to desktop `MarkdownRenderer` that overrides h1/h2/h3 styles to normal body text size (`text-sm font-normal`) when rendering in a collapsed preview context
- Pass `collapsed={!isExpanded && shouldCollapse}` to `MarkdownRenderer` in the `CompactMessage` component so collapsed agent response previews no longer display oversized heading styles
- Strip raw markdown heading markers (`# `, `## `, etc.) from the mobile collapsed text preview in `getCollapsedMessagePreview`

## Test plan

- [ ] Open a conversation where an agent response starts with `# Heading` markdown
- [ ] Verify the collapsed preview shows the heading text at normal body font size, not oversized
- [ ] Expand the message and verify the heading renders at full H1 size as expected
- [ ] On mobile, verify collapsed preview shows heading text without leading `#` symbols

Fixes #390

https://claude.ai/code/session_01SZoZrBcWxhZvdLXpYU8qZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01SZoZrBcWxhZvdLXpYU8qZ4)_