### PR TITLE
fix(mobile): make speaker toggle stop active voice playback

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -529,9 +529,20 @@ export default function ChatScreen({ route, navigation }: any) {
   const ttsEnabled = config.ttsEnabled !== false; // default true
   const toggleTts = async () => {
     const next = !ttsEnabled;
-    // Stop any currently playing TTS when disabling
+    // Stop any currently playing TTS when disabling. The speaker icon doubles
+    // as a "mute" control, so it must silence both native and remote (Edge)
+    // playback and clear the auto-speech queue/state so nothing resumes.
     if (!next) {
+      intendedSpeakingIndexRef.current = null;
       Speech.stop();
+      stopRemoteTts();
+      queuedResponseEventsRef.current = [];
+      activeAutoSpeechEventIdRef.current = null;
+      setSpeakingMessageIndex(null);
+      if (handsFreeRef.current) {
+        handsFreeController.onSpeechFinished();
+        voiceLog('tts-stopped', 'Assistant speech stopped from speaker toggle.');
+      }
     }
     const nextCfg = { ...config, ttsEnabled: next } as any;
     setConfig(nextCfg);

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -504,6 +504,11 @@ export default function ChatScreen({ route, navigation }: any) {
   const handsFreeRef = useRef<boolean>(handsFree);
   useEffect(() => { handsFreeRef.current = !!config.handsFree; }, [config.handsFree]);
   const handsFreePhaseRef = useRef<HandsFreePhase>('sleeping');
+  // Track ttsEnabled in a ref so speech callbacks resolved before a mute-toggle
+  // (e.g. in-flight send() progress callbacks) still see the latest setting and
+  // bail before queueing or playing audio.
+  const ttsEnabledRef = useRef<boolean>(config.ttsEnabled !== false);
+  useEffect(() => { ttsEnabledRef.current = config.ttsEnabled !== false; }, [config.ttsEnabled]);
   const [appState, setAppState] = useState<AppStateStatus>(AppState.currentState);
   const isAppActive = appState === 'active';
   const handsFreeRuntimeActive = handsFree && isFocused && isAppActive;
@@ -539,7 +544,10 @@ export default function ChatScreen({ route, navigation }: any) {
       queuedResponseEventsRef.current = [];
       activeAutoSpeechEventIdRef.current = null;
       setSpeakingMessageIndex(null);
-      if (handsFreeRef.current) {
+      // Only transition the hands-free controller when it was actually speaking;
+      // calling onSpeechFinished mid-`processing` would prematurely return to
+      // listening while a request is still in-flight.
+      if (handsFreeRef.current && handsFreePhaseRef.current === 'speaking') {
         handsFreeController.onSpeechFinished();
         voiceLog('tts-stopped', 'Assistant speech stopped from speaker toggle.');
       }
@@ -1046,6 +1054,12 @@ export default function ChatScreen({ route, navigation }: any) {
 	  ]);
 
 	  const speakAssistantResponse = useCallback((content: string, reason: string, onSettled?: () => void) => {
+		// Honor a mute that may have happened after this callback was scheduled but
+		// before it ran (stale closures inside in-flight send() progress handlers).
+		if (!ttsEnabledRef.current) {
+			onSettled?.();
+			return false;
+		}
 		const processedText = preprocessTextForTTS(content);
 		if (!processedText) {
 				onSettled?.();
@@ -1178,7 +1192,9 @@ export default function ChatScreen({ route, navigation }: any) {
   }, [speakAssistantResponse]);
 
   const enqueueResponseEventsForSpeech = useCallback((events: AgentUserResponseEvent[]) => {
-    if (config.ttsEnabled === false || !events.length) return;
+    // Use the ref alongside the captured config so a mute that landed after this
+    // callback was scheduled still suppresses queueing.
+    if (config.ttsEnabled === false || !ttsEnabledRef.current || !events.length) return;
 
     const queuedIds = new Set(queuedResponseEventsRef.current.map((event) => event.id));
     const activeId = activeAutoSpeechEventIdRef.current;


### PR DESCRIPTION
## Summary

Fixes #388. The mobile speaker icon (🔊/🔇 in the chat composer) toggles `ttsEnabled` but only called `Speech.stop()` when disabling. That left Edge TTS playback running, the auto-speech queue full of pending response events, and per-message speaking state pointing at a message that was no longer being spoken — so tapping the icon did not actually mute ongoing voice.

`toggleTts` now, when toggling off:

- Calls `stopRemoteTts()` in addition to `Speech.stop()` so Edge TTS playback stops too.
- Drains `queuedResponseEventsRef` and clears `activeAutoSpeechEventIdRef` so queued auto-speech events don't resume.
- Resets `speakingMessageIndex` and `intendedSpeakingIndexRef` so the per-message ⏹/🔊 button reflects the muted state.
- Notifies the hands-free controller (`onSpeechFinished`) and emits a `tts-stopped` voice log entry when hands-free is active, matching the other stop paths.

Subsequent playback is unaffected — toggling TTS back on leaves the queue empty and the next assistant response or per-message tap starts fresh.

## Test plan

- [ ] Manual: with TTS on and an assistant response speaking, tap the speaker icon and confirm voice stops immediately on both native and Edge TTS providers.
- [ ] Manual: with multiple queued auto-speech events, tap the speaker icon mid-playback and confirm queued events do not resume.
- [ ] Manual: tap a per-message 🔊, then tap the global speaker icon — the per-message button reverts from ⏹ to 🔊.
- [ ] Manual: hands-free mode active — toggling off logs `tts-stopped` and the controller transitions correctly.
- [x] `pnpm test` in `apps/mobile` (only pre-existing unrelated `metro-config-watchfolders` failure).

https://claude.ai/code/session_0196XvTc6LWsD4NfvNmL7ktU

---
_Generated by [Claude Code](https://claude.ai/code/session_0196XvTc6LWsD4NfvNmL7ktU)_