### PR TITLE
Group repeat task sessions into a collapsible sidepanel section

### DIFF
--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -15,6 +15,7 @@ import { conversationService } from "./conversation-service"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { agentProfileService, createSessionSnapshotFromProfile } from "./agent-profile-service"
 import type { LoopConfig, SessionProfileSnapshot } from "../shared/types"
+import { formatRepeatTaskTitle } from "../shared/repeat-tasks"
 import type { RendererHandlers } from "./renderer-handlers"
 import { WINDOWS } from "./window"
 import { getAgentsLayerPaths } from "./agents-files/modular-config"
@@ -345,7 +346,7 @@ class LoopService {
         }
       }
 
-      const conversationTitle = `[Repeat] ${loop.name}`
+      const conversationTitle = formatRepeatTaskTitle(loop.name)
       // Always start snoozed so the panel stays hidden during execution.
       // When `speakOnTrigger` is set, we unsnooze *after* the loop completes
       // so the renderer's TTS auto-play gate fires on the finished response

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   hasUnreadAgentResponse,
   isSidebarSessionCurrentlyViewed,
   orderActiveSessionsByPinnedFirst,
+  partitionPinnedAndUnpinnedTaskEntries,
   partitionTaskAndUserEntries,
 } from "@renderer/lib/sidebar-sessions"
 import { useLocation, useNavigate } from "react-router-dom"
@@ -457,25 +458,43 @@ export function ActiveAgentsSidebar({
     archivedSessionIds,
   ])
 
-  const { userSidebarSessions, taskSidebarSessions } = useMemo(
-    () => {
-      const { userEntries, taskEntries } = partitionTaskAndUserEntries(sidebarSessions)
-      return { userSidebarSessions: userEntries, taskSidebarSessions: taskEntries }
-    },
-    [sidebarSessions],
-  )
+  const {
+    userSidebarSessions,
+    pinnedTaskSidebarSessions,
+    unpinnedTaskSidebarSessions,
+  } = useMemo(() => {
+    const { userEntries, taskEntries } = partitionTaskAndUserEntries(sidebarSessions)
+    const { pinnedTaskEntries, unpinnedTaskEntries } =
+      partitionPinnedAndUnpinnedTaskEntries(taskEntries, pinnedSessionIds)
+    return {
+      userSidebarSessions: userEntries,
+      pinnedTaskSidebarSessions: pinnedTaskEntries,
+      unpinnedTaskSidebarSessions: unpinnedTaskEntries,
+    }
+  }, [sidebarSessions, pinnedSessionIds])
 
-  const hasTasks = taskSidebarSessions.length > 0
-  const showTasksSection = hasTasks && !tasksSectionHidden
+  const hasPinnedTasks = pinnedTaskSidebarSessions.length > 0
+  const hasUnpinnedTasks = unpinnedTaskSidebarSessions.length > 0
+  // Pinned tasks always render at the top regardless of section state, so we
+  // only need the Tasks subsection when there are unpinned tasks to show.
+  const showTasksSection = hasUnpinnedTasks && !tasksSectionHidden
   const tasksListVisible = showTasksSection && tasksSectionExpanded
 
-  // Hotkeys (Cmd/Ctrl+1..9) target only entries that are currently rendered.
+  // Hotkeys (Cmd/Ctrl+1..9) target only entries that are currently rendered,
+  // in the same order as they appear: pinned tasks → user sessions →
+  // unpinned tasks (when the tasks subsection is expanded).
   const visibleSidebarSessions = useMemo(
-    () =>
-      tasksListVisible
-        ? [...userSidebarSessions, ...taskSidebarSessions]
-        : userSidebarSessions,
-    [tasksListVisible, userSidebarSessions, taskSidebarSessions],
+    () => [
+      ...pinnedTaskSidebarSessions,
+      ...userSidebarSessions,
+      ...(tasksListVisible ? unpinnedTaskSidebarSessions : []),
+    ],
+    [
+      pinnedTaskSidebarSessions,
+      userSidebarSessions,
+      tasksListVisible,
+      unpinnedTaskSidebarSessions,
+    ],
   )
 
   const hasAnySessions = sidebarSessions.length > 0
