### PR TITLE
Link agent sessions and show cross-agent message provenance

### DIFF
--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -1147,6 +1147,7 @@ export class ConversationService {
     role: "user" | "assistant" | "tool",
     toolCalls?: Array<{ name: string; arguments: any }>,
     toolResults?: Array<{ success: boolean; content: string; error?: string }>,
+    options?: { sourceAgent?: ConversationMessage["sourceAgent"] },
   ): Promise<Conversation | null> {
     return this.enqueueConversationMutation(conversationId, async () => {
       try {
@@ -1175,6 +1176,7 @@ export class ConversationService {
           timestamp: Date.now(),
           toolCalls,
           toolResults,
+          ...(options?.sourceAgent ? { sourceAgent: options.sourceAgent } : {}),
         }
 
         conversation.messages.push(message)

--- a/apps/desktop/src/main/message-queue-service.ts
+++ b/apps/desktop/src/main/message-queue-service.ts
@@ -1,8 +1,17 @@
-import { QueuedMessage, MessageQueue } from "../shared/types"
+import { QueuedMessage, MessageQueue, AgentSessionRef } from "../shared/types"
 import { logApp } from "./debug"
 import { getRendererHandlers } from "@egoist/tipc/main"
 import { RendererHandlers } from "./renderer-handlers"
 import { WINDOWS } from "./window"
+
+export interface EnqueueOptions {
+  /** Session that was active when this message was queued (for resuming the same session). */
+  sessionId?: string
+  /** Cross-agent provenance: the originating agent session, if any. */
+  source?: AgentSessionRef
+  /** Cross-agent provenance: the target agent session, if any. */
+  target?: AgentSessionRef
+}
 
 /**
  * Service for managing message queues per conversation.
@@ -91,16 +100,30 @@ class MessageQueueService {
   }
 
   /**
-   * Add a message to the queue for a conversation
+   * Add a message to the queue for a conversation.
+   * Accepts either a legacy `sessionId` string or an options object that can also
+   * carry cross-agent source/target provenance for messages enqueued via
+   * `send_agent_message`.
    */
-  enqueue(conversationId: string, text: string, sessionId?: string): QueuedMessage {
+  enqueue(
+    conversationId: string,
+    text: string,
+    sessionIdOrOptions?: string | EnqueueOptions,
+  ): QueuedMessage {
+    const options: EnqueueOptions =
+      typeof sessionIdOrOptions === "string"
+        ? { sessionId: sessionIdOrOptions }
+        : sessionIdOrOptions ?? {}
+
     const message: QueuedMessage = {
       id: this.generateMessageId(),
       conversationId,
-      sessionId,
+      sessionId: options.sessionId,
       text,
       createdAt: Date.now(),
       status: "pending",
+      ...(options.source ? { source: options.source } : {}),
+      ...(options.target ? { target: options.target } : {}),
     }
 
     const queue = this.queues.get(conversationId) || []

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -517,7 +517,10 @@ const toolHandlers: Record<string, ToolHandler> = {
     }
   },
 
-  send_agent_message: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+  send_agent_message: async (
+    args: Record<string, unknown>,
+    context: BuiltinToolContext,
+  ): Promise<MCPToolResult> => {
     // Validate required parameters with proper type guards
     if (!args.sessionId || typeof args.sessionId !== "string") {
       return {
@@ -585,8 +588,30 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
+    // Capture cross-agent provenance so the queue/conversation UI can show where
+    // this message came from and let the user navigate back to the source.
+    const sourceSessionId = context?.sessionId
+    const sourceSession = sourceSessionId
+      ? agentSessionTracker.getSession(sourceSessionId)
+      : undefined
+    const source = sourceSessionId
+      ? {
+          sessionId: sourceSessionId,
+          conversationId: sourceSession?.conversationId,
+          agentName: sourceSession?.conversationTitle,
+        }
+      : undefined
+    const target = {
+      sessionId,
+      conversationId: session.conversationId,
+      agentName: session.conversationTitle,
+    }
+
     // Queue message for the target agent's conversation
-    const queuedMessage = messageQueueService.enqueue(session.conversationId, message)
+    const queuedMessage = messageQueueService.enqueue(session.conversationId, message, {
+      source,
+      target,
+    })
 
     return {
       content: [
@@ -597,6 +622,8 @@ const toolHandlers: Record<string, ToolHandler> = {
             sessionId,
             conversationId: session.conversationId,
             queuedMessageId: queuedMessage.id,
+            ...(source ? { source } : {}),
+            target,
             message: `Message queued for agent session ${sessionId} (${session.conversationTitle})`,
           }, null, 2),
         },

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -53,6 +53,7 @@ import {
   MCPServerConfig,
   Conversation,
   ConversationHistoryItem,
+  ConversationMessage,
   AgentProgressUpdate,
   SessionProfileSnapshot,
   LoopConfig,
@@ -531,6 +532,7 @@ async function processWithAgentMode(
           toolResults?: any[]
           timestamp?: number
           branchMessageIndex?: number
+          sourceAgent?: ConversationMessage["sourceAgent"]
         }>
       | undefined
 
@@ -563,6 +565,9 @@ async function processWithAgentMode(
             isError: !tr.success,
           })),
           branchMessageIndex: branchMessageIndexMap[index],
+          // Preserve cross-agent provenance so the live UI can keep showing the
+          // "from <agent>" link on prior queued messages within this conversation.
+          ...(msg.sourceAgent ? { sourceAgent: msg.sourceAgent } : {}),
         }))
 
         logLLM(`[tipc.ts processWithAgentMode] previousConversationHistory roles: [${previousConversationHistory.map(m => m.role).join(', ')}]`)
@@ -897,11 +902,16 @@ async function processQueuedMessages(conversationId: string): Promise<void> {
       try {
         // Only add to conversation history if not already added (prevents duplicates on retry)
         if (!queuedMessage.addedToHistory) {
-          // Add the queued message to the conversation
+          // Add the queued message to the conversation. When the message originated from
+          // another agent session (via send_agent_message), preserve that provenance on
+          // the conversation message so the UI can render a "from <agent>" link.
           const addResult = await conversationService.addMessageToConversation(
             conversationId,
             queuedMessage.text,
             "user",
+            undefined,
+            undefined,
+            queuedMessage.source ? { sourceAgent: queuedMessage.source } : undefined,
           )
           // If adding to history failed (conversation not found/IO error), treat as failure
           // Don't continue processing since the message wasn't recorded

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -102,6 +102,8 @@ type DisplayItem =
       responseEvent?: AgentUserResponseEvent
       /** Absolute raw-history index to use when branching from this message */
       branchMessageIndex?: number
+      /** Cross-agent provenance for messages injected by another agent session. */
+      sourceAgent?: import("@shared/types").AgentSessionRef
     } }
   | { kind: "tool_execution"; id: string; data: {
       timestamp: number
@@ -631,6 +633,58 @@ function hasActiveTextSelection(container?: HTMLElement | null): boolean {
   )
 }
 
+/**
+ * Small inline link rendered on cross-agent injected user messages.
+ * Lets the user navigate back to the agent session that originated the message
+ * (live session if still active, otherwise the saved conversation).
+ */
+const CrossAgentSourceBadge: React.FC<{
+  sourceAgent: import("@shared/types").AgentSessionRef
+}> = ({ sourceAgent }) => {
+  const navigate = useNavigate()
+  const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
+  const setExpandedSessionId = useAgentStore((s) => s.setExpandedSessionId)
+  const setViewedConversationId = useAgentStore((s) => s.setViewedConversationId)
+  const activeSessionsById = useAgentStore((s) => s.agentProgressById)
+
+  const label = sourceAgent.agentName?.trim() || sourceAgent.sessionId.slice(0, 8)
+  const isLive = activeSessionsById.has(sourceAgent.sessionId)
+  const canNavigate = isLive || !!sourceAgent.conversationId
+
+  return (
+    <button
+      type="button"
+      disabled={!canNavigate}
+      onClick={(e) => {
+        e.stopPropagation()
+        if (isLive) {
+          setViewedConversationId(null)
+          navigate("/", { state: { clearPendingConversation: true } })
+          setFocusedSessionId(sourceAgent.sessionId)
+          setExpandedSessionId(sourceAgent.sessionId)
+          return
+        }
+        if (sourceAgent.conversationId) {
+          setFocusedSessionId(null)
+          setExpandedSessionId(null)
+          setViewedConversationId(sourceAgent.conversationId)
+          navigate(`/${sourceAgent.conversationId}`)
+        }
+      }}
+      title={`Sent from agent ${label} (${sourceAgent.sessionId})`}
+      className={cn(
+        "mb-1 inline-flex max-w-full items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium",
+        "bg-blue-100/80 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300",
+        canNavigate && "hover:bg-blue-200/80 dark:hover:bg-blue-900/60 hover:underline cursor-pointer",
+        !canNavigate && "opacity-70 cursor-default",
+      )}
+    >
+      <Bot className="h-3 w-3 shrink-0" />
+      <span className="truncate">from {label}</span>
+    </button>
+  )
+}
+
 type CompactMessageProps = {
   message: {
     role: "user" | "assistant" | "tool"
@@ -641,6 +695,7 @@ type CompactMessageProps = {
     toolResults?: Array<{ success: boolean; content: string; error?: string }>
     timestamp: number
     responseEvent?: AgentUserResponseEvent
+    sourceAgent?: import("@shared/types").AgentSessionRef
   }
   ttsText?: string
   isLast: boolean
@@ -974,6 +1029,9 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
         onClick={shouldToggleFromContentClick ? handleToggleExpand : undefined}
       >
         <div className="flex-1 min-w-0">
+          {message.role === "user" && message.sourceAgent && (
+            <CrossAgentSourceBadge sourceAgent={message.sourceAgent} />
+          )}
           <div className={cn(
             "leading-relaxed text-left",
             !isExpanded && shouldCollapse && "line-clamp-2"
@@ -3438,6 +3496,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     toolResults?: Array<{ success: boolean; content: string; error?: string }>
     /** Absolute raw-history index to use when branching from this message */
     branchMessageIndex?: number
+    sourceAgent?: import("@shared/types").AgentSessionRef
   }>>(() => {
     const nextMessages: Array<{
       role: "user" | "assistant" | "tool"
@@ -3448,6 +3507,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       toolCalls?: Array<{ name: string; arguments: any }>
       toolResults?: Array<{ success: boolean; content: string; error?: string }>
       branchMessageIndex?: number
+      sourceAgent?: import("@shared/types").AgentSessionRef
     }> = []
     const fallbackBaseTimestamp =
       conversationHistory?.[conversationHistory.length - 1]?.timestamp ??
@@ -3476,6 +3536,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             toolCalls: entry.toolCalls,
             toolResults: entry.toolResults,
             branchMessageIndex: entry.branchMessageIndex,
+            sourceAgent: entry.sourceAgent,
           })
         })
 

--- a/apps/desktop/src/renderer/src/components/message-queue-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/message-queue-panel.tsx
@@ -1,10 +1,80 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useCallback } from "react"
+import { useNavigate } from "react-router-dom"
 import { cn } from "@renderer/lib/utils"
-import { Clock, Trash2, Check, ChevronDown, ChevronUp, AlertCircle, Loader2, Play, Pause, Pencil, RotateCcw } from "lucide-react"
+import { Clock, Trash2, Check, ChevronDown, ChevronUp, AlertCircle, Loader2, Play, Pause, Pencil, RotateCcw, ArrowRight, CornerDownRight } from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
-import { QueuedMessage } from "@shared/types"
+import { QueuedMessage, AgentSessionRef } from "@shared/types"
 import { useMutation } from "@tanstack/react-query"
 import { tipcClient } from "@renderer/lib/tipc-client"
+import { useAgentStore } from "@renderer/stores/agent-store"
+
+/**
+ * Navigate to a referenced agent session: focus the live session if it is
+ * still running, otherwise open the saved conversation. Mirrors the behavior
+ * in ActiveAgentsSidebar so sourceAgent/targetAgent links work consistently.
+ */
+function useNavigateToAgentSessionRef() {
+  const navigate = useNavigate()
+  const setFocusedSessionId = useAgentStore((s) => s.setFocusedSessionId)
+  const setExpandedSessionId = useAgentStore((s) => s.setExpandedSessionId)
+  const setViewedConversationId = useAgentStore((s) => s.setViewedConversationId)
+  const activeSessionsById = useAgentStore((s) => s.agentProgressById)
+
+  return useCallback(
+    (ref: AgentSessionRef) => {
+      const isLive = activeSessionsById.has(ref.sessionId)
+      if (isLive) {
+        setViewedConversationId(null)
+        navigate("/", { state: { clearPendingConversation: true } })
+        setFocusedSessionId(ref.sessionId)
+        setExpandedSessionId(ref.sessionId)
+        return
+      }
+      if (ref.conversationId) {
+        setFocusedSessionId(null)
+        setExpandedSessionId(null)
+        setViewedConversationId(ref.conversationId)
+        navigate(`/${ref.conversationId}`)
+      }
+    },
+    [activeSessionsById, navigate, setExpandedSessionId, setFocusedSessionId, setViewedConversationId],
+  )
+}
+
+function AgentSessionLink({
+  ref,
+  prefixIcon,
+  className,
+}: {
+  ref: AgentSessionRef
+  prefixIcon?: React.ReactNode
+  className?: string
+}) {
+  const navigateToRef = useNavigateToAgentSessionRef()
+  const label = ref.agentName?.trim() || ref.sessionId.slice(0, 8)
+  const isClickable = !!ref.conversationId || true
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        navigateToRef(ref)
+      }}
+      disabled={!isClickable}
+      title={`Open ${label} (${ref.sessionId})`}
+      className={cn(
+        "inline-flex max-w-full items-center gap-0.5 rounded px-1 py-0.5 text-[10px] font-medium",
+        "text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors",
+        "underline decoration-dotted underline-offset-2",
+        className,
+      )}
+    >
+      {prefixIcon}
+      <span className="truncate">{label}</span>
+    </button>
+  )
+}
 
 interface MessageQueuePanelProps {
   conversationId: string
@@ -159,6 +229,29 @@ function QueuedMessageItem({
           )}
           <div className="flex min-w-0 flex-1 items-start gap-1.5">
             <div className="min-w-0 flex-1">
+              {(message.source || message.target) && (
+                <div className="mb-0.5 flex flex-wrap items-center gap-1 text-[10px] text-muted-foreground">
+                  {message.source && (
+                    <>
+                      <span>From</span>
+                      <AgentSessionLink
+                        ref={message.source}
+                        prefixIcon={<CornerDownRight className="h-3 w-3" />}
+                      />
+                    </>
+                  )}
+                  {message.source && message.target && <span>·</span>}
+                  {message.target && (
+                    <>
+                      <span>To</span>
+                      <AgentSessionLink
+                        ref={message.target}
+                        prefixIcon={<ArrowRight className="h-3 w-3" />}
+                      />
+                    </>
+                  )}
+                </div>
+              )}
               <p
                 className={cn(
                   "text-xs leading-snug",

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -648,6 +648,7 @@ export function Component() {
         toolResults: m.toolResults,
         timestamp: m.timestamp,
         branchMessageIndex: branchMessageIndexOffset + branchMessageIndexMap[index],
+        ...(m.sourceAgent ? { sourceAgent: m.sourceAgent } : {}),
       })),
     }
   }, [pendingResumeConversationId, pendingResumeConversationQuery.data, pendingContinuationStartedAt])

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -170,7 +170,8 @@ export interface DetailedToolInfo {
 // AgentStepSummary — re-exported from @dotagents/shared (see above)
 
 // Message Queue Types — re-exported from shared package
-export type { QueuedMessage, MessageQueue } from '@dotagents/shared'
+export type { QueuedMessage, MessageQueue, AgentSessionRef } from '@dotagents/shared'
+import type { AgentSessionRef } from '@dotagents/shared'
 
 // Conversation Types
 export interface ConversationMessage {
@@ -191,6 +192,13 @@ export interface ConversationMessage {
    * Only set when isSummary is true.
    */
   summarizedMessageCount?: number
+  /**
+   * When set, this message was injected into the conversation by another agent
+   * session (e.g. via the send_agent_message tool). Preserved on the message so
+   * the UI can render a "from <agent>" provenance link even after the queued
+   * message has been consumed.
+   */
+  sourceAgent?: AgentSessionRef
 }
 
 export interface ConversationCompactionMetadata {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -45,6 +45,12 @@ export interface ConversationHistoryMessage extends BaseChatMessage {
    * action (like branching) needs to target this displayed message.
    */
   branchMessageIndex?: number;
+  /**
+   * Cross-agent provenance: the originating agent session for messages injected
+   * into this conversation by another agent (e.g. via send_agent_message). Lets
+   * the UI render a clickable "from <agent>" link back to the source session.
+   */
+  sourceAgent?: AgentSessionRef;
 }
 
 /**
@@ -62,6 +68,19 @@ export interface ChatApiResponse {
 }
 
 /**
+ * Reference to an agent session that originated or received a cross-agent message.
+ * Used to render clickable provenance links in the queue and conversation UI.
+ */
+export interface AgentSessionRef {
+  /** Session id of the source/target agent (matches AgentSession.id) */
+  sessionId: string;
+  /** Conversation id linked to that session, when available */
+  conversationId?: string;
+  /** Display name (conversation/session title) at the time the link was captured */
+  agentName?: string;
+}
+
+/**
  * Queued message - represents a message waiting to be processed.
  * Used when the agent is busy processing and messages are queued for later.
  */
@@ -76,6 +95,10 @@ export interface QueuedMessage {
   errorMessage?: string;
   /** Indicates the message was added to conversation history before processing failed */
   addedToHistory?: boolean;
+  /** When set, this queued message originated from another agent session (e.g. via send_agent_message). */
+  source?: AgentSessionRef;
+  /** When set, identifies the target agent session this queued message was directed at. */
+  target?: AgentSessionRef;
 }
 
 /**


### PR DESCRIPTION
Closes #410.

## Summary
When one agent calls `send_agent_message` to inject a prompt into another agent's session, preserve the source/target session metadata so the user can trace cross-agent coordination from the UI.

## Changes
- **Shared types** (`packages/shared/src/types.ts`): added `AgentSessionRef` and optional `source` / `target` fields to `QueuedMessage`, plus `sourceAgent` on `ConversationHistoryMessage`.
- **Desktop conversation type** (`apps/desktop/src/shared/types.ts`): persisted `sourceAgent` on `ConversationMessage` so the link survives after the queued message is consumed.
- **`send_agent_message` tool** (`apps/desktop/src/main/runtime-tools.ts`): captures the calling session as the source and the destination session as the target, including conversation id and title for navigation.
- **Message queue service** (`apps/desktop/src/main/message-queue-service.ts`): `enqueue` now accepts an options object carrying the source/target refs (the legacy `sessionId` string call signature still works).
- **Queue processor** (`apps/desktop/src/main/tipc.ts`): when a queued cross-agent message is added to conversation history, the originating session is preserved on the stored message; the prior-history mapping fed back to the agent loop also preserves `sourceAgent` so subsequent live progress updates keep the badge visible.
- **`addMessageToConversation`** (`apps/desktop/src/main/conversation-service.ts`): accepts an optional `sourceAgent` and stores it on the `ConversationMessage`.
- **Message queue panel UI** (`apps/desktop/src/renderer/src/components/message-queue-panel.tsx`): when a queued message has provenance, renders compact "From <agent>" / "To <agent>" links above the text. Clicking a link focuses the live session if it's still running, otherwise opens the saved conversation.
- **Conversation messages UI** (`apps/desktop/src/renderer/src/components/agent-progress.tsx`): user messages with a stored `sourceAgent` show a small "from <agent>" badge that navigates back to the originating session, mirroring the saved-conversation render path.
- **Saved-conversation resume** (`apps/desktop/src/renderer/src/pages/sessions.tsx`): the synthetic `conversationHistory` built when resuming a saved conversation now propagates `sourceAgent`.

## Test plan
- [x] `pnpm --filter @dotagents/shared build` and `pnpm --filter @dotagents/core build`
- [x] `apps/desktop` `pnpm typecheck:node`
- [x] `apps/desktop` `pnpm typecheck:web`
- [x] `pnpm vitest run src/main/runtime-tools.respond-to-user.test.ts src/renderer/src/components/queue-leak-regression.test.ts`
- [x] `pnpm vitest run src/renderer/src/components/agent-progress.response-history.test.ts src/renderer/src/components/agent-progress.interaction.test.ts`
- [x] `pnpm vitest run src/main/llm.respond-to-user-history.test.ts`
- [x] `packages/shared` `pnpm test`
- [ ] Manual: agent A calls `send_agent_message` against agent B; verify queue panel shows "From <A>" link, clicking it focuses A's session; once consumed, B's conversation shows the "from <A>" badge on the user message and clicking it navigates back to A's saved conversation.

https://claude.ai/code/session_011e4GUzHKGoEz57zzUPtdPF

---
_Generated by [Claude Code](https://claude.ai/code/session_011e4GUzHKGoEz57zzUPtdPF)_