### PR TITLE
Show day/week labels for sidebar durations past 24h

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -30,6 +30,7 @@ import {
   partitionPinnedAndUnpinnedTaskEntries,
   partitionTaskAndUserEntries,
 } from "@renderer/lib/sidebar-sessions"
+import { formatSidebarDuration } from "@renderer/lib/sidebar-duration"
 import { useLocation, useNavigate } from "react-router-dom"
 import { AgentSelector } from "./agent-selector"
 import { PredefinedPromptsMenu } from "./predefined-prompts-menu"
@@ -125,17 +126,7 @@ function getSessionLastMessageTimestamp(
 }
 
 function formatMinutesAgo(timestamp: number): string | null {
-  if (!timestamp || !Number.isFinite(timestamp)) return null
-  const minutesAgo = Math.max(Math.floor((Date.now() - timestamp) / 60_000), 0)
-  if (minutesAgo < 60) {
-    return minutesAgo === 1 ? "1m" : `${minutesAgo}m`
-  }
-
-  const hours = Math.floor(minutesAgo / 60)
-  const remainderMinutes = minutesAgo % 60
-  const hourLabel = `${hours}h`
-  const minuteLabel = remainderMinutes > 0 ? ` ${remainderMinutes}m` : ""
-  return `${hourLabel}${minuteLabel}`
+  return formatSidebarDuration(timestamp)
 }
 
 function getSidebarSessionPreview(progress?: AgentProgressUpdate | null): string | null {

--- a/apps/desktop/src/renderer/src/lib/sidebar-duration.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-duration.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { formatSidebarDuration } from "./sidebar-duration"
+
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0)
+const MIN = 60_000
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+const WEEK = 7 * DAY
+
+describe("formatSidebarDuration", () => {
+  it("returns null for missing or non-finite timestamps", () => {
+    expect(formatSidebarDuration(0, NOW)).toBeNull()
+    expect(formatSidebarDuration(Number.NaN, NOW)).toBeNull()
+    expect(formatSidebarDuration(Number.POSITIVE_INFINITY, NOW)).toBeNull()
+  })
+
+  it("formats sub-hour durations in minutes", () => {
+    expect(formatSidebarDuration(NOW, NOW)).toBe("0m")
+    expect(formatSidebarDuration(NOW - 1 * MIN, NOW)).toBe("1m")
+    expect(formatSidebarDuration(NOW - 5 * MIN, NOW)).toBe("5m")
+    expect(formatSidebarDuration(NOW - 59 * MIN, NOW)).toBe("59m")
+  })
+
+  it("formats hour-scale durations with optional minutes", () => {
+    expect(formatSidebarDuration(NOW - 1 * HOUR, NOW)).toBe("1h")
+    expect(formatSidebarDuration(NOW - (2 * HOUR + 30 * MIN), NOW)).toBe("2h 30m")
+    expect(formatSidebarDuration(NOW - 23 * HOUR, NOW)).toBe("23h")
+    expect(formatSidebarDuration(NOW - (23 * HOUR + 59 * MIN), NOW)).toBe("23h 59m")
+  })
+
+  it("switches to day labels at the 24h boundary", () => {
+    expect(formatSidebarDuration(NOW - 24 * HOUR, NOW)).toBe("1d")
+    expect(formatSidebarDuration(NOW - (24 * HOUR + 1 * MIN), NOW)).toBe("1d")
+    expect(formatSidebarDuration(NOW - (47 * HOUR + 59 * MIN), NOW)).toBe("1d")
+    expect(formatSidebarDuration(NOW - 2 * DAY, NOW)).toBe("2d")
+    expect(formatSidebarDuration(NOW - 6 * DAY, NOW)).toBe("6d")
+  })
+
+  it("does not roll a 23h59m duration into a day", () => {
+    expect(formatSidebarDuration(NOW - (23 * HOUR + 59 * MIN), NOW)).not.toMatch(/d$/)
+  })
+
+  it("switches to week labels at the 7d boundary", () => {
+    expect(formatSidebarDuration(NOW - 7 * DAY, NOW)).toBe("1w")
+    expect(formatSidebarDuration(NOW - (7 * DAY + 1 * MIN), NOW)).toBe("1w")
+    expect(formatSidebarDuration(NOW - (13 * DAY + 23 * HOUR), NOW)).toBe("1w")
+    expect(formatSidebarDuration(NOW - 2 * WEEK, NOW)).toBe("2w")
+    expect(formatSidebarDuration(NOW - 5 * WEEK, NOW)).toBe("5w")
+  })
+
+  it("clamps negative deltas (clock skew) to 0m", () => {
+    expect(formatSidebarDuration(NOW + 5 * MIN, NOW)).toBe("0m")
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/sidebar-duration.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-duration.ts
@@ -1,0 +1,27 @@
+export function formatSidebarDuration(
+  timestamp: number,
+  now: number = Date.now(),
+): string | null {
+  if (!timestamp || !Number.isFinite(timestamp)) return null
+  const minutesAgo = Math.max(Math.floor((now - timestamp) / 60_000), 0)
+
+  if (minutesAgo < 60) {
+    return minutesAgo === 1 ? "1m" : `${minutesAgo}m`
+  }
+
+  const hours = Math.floor(minutesAgo / 60)
+  if (hours < 24) {
+    const remainderMinutes = minutesAgo % 60
+    const hourLabel = `${hours}h`
+    const minuteLabel = remainderMinutes > 0 ? ` ${remainderMinutes}m` : ""
+    return `${hourLabel}${minuteLabel}`
+  }
+
+  const days = Math.floor(hours / 24)
+  if (days < 7) {
+    return `${days}d`
+  }
+
+  const weeks = Math.floor(days / 7)
+  return `${weeks}w`
+}


### PR DESCRIPTION
Closes #414.

## Summary
Sidebar session durations kept growing into `25h`, `48h`, … once a session ran longer than a day. They now compact to days/weeks past the 24h mark.

- `< 24h`: existing format (unchanged — `5m`, `2h`, `2h 30m`)
- `24h` ≤ d `< 7d`: floor to days → `1d`, `2d`, … `6d`
- `≥ 7d`: floor to weeks → `1w`, `2w`, …
- Negative deltas (clock skew) still clamp to `0m`, matching previous behavior.

## Changes
- New helper `apps/desktop/src/renderer/src/lib/sidebar-duration.ts` (`formatSidebarDuration`) with an injectable `now` for deterministic testing.
- `active-agents-sidebar.tsx` now delegates to the helper.
- New unit tests `sidebar-duration.test.ts` covering null/non-finite inputs, sub-hour, hour-with-minutes, the 24h boundary, the 7d boundary, week buckets, and clock skew.

## Test plan
- [x] `vitest run src/renderer/src/lib/sidebar-duration.test.ts` (7/7 pass)
- [x] `vitest run src/renderer/src/components/active-agents-sidebar.status-colors.test.ts` (8/8 pass — no regressions in the sidebar source-shape tests)
- [ ] Manual: leave a session running > 24h and confirm the sidebar shows `1d` (not `24h`); past 7d shows `1w`.

https://claude.ai/code/session_0154bvYRnfVEEWBuggudDFsL

---
_Generated by [Claude Code](https://claude.ai/code/session_0154bvYRnfVEEWBuggudDFsL)_