### PR TITLE
Fix dictation transcript post-processing

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -18,7 +18,7 @@ import { agentSessionTracker } from "./agent-session-tracker"
 import { conversationService } from "./conversation-service"
 import { getAcpSessionTitleOverride } from "./acp-session-state"
 import { hasRepeatTaskTitlePrefix } from "../shared/repeat-tasks"
-import { getCurrentPresetName } from "@dotagents/shared"
+import { DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT, getCurrentPresetName } from "@dotagents/shared"
 import {
   createAgentTrace,
   endAgentTrace,
@@ -197,14 +197,11 @@ function isInvalidExecuteCommandSkillIdFailure(toolName: string | undefined, res
 export async function postProcessTranscript(transcript: string) {
   const config = configStore.get()
 
-  if (
-    !config.transcriptPostProcessingEnabled ||
-    !config.transcriptPostProcessingPrompt
-  ) {
+  if (!config.transcriptPostProcessingEnabled) {
     return transcript
   }
 
-  let prompt = config.transcriptPostProcessingPrompt
+  let prompt = config.transcriptPostProcessingPrompt?.trim() || DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT
 
   if (prompt.includes("{transcript}")) {
     prompt = prompt.replaceAll("{transcript}", transcript)

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -228,10 +228,7 @@ function float32ToWav(samples: Float32Array, sampleRate: number): Buffer {
 async function postProcessTranscriptSafely(transcript: string, context: string): Promise<string> {
   const config = configStore.get()
 
-  if (
-    !config.transcriptPostProcessingEnabled ||
-    !config.transcriptPostProcessingPrompt
-  ) {
+  if (!config.transcriptPostProcessingEnabled) {
     return transcript
   }
 
@@ -2222,6 +2219,8 @@ export const router = {
               transcript = json.text
             }
 
+            transcript = await postProcessTranscriptSafely(transcript, "createMcpRecording queued")
+
             // Save the recording file
             const recordingId = Date.now().toString()
             fs.writeFileSync(
@@ -2402,6 +2401,8 @@ export const router = {
           const json: { text: string } = await transcriptResponse.json()
           transcript = json.text
         }
+
+      transcript = await postProcessTranscriptSafely(transcript, "createMcpRecording")
 
       const messageText = appendScreenshotToTranscript(transcript, input.screenshot)
       let agentInputText = messageText

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -992,6 +992,23 @@ export function Component() {
             </div>
           </Control>
 
+          <Control label={<ControlLabel label="Transcript Processing" tooltip="Clean up punctuation, capitalization, or obvious speech-to-text mistakes after dictation." />} className="px-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Switch
+                checked={configQuery.data.transcriptPostProcessingEnabled ?? false}
+                onCheckedChange={(value) => {
+                  saveConfig({ transcriptPostProcessingEnabled: value })
+                }}
+              />
+              <Button variant="outline" size="sm" onClick={() => navigate("/settings/models")}>
+                Configure
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                Prompt, provider, and model live on the Models page.
+              </p>
+            </div>
+          </Control>
+
           <Control label={<ControlLabel label="Language" tooltip="Select the language for speech transcription. 'Auto-detect' lets the model determine the language automatically based on your speech." />} className="px-3">
             <Select
               value={configQuery.data.sttLanguage || "auto"}

--- a/apps/desktop/tests/dictation-postprocessing-fallback.test.mjs
+++ b/apps/desktop/tests/dictation-postprocessing-fallback.test.mjs
@@ -24,3 +24,14 @@ test('dictation recording falls back to raw transcript when post-processing fail
     /createRecording:[\s\S]*postProcessTranscriptSafely\(json\.text, "createRecording"\)/,
   )
 })
+
+test('agent voice recordings apply transcript post-processing before queueing or processing', () => {
+  assert.match(
+    tipcSource,
+    /createMcpRecording:[\s\S]*postProcessTranscriptSafely\(transcript, "createMcpRecording queued"\)[\s\S]*messageQueueService\.enqueue/,
+  )
+  assert.match(
+    tipcSource,
+    /createMcpRecording:[\s\S]*postProcessTranscriptSafely\(transcript, "createMcpRecording"\)[\s\S]*appendScreenshotToTranscript/,
+  )
+})

--- a/apps/desktop/tests/stt-model-wiring.test.mjs
+++ b/apps/desktop/tests/stt-model-wiring.test.mjs
@@ -12,8 +12,10 @@ const sttModelsSource = readFileSync(new URL('../../../packages/shared/src/stt-m
 
 test('speech-to-text general settings link model configuration to the models page', () => {
   assert.match(settingsGeneralSource, /label="Model Selection"/)
+  assert.match(settingsGeneralSource, /label="Transcript Processing"/)
   assert.match(settingsGeneralSource, /navigate\("\/settings\/models"\)/)
   assert.match(settingsGeneralSource, /Open Models page/)
+  assert.match(settingsGeneralSource, /Prompt, provider, and model live on the Models page\./)
 })
 
 test('router and navigation split models and providers into separate pages', () => {
@@ -28,7 +30,7 @@ test('models page consolidates transcript processing with its provider, model, a
   assert.match(settingsModelsSource, /ControlGroup title="Choose a Provider for Each Job" collapsible/)
   assert.match(settingsModelsSource, /ControlGroup title="Transcript Processing" collapsible/)
   assert.match(settingsModelsSource, /ControlGroup title="Speech & Voice Models" collapsible/)
-  assert.match(settingsModelsSource, /ControlGroup title="Agent Models" collapsible/)
+  assert.match(settingsModelsSource, /ControlGroup title="Agent Models"/)
   assert.match(settingsModelsSource, /ControlGroup title="Advanced Agent Models" collapsible/)
   assert.match(settingsModelsSource, /label="Speech-to-Text"/)
   assert.match(settingsModelsSource, /label="Text-to-Speech"/)

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,7 +4,7 @@ import os from "os"
 import type { Config, ModelPreset } from "./types"
 import type { PathResolver } from "./interfaces/path-resolver"
 import { container, ServiceTokens } from "./service-container"
-import { getBuiltInModelPresets, DEFAULT_MODEL_PRESET_ID } from "@dotagents/shared"
+import { getBuiltInModelPresets, DEFAULT_MODEL_PRESET_ID, DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT } from "@dotagents/shared"
 
 import {
   getAgentsLayerPaths,
@@ -246,6 +246,11 @@ const getConfig = (): LoadedConfig => {
     sttProviderId: "openai",
     openaiSttModel: "whisper-1",
     groqSttModel: "whisper-large-v3-turbo",
+
+    // Transcript post-processing defaults
+    transcriptPostProcessingEnabled: false,
+    transcriptPostProcessingProviderId: "openai",
+    transcriptPostProcessingPrompt: DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT,
 
     // Parakeet STT defaults
     parakeetNumThreads: 2,

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -37,6 +37,14 @@ export const CHAT_PROVIDERS = [
 
 export type CHAT_PROVIDER_ID = (typeof CHAT_PROVIDERS)[number]["value"];
 
+export const DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT = [
+  "Clean up the transcript for punctuation, capitalization, and obvious speech-to-text mistakes.",
+  "Preserve the original meaning and wording as much as possible.",
+  "Do not answer the transcript or add commentary. Return only the cleaned transcript.",
+  "",
+  "{transcript}",
+].join("\n");
+
 export const TTS_PROVIDERS = [
   { label: "OpenAI", value: "openai" },
   { label: "Groq", value: "groq" },


### PR DESCRIPTION
## Summary
- add a discoverable Transcript Processing toggle under Speech-to-Text settings
- provide a default transcript post-processing prompt so enabling cleanup works without custom prompt text
- apply transcript post-processing to agent voice recordings before queueing or processing

## Validation
- pnpm build:shared
- pnpm exec node --test apps/desktop/tests/dictation-postprocessing-fallback.test.mjs apps/desktop/tests/stt-model-wiring.test.mjs
- pnpm --filter @dotagents/shared typecheck
- pnpm --filter @dotagents/core typecheck
- pnpm --filter @dotagents/desktop typecheck
- git diff --check
