### PR TITLE
Fix skill refresh and reasoning-stub finalization

### DIFF
--- a/apps/desktop/src/main/llm-continuation-guards.ts
+++ b/apps/desktop/src/main/llm-continuation-guards.ts
@@ -18,7 +18,8 @@ const PARTIAL_ANALYSIS_SIGNAL_REGEX = /\b(mid-analysis|laid out the (?:three )?r
 const STRATEGY_REQUEST_SIGNAL_REGEX = /\b(which approach to take|what do you want to do|hard reset|selective revert|cherry-pick|clean commit hash|last clean commit hash)\b/i
 const STRATEGY_REQUEST_REASON_REGEX = /\b(strategy|approach|commit hash|baseline commit|recovery)\b/i
 const EXPLICIT_ASK_FIRST_REGEX = /\b(ask me first|ask before|check with me first|get my approval first|before you (?:merge|open|submit|push|create))\b/i
-const THINK_BLOCK_REGEX = /<think>[\s\S]*?<\/think>/gi
+const THINK_BLOCK_REGEX = /<\s*think\b[^>]*>[\s\S]*?<\s*\/\s*think\s*>/gi
+const THINK_TAG_REGEX = /<\/?\s*think\b[^>]*>/i
 
 type ConversationHistoryLike = Array<{
   role?: string
@@ -146,7 +147,9 @@ export function isGarbledToolCallText(content?: string): boolean {
 export function isDeliverableResponseContent(content?: string): boolean {
   const trimmed = typeof content === "string" ? content.trim() : ""
   if (!trimmed) return false
-  if (!trimmed.replace(THINK_BLOCK_REGEX, "").trim()) return false
+  const contentWithoutThinkBlocks = trimmed.replace(THINK_BLOCK_REGEX, "").trim()
+  if (!contentWithoutThinkBlocks) return false
+  if (THINK_TAG_REGEX.test(contentWithoutThinkBlocks)) return false
   if (isGarbledToolCallText(trimmed)) return false
   if (RAW_TOOL_TRANSCRIPT_REGEX.test(trimmed)) return false
   if (isProgressUpdateResponse(trimmed)) return false

--- a/apps/desktop/src/main/llm-continuation-guards.ts
+++ b/apps/desktop/src/main/llm-continuation-guards.ts
@@ -18,6 +18,7 @@ const PARTIAL_ANALYSIS_SIGNAL_REGEX = /\b(mid-analysis|laid out the (?:three )?r
 const STRATEGY_REQUEST_SIGNAL_REGEX = /\b(which approach to take|what do you want to do|hard reset|selective revert|cherry-pick|clean commit hash|last clean commit hash)\b/i
 const STRATEGY_REQUEST_REASON_REGEX = /\b(strategy|approach|commit hash|baseline commit|recovery)\b/i
 const EXPLICIT_ASK_FIRST_REGEX = /\b(ask me first|ask before|check with me first|get my approval first|before you (?:merge|open|submit|push|create))\b/i
+const THINK_BLOCK_REGEX = /<think>[\s\S]*?<\/think>/gi
 
 type ConversationHistoryLike = Array<{
   role?: string
@@ -145,6 +146,7 @@ export function isGarbledToolCallText(content?: string): boolean {
 export function isDeliverableResponseContent(content?: string): boolean {
   const trimmed = typeof content === "string" ? content.trim() : ""
   if (!trimmed) return false
+  if (!trimmed.replace(THINK_BLOCK_REGEX, "").trim()) return false
   if (isGarbledToolCallText(trimmed)) return false
   if (RAW_TOOL_TRANSCRIPT_REGEX.test(trimmed)) return false
   if (isProgressUpdateResponse(trimmed)) return false

--- a/apps/desktop/src/main/llm.continuation-guards.test.ts
+++ b/apps/desktop/src/main/llm.continuation-guards.test.ts
@@ -177,6 +177,8 @@ describe("continuation guard helpers", () => {
 
   it("rejects pure thinking blocks as non-deliverable content", () => {
     expect(isDeliverableResponseContent("<think>Need to inspect more chunks.</think>")).toBe(false)
+    expect(isDeliverableResponseContent("<think>Need to inspect more chunks.")).toBe(false)
+    expect(isDeliverableResponseContent("Need to inspect more chunks.</think>")).toBe(false)
     expect(resolveIterationLimitFinalContent({
       finalContent: "<think>Need to inspect more chunks.</think>",
       conversationHistory: [{ role: "assistant", content: "<think>Still planning.</think>" }],

--- a/apps/desktop/src/main/llm.continuation-guards.test.ts
+++ b/apps/desktop/src/main/llm.continuation-guards.test.ts
@@ -175,6 +175,18 @@ describe("continuation guard helpers", () => {
     expect(isDeliverableResponseContent("[Calling tools: read_file]")).toBe(false)
   })
 
+  it("rejects pure thinking blocks as non-deliverable content", () => {
+    expect(isDeliverableResponseContent("<think>Need to inspect more chunks.</think>")).toBe(false)
+    expect(resolveIterationLimitFinalContent({
+      finalContent: "<think>Need to inspect more chunks.</think>",
+      conversationHistory: [{ role: "assistant", content: "<think>Still planning.</think>" }],
+      hasRecentErrors: false,
+    })).toEqual({
+      content: "Task reached maximum iteration limit while still in progress. Some actions may have been completed successfully - please review the tool results above.",
+      usedExplicitUserResponse: false,
+    })
+  })
+
   it("rejects tool placeholders with trailing content (relaxed anchor)", () => {
     expect(isDeliverableResponseContent("[Calling tools: mark_work_complete] some trailing text")).toBe(false)
   })

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -127,6 +127,7 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       "session-clean-final",
       "session-windowed-progress",
       "session-reasoning-stub",
+      "session-reasoning-only-empty-retry",
     )
   })
 
@@ -321,6 +322,40 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       .map((message: any) => message.content)
       .join("\n")
     expect(secondPrompt).toContain("without first providing the final user-facing answer")
+  })
+
+  it("treats reasoning-summary-only responses as empty and retries", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+
+    mocks.makeLLMCallWithStreamingAndTools
+      .mockResolvedValueOnce({
+        content: undefined,
+        reasoningSummary: "I should keep working before answering.",
+        toolCalls: undefined,
+      })
+      .mockResolvedValueOnce({ content: "Recovered after retry", toolCalls: [] })
+
+    const result = await processTranscriptWithAgentMode(
+      "Finish this",
+      availableTools as any,
+      makeExecuteToolCall("session-reasoning-only-empty-retry", 1),
+      4,
+      [],
+      "conv-reasoning-only-empty-retry",
+      "session-reasoning-only-empty-retry",
+      undefined,
+      undefined,
+      1,
+    )
+
+    expect(result.content).toBe("Recovered after retry")
+    expect(mocks.makeLLMCallWithStreamingAndTools).toHaveBeenCalledTimes(2)
+
+    const retryPrompt = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[1]?.[0] ?? [])
+      .map((message: any) => message.content)
+      .join("\n")
+    expect(retryPrompt).toContain("Previous request had empty response")
+    expect(result.conversationHistory.some((message) => message.role === "assistant" && message.content.includes("I should keep working"))).toBe(false)
   })
 
   it("only generates a separate final summary when final-summary mode is enabled", async () => {

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   updateSession: vi.fn(),
   getCurrentProfile: vi.fn(() => undefined),
   getSkills: vi.fn(() => []),
+  refreshFromDisk: vi.fn(() => []),
   getEnabledSkillsInstructionsForProfile: vi.fn(() => ""),
   getAcpSessionTitleOverride: vi.fn((_: string): string | undefined => undefined),
 }))
@@ -54,7 +55,7 @@ vi.mock("./summarization-service", () => ({ isSummarizationEnabled: vi.fn(() => 
 vi.mock("./knowledge-notes-service", () => ({ knowledgeNotesService: { createNoteFromSummary: vi.fn(), saveNote: vi.fn() } }))
 vi.mock("./agent-run-utils", () => ({ appendAgentStopNote: vi.fn(), resolveAgentIterationLimits: vi.fn((maxIterations: number) => ({ loopMaxIterations: maxIterations, guardrailBudget: maxIterations })) }))
 vi.mock("./agent-profile-service", () => ({ agentProfileService: { getCurrentProfile: mocks.getCurrentProfile } }))
-vi.mock("./skills-service", () => ({ skillsService: { getSkills: mocks.getSkills, getEnabledSkillsInstructionsForProfile: mocks.getEnabledSkillsInstructionsForProfile } }))
+vi.mock("./skills-service", () => ({ skillsService: { getSkills: mocks.getSkills, refreshFromDisk: mocks.refreshFromDisk, getEnabledSkillsInstructionsForProfile: mocks.getEnabledSkillsInstructionsForProfile } }))
 vi.mock("./working-notes-runtime", () => ({ loadWorkingKnowledgeNotesForPrompt: vi.fn(() => []) }))
 
 const availableTools = [
@@ -125,6 +126,7 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       "session-review-loop-final-answer",
       "session-clean-final",
       "session-windowed-progress",
+      "session-reasoning-stub",
     )
   })
 
@@ -278,6 +280,47 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       .join("\n")
     expect(secondPrompt).toContain("without first providing the final user-facing answer")
     expect(secondPrompt).toContain("Do not add a second recap or summary")
+  })
+
+  it("does not finalize with a reasoning summary as the user-facing answer", async () => {
+    currentConfig.mcpVerifyCompletionEnabled = true
+    currentConfig.mcpFinalSummaryEnabled = false
+    const { processTranscriptWithAgentMode } = await import("./llm")
+
+    mocks.makeLLMCallWithStreamingAndTools
+      .mockResolvedValueOnce({
+        content: undefined,
+        reasoningSummary: "I should inspect more transcript chunks, but I am about to stop.",
+        toolCalls: [{ name: "mark_work_complete", arguments: { summary: "Internal stop" } }],
+      })
+      .mockResolvedValueOnce({ content: "", toolCalls: [
+        { name: "respond_to_user", arguments: { text: "I inspected the next chunk and added 50 more topics." } },
+        { name: "mark_work_complete", arguments: { summary: "Delivered the additional topics" } },
+      ] })
+
+    mocks.verifyCompletionWithFetch.mockResolvedValue({ isComplete: true, conversationState: "complete", confidence: 0.97, missingItems: [] })
+
+    const result = await processTranscriptWithAgentMode(
+      "Gather another 50 missed topics",
+      availableTools as any,
+      makeExecuteToolCall("session-reasoning-stub", 1),
+      4,
+      [],
+      "conv-reasoning-stub",
+      "session-reasoning-stub",
+      undefined,
+      undefined,
+      1,
+    )
+
+    expect(result.content).toBe("I inspected the next chunk and added 50 more topics.")
+    expect(result.content).not.toContain("<think>")
+    expect(result.conversationHistory.some((message) => message.role === "assistant" && message.content.includes("<think>"))).toBe(false)
+
+    const secondPrompt = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[1]?.[0] ?? [])
+      .map((message: any) => message.content)
+      .join("\n")
+    expect(secondPrompt).toContain("without first providing the final user-facing answer")
   })
 
   it("only generates a separate final summary when final-summary mode is enabled", async () => {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1906,9 +1906,8 @@ export async function processTranscriptWithAgentMode(
 
     const hasValidContent = llmResponse?.content && llmResponse.content.trim().length > 0
     const hasValidToolCalls = llmResponse?.toolCalls && Array.isArray(llmResponse.toolCalls) && llmResponse.toolCalls.length > 0
-    const hasValidReasoningSummary = !!llmResponse?.reasoningSummary?.trim()
 
-    if (!llmResponse || (!hasValidContent && !hasValidToolCalls && !hasValidReasoningSummary)) {
+    if (!llmResponse || (!hasValidContent && !hasValidToolCalls)) {
       emptyResponseRetryCount++
       logLLM(`❌ LLM null/empty response on iteration ${iteration} (retry ${emptyResponseRetryCount}/${MAX_EMPTY_RESPONSE_RETRIES})`)
       logLLM("Response details:", {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -243,7 +243,7 @@ export async function processTranscriptWithTools(
     : []
   // null means "all skills enabled by default" — resolve to all available skill IDs
   const enabledSkillIds = enabledSkillIdsOrNull === null
-    ? skillsService.getSkills().map(s => s.id)
+    ? skillsService.refreshFromDisk().map(s => s.id)
     : enabledSkillIdsOrNull
   const skillsInstructions = skillsService.getEnabledSkillsInstructionsForProfile(enabledSkillIds)
   const skillsIndex = extractSkillsIndexForMinimalPrompt(skillsInstructions)
@@ -1027,7 +1027,7 @@ export async function processTranscriptWithAgentMode(
     const snapshotSkillsConfig = effectiveProfileSnapshot?.skillsConfig
     // When skillsConfig is undefined or allSkillsDisabledByDefault is false, all skills are enabled
     const enabledSkillIds = (!snapshotSkillsConfig || !snapshotSkillsConfig.allSkillsDisabledByDefault)
-      ? skillsService.getSkills().map(s => s.id)
+      ? skillsService.refreshFromDisk().map(s => s.id)
       : (snapshotSkillsConfig.enabledSkillIds ?? [])
     logLLM(`[processTranscriptWithAgentMode] Loading skills for session ${currentSessionId}. enabledSkillIds: [${enabledSkillIds.join(', ')}]`)
     profileSkillsInstructions = skillsService.getEnabledSkillsInstructionsForProfile(enabledSkillIds)
@@ -1971,8 +1971,10 @@ export async function processTranscriptWithAgentMode(
     // Reset empty response counter on successful response
     emptyResponseRetryCount = 0
 
-    // Prepend reasoning summary wrapped in <tool_call>think> tags so the existing
-    // ThinkSection UI renders it as a collapsible thinking block.
+    // Build a display-only reasoning block for the progress UI. Do not mutate
+    // llmResponse.content: reasoning summaries are internal thinking and must
+    // never be treated as deliverable/final user-facing content.
+    let reasoningDisplayContent: string | undefined
     if (llmResponse.reasoningSummary) {
       // Sanitize reasoningSummary to prevent nested think tags from
       // breaking parseThinkSections()'s regex-based extraction.
@@ -1980,7 +1982,7 @@ export async function processTranscriptWithAgentMode(
         .replace(/<\/think>/gi, "")
         .replace(/<think>/gi, "")
       const thinkBlock = `<think>\n${sanitized}\n</think>`
-      llmResponse.content = llmResponse.content
+      reasoningDisplayContent = llmResponse.content
         ? `${thinkBlock}\n\n${llmResponse.content}`
         : thinkBlock
     }
@@ -1988,7 +1990,7 @@ export async function processTranscriptWithAgentMode(
     // Update thinking step with actual LLM content and mark as completed.
     // Strip any raw tool-marker tokens (e.g. <|tool_call_begin|>) so they
     // don't leak into the progress UI before the marker-recovery branch runs.
-    const displayContent = (llmResponse.content || "").replace(/<\|[^|]*\|>/g, "").trim()
+    const displayContent = (reasoningDisplayContent || llmResponse.content || "").replace(/<\|[^|]*\|>/g, "").trim()
     thinkingStep.status = "completed"
     thinkingStep.llmContent = displayContent
     if (displayContent) {

--- a/apps/desktop/src/main/runtime-tools.execute-command.test.ts
+++ b/apps/desktop/src/main/runtime-tools.execute-command.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockGetSkill = vi.fn()
 const mockGetSkills = vi.fn()
+const mockRefreshFromDisk = vi.fn()
 const mockGetSession = vi.fn()
 const mockLoadConversation = vi.fn()
 
@@ -28,6 +29,7 @@ vi.mock("./skills-service", () => ({
   skillsService: {
     getSkill: mockGetSkill,
     getSkills: mockGetSkills,
+    refreshFromDisk: mockRefreshFromDisk,
     upgradeGitHubSkillToLocal: vi.fn(),
   },
 }))
@@ -77,6 +79,7 @@ describe("runtime-tools execute_command", () => {
     vi.clearAllMocks()
     mockGetSkill.mockReturnValue(undefined)
     mockGetSkills.mockReturnValue([{ id: "agent-skill-creation" }, { id: "frontend-design" }])
+    mockRefreshFromDisk.mockReturnValue([{ id: "agent-skill-creation" }, { id: "frontend-design" }])
     mockGetSession.mockReturnValue(undefined)
     mockLoadConversation.mockResolvedValue(null)
   })

--- a/apps/desktop/src/main/runtime-tools.skill-access.test.ts
+++ b/apps/desktop/src/main/runtime-tools.skill-access.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mockGetSkill = vi.fn()
 const mockGetSkills = vi.fn()
+const mockRefreshFromDisk = vi.fn()
 const mockGetSessionProfileSnapshot = vi.fn()
 const mockGetTrackerSessionProfileSnapshot = vi.fn()
 const mockGetCurrentProfile = vi.fn()
@@ -37,6 +38,7 @@ vi.mock("./skills-service", () => ({
   skillsService: {
     getSkill: mockGetSkill,
     getSkills: mockGetSkills,
+    refreshFromDisk: mockRefreshFromDisk,
     upgradeGitHubSkillToLocal: vi.fn(),
   },
 }))
@@ -57,6 +59,10 @@ describe("runtime-tools skill access", () => {
       filePath: "/tmp/disabled-skill/SKILL.md",
     })
     mockGetSkills.mockReturnValue([
+      { id: "allowed-skill", name: "Allowed Skill", instructions: "allowed instructions" },
+      { id: "disabled-skill", name: "Disabled Skill", instructions: "secret instructions" },
+    ])
+    mockRefreshFromDisk.mockReturnValue([
       { id: "allowed-skill", name: "Allowed Skill", instructions: "allowed instructions" },
       { id: "disabled-skill", name: "Disabled Skill", instructions: "secret instructions" },
     ])
@@ -93,6 +99,28 @@ describe("runtime-tools skill access", () => {
     expect(result?.isError).toBe(true)
     const payload = JSON.parse(String(result?.content[0]?.text))
     expect(payload.skillId).toBe("disabled-skill")
+  })
+
+  it("refreshes the skill registry before loading instructions", async () => {
+    mockGetSessionProfileSnapshot.mockReturnValue({
+      profileId: "main-agent",
+      profileName: "Main Agent",
+      guidelines: "",
+      skillsConfig: { allSkillsDisabledByDefault: false },
+    })
+    mockGetSkill.mockReturnValue({
+      id: "fresh-skill",
+      name: "Fresh Skill",
+      instructions: "fresh instructions",
+      filePath: "/tmp/fresh-skill/skill.md",
+    })
+
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool("load_skill_instructions", { skillId: "fresh-skill" }, "session-1")
+
+    expect(mockRefreshFromDisk).toHaveBeenCalledTimes(1)
+    expect(result?.isError).toBe(false)
+    expect(String(result?.content[0]?.text)).toContain("fresh instructions")
   })
 
   it("blocks executing commands inside a disabled skill directory", async () => {

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -1074,6 +1074,10 @@ const toolHandlers: Record<string, ToolHandler> = {
     let ignoredInvalidSkillIdWarning: ReturnType<typeof buildIgnoredExecuteCommandSkillIdWarning> | undefined
 
     if (skillId) {
+      // Pick up skills added or edited directly in .agents/skills while the app
+      // process is still running.
+      skillsService.refreshFromDisk()
+
       // Find the skill and get its directory
       let skill = skillsService.getSkill(skillId)
       if (!skill) {
@@ -1430,6 +1434,9 @@ const toolHandlers: Record<string, ToolHandler> = {
 
     const skillId = args.skillId.trim()
     const { skillsService } = await import("./skills-service")
+    // Pick up skills added or edited directly in .agents/skills while the app
+    // process is still running.
+    skillsService.refreshFromDisk()
     const skill = skillsService.getSkill(skillId)
 
     if (!skill) {

--- a/apps/desktop/src/main/skills-service.ts
+++ b/apps/desktop/src/main/skills-service.ts
@@ -696,6 +696,11 @@ class SkillsService {
     return this.getSkills().find((s) => s.filePath === filePath)
   }
 
+  refreshFromDisk(): AgentSkill[] {
+    this.loadFromDisk({ migrateLegacy: false })
+    return this.skills
+  }
+
   createSkill(
     name: string,
     description: string,
@@ -947,7 +952,9 @@ class SkillsService {
       return ""
     }
 
-    const allSkills = this.getSkills()
+    // Refresh here so a new agent session sees skills added directly on disk
+    // while the app process is still running.
+    const allSkills = this.refreshFromDisk()
     // Filter by the profile's enabled list
     const enabledSkills = allSkills.filter(skill =>
       enabledSkillIds.includes(skill.id)
@@ -1302,10 +1309,8 @@ Skills directory: \`${workspaceSkillsDir ?? globalSkillsDir}\`${workspaceSkillsD
    * Now it only reloads from .agents layers (global + workspace).
    */
   scanSkillsFolder(): AgentSkill[] {
-    this.ensureInitialized()
-
     // Reload from .agents to pick up any manual edits or new skill files.
-    this.loadFromDisk({ migrateLegacy: false })
+    this.refreshFromDisk()
 
     // No longer scan the legacy skillsFolder — the canonical location is .agents/skills/.
     return []
@@ -1361,6 +1366,11 @@ function handleWatcherEvent(eventType: string, filename: string | null): void {
       // On Linux, refresh subdirectory watchers when structure changes
       if (process.platform === "linux" && (isDirectory || isUnknownChange)) {
         refreshLinuxSubdirectoryWatchers()
+      }
+      try {
+        skillsService.refreshFromDisk()
+      } catch (error) {
+        logApp("Failed to refresh skills after folder change:", error)
       }
       notifySkillsFolderChanged()
     }, DEBOUNCE_MS)

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -4605,7 +4605,7 @@ export const router = {
       // Pass all available skill IDs so the toggle can properly transition
       // from "all enabled by default" to explicit opt-in mode
       const { skillsService } = await import("./skills-service")
-      const allSkillIds = skillsService.getSkills().map(s => s.id)
+      const allSkillIds = skillsService.refreshFromDisk().map(s => s.id)
       return agentProfileService.toggleProfileSkill(input.profileId, input.skillId, allSkillIds)
     }),
 
@@ -4622,7 +4622,7 @@ export const router = {
       if (enabledSkillIds === null) {
         // null means "all skills enabled" — return all available skill IDs
         const { skillsService } = await import("./skills-service")
-        return skillsService.getSkills().map(s => s.id)
+        return skillsService.refreshFromDisk().map(s => s.id)
       }
       return enabledSkillIds
     }),
@@ -4635,7 +4635,7 @@ export const router = {
       const enabledSkillIds = agentProfileService.getEnabledSkillIdsForProfile(input.profileId)
       if (enabledSkillIds === null) {
         // null means "all skills enabled" — use all available skill IDs
-        const allSkillIds = skillsService.getSkills().map(s => s.id)
+        const allSkillIds = skillsService.refreshFromDisk().map(s => s.id)
         return skillsService.getEnabledSkillsInstructionsForProfile(allSkillIds)
       }
       return skillsService.getEnabledSkillsInstructionsForProfile(enabledSkillIds)


### PR DESCRIPTION
## Summary

- Refresh the in-memory skills registry from disk before load_skill_instructions, skill-scoped execute_command, Available Skills generation, and skill settings paths.
- Refresh the registry when the .agents/skills watcher observes on-disk changes.
- Keep Codex/OpenAI reasoning summaries display-only so think stubs cannot become final user-facing content.
- Reject pure thinking blocks as non-deliverable content and add regression coverage for the reasoning-stub finalization path.

## Validation

- pnpm --filter @dotagents/desktop exec vitest run src/main/llm.respond-to-user-history.test.ts src/main/llm.continuation-guards.test.ts src/main/runtime-tools.skill-access.test.ts src/main/runtime-tools.execute-command.test.ts
  - 4 files passed, 45 tests passed
- pnpm --filter @dotagents/desktop run typecheck:node
  - passed

## Notes

Unrelated untracked local files were left out of this PR.