### PR TITLE
Suppress TTS auto-play for reopened historical sessions

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
@@ -37,4 +37,10 @@ describe("agent progress TTS guardrails", () => {
     expect(agentProgressSource).toContain('isLast &&')
   })
 
+  it("suppresses auto-play for historical sessions that mount with progress already complete", () => {
+    expect(agentProgressSource).toContain('const observedLiveProgressRef = useRef(false)')
+    expect(agentProgressSource).toContain('if (!observedLiveProgressRef.current) {')
+    expect(agentProgressSource).toContain('consumeSessionForcedAutoPlay(sessionId)')
+  })
+
 })

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -39,7 +39,7 @@ import { ACPSessionBadge } from "./acp-session-badge"
 import { AgentSummaryView } from "./agent-summary-view"
 import { LoadingSpinner } from "./ui/loading-spinner"
 import { extractSubAgentToolDisplayContent } from "@shared/delegation-tool-display"
-import { buildContentTTSKey, buildResponseEventTTSKey, hasTTSPlayed, markTTSPlayed, removeTTSKey } from "@renderer/lib/tts-tracking"
+import { buildContentTTSKey, buildResponseEventTTSKey, consumeSessionForcedAutoPlay, hasTTSPlayed, markTTSPlayed, removeTTSKey } from "@renderer/lib/tts-tracking"
 import { ttsManager } from "@renderer/lib/tts-manager"
 import { sanitizeMessageContentForDisplay, sanitizeMessageContentForSpeech } from "@dotagents/shared/message-display-utils"
 import { toast } from "sonner"
@@ -678,6 +678,11 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const inFlightTtsKeysRef = useRef<string[]>([])
   // Track the last ttsSource that was successfully auto-played to prevent replay on follow-up messages
   const lastAutoPlayedSourceRef = useRef<string | null>(null)
+  // Track whether the agent's progress was ever observed in a non-complete state during
+  // this component's lifetime. Live runs (including mid-turn respond_to_user emissions)
+  // always pass through `isComplete=false` first; reopened/historical sessions mount with
+  // `isComplete=true` from the start. Auto-play is gated on having observed an active run.
+  const observedLiveProgressRef = useRef(false)
   const configQuery = useConfigQuery()
   const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)
 
@@ -833,6 +838,18 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
     }
   }, [ttsSource])
 
+  // Detect whether this component has observed the parent agent in a non-complete
+  // state. Reopened/historical sessions mount with `isComplete=true` from the very
+  // first render, so the ref stays false and the auto-play effect treats those
+  // messages as historical. Live runs (including mid-turn respond_to_user updates
+  // before the agent overall completes) pass through `isComplete=false`, flipping
+  // the ref so subsequent final renders may auto-play.
+  useEffect(() => {
+    if (!isComplete) {
+      observedLiveProgressRef.current = true
+    }
+  }, [isComplete])
+
   // Check if TTS button should be shown for this message (any completed assistant message with content)
   const shouldShowTTSButton =
     message.role === "assistant" &&
@@ -871,6 +888,20 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
     // historical, so auto-playing its TTS would replay an already-heard response.
     if (sessionId?.startsWith("pending-")) {
       return
+    }
+
+    // Reopening a previous session re-renders its last assistant message with
+    // `isComplete=true` from the first render. Treat as historical when the
+    // component never observed the parent agent in a non-complete state under
+    // its own lifetime. Manual TTS playback remains available via the play
+    // button. The speakOnTrigger path explicitly authorizes one auto-play via
+    // markSessionForcedAutoPlay, which we consume here so the historical guard
+    // does not suppress that flow.
+    if (!observedLiveProgressRef.current) {
+      const forced = sessionId ? consumeSessionForcedAutoPlay(sessionId) : false
+      if (!forced) {
+        return
+      }
     }
 
     // Guard against replaying the same content on follow-up user messages.

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -5,7 +5,7 @@ import { useAgentStore, useConversationStore } from '@renderer/stores'
 import { AgentProgressUpdate, QueuedMessage } from '@shared/types'
 import { queryClient } from '@renderer/lib/queries'
 import { ttsManager } from '@renderer/lib/tts-manager'
-import { clearSessionTTSTracking } from '@renderer/lib/tts-tracking'
+import { clearSessionTTSTracking, markSessionForcedAutoPlay } from '@renderer/lib/tts-tracking'
 import { logUI } from '@renderer/lib/debug'
 
 const areStringArraysEqual = (left: string[], right: string[]): boolean => {
@@ -142,11 +142,16 @@ export function useStoreSync() {
     return unlisten
   }, [setSessionSnoozed])
 