@@ -1186,10 +1205,28 @@ export function ActiveAgentsSidebar({
             )
             }
 
+            // Hotkey ordering must mirror render ordering exactly; see
+            // visibleSidebarSessions above.
+            const pinnedOffset = 0
+            const userOffset = pinnedTaskSidebarSessions.length
+            const unpinnedTasksOffset = userOffset + userSidebarSessions.length
+
             return (
               <>
+                {hasPinnedTasks && (
+                  <div className="flex items-center gap-1 px-1.5 pb-0.5 pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                    <Pin className="h-3 w-3 -rotate-45 shrink-0 text-muted-foreground/70" />
+                    <span className="select-none">Pinned tasks</span>
+                    <span className="ml-1 rounded-full bg-muted-foreground/20 px-1.5 py-px text-[9px] font-medium leading-none text-muted-foreground">
+                      {pinnedTaskSidebarSessions.length}
+                    </span>
+                  </div>
+                )}
+                {pinnedTaskSidebarSessions.map((entry, idx) =>
+                  renderSessionRow(entry, pinnedOffset + idx),
+                )}
                 {userSidebarSessions.map((entry, idx) =>
-                  renderSessionRow(entry, idx),
+                  renderSessionRow(entry, userOffset + idx),
                 )}
                 {showTasksSection && (
                   <div className="mt-1 flex items-center gap-1 px-1.5 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
@@ -1208,7 +1245,7 @@ export function ActiveAgentsSidebar({
                     </button>
                     <span className="select-none">Tasks</span>
                     <span className="ml-1 rounded-full bg-muted-foreground/20 px-1.5 py-px text-[9px] font-medium leading-none text-muted-foreground">
-                      {taskSidebarSessions.length}
+                      {unpinnedTaskSidebarSessions.length}
                     </span>
                     <div className="ml-auto">
                       <DropdownMenu>
@@ -1232,16 +1269,16 @@ export function ActiveAgentsSidebar({
                   </div>
                 )}
                 {tasksListVisible &&
-                  taskSidebarSessions.map((entry, idx) =>
-                    renderSessionRow(entry, userSidebarSessions.length + idx),
+                  unpinnedTaskSidebarSessions.map((entry, idx) =>
+                    renderSessionRow(entry, unpinnedTasksOffset + idx),
                   )}
-                {hasTasks && tasksSectionHidden && (
+                {hasUnpinnedTasks && tasksSectionHidden && (
                   <button
                     type="button"
                     onClick={() => setTasksSectionHidden(false)}
                     className="text-muted-foreground hover:bg-accent/50 hover:text-foreground mt-1 w-full rounded px-1.5 py-1 text-left text-[11px] transition-colors"
                   >
-                    Show tasks ({taskSidebarSessions.length})
+                    Show tasks ({unpinnedTaskSidebarSessions.length})
                   </button>
                 )}
               </>

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   hasUnreadAgentResponse,
   isSidebarSessionCurrentlyViewed,
   orderActiveSessionsByPinnedFirst,
+  partitionTaskAndUserEntries,
 } from "@renderer/lib/sidebar-sessions"
 import { useLocation, useNavigate } from "react-router-dom"
 import { AgentSelector } from "./agent-selector"
@@ -121,6 +122,26 @@ const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toLowerCas
 const SHORTCUT_MOD_SYMBOL = IS_MAC ? "⌘" : "Ctrl"
 
 const STORAGE_KEY = "active-agents-sidebar-expanded"
+const TASKS_SECTION_EXPANDED_STORAGE_KEY = "sidebar-tasks-section-expanded"
+const TASKS_SECTION_HIDDEN_STORAGE_KEY = "sidebar-tasks-section-hidden"
+
+function readBooleanFromStorage(key: string, fallback: boolean): boolean {
+  try {
+    const stored = localStorage.getItem(key)
+    if (stored === null) return fallback
+    return stored === "true"
+  } catch {
+    return fallback
+  }
+}
+
+function writeBooleanToStorage(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, String(value))
+  } catch {
+    // localStorage may be unavailable; ignore.
+  }
+}
 
 function SessionOverflowMenu({
   sessionTitle,
@@ -201,6 +222,14 @@ export function ActiveAgentsSidebar({
     })
     return initial
   })
+  // Default the Tasks subsection to collapsed so user sessions stay
+  // foregrounded; respect remembered state once the user has toggled it.
+  const [tasksSectionExpanded, setTasksSectionExpanded] = useState(() =>
+    readBooleanFromStorage(TASKS_SECTION_EXPANDED_STORAGE_KEY, false),
+  )
+  const [tasksSectionHidden, setTasksSectionHidden] = useState(() =>
+    readBooleanFromStorage(TASKS_SECTION_HIDDEN_STORAGE_KEY, false),
+  )
 
   const focusedSessionId = useAgentStore((s) => s.focusedSessionId)
   const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
@@ -428,6 +457,27 @@ export function ActiveAgentsSidebar({
     archivedSessionIds,
   ])
 
+  const { userSidebarSessions, taskSidebarSessions } = useMemo(
+    () => {
+      const { userEntries, taskEntries } = partitionTaskAndUserEntries(sidebarSessions)
+      return { userSidebarSessions: userEntries, taskSidebarSessions: taskEntries }
+    },
+    [sidebarSessions],
+  )
+
+  const hasTasks = taskSidebarSessions.length > 0
+  const showTasksSection = hasTasks && !tasksSectionHidden
+  const tasksListVisible = showTasksSection && tasksSectionExpanded
+
+  // Hotkeys (Cmd/Ctrl+1..9) target only entries that are currently rendered.
+  const visibleSidebarSessions = useMemo(
+    () =>
+      tasksListVisible
+        ? [...userSidebarSessions, ...taskSidebarSessions]
+        : userSidebarSessions,
+    [tasksListVisible, userSidebarSessions, taskSidebarSessions],
+  )
+
   const hasAnySessions = sidebarSessions.length > 0
 
   useEffect(() => {
@@ -458,6 +508,14 @@ export function ActiveAgentsSidebar({
       })
     }
   }, [isExpanded])
+
+  useEffect(() => {
+    writeBooleanToStorage(TASKS_SECTION_EXPANDED_STORAGE_KEY, tasksSectionExpanded)
+  }, [tasksSectionExpanded])
+
+  useEffect(() => {
+    writeBooleanToStorage(TASKS_SECTION_HIDDEN_STORAGE_KEY, tasksSectionHidden)
+  }, [tasksSectionHidden])
 
   const handleActiveSessionSelect = useCallback((sessionId: string) => {
     logUI("[ActiveAgentsSidebar] Active session selected:", sessionId)
@@ -499,7 +557,7 @@ export function ActiveAgentsSidebar({
       if (isNaN(digit) || digit < 1 || digit > 9) return
 
       const index = digit - 1
-      const target = sidebarSessions[index]
+      const target = visibleSidebarSessions[index]
       if (!target) return
 
       e.preventDefault()
@@ -530,7 +588,7 @@ export function ActiveAgentsSidebar({
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [sidebarSessions, handleSavedConversationOpen, handleActiveSessionSelect])
+  }, [visibleSidebarSessions, handleSavedConversationOpen, handleActiveSessionSelect])
 
   const handleStopSession = async (sessionId: string, e: React.MouseEvent) => {
     e.stopPropagation() // Prevent session focus when clicking stop
@@ -826,7 +884,11 @@ export function ActiveAgentsSidebar({
           className="mt-1 max-h-[45vh] space-y-0.5 overflow-y-auto pl-2 pr-1 scrollbar-none"
           onScroll={handleSidebarSessionsScroll}
         >
-          {sidebarSessions.map(({ session, isSavedConversation, key }, index) => {
+          {(() => {
+            const renderSessionRow = (
+              { session, isSavedConversation, key }: SidebarSessionEntry,
+              index: number,
+            ) => {
             const isFocused = focusedSessionId === session.id
             const isSessionExpanded = expandedSessionId === session.id
             const isCurrentView = isSidebarSessionCurrentlyViewed(session, {
@@ -1122,7 +1184,69 @@ export function ActiveAgentsSidebar({
                 </div>
               </div>
             )
-          })}
+            }
+
+            return (
+              <>
+                {userSidebarSessions.map((entry, idx) =>
+                  renderSessionRow(entry, idx),
+                )}
+                {showTasksSection && (
+                  <div className="mt-1 flex items-center gap-1 px-1.5 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                    <button
+                      type="button"
+                      onClick={() => setTasksSectionExpanded((v) => !v)}
+                      className="hover:text-foreground focus:ring-ring flex shrink-0 items-center rounded focus:outline-none focus:ring-1"
+                      aria-label={tasksSectionExpanded ? "Collapse tasks" : "Expand tasks"}
+                      aria-expanded={tasksSectionExpanded}
+                    >
+                      {tasksSectionExpanded ? (
+                        <ChevronDown className="h-3 w-3" />
+                      ) : (
+                        <ChevronRight className="h-3 w-3" />
+                      )}
+                    </button>
+                    <span className="select-none">Tasks</span>
+                    <span className="ml-1 rounded-full bg-muted-foreground/20 px-1.5 py-px text-[9px] font-medium leading-none text-muted-foreground">
+                      {taskSidebarSessions.length}
+                    </span>
+                    <div className="ml-auto">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className="hover:bg-accent focus-visible:ring-ring flex h-4 w-4 items-center justify-center rounded transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+                            aria-label="Tasks section actions"
+                            title="Tasks section actions"
+                          >
+                            <MoreHorizontal className="h-3 w-3" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onSelect={() => setTasksSectionHidden(true)}>
+                            Hide tasks section
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </div>
+                )}
+                {tasksListVisible &&
+                  taskSidebarSessions.map((entry, idx) =>
+                    renderSessionRow(entry, userSidebarSessions.length + idx),
+                  )}
+                {hasTasks && tasksSectionHidden && (
+                  <button
+                    type="button"
+                    onClick={() => setTasksSectionHidden(false)}
+                    className="text-muted-foreground hover:bg-accent/50 hover:text-foreground mt-1 w-full rounded px-1.5 py-1 text-left text-[11px] transition-colors"
+                  >
+                    Show tasks ({taskSidebarSessions.length})
+                  </button>
+                )}
+              </>
+            )
+          })()}
 
           {hasMoreSavedConversations && (
             <button

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
@@ -7,6 +7,7 @@ import {
   isSidebarSessionCurrentlyViewed,
   isTaskSession,
   orderActiveSessionsByPinnedFirst,
+  partitionPinnedAndUnpinnedTaskEntries,
   partitionTaskAndUserEntries,
 } from "./sidebar-sessions"
 
@@ -129,6 +130,34 @@ describe("partitionTaskAndUserEntries", () => {
 
     expect(userEntries.map((e) => e.session.id)).toEqual(["u1", "u2"])
     expect(taskEntries.map((e) => e.session.id)).toEqual(["t1", "t2"])
+  })
+})
+
+describe("partitionPinnedAndUnpinnedTaskEntries", () => {
+  it("returns all entries as unpinned when no pins are set", () => {
+    const entries = [
+      { session: { id: "t1", conversationId: "c1" } },
+      { session: { id: "t2", conversationId: "c2" } },
+    ]
+    const { pinnedTaskEntries, unpinnedTaskEntries } =
+      partitionPinnedAndUnpinnedTaskEntries(entries, new Set())
+
+    expect(pinnedTaskEntries).toEqual([])
+    expect(unpinnedTaskEntries.map((e) => e.session.id)).toEqual(["t1", "t2"])
+  })
+
+  it("splits entries by conversation pin state while preserving order", () => {
+    const entries = [
+      { session: { id: "t1", conversationId: "c1" } },
+      { session: { id: "t2", conversationId: "c2" } },
+      { session: { id: "t3", conversationId: "c3" } },
+      { session: { id: "t4" } },
+    ]
+    const { pinnedTaskEntries, unpinnedTaskEntries } =
+      partitionPinnedAndUnpinnedTaskEntries(entries, new Set(["c1", "c3"]))
+
+    expect(pinnedTaskEntries.map((e) => e.session.id)).toEqual(["t1", "t3"])
+    expect(unpinnedTaskEntries.map((e) => e.session.id)).toEqual(["t2", "t4"])
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
@@ -5,7 +5,9 @@ import {
   getLatestAgentResponseTimestamp,
   hasUnreadAgentResponse,
   isSidebarSessionCurrentlyViewed,
+  isTaskSession,
   orderActiveSessionsByPinnedFirst,
+  partitionTaskAndUserEntries,
 } from "./sidebar-sessions"
 
 const activeSession = (id: string, conversationId?: string) => ({
@@ -101,6 +103,32 @@ describe("isSidebarSessionCurrentlyViewed", () => {
         viewedConversationId: "conversation-1",
       }),
     ).toBe(false)
+  })
+})
+
+describe("isTaskSession", () => {
+  it("flags sessions whose title carries the [Repeat] prefix", () => {
+    expect(isTaskSession({ id: "s", conversationTitle: "[Repeat] Daily standup" })).toBe(true)
+  })
+
+  it("ignores sessions without the prefix", () => {
+    expect(isTaskSession({ id: "s", conversationTitle: "Daily standup" })).toBe(false)
+    expect(isTaskSession({ id: "s" })).toBe(false)
+  })
+})
+
+describe("partitionTaskAndUserEntries", () => {
+  it("splits entries into user and task lists while preserving order", () => {
+    const entries = [
+      { session: { id: "u1", conversationTitle: "Hello" } },
+      { session: { id: "t1", conversationTitle: "[Repeat] Cron" } },
+      { session: { id: "u2", conversationTitle: "Quick question" } },
+      { session: { id: "t2", conversationTitle: "[Repeat] Reports" } },
+    ]
+    const { userEntries, taskEntries } = partitionTaskAndUserEntries(entries)
+
+    expect(userEntries.map((e) => e.session.id)).toEqual(["u1", "u2"])
+    expect(taskEntries.map((e) => e.session.id)).toEqual(["t1", "t2"])
   })
 })
 

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
@@ -1,4 +1,5 @@
 import type { AgentProgressUpdate } from "@shared/types"
+import { hasRepeatTaskTitlePrefix } from "@shared/repeat-tasks"
 
 type SessionLike = {
   id: string
@@ -10,16 +11,13 @@ type TitledSessionLike = SessionLike & {
 }
 
 /**
- * Sessions started by the repeat-task loop service are created with a
- * `[Repeat] ` title prefix (see apps/desktop/src/main/loop-service.ts).
+ * Sessions started by the repeat-task loop service get the shared
+ * `TASK_SESSION_TITLE_PREFIX` (see apps/desktop/src/shared/repeat-tasks.ts).
  * We use that prefix as the canonical signal for "task" entries in the
  * sidebar so they can be grouped separately from user-driven sessions.
  */
-export const TASK_SESSION_TITLE_PREFIX = "[Repeat] "
-
 export function isTaskSession(session: TitledSessionLike): boolean {
-  const title = session.conversationTitle
-  return typeof title === "string" && title.startsWith(TASK_SESSION_TITLE_PREFIX)
+  return hasRepeatTaskTitlePrefix(session.conversationTitle)
 }
 
 export function partitionTaskAndUserEntries<T extends { session: TitledSessionLike }>(
@@ -35,6 +33,29 @@ export function partitionTaskAndUserEntries<T extends { session: TitledSessionLi
     }
   }
   return { userEntries, taskEntries }
+}
+
+export function partitionPinnedAndUnpinnedTaskEntries<
+  T extends { session: SessionLike },
+>(
+  taskEntries: T[],
+  pinnedSessionIds: ReadonlySet<string>,
+): { pinnedTaskEntries: T[]; unpinnedTaskEntries: T[] } {
+  if (taskEntries.length === 0 || pinnedSessionIds.size === 0) {
+    return { pinnedTaskEntries: [], unpinnedTaskEntries: taskEntries }
+  }
+
+  const pinnedTaskEntries: T[] = []
+  const unpinnedTaskEntries: T[] = []
+  for (const entry of taskEntries) {
+    const conversationId = entry.session.conversationId
+    if (conversationId && pinnedSessionIds.has(conversationId)) {
+      pinnedTaskEntries.push(entry)
+    } else {
+      unpinnedTaskEntries.push(entry)
+    }
+  }
+  return { pinnedTaskEntries, unpinnedTaskEntries }
 }
 
 interface SidebarSessionViewState {

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
@@ -5,6 +5,38 @@ type SessionLike = {
   conversationId?: string
 }
 
+type TitledSessionLike = SessionLike & {
+  conversationTitle?: string
+}
+
+/**
+ * Sessions started by the repeat-task loop service are created with a
+ * `[Repeat] ` title prefix (see apps/desktop/src/main/loop-service.ts).
+ * We use that prefix as the canonical signal for "task" entries in the
+ * sidebar so they can be grouped separately from user-driven sessions.
+ */
+export const TASK_SESSION_TITLE_PREFIX = "[Repeat] "
+
+export function isTaskSession(session: TitledSessionLike): boolean {
+  const title = session.conversationTitle
+  return typeof title === "string" && title.startsWith(TASK_SESSION_TITLE_PREFIX)
+}
+
+export function partitionTaskAndUserEntries<T extends { session: TitledSessionLike }>(
+  entries: T[],
+): { userEntries: T[]; taskEntries: T[] } {
+  const userEntries: T[] = []
+  const taskEntries: T[] = []
+  for (const entry of entries) {
+    if (isTaskSession(entry.session)) {
+      taskEntries.push(entry)
+    } else {
+      userEntries.push(entry)
+    }
+  }
+  return { userEntries, taskEntries }
+}
+
 interface SidebarSessionViewState {
   isPast: boolean
   focusedSessionId?: string | null

--- a/apps/desktop/src/shared/repeat-tasks.ts
+++ b/apps/desktop/src/shared/repeat-tasks.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared contract between the main-process loop service and the renderer
+ * sidebar for distinguishing scheduled-task sessions from user sessions.
+ *
+ * The loop service tags every repeat-task conversation by prefixing the
+ * conversation title with this string. The sidebar uses the same prefix
+ * to group those entries into the dedicated Tasks section. Keep both
+ * sides reading from this module so the contract can't drift.
+ */
+export const TASK_SESSION_TITLE_PREFIX = "[Repeat] "
+
+export function formatRepeatTaskTitle(taskName: string): string {
+  return `${TASK_SESSION_TITLE_PREFIX}${taskName}`
+}
+
+export function hasRepeatTaskTitlePrefix(title: string | undefined | null): boolean {
+  return typeof title === "string" && title.startsWith(TASK_SESSION_TITLE_PREFIX)
+}


### PR DESCRIPTION
## Summary

Resolves #376 — separates repeat-task entries from user sessions in the desktop Sessions sidepanel.

The loop service starts sessions with a `[Repeat] ` title prefix (`apps/desktop/src/main/loop-service.ts:348`); we use that as the canonical signal for "task" entries.

- **User vs. task split** — `active-agents-sidebar.tsx` partitions `sidebarSessions` into user entries and task entries via a new `isTaskSession` / `partitionTaskAndUserEntries` helper in `sidebar-sessions.ts`.
- **Collapsible Tasks subsection** — collapsed by default; expand state persists in `localStorage` (`sidebar-tasks-section-expanded`).
- **Hide / unhide** — a dropdown on the Tasks section header offers "Hide tasks section". When hidden, a "Show tasks (N)" footer appears below the user list so it's discoverable. Hidden state persists (`sidebar-tasks-section-hidden`).
- **Hotkeys stay coherent** — `Cmd/Ctrl+1..9` now target the visible flattened list (user entries, plus task entries when the subsection is expanded), so the badge index always matches what's rendered.

## Test plan

- [x] `pnpm --filter @dotagents/desktop run typecheck`
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/lib/sidebar-sessions.test.ts src/renderer/src/components/active-agents-sidebar.status-colors.test.ts` (17 passed)
- [ ] Manual: open desktop app, trigger a Repeat task, confirm it appears under collapsible "Tasks" with count badge; toggle hide/show; restart app to confirm state persists.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDYMAun6xVxnz2S4C3CgzG)_