-  // Clear stale TTS tracking keys for a session (sent before speakOnTrigger unsnooze)
+  // Clear stale TTS tracking keys for a session (sent before speakOnTrigger unsnooze).
+  // Also mark the session as authorized for one forced auto-play, so the renderer's
+  // historical-message guard does not suppress speakOnTrigger when the session's
+  // CompactMessage mounts with an already-final assistant response after the panel
+  // reveals it.
   useEffect(() => {
     const unlisten = rendererHandlers.clearSessionTTSKeys.listen(
       (sessionId: string) => {
         clearSessionTTSTracking(sessionId)
+        markSessionForcedAutoPlay(sessionId)
       }
     )
     return unlisten

--- a/apps/desktop/src/renderer/src/lib/tts-tracking.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tts-tracking.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildContentTTSKey,
+  buildResponseEventTTSKey,
+  clearSessionTTSTracking,
+  consumeSessionForcedAutoPlay,
+  hasTTSPlayed,
+  markSessionForcedAutoPlay,
+  markTTSPlayed,
+  removeTTSKey,
+} from "./tts-tracking"
+
+describe("tts-tracking", () => {
+  it("builds session-scoped keys for response events and content fallbacks", () => {
+    expect(buildResponseEventTTSKey("session-1", "evt-1", "final")).toBe("session-1:final:event:evt-1")
+    expect(buildContentTTSKey("session-1", "hello", "final")).toBe("session-1:final:content:hello")
+    expect(buildResponseEventTTSKey(undefined, "evt-1")).toBeNull()
+    expect(buildContentTTSKey(undefined, "hello")).toBeNull()
+  })
+
+  it("clears only entries scoped to a given session", () => {
+    const keepKey = buildContentTTSKey("session-keep", "x", "final")!
+    const clearKey = buildContentTTSKey("session-clear", "y", "final")!
+
+    markTTSPlayed(keepKey)
+    markTTSPlayed(clearKey)
+    clearSessionTTSTracking("session-clear")
+
+    expect(hasTTSPlayed(keepKey)).toBe(true)
+    expect(hasTTSPlayed(clearKey)).toBe(false)
+    removeTTSKey(keepKey)
+  })
+
+  it("marks and consumes forced auto-play once per session", () => {
+    const sessionId = "session-forced"
+    expect(consumeSessionForcedAutoPlay(sessionId)).toBe(false)
+
+    markSessionForcedAutoPlay(sessionId)
+    expect(consumeSessionForcedAutoPlay(sessionId)).toBe(true)
+    expect(consumeSessionForcedAutoPlay(sessionId)).toBe(false)
+  })
+
+  it("scopes forced auto-play markers per session", () => {
+    markSessionForcedAutoPlay("session-a")
+    expect(consumeSessionForcedAutoPlay("session-b")).toBe(false)
+    expect(consumeSessionForcedAutoPlay("session-a")).toBe(true)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/tts-tracking.ts
+++ b/apps/desktop/src/renderer/src/lib/tts-tracking.ts
@@ -54,3 +54,19 @@ export function clearSessionTTSTracking(sessionId: string): void {
   }
 }
 
+/**
+ * Sessions explicitly authorized for the next auto-play even if their CompactMessage
+ * mounts with an already-final assistant message (e.g. speakOnTrigger after a snoozed
+ * loop completes and the panel reveals the session). The flag is consumed by the
+ * first auto-play attempt for that session.
+ */
+const sessionsWithForcedAutoPlay = new Set<string>()
+
+export function markSessionForcedAutoPlay(sessionId: string): void {
+  sessionsWithForcedAutoPlay.add(sessionId)
+}
+
+export function consumeSessionForcedAutoPlay(sessionId: string): boolean {
+  return sessionsWithForcedAutoPlay.delete(sessionId)
+}
+


### PR DESCRIPTION
## Summary
Fixes #409. Reopening a previous session no longer auto-plays TTS for the
last historical assistant message, while keeping it manually replayable
via the play button.

- Adds an `observedLiveProgressRef` per `CompactMessage` that flips to
  `true` only when the agent is observed with `isComplete=false` during
  the component's lifetime. Historical sessions mount with
  `isComplete=true` from the very first render, so the ref stays
  `false` and the auto-play effect treats the message as historical.
- Live runs (including mid-turn `respond_to_user` updates emitted
  before the agent overall completes) still pass through
  `isComplete=false`, so auto-play continues to fire as before.
- Preserves `speakOnTrigger`: `clearSessionTTSKeys` now also calls a
  new `markSessionForcedAutoPlay(sessionId)`, which the auto-play
  effect consumes once to bypass the historical guard when the panel
  reveals a previously-snoozed loop run that has already completed.

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/lib/tts-tracking.test.ts src/renderer/src/components/agent-progress.snoozed-tts.test.ts`
- [x] `pnpm exec vitest run src/renderer/src` (295 tests)
- [ ] Manual: reopen a saved session with TTS enabled and auto-play
      enabled — no audio should play; the play button should still
      generate/play TTS.
- [ ] Manual: send a new prompt — assistant response auto-plays as
      before.
- [ ] Manual: trigger a `speakOnTrigger` loop — completed response
      auto-plays after the panel reveals the session.

https://claude.ai/code/session_01JwxhRc3tu8hrEcinUuK7Mh

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwxhRc3tu8hrEcinUuK7Mh)_