### PR TITLE
Redesign model settings routing

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -19,7 +19,7 @@ const CHATGPT_CODEX_SCOPE = "openid profile email offline_access"
 const CHATGPT_CODEX_REDIRECT_URI = "http://localhost:1455/auth/callback"
 const CHATGPT_CODEX_STORAGE_KEY = `${DEFAULT_CHATGPT_WEB_BASE_URL}/backend-api/codex/responses`
 
-type ChatGptWebModelContext = "mcp" | "transcript"
+type ChatGptWebModelContext = "mcp" | "transcript" | "summary"
 type CodexReasoningEffort = "minimal" | "low" | "medium" | "high"
 
 export interface ChatGptWebMessage {
@@ -509,7 +509,10 @@ async function resolveChatGptWebAuth(signal?: AbortSignal): Promise<ResolvedChat
 function getConfiguredChatGptWebModel(modelContext: ChatGptWebModelContext): string {
   const config = configStore.get()
   if (modelContext === "mcp") {
-    return config.mcpToolsChatgptWebModel || DEFAULT_CHATGPT_WEB_MODEL
+    return config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHATGPT_WEB_MODEL
+  }
+  if (modelContext === "summary") {
+    return config.dualModelWeakChatgptWebModel || config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHATGPT_WEB_MODEL
   }
   return config.transcriptPostProcessingChatgptWebModel || DEFAULT_CHATGPT_WEB_MODEL
 }

--- a/apps/desktop/src/main/note-candidates.test.ts
+++ b/apps/desktop/src/main/note-candidates.test.ts
@@ -37,6 +37,14 @@ vi.mock("@ai-sdk/openai", () => ({
   })),
 }))
 
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: vi.fn(() => vi.fn(() => ({}))),
+}))
+
+vi.mock("./chatgpt-web-provider", () => ({
+  makeChatGptWebCompletion: vi.fn(),
+}))
+
 function enableSummarization() {
   mockConfig = {
     dualModelEnabled: true,
@@ -140,6 +148,61 @@ describe("summarizeAgentStep", () => {
     expect(summary?.noteCandidates).toEqual([])
     expect(summary?.actionSummary).toBe("hello world")
     expect(summary?.importance).toBe("medium")
+  })
+
+  it("supports provider-level Groq summarization without a preset", async () => {
+    mockConfig = {
+      dualModelEnabled: true,
+      dualModelWeakProviderId: "groq",
+      dualModelWeakGroqModel: "llama-3.3-70b-versatile",
+      groqApiKey: "groq-key",
+      groqBaseUrl: "https://api.groq.com/openai/v1",
+      modelPresets: [],
+    }
+    const { generateText } = await import("ai")
+    const { createOpenAI } = await import("@ai-sdk/openai")
+    const { summarizeAgentStep } = await import("./summarization-service")
+
+    vi.mocked(generateText).mockResolvedValue({
+      text: JSON.stringify({
+        actionSummary: "summarized with groq",
+        noteCandidates: [],
+        importance: "medium",
+      }),
+    } as any)
+
+    const summary = await summarizeAgentStep({ sessionId: "s", stepNumber: 3 } as any)
+
+    expect(summary?.actionSummary).toBe("summarized with groq")
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: "groq-key",
+      baseURL: "https://api.groq.com/openai/v1",
+    })
+  })
+
+  it("routes OpenAI Codex summarization through the summary model context", async () => {
+    mockConfig = {
+      dualModelEnabled: true,
+      dualModelWeakProviderId: "chatgpt-web",
+      dualModelWeakChatgptWebModel: "gpt-5.3-codex-spark",
+      modelPresets: [],
+    }
+    const { makeChatGptWebCompletion } = await import("./chatgpt-web-provider")
+    const { summarizeAgentStep } = await import("./summarization-service")
+
+    vi.mocked(makeChatGptWebCompletion).mockResolvedValue(JSON.stringify({
+      actionSummary: "summarized with codex",
+      noteCandidates: [],
+      importance: "medium",
+    }))
+
+    const summary = await summarizeAgentStep({ sessionId: "s", stepNumber: 4 } as any)
+
+    expect(summary?.actionSummary).toBe("summarized with codex")
+    expect(makeChatGptWebCompletion).toHaveBeenCalledWith(
+      [{ role: "user", content: expect.stringContaining("Respond ONLY with valid JSON") }],
+      { modelContext: "summary" },
+    )
   })
 })
 

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -3096,6 +3096,11 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         mcpVerifyCompletionEnabled: cfg.mcpVerifyCompletionEnabled ?? true,
         mcpFinalSummaryEnabled: cfg.mcpFinalSummaryEnabled ?? false,
         dualModelEnabled: cfg.dualModelEnabled ?? false,
+        dualModelWeakProviderId: cfg.dualModelWeakProviderId ?? "openai",
+        dualModelWeakModelName: cfg.dualModelWeakModelName,
+        dualModelWeakGroqModel: cfg.dualModelWeakGroqModel,
+        dualModelWeakGeminiModel: cfg.dualModelWeakGeminiModel,
+        dualModelWeakChatgptWebModel: cfg.dualModelWeakChatgptWebModel,
         mcpUnlimitedIterations: cfg.mcpUnlimitedIterations ?? true,
         // Tool Execution
         mcpContextReductionEnabled: cfg.mcpContextReductionEnabled ?? true,
@@ -3314,6 +3319,21 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
 
       if (typeof body.dualModelEnabled === "boolean") {
         updates.dualModelEnabled = body.dualModelEnabled
+      }
+      if (typeof body.dualModelWeakProviderId === "string" && validProviders.includes(body.dualModelWeakProviderId)) {
+        updates.dualModelWeakProviderId = body.dualModelWeakProviderId as "openai" | "groq" | "gemini" | "chatgpt-web"
+      }
+      if (typeof body.dualModelWeakModelName === "string") {
+        updates.dualModelWeakModelName = body.dualModelWeakModelName
+      }
+      if (typeof body.dualModelWeakGroqModel === "string") {
+        updates.dualModelWeakGroqModel = body.dualModelWeakGroqModel
+      }
+      if (typeof body.dualModelWeakGeminiModel === "string") {
+        updates.dualModelWeakGeminiModel = body.dualModelWeakGeminiModel
+      }
+      if (typeof body.dualModelWeakChatgptWebModel === "string") {
+        updates.dualModelWeakChatgptWebModel = body.dualModelWeakChatgptWebModel
       }
 
       if (typeof body.mcpUnlimitedIterations === "boolean") {

--- a/apps/desktop/src/main/summarization-service.ts
+++ b/apps/desktop/src/main/summarization-service.ts
@@ -7,11 +7,35 @@
 
 import { generateText } from "ai"
 import { createOpenAI } from "@ai-sdk/openai"
+import { createGoogleGenerativeAI } from "@ai-sdk/google"
 import { configStore } from "./config"
 import { logLLM, isDebugLLM } from "./debug"
 import { getBuiltInModelPresets, DEFAULT_MODEL_PRESET_ID } from "@dotagents/shared"
 import type { LanguageModel } from "ai"
 import type { AgentStepSummary, ModelPreset } from "../shared/types"
+import { makeChatGptWebCompletion } from "./chatgpt-web-provider"
+
+type SummarizationProviderId = "openai" | "groq" | "gemini" | "chatgpt-web"
+
+interface WeakModelConfig {
+  providerId: SummarizationProviderId
+  model: string
+  apiKey?: string
+  baseUrl?: string
+}
+
+const DEFAULT_SUMMARIZATION_MODELS: Record<SummarizationProviderId, string> = {
+  openai: "gpt-4.1-mini",
+  groq: "openai/gpt-oss-120b",
+  gemini: "gemini-2.5-flash",
+  "chatgpt-web": "gpt-5.4-mini",
+}
+
+function normalizeSummarizationProviderId(providerId: unknown): SummarizationProviderId {
+  return providerId === "groq" || providerId === "gemini" || providerId === "chatgpt-web"
+    ? providerId
+    : "openai"
+}
 
 export interface SummarizationInput {
   sessionId: string
@@ -59,16 +83,46 @@ function getPresetById(presetId: string): ModelPreset | undefined {
 }
 
 /**
- * Get the weak model configuration from settings using presets
+ * Get the weak model configuration from settings.
+ *
+ * OpenAI-compatible summarization keeps using presets because the preset owns
+ * the base URL/API key. Other providers use their provider-level auth and a
+ * provider-specific model field.
  */
-function getWeakModelConfig(): { model: string; apiKey: string; baseUrl: string } | null {
+function getWeakModelConfig(): WeakModelConfig | null {
   const config = configStore.get()
 
   if (!config.dualModelEnabled) {
     return null
   }
 
-  // Get preset ID - fall back to current model preset if not set
+  const providerId = normalizeSummarizationProviderId(config.dualModelWeakProviderId)
+
+  if (providerId === "groq") {
+    return {
+      providerId,
+      model: config.dualModelWeakGroqModel || config.agentGroqModel || config.mcpToolsGroqModel || DEFAULT_SUMMARIZATION_MODELS.groq,
+      apiKey: config.groqApiKey || "",
+      baseUrl: config.groqBaseUrl || "https://api.groq.com/openai/v1",
+    }
+  }
+
+  if (providerId === "gemini") {
+    return {
+      providerId,
+      model: config.dualModelWeakGeminiModel || config.agentGeminiModel || config.mcpToolsGeminiModel || DEFAULT_SUMMARIZATION_MODELS.gemini,
+      apiKey: config.geminiApiKey || "",
+      baseUrl: config.geminiBaseUrl || undefined,
+    }
+  }
+
+  if (providerId === "chatgpt-web") {
+    return {
+      providerId,
+      model: config.dualModelWeakChatgptWebModel || config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_SUMMARIZATION_MODELS["chatgpt-web"],
+    }
+  }
+
   const presetId = config.dualModelWeakPresetId || config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
   const preset = getPresetById(presetId)
 
@@ -76,10 +130,15 @@ function getWeakModelConfig(): { model: string; apiKey: string; baseUrl: string 
     return null
   }
 
-  // Get model name - fall back to a default if not set
-  const model = config.dualModelWeakModelName || preset.agentModel || preset.mcpToolsModel || "gpt-4.1-mini"
+  const model =
+    config.dualModelWeakModelName ||
+    preset.summarizationModel ||
+    preset.agentModel ||
+    preset.mcpToolsModel ||
+    DEFAULT_SUMMARIZATION_MODELS.openai
 
   return {
+    providerId,
     model,
     apiKey: preset.apiKey,
     baseUrl: preset.baseUrl,
@@ -89,24 +148,63 @@ function getWeakModelConfig(): { model: string; apiKey: string; baseUrl: string 
 /**
  * Create a language model instance for the weak model
  */
-function createWeakModel(): LanguageModel | null {
-  const modelConfig = getWeakModelConfig()
-  if (!modelConfig) {
+function createWeakModel(modelConfig: WeakModelConfig): LanguageModel | null {
+  const { providerId, model, apiKey, baseUrl } = modelConfig
+
+  if (providerId === "chatgpt-web") {
     return null
   }
 
-  const { model, apiKey, baseUrl } = modelConfig
-
-  if (isDebugLLM()) {
-    logLLM(`[SummarizationService] Creating weak model: ${model} at ${baseUrl}`)
+  if (!apiKey) {
+    return null
   }
 
-  // All presets use OpenAI-compatible API
+  if (providerId === "gemini") {
+    if (isDebugLLM()) {
+      logLLM(`[SummarizationService] Creating Gemini weak model: ${model}`)
+    }
+
+    const google = createGoogleGenerativeAI({
+      apiKey,
+      baseURL: baseUrl,
+    })
+    return google(model)
+  }
+
+  if (isDebugLLM()) {
+    logLLM(`[SummarizationService] Creating ${providerId} weak model: ${model} at ${baseUrl}`)
+  }
+
   const openai = createOpenAI({
     apiKey,
     baseURL: baseUrl,
   })
   return openai.chat(model)
+}
+
+async function generateSummaryText(modelConfig: WeakModelConfig, prompt: string): Promise<string | null> {
+  if (modelConfig.providerId === "chatgpt-web") {
+    if (isDebugLLM()) {
+      logLLM(`[SummarizationService] Creating ChatGPT Codex weak model: ${modelConfig.model}`)
+    }
+
+    return await makeChatGptWebCompletion(
+      [{ role: "user", content: prompt }],
+      { modelContext: "summary" },
+    )
+  }
+
+  const model = createWeakModel(modelConfig)
+  if (!model) {
+    return null
+  }
+
+  const result = await generateText({
+    model,
+    prompt,
+  })
+
+  return result.text || ""
 }
 
 /**
@@ -246,10 +344,20 @@ function parseSummaryResponse(response: string, input: SummarizationInput): Agen
  */
 export function isSummarizationEnabled(): boolean {
   const config = configStore.get()
-  // Check if dual model is enabled and we have a valid weak model preset
-  const presetId = config.dualModelWeakPresetId || config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
-  const preset = getPresetById(presetId)
-  return config.dualModelEnabled === true && !!preset && !!preset.apiKey
+  if (config.dualModelEnabled !== true) {
+    return false
+  }
+
+  const modelConfig = getWeakModelConfig()
+  if (!modelConfig) {
+    return false
+  }
+
+  if (modelConfig.providerId === "chatgpt-web") {
+    return true
+  }
+
+  return !!modelConfig.apiKey
 }
 
 /**
@@ -285,8 +393,8 @@ export async function summarizeAgentStep(
     return null
   }
 
-  const model = createWeakModel()
-  if (!model) {
+  const modelConfig = getWeakModelConfig()
+  if (!modelConfig) {
     if (isDebugLLM()) {
       logLLM("[SummarizationService] Weak model not configured, skipping summarization")
     }
@@ -300,12 +408,15 @@ export async function summarizeAgentStep(
       logLLM("[SummarizationService] Generating summary for step", input.stepNumber)
     }
 
-    const result = await generateText({
-      model,
-      prompt,
-    })
+    const summaryText = await generateSummaryText(modelConfig, prompt)
+    if (!summaryText) {
+      if (isDebugLLM()) {
+        logLLM("[SummarizationService] Weak model returned no summary text")
+      }
+      return null
+    }
 
-    const summary = parseSummaryResponse(result.text || "", input)
+    const summary = parseSummaryResponse(summaryText, input)
 
     if (isDebugLLM()) {
       logLLM("[SummarizationService] Generated summary:", summary)

--- a/apps/desktop/src/renderer/src/components/model-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/model-selector.tsx
@@ -44,6 +44,8 @@ export function ModelSelector({
   const [customInputDraft, setCustomInputDraft] = useState(value || "")
   const searchInputRef = useRef<HTMLInputElement>(null)
   const customInputRef = useRef<HTMLInputElement>(null)
+  const onValueChangeRef = useRef(onValueChange)
+  const lastAutoSelectRef = useRef<string | null>(null)
 
   const configQuery = useConfigQuery()
   const currentPresetId = providerId === "openai"
@@ -51,6 +53,10 @@ export function ModelSelector({
     : undefined
 
   const modelsQuery = useAvailableModelsQuery(providerId, !!providerId, currentPresetId)
+
+  useEffect(() => {
+    onValueChangeRef.current = onValueChange
+  }, [onValueChange])
 
   useEffect(() => {
     logRender('ModelSelector', 'mount/update', {
@@ -136,11 +142,23 @@ export function ModelSelector({
   }, [value, selectableModels, useCustomInput])
 
   useEffect(() => {
-    if (!value && selectableModels.length > 0 && !useCustomInput) {
-      logUI('[ModelSelector] Auto-selecting first model:', selectableModels[0].id)
-      onValueChange(selectableModels[0].id)
+    const firstModelId = selectableModels[0]?.id
+    if (value || useCustomInput || !firstModelId) {
+      if (value || useCustomInput) {
+        lastAutoSelectRef.current = null
+      }
+      return
     }
-  }, [value, selectableModels, useCustomInput, onValueChange])
+
+    const autoSelectKey = `${providerId}:${firstModelId}`
+    if (lastAutoSelectRef.current === autoSelectKey) {
+      return
+    }
+
+    lastAutoSelectRef.current = autoSelectKey
+    logUI('[ModelSelector] Auto-selecting first model:', firstModelId)
+    onValueChangeRef.current(firstModelId)
+  }, [value, selectableModels, useCustomInput, providerId])
 
   // Filter models based on search query
   const filteredModels = selectableModels.filter((model) => {

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ElementType, type ReactNode } from "react"
-import { Control, ControlGroup, ControlLabel } from "@renderer/components/ui/control"
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { ControlGroup } from "@renderer/components/ui/control"
 import { Input } from "@renderer/components/ui/input"
 import { Textarea } from "@renderer/components/ui/textarea"
 import {
@@ -12,7 +12,7 @@ import {
 import { Switch } from "@renderer/components/ui/switch"
 import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
 import { ModelPresetManager } from "@renderer/components/model-preset-manager"
-import { ModelSelector, ProviderModelSelector } from "@renderer/components/model-selector"
+import { ModelSelector } from "@renderer/components/model-selector"
 import { PresetModelSelector } from "@renderer/components/preset-model-selector"
 import { Config, ModelPreset } from "@shared/types"
 import {
@@ -38,43 +38,176 @@ import {
   getBuiltInModelPresets,
 } from "@dotagents/shared"
 import { getDefaultSttModel } from "@dotagents/shared/stt-models"
-import { Mic, FileText, Volume2, Bot, Zap, BookOpen, Settings2 } from "lucide-react"
+import { Mic, FileText, Volume2, Bot, BookOpen, Settings2, type LucideIcon } from "lucide-react"
 
 const SETTINGS_TEXT_SAVE_DEBOUNCE_MS = 400
 
-function RoleProviderSelector({
+const DEFAULT_CHAT_MODELS: Record<CHAT_PROVIDER_ID, string> = {
+  openai: "gpt-4.1-mini",
+  groq: "openai/gpt-oss-120b",
+  gemini: "gemini-2.5-flash",
+  "chatgpt-web": "gpt-5.4-mini",
+}
+
+type ProviderOption = {
+  label: string
+  value: string
+}
+
+type OpenAiPresetModelType = "agentModel" | "transcriptProcessingModel" | "summarizationModel"
+
+function RouteRow({
+  icon: Icon,
+  title,
+  description,
+  action,
+  children,
+}: {
+  icon: LucideIcon
+  title: string
+  description: string
+  action?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <div className="px-3 py-3">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,220px)_minmax(0,1fr)]">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted/30">
+            <Icon className="h-4 w-4 text-muted-foreground" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 items-center justify-between gap-3">
+              <h3 className="truncate text-sm font-semibold">{title}</h3>
+              {action && <div className="shrink-0">{action}</div>}
+            </div>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">{description}</p>
+          </div>
+        </div>
+        <div className="min-w-0 space-y-3">{children}</div>
+      </div>
+    </div>
+  )
+}
+
+function RouteField({
   label,
-  tooltip,
+  description,
+  children,
+}: {
+  label: string
+  description?: string
+  children: ReactNode
+}) {
+  return (
+    <div className="grid gap-1.5 md:grid-cols-[112px_minmax(0,1fr)] md:items-start">
+      <div className="min-w-0 pt-2">
+        <div className="text-sm font-medium">{label}</div>
+        {description && <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{description}</p>}
+      </div>
+      <div className="min-w-0">{children}</div>
+    </div>
+  )
+}
+
+function ProviderSelect({
   value,
   onChange,
   providers,
-  icon: Icon,
 }: {
-  label: ReactNode
-  tooltip: string
   value: string
   onChange: (value: string) => void
-  providers: readonly { label: string; value: string }[]
-  icon: ElementType
+  providers: readonly ProviderOption[]
 }) {
   return (
-    <Control
-      label={<ControlLabel label={<span className="flex items-center gap-2"><Icon className="h-4 w-4 text-muted-foreground" />{label}</span>} tooltip={tooltip} />}
-      className="px-3"
-    >
-      <Select value={value} onValueChange={onChange}>
-        <SelectTrigger className="w-full sm:w-[220px]">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {providers.map((provider) => (
-            <SelectItem key={provider.value} value={provider.value}>
-              {provider.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </Control>
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-full sm:w-[280px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {providers.map((provider) => (
+          <SelectItem key={provider.value} value={provider.value}>
+            {provider.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function PresetSelect({
+  value,
+  presets,
+  onChange,
+}: {
+  value: string
+  presets: ModelPreset[]
+  onChange: (value: string) => void
+}) {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-full sm:w-[280px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {presets.map((preset) => (
+          <SelectItem key={preset.id} value={preset.id}>
+            {preset.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function OpenAiPresetModelFields({
+  presetId,
+  preset,
+  presets,
+  modelValue,
+  modelLabel,
+  placeholder,
+  onPresetChange,
+  onModelChange,
+}: {
+  presetId: string
+  preset?: ModelPreset
+  presets: ModelPreset[]
+  modelValue?: string
+  modelLabel: string
+  placeholder: string
+  onPresetChange: (value: string) => void
+  onModelChange: (value: string) => void
+}) {
+  return (
+    <div className="space-y-3">
+      <RouteField label="Preset" description="Base URL and API key">
+        <PresetSelect value={presetId} presets={presets} onChange={onPresetChange} />
+      </RouteField>
+      <RouteField label="Model">
+        {preset ? (
+          <PresetModelSelector
+            presetId={presetId}
+            baseUrl={preset.baseUrl}
+            apiKey={preset.apiKey}
+            value={modelValue || ""}
+            onValueChange={onModelChange}
+            label={modelLabel}
+            placeholder={placeholder}
+          />
+        ) : (
+          <p className="py-2 text-sm text-muted-foreground">Select a valid OpenAI-compatible preset.</p>
+        )}
+      </RouteField>
+    </div>
+  )
+}
+
+function DisabledRouteNote({ children }: { children: ReactNode }) {
+  return (
+    <p className="rounded-md border border-dashed px-3 py-2 text-sm text-muted-foreground">
+      {children}
+    </p>
   )
 }
 
@@ -149,246 +282,488 @@ export function Component() {
   if (!configQuery.data) return null
 
   const config = configQuery.data
+  const currentPresetId = config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
+  const currentPreset = getPresetById(currentPresetId)
   const sttProviderId = config.sttProviderId || "openai"
   const transcriptProcessingProviderId = config.transcriptPostProcessingProviderId || "openai"
   const ttsProviderId = config.ttsProviderId || "openai"
   const agentProviderId = config.agentProviderId || config.mcpToolsProviderId || "openai"
   const transcriptProcessingEnabled = config.transcriptPostProcessingEnabled ?? false
-  const usesOpenAiCompatiblePreset =
-    agentProviderId === "openai" ||
-    (transcriptProcessingEnabled && transcriptProcessingProviderId === "openai") ||
-    (config.dualModelEnabled ?? false)
-  const transcriptProcessingModel = transcriptProcessingProviderId === "openai"
-    ? config.transcriptPostProcessingOpenaiModel
-    : transcriptProcessingProviderId === "groq"
-      ? config.transcriptPostProcessingGroqModel
-      : transcriptProcessingProviderId === "gemini"
-        ? config.transcriptPostProcessingGeminiModel
-        : config.transcriptPostProcessingChatgptWebModel
   const dualModelEnabled = config.dualModelEnabled ?? false
-  const strongPresetId = config.dualModelStrongPresetId || config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
+  const summarizationProviderId = (config.dualModelWeakProviderId || "openai") as CHAT_PROVIDER_ID
   const weakPresetId = config.dualModelWeakPresetId || config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
-  const strongPreset = getPresetById(strongPresetId)
   const weakPreset = getPresetById(weakPresetId)
 
+  const agentOpenAiModel = config.agentOpenaiModel || config.mcpToolsOpenaiModel || currentPreset?.agentModel || currentPreset?.mcpToolsModel || ""
+  const agentModelValue = agentProviderId === "groq"
+    ? config.agentGroqModel || config.mcpToolsGroqModel || DEFAULT_CHAT_MODELS.groq
+    : agentProviderId === "gemini"
+      ? config.agentGeminiModel || config.mcpToolsGeminiModel || DEFAULT_CHAT_MODELS.gemini
+      : agentProviderId === "chatgpt-web"
+        ? config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHAT_MODELS["chatgpt-web"]
+        : agentOpenAiModel
+  const transcriptProcessingOpenAiModel =
+    config.transcriptPostProcessingOpenaiModel || currentPreset?.transcriptProcessingModel || ""
+  const transcriptProcessingModel = transcriptProcessingProviderId === "openai"
+    ? transcriptProcessingOpenAiModel
+    : transcriptProcessingProviderId === "groq"
+      ? config.transcriptPostProcessingGroqModel || config.agentGroqModel || config.mcpToolsGroqModel || DEFAULT_CHAT_MODELS.groq
+      : transcriptProcessingProviderId === "gemini"
+        ? config.transcriptPostProcessingGeminiModel || config.agentGeminiModel || config.mcpToolsGeminiModel || DEFAULT_CHAT_MODELS.gemini
+        : config.transcriptPostProcessingChatgptWebModel || config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHAT_MODELS["chatgpt-web"]
+  const summarizationModelValue = summarizationProviderId === "groq"
+    ? config.dualModelWeakGroqModel || config.agentGroqModel || config.mcpToolsGroqModel || DEFAULT_CHAT_MODELS.groq
+    : summarizationProviderId === "gemini"
+      ? config.dualModelWeakGeminiModel || config.agentGeminiModel || config.mcpToolsGeminiModel || DEFAULT_CHAT_MODELS.gemini
+      : summarizationProviderId === "chatgpt-web"
+        ? config.dualModelWeakChatgptWebModel || config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHAT_MODELS["chatgpt-web"]
+        : config.dualModelWeakModelName || weakPreset?.summarizationModel
+
+  const saveModelWithPreset = (
+    presetId: string,
+    modelType: OpenAiPresetModelType,
+    modelId: string,
+    configUpdates: Partial<Config>,
+  ) => {
+    const existingPresets = config.modelPresets || []
+    const presetIndex = existingPresets.findIndex((preset) => preset.id === presetId)
+    let updatedPresets: ModelPreset[]
+
+    if (presetIndex >= 0) {
+      updatedPresets = existingPresets.map((preset) =>
+        preset.id === presetId
+          ? { ...preset, [modelType]: modelId, updatedAt: Date.now() }
+          : preset,
+      )
+    } else {
+      const builtInPreset = getBuiltInModelPresets().find((preset) => preset.id === presetId)
+      if (!builtInPreset) {
+        saveConfig(configUpdates)
+        return
+      }
+      updatedPresets = [
+        ...existingPresets,
+        {
+          ...builtInPreset,
+          apiKey: "",
+          [modelType]: modelId,
+          updatedAt: Date.now(),
+        },
+      ]
+    }
+
+    saveConfig({
+      ...configUpdates,
+      modelPresets: updatedPresets,
+    })
+  }
+
+  const handleCurrentPresetChange = (presetId: string) => {
+    const preset = getPresetById(presetId)
+    if (!preset) {
+      saveConfig({ currentModelPresetId: presetId })
+      return
+    }
+
+    const updates: Partial<Config> = {
+      currentModelPresetId: presetId,
+      openaiBaseUrl: preset.baseUrl,
+      openaiApiKey: preset.apiKey,
+    }
+    const agentModel = preset.agentModel || preset.mcpToolsModel
+    if (agentModel) {
+      updates.agentOpenaiModel = agentModel
+      updates.mcpToolsOpenaiModel = agentModel
+    }
+    if (preset.transcriptProcessingModel) {
+      updates.transcriptPostProcessingOpenaiModel = preset.transcriptProcessingModel
+    }
+    if (preset.summarizationModel && !config.dualModelWeakPresetId) {
+      updates.dualModelWeakModelName = preset.summarizationModel
+    }
+    saveConfig(updates)
+  }
+
+  const handleSummarizationPresetChange = (presetId: string) => {
+    const preset = getPresetById(presetId)
+    saveConfig({
+      dualModelWeakPresetId: presetId,
+      ...(preset?.summarizationModel ? { dualModelWeakModelName: preset.summarizationModel } : {}),
+    })
+  }
+
+  const handleAgentProviderChange = (value: string) => {
+    const providerId = value as CHAT_PROVIDER_ID
+    const updates: Partial<Config> = { agentProviderId: providerId }
+
+    if (providerId === "groq" && !config.agentGroqModel && !config.mcpToolsGroqModel) {
+      updates.agentGroqModel = DEFAULT_CHAT_MODELS.groq
+    } else if (providerId === "gemini" && !config.agentGeminiModel && !config.mcpToolsGeminiModel) {
+      updates.agentGeminiModel = DEFAULT_CHAT_MODELS.gemini
+    } else if (providerId === "chatgpt-web" && !config.agentChatgptWebModel && !config.mcpToolsChatgptWebModel) {
+      updates.agentChatgptWebModel = DEFAULT_CHAT_MODELS["chatgpt-web"]
+    }
+
+    saveConfig(updates)
+  }
+
+  const handleSummarizationProviderChange = (value: string) => {
+    const providerId = value as CHAT_PROVIDER_ID
+    const updates: Partial<Config> = { dualModelWeakProviderId: providerId }
+
+    if (providerId === "groq" && !config.dualModelWeakGroqModel) {
+      updates.dualModelWeakGroqModel = config.agentGroqModel || config.mcpToolsGroqModel || DEFAULT_CHAT_MODELS.groq
+    } else if (providerId === "gemini" && !config.dualModelWeakGeminiModel) {
+      updates.dualModelWeakGeminiModel = config.agentGeminiModel || config.mcpToolsGeminiModel || DEFAULT_CHAT_MODELS.gemini
+    } else if (providerId === "chatgpt-web" && !config.dualModelWeakChatgptWebModel) {
+      updates.dualModelWeakChatgptWebModel =
+        config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHAT_MODELS["chatgpt-web"]
+    }
+
+    saveConfig(updates)
+  }
+
+  const handleTranscriptProcessingProviderChange = (value: string) => {
+    const providerId = value as CHAT_PROVIDER_ID
+    const updates: Partial<Config> = { transcriptPostProcessingProviderId: providerId }
+
+    if (providerId === "groq" && !config.transcriptPostProcessingGroqModel) {
+      updates.transcriptPostProcessingGroqModel = config.agentGroqModel || config.mcpToolsGroqModel || DEFAULT_CHAT_MODELS.groq
+    } else if (providerId === "gemini" && !config.transcriptPostProcessingGeminiModel) {
+      updates.transcriptPostProcessingGeminiModel =
+        config.agentGeminiModel || config.mcpToolsGeminiModel || DEFAULT_CHAT_MODELS.gemini
+    } else if (providerId === "chatgpt-web" && !config.transcriptPostProcessingChatgptWebModel) {
+      updates.transcriptPostProcessingChatgptWebModel =
+        config.agentChatgptWebModel || config.mcpToolsChatgptWebModel || DEFAULT_CHAT_MODELS["chatgpt-web"]
+    }
+
+    saveConfig(updates)
+  }
+
+  const saveSummarizationModel = (value: string) => {
+    if (summarizationProviderId === "groq") {
+      saveConfig({ dualModelWeakGroqModel: value })
+    } else if (summarizationProviderId === "gemini") {
+      saveConfig({ dualModelWeakGeminiModel: value })
+    } else if (summarizationProviderId === "chatgpt-web") {
+      saveConfig({ dualModelWeakChatgptWebModel: value })
+    } else {
+      saveModelWithPreset(weakPresetId, "summarizationModel", value, { dualModelWeakModelName: value })
+    }
+  }
+
+  const saveTranscriptProcessingModel = (value: string) => {
+    if (transcriptProcessingProviderId === "groq") {
+      saveConfig({ transcriptPostProcessingGroqModel: value })
+    } else if (transcriptProcessingProviderId === "gemini") {
+      saveConfig({ transcriptPostProcessingGeminiModel: value })
+    } else if (transcriptProcessingProviderId === "chatgpt-web") {
+      saveConfig({ transcriptPostProcessingChatgptWebModel: value })
+    } else {
+      saveModelWithPreset(currentPresetId, "transcriptProcessingModel", value, {
+        transcriptPostProcessingOpenaiModel: value,
+      })
+    }
+  }
+
+  const saveAgentModel = (value: string) => {
+    if (agentProviderId === "groq") {
+      saveConfig({ agentGroqModel: value })
+    } else if (agentProviderId === "gemini") {
+      saveConfig({ agentGeminiModel: value })
+    } else if (agentProviderId === "chatgpt-web") {
+      saveConfig({ agentChatgptWebModel: value })
+    } else {
+      saveModelWithPreset(currentPresetId, "agentModel", value, {
+        agentOpenaiModel: value,
+        mcpToolsOpenaiModel: value,
+      })
+    }
+  }
+
   return (
-    <div className="mx-auto max-w-4xl px-6 pb-10 pt-8">
+    <div className="mx-auto max-w-5xl px-6 pb-10 pt-8">
       <div className="space-y-6">
         <div className="rounded-lg border bg-muted/20 px-4 py-3">
           <h2 className="text-sm font-semibold">Model Selection</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            Choose which provider powers each job, then pick the model or voice for that job here. API keys, base URLs,
-            and local engine downloads live on the Providers page.
+            Configure each model-powered job in one place. Provider credentials, base URLs, and local engine downloads
+            stay on the Providers page.
           </p>
         </div>
 
-        <ControlGroup title="Agent Models">
-          <div className="mx-3 my-2 rounded-md border border-muted bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-            Choose which model powers the main agent. OpenAI-compatible presets can carry both an agent model and a transcript processing model.
-          </div>
-
-          {usesOpenAiCompatiblePreset && (
-            <div className="px-3 py-2 border-b">
-              <div className="pb-3">
-                <span className="text-sm font-medium">OpenAI-Compatible Preset</span>
-                <p className="text-xs text-muted-foreground">
-                  Use this when Agent or Transcript Processing is set to OpenAI-compatible.
-                </p>
-              </div>
-              <ModelPresetManager
-                showAgentModel={agentProviderId === "openai"}
-                showTranscriptCleanupModel={transcriptProcessingEnabled && transcriptProcessingProviderId === "openai"}
-              />
-            </div>
-          )}
-
-          {(agentProviderId === "groq" || agentProviderId === "gemini" || agentProviderId === "chatgpt-web") && (
-            <div className="px-3 py-2">
-              <ProviderModelSelector
-                providerId={agentProviderId}
-                mcpModel={
-                  agentProviderId === "groq"
-                    ? config.agentGroqModel || config.mcpToolsGroqModel
-                    : agentProviderId === "gemini"
-                      ? config.agentGeminiModel || config.mcpToolsGeminiModel
-                      : config.agentChatgptWebModel || config.mcpToolsChatgptWebModel
-                }
-                onMcpModelChange={(value) =>
-                  saveConfig(
-                    agentProviderId === "groq"
-                      ? { agentGroqModel: value }
-                      : agentProviderId === "gemini"
-                        ? { agentGeminiModel: value }
-                        : { agentChatgptWebModel: value },
-                  )
-                }
-                showMcpModel={true}
-                showTranscriptModel={false}
-              />
-            </div>
-          )}
-
-          {!usesOpenAiCompatiblePreset && agentProviderId === "openai" && (
-            <p className="px-3 py-2 text-sm text-muted-foreground">
-              OpenAI-compatible preset controls appear here when Agent or Transcript Processing uses that provider.
-            </p>
-          )}
-        </ControlGroup>
-
-
-        <ControlGroup title="Choose a Provider for Each Job" collapsible>
-          <RoleProviderSelector
-            label="Speech-to-Text"
-            tooltip="Choose which provider listens to your audio and turns it into text."
-            value={sttProviderId}
-            onChange={(value) => saveConfig({ sttProviderId: value as STT_PROVIDER_ID })}
-            providers={STT_PROVIDERS}
-            icon={Mic}
-          />
-
-          <RoleProviderSelector
-            label="Text-to-Speech"
-            tooltip="Choose which provider turns text back into audio."
-            value={ttsProviderId}
-            onChange={(value) => saveConfig({ ttsProviderId: value as TTS_PROVIDER_ID })}
-            providers={TTS_PROVIDERS}
-            icon={Volume2}
-          />
-
-          <RoleProviderSelector
-            label="Agent"
-            tooltip="Choose which provider powers the main agent model for reasoning, skills, and tools."
-            value={agentProviderId}
-            onChange={(value) => saveConfig({ agentProviderId: value as CHAT_PROVIDER_ID })}
-            providers={CHAT_PROVIDERS}
+        <ControlGroup title="Model Routing">
+          <RouteRow
             icon={Bot}
-          />
-        </ControlGroup>
-
-        <ControlGroup title="Transcript Processing" collapsible>
-          <Control
-            label={<ControlLabel label="Enabled" tooltip="Optionally clean up punctuation, formatting, or wording after transcription and before the transcript is used elsewhere." />}
-            className="px-3"
+            title="Agent"
+            description="Main reasoning model for agent work, skills, tools, and MCP calls."
           >
-            <Switch
-              checked={transcriptProcessingEnabled}
-              onCheckedChange={(checked) => saveConfig({ transcriptPostProcessingEnabled: checked })}
-            />
-          </Control>
-
-          {transcriptProcessingEnabled && (
-            <>
-              <RoleProviderSelector
-                label="Provider"
-                tooltip="Choose which provider handles transcript processing when it is enabled."
-                value={transcriptProcessingProviderId}
-                onChange={(value) => saveConfig({ transcriptPostProcessingProviderId: value as CHAT_PROVIDER_ID })}
+            <RouteField label="Provider">
+              <ProviderSelect
+                value={agentProviderId}
+                onChange={handleAgentProviderChange}
                 providers={CHAT_PROVIDERS}
-                icon={FileText}
               />
-
-              <div className="border-t px-3 py-2">
-                {transcriptProcessingProviderId === "openai" ? (
-                  <Control
-                    label={<ControlLabel label="Transcript Processing model" tooltip="OpenAI-compatible transcript processing is selected through the preset section below." />}
-                  >
-                    <p className="text-sm text-muted-foreground">
-                      OpenAI-compatible transcript processing models are selected in the OpenAI-Compatible Preset section below.
-                    </p>
-                  </Control>
-                ) : (
-                  <ModelSelector
-                    providerId={transcriptProcessingProviderId}
-                    value={transcriptProcessingModel}
-                    onValueChange={(value) => {
-                      if (transcriptProcessingProviderId === "groq") {
-                        saveConfig({ transcriptPostProcessingGroqModel: value })
-                      } else if (transcriptProcessingProviderId === "gemini") {
-                        saveConfig({ transcriptPostProcessingGeminiModel: value })
-                      } else {
-                        saveConfig({ transcriptPostProcessingChatgptWebModel: value })
-                      }
-                    }}
-                    label="Transcript Processing model"
-                    placeholder="Select model for transcript processing"
-                    excludeTranscriptionOnlyModels={true}
-                  />
-                )}
-              </div>
-
-              <Control
-                label={<ControlLabel label="Prompt" tooltip="Custom prompt for transcript processing. Use {transcript} to insert the original transcript." />}
-                className="border-t px-3 py-2"
-              >
-                <div className="w-full space-y-2">
-                  <Textarea
-                    rows={6}
-                    value={transcriptProcessingPromptDraft}
-                    onChange={(e) => updateTranscriptProcessingPromptDraft(e.currentTarget.value)}
-                    onBlur={(e) => flushTranscriptProcessingPromptSave(e.currentTarget.value)}
-                    placeholder="Custom instructions for transcript processing..."
-                    className="min-h-[120px]"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Use <span className="select-text">{"{transcript}"}</span> to insert the original transcript.
-                  </p>
-                </div>
-              </Control>
-            </>
-          )}
-        </ControlGroup>
-
-        <ControlGroup title="Speech & Voice Models" collapsible>
-          <div className="px-3 py-2">
-            {sttProviderId === "parakeet" ? (
-              <Control
-                label={<ControlLabel label="Speech-to-Text model" tooltip="Parakeet uses the local speech-to-text model bundle managed on the Providers page." />}
-              >
-                <p className="text-sm text-muted-foreground">
-                  Parakeet uses its local downloaded model bundle. Manage installation and runtime settings on Providers.
-                </p>
-              </Control>
+            </RouteField>
+            {agentProviderId === "openai" ? (
+              <OpenAiPresetModelFields
+                presetId={currentPresetId}
+                preset={currentPreset}
+                presets={allPresets}
+                modelValue={agentOpenAiModel}
+                modelLabel="Agent model"
+                placeholder="Select model for agent reasoning"
+                onPresetChange={handleCurrentPresetChange}
+                onModelChange={saveAgentModel}
+              />
             ) : (
-              <ModelSelector
-                providerId={sttProviderId}
-                value={sttProviderId === "openai" ? config.openaiSttModel || getDefaultSttModel("openai") : config.groqSttModel || getDefaultSttModel("groq")}
-                onValueChange={(value) => saveConfig(sttProviderId === "openai" ? { openaiSttModel: value } : { groqSttModel: value })}
-                label="Speech-to-Text model"
-                placeholder="Select model for speech transcription"
-                onlyTranscriptionModels={true}
-              />
+              <RouteField label="Model">
+                <ModelSelector
+                  providerId={agentProviderId}
+                  value={agentModelValue}
+                  onValueChange={saveAgentModel}
+                  label="Agent model"
+                  placeholder="Select model for agent reasoning"
+                  excludeTranscriptionOnlyModels={true}
+                />
+              </RouteField>
             )}
-          </div>
+          </RouteRow>
 
-          <div className="border-t px-3 py-2">
-            <div className="pb-2">
-              <span className="text-sm font-medium">Text-to-Speech model and voice</span>
-              <p className="text-xs text-muted-foreground">
-                Pick the voice stack for the currently selected text-to-speech provider.
-              </p>
-            </div>
+          <RouteRow
+            icon={BookOpen}
+            title="Summarization"
+            description="Optional lightweight model for UI summaries and knowledge-note summaries."
+            action={
+              <Switch
+                checked={dualModelEnabled}
+                onCheckedChange={(checked) => saveConfig({ dualModelEnabled: checked })}
+              />
+            }
+          >
+            {dualModelEnabled ? (
+              <>
+                <RouteField label="Provider">
+                  <ProviderSelect
+                    value={summarizationProviderId}
+                    onChange={handleSummarizationProviderChange}
+                    providers={CHAT_PROVIDERS}
+                  />
+                </RouteField>
+                {summarizationProviderId === "openai" ? (
+                  <OpenAiPresetModelFields
+                    presetId={weakPresetId}
+                    preset={weakPreset}
+                    presets={allPresets}
+                    modelValue={summarizationModelValue}
+                    modelLabel="Summarization model"
+                    placeholder="Select model for summarization"
+                    onPresetChange={handleSummarizationPresetChange}
+                    onModelChange={saveSummarizationModel}
+                  />
+                ) : (
+                  <RouteField label="Model">
+                    <ModelSelector
+                      providerId={summarizationProviderId}
+                      value={summarizationModelValue || ""}
+                      onValueChange={saveSummarizationModel}
+                      label="Summarization model"
+                      placeholder="Select model for summarization"
+                      excludeTranscriptionOnlyModels={true}
+                    />
+                  </RouteField>
+                )}
+                <div className="grid gap-3 xl:grid-cols-2">
+                  <RouteField label="Frequency">
+                    <Select
+                      value={config.dualModelSummarizationFrequency || "every_response"}
+                      onValueChange={(value) =>
+                        saveConfig({ dualModelSummarizationFrequency: value as "every_response" | "major_steps_only" })
+                      }
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="every_response">Every Response</SelectItem>
+                        <SelectItem value="major_steps_only">Major Steps Only</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </RouteField>
+                  <RouteField label="Detail">
+                    <Select
+                      value={config.dualModelSummaryDetailLevel || "compact"}
+                      onValueChange={(value) =>
+                        saveConfig({ dualModelSummaryDetailLevel: value as "compact" | "detailed" })
+                      }
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="compact">Compact</SelectItem>
+                        <SelectItem value="detailed">Detailed</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </RouteField>
+                </div>
+              </>
+            ) : (
+              <DisabledRouteNote>Summaries use the Agent model while this is off.</DisabledRouteNote>
+            )}
+          </RouteRow>
+
+          <RouteRow
+            icon={FileText}
+            title="Transcript Cleanup"
+            description="Optional pass that cleans transcription text before it is used elsewhere."
+            action={
+              <Switch
+                checked={transcriptProcessingEnabled}
+                onCheckedChange={(checked) => saveConfig({ transcriptPostProcessingEnabled: checked })}
+              />
+            }
+          >
+            {transcriptProcessingEnabled ? (
+              <>
+                <RouteField label="Provider">
+                  <ProviderSelect
+                    value={transcriptProcessingProviderId}
+                    onChange={handleTranscriptProcessingProviderChange}
+                    providers={CHAT_PROVIDERS}
+                  />
+                </RouteField>
+                {transcriptProcessingProviderId === "openai" ? (
+                  <OpenAiPresetModelFields
+                    presetId={currentPresetId}
+                    preset={currentPreset}
+                    presets={allPresets}
+                    modelValue={transcriptProcessingModel}
+                    modelLabel="Transcript cleanup model"
+                    placeholder="Select model for transcript cleanup"
+                    onPresetChange={handleCurrentPresetChange}
+                    onModelChange={saveTranscriptProcessingModel}
+                  />
+                ) : (
+                  <RouteField label="Model">
+                    <ModelSelector
+                      providerId={transcriptProcessingProviderId}
+                      value={transcriptProcessingModel || ""}
+                      onValueChange={saveTranscriptProcessingModel}
+                      label="Transcript cleanup model"
+                      placeholder="Select model for transcript cleanup"
+                      excludeTranscriptionOnlyModels={true}
+                    />
+                  </RouteField>
+                )}
+                <details className="rounded-md border">
+                  <summary className="cursor-pointer px-3 py-2 text-sm font-medium">Prompt</summary>
+                  <div className="border-t p-3">
+                    <Textarea
+                      rows={6}
+                      value={transcriptProcessingPromptDraft}
+                      onChange={(event) => updateTranscriptProcessingPromptDraft(event.currentTarget.value)}
+                      onBlur={(event) => flushTranscriptProcessingPromptSave(event.currentTarget.value)}
+                      placeholder="Custom instructions for transcript processing..."
+                      className="min-h-[120px]"
+                    />
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Use <span className="select-text">{"{transcript}"}</span> to insert the original transcript.
+                    </p>
+                  </div>
+                </details>
+              </>
+            ) : (
+              <DisabledRouteNote>Raw transcription text is passed through unchanged.</DisabledRouteNote>
+            )}
+          </RouteRow>
+
+          <RouteRow
+            icon={Mic}
+            title="Speech-to-Text"
+            description="Transcription model for microphone input and dictated messages."
+          >
+            <RouteField label="Provider">
+              <ProviderSelect
+                value={sttProviderId}
+                onChange={(value) => saveConfig({ sttProviderId: value as STT_PROVIDER_ID })}
+                providers={STT_PROVIDERS}
+              />
+            </RouteField>
+            <RouteField label="Model">
+              {sttProviderId === "parakeet" ? (
+                <p className="py-2 text-sm text-muted-foreground">
+                  Parakeet uses the local model bundle managed on Providers.
+                </p>
+              ) : (
+                <ModelSelector
+                  providerId={sttProviderId}
+                  value={
+                    sttProviderId === "openai"
+                      ? config.openaiSttModel || getDefaultSttModel("openai")
+                      : config.groqSttModel || getDefaultSttModel("groq")
+                  }
+                  onValueChange={(value) =>
+                    saveConfig(sttProviderId === "openai" ? { openaiSttModel: value } : { groqSttModel: value })
+                  }
+                  label="Speech-to-Text model"
+                  placeholder="Select model for speech transcription"
+                  onlyTranscriptionModels={true}
+                />
+              )}
+            </RouteField>
+          </RouteRow>
+
+          <RouteRow
+            icon={Volume2}
+            title="Text-to-Speech"
+            description="Voice model, voice identity, and synthesis quality for spoken replies."
+          >
+            <RouteField label="Provider">
+              <ProviderSelect
+                value={ttsProviderId}
+                onChange={(value) => saveConfig({ ttsProviderId: value as TTS_PROVIDER_ID })}
+                providers={TTS_PROVIDERS}
+              />
+            </RouteField>
 
             {ttsProviderId === "openai" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the OpenAI TTS model to use." />}>
-                  <Select value={config.openaiTtsModel || "gpt-4o-mini-tts"} onValueChange={(value) => saveConfig({ openaiTtsModel: value as "gpt-4o-mini-tts" | "tts-1" | "tts-1-hd" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <RouteField label="Model">
+                  <Select
+                    value={config.openaiTtsModel || "gpt-4o-mini-tts"}
+                    onValueChange={(value) =>
+                      saveConfig({ openaiTtsModel: value as "gpt-4o-mini-tts" | "tts-1" | "tts-1-hd" })
+                    }
+                  >
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {OPENAI_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {OPENAI_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for OpenAI TTS." />}>
-                  <Select value={config.openaiTtsVoice || "alloy"} onValueChange={(value) => saveConfig({ openaiTtsVoice: value as "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                </RouteField>
+                <RouteField label="Voice">
+                  <Select
+                    value={config.openaiTtsVoice || "alloy"}
+                    onValueChange={(value) =>
+                      saveConfig({ openaiTtsVoice: value as "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" })
+                    }
+                  >
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {OPENAI_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {OPENAI_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Text-to-Speech speed" tooltip="Speech speed between 0.25 and 4.0." />}>
+                </RouteField>
+                <RouteField label="Speed">
                   <Input
                     type="number"
                     min="0.25"
@@ -396,93 +771,120 @@ export function Component() {
                     step="0.25"
                     defaultValue={config.openaiTtsSpeed?.toString()}
                     placeholder="1.0"
-                    onChange={(e) => {
-                      const speed = parseFloat(e.currentTarget.value)
+                    className="w-full sm:w-[140px]"
+                    onChange={(event) => {
+                      const speed = parseFloat(event.currentTarget.value)
                       if (!isNaN(speed) && speed >= 0.25 && speed <= 4.0) {
                         saveConfig({ openaiTtsSpeed: speed })
                       }
                     }}
                   />
-                </Control>
+                </RouteField>
               </>
             )}
 
             {ttsProviderId === "groq" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Groq TTS model to use." />}>
+                <RouteField label="Model">
                   <Select
                     value={config.groqTtsModel || "canopylabs/orpheus-v1-english"}
                     onValueChange={(value) => {
                       const defaultVoice = value === "canopylabs/orpheus-arabic-saudi" ? "fahad" : "troy"
-                      saveConfig({ groqTtsModel: value as "canopylabs/orpheus-v1-english" | "canopylabs/orpheus-arabic-saudi", groqTtsVoice: defaultVoice })
+                      saveConfig({
+                        groqTtsModel: value as "canopylabs/orpheus-v1-english" | "canopylabs/orpheus-arabic-saudi",
+                        groqTtsVoice: defaultVoice,
+                      })
                     }}
                   >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {GROQ_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {GROQ_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Groq TTS." />}>
+                </RouteField>
+                <RouteField label="Voice">
                   <Select
                     value={config.groqTtsVoice || (config.groqTtsModel === "canopylabs/orpheus-arabic-saudi" ? "fahad" : "troy")}
                     onValueChange={(value) => saveConfig({ groqTtsVoice: value })}
                   >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
                       {(config.groqTtsModel === "canopylabs/orpheus-arabic-saudi" ? GROQ_TTS_VOICES_ARABIC : GROQ_TTS_VOICES_ENGLISH).map((voice) => (
                         <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
-                </Control>
+                </RouteField>
               </>
             )}
 
             {ttsProviderId === "gemini" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Gemini TTS model to use." />}>
-                  <Select value={config.geminiTtsModel || "gemini-2.5-flash-preview-tts"} onValueChange={(value) => saveConfig({ geminiTtsModel: value as "gemini-2.5-flash-preview-tts" | "gemini-2.5-pro-preview-tts" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <RouteField label="Model">
+                  <Select
+                    value={config.geminiTtsModel || "gemini-2.5-flash-preview-tts"}
+                    onValueChange={(value) =>
+                      saveConfig({ geminiTtsModel: value as "gemini-2.5-flash-preview-tts" | "gemini-2.5-pro-preview-tts" })
+                    }
+                  >
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {GEMINI_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {GEMINI_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Gemini TTS." />}>
+                </RouteField>
+                <RouteField label="Voice">
                   <Select value={config.geminiTtsVoice || "Kore"} onValueChange={(value) => saveConfig({ geminiTtsVoice: value })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {GEMINI_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {GEMINI_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
+                </RouteField>
               </>
             )}
 
             {ttsProviderId === "edge" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Edge TTS model to use." />}>
+                <RouteField label="Model">
                   <Select value={config.edgeTtsModel || "edge-tts"} onValueChange={(value) => saveConfig({ edgeTtsModel: value as "edge-tts" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {EDGE_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {EDGE_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Edge TTS." />}>
+                </RouteField>
+                <RouteField label="Voice">
                   <Select value={config.edgeTtsVoice || "en-US-AriaNeural"} onValueChange={(value) => saveConfig({ edgeTtsVoice: value })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {EDGE_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {EDGE_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Text-to-Speech speed" tooltip="Speech speed between 0.5 and 2.0." />}>
+                </RouteField>
+                <RouteField label="Speed">
                   <Input
                     type="number"
                     min="0.5"
@@ -490,185 +892,116 @@ export function Component() {
                     step="0.1"
                     defaultValue={config.edgeTtsRate?.toString()}
                     placeholder="1.0"
-                    onChange={(e) => {
-                      const speed = parseFloat(e.currentTarget.value)
+                    className="w-full sm:w-[140px]"
+                    onChange={(event) => {
+                      const speed = parseFloat(event.currentTarget.value)
                       if (!isNaN(speed) && speed >= 0.5 && speed <= 2.0) {
                         saveConfig({ edgeTtsRate: speed })
                       }
                     }}
                   />
-                </Control>
-                <p className="pb-2 text-xs text-muted-foreground">Edge TTS is cloud-based and does not require an API key.</p>
+                </RouteField>
+                <p className="text-xs text-muted-foreground">Edge TTS is cloud-based and does not require an API key.</p>
               </>
             )}
 
             {ttsProviderId === "kitten" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the local Kitten voice to use." />}>
-                  <Select value={String(config.kittenVoiceId ?? 0)} onValueChange={(value) => saveConfig({ kittenVoiceId: parseInt(value) })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <RouteField label="Voice">
+                  <Select value={String(config.kittenVoiceId ?? 0)} onValueChange={(value) => saveConfig({ kittenVoiceId: parseInt(value, 10) })}>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {KITTEN_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={String(voice.value)}>{voice.label}</SelectItem>)}
+                      {KITTEN_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={String(voice.value)}>{voice.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-                <p className="pb-2 text-xs text-muted-foreground">Kitten download and voice testing live on Providers.</p>
+                </RouteField>
+                <p className="text-xs text-muted-foreground">Kitten download and voice testing live on Providers.</p>
               </>
             )}
 
             {ttsProviderId === "supertonic" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Select the Supertonic voice style." />}>
+                <RouteField label="Voice">
                   <Select value={config.supertonicVoice ?? "M1"} onValueChange={(value) => saveConfig({ supertonicVoice: value })}>
-                    <SelectTrigger className="w-full sm:w-[180px]"><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {SUPERTONIC_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {SUPERTONIC_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Language" tooltip="Select the language for speech synthesis." />}>
+                </RouteField>
+                <RouteField label="Language">
                   <Select value={config.supertonicLanguage ?? "en"} onValueChange={(value) => saveConfig({ supertonicLanguage: value })}>
-                    <SelectTrigger className="w-full sm:w-[180px]"><SelectValue /></SelectTrigger>
+                    <SelectTrigger className="w-full sm:w-[280px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {SUPERTONIC_TTS_LANGUAGES.map((language) => <SelectItem key={language.value} value={language.value}>{language.label}</SelectItem>)}
+                      {SUPERTONIC_TTS_LANGUAGES.map((language) => (
+                        <SelectItem key={language.value} value={language.value}>{language.label}</SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Speed" tooltip="Speech speed multiplier." />}>
-                  <Input
-                    type="number"
-                    min={0.5}
-                    max={2.0}
-                    step={0.05}
-                    className="w-full sm:w-[100px]"
-                    value={config.supertonicSpeed ?? 1.05}
-                    onChange={(e) => {
-                      const val = parseFloat(e.currentTarget.value)
-                      if (!isNaN(val) && val >= 0.5 && val <= 2.0) {
-                        saveConfig({ supertonicSpeed: val })
-                      }
-                    }}
-                  />
-                </Control>
-
-                <Control label={<ControlLabel label="Quality Steps" tooltip="Higher values improve quality but slow synthesis." />}>
-                  <Input
-                    type="number"
-                    min={2}
-                    max={10}
-                    step={1}
-                    className="w-full sm:w-[100px]"
-                    value={config.supertonicSteps ?? 5}
-                    onChange={(e) => {
-                      const val = parseInt(e.currentTarget.value)
-                      if (!isNaN(val) && val >= 2 && val <= 10) {
-                        saveConfig({ supertonicSteps: val })
-                      }
-                    }}
-                  />
-                </Control>
-                <p className="pb-2 text-xs text-muted-foreground">Supertonic downloads and quick voice tests live on Providers.</p>
+                </RouteField>
+                <div className="grid gap-3 xl:grid-cols-2">
+                  <RouteField label="Speed">
+                    <Input
+                      type="number"
+                      min={0.5}
+                      max={2.0}
+                      step={0.05}
+                      className="w-full sm:w-[140px]"
+                      value={config.supertonicSpeed ?? 1.05}
+                      onChange={(event) => {
+                        const val = parseFloat(event.currentTarget.value)
+                        if (!isNaN(val) && val >= 0.5 && val <= 2.0) {
+                          saveConfig({ supertonicSpeed: val })
+                        }
+                      }}
+                    />
+                  </RouteField>
+                  <RouteField label="Quality">
+                    <Input
+                      type="number"
+                      min={2}
+                      max={10}
+                      step={1}
+                      className="w-full sm:w-[140px]"
+                      value={config.supertonicSteps ?? 5}
+                      onChange={(event) => {
+                        const val = parseInt(event.currentTarget.value, 10)
+                        if (!isNaN(val) && val >= 2 && val <= 10) {
+                          saveConfig({ supertonicSteps: val })
+                        }
+                      }}
+                    />
+                  </RouteField>
+                </div>
+                <p className="text-xs text-muted-foreground">Supertonic downloads and quick voice tests live on Providers.</p>
               </>
             )}
-          </div>
+          </RouteRow>
         </ControlGroup>
 
-        <ControlGroup title="Advanced Agent Models" collapsible>
-          <Control
-            label={<ControlLabel label="Enable summarization model" tooltip="Use a separate model for UI and knowledge-note summaries." />}
-            className="px-3"
-          >
-            <Switch checked={dualModelEnabled} onCheckedChange={(checked) => saveConfig({ dualModelEnabled: checked })} />
-          </Control>
-
-          {dualModelEnabled && (
-            <>
-              <div className="px-3 py-3 space-y-3 border-t">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <Zap className="h-4 w-4 text-yellow-500" />
-                  Strong Model (Planning)
-                </div>
-                <p className="text-xs text-muted-foreground">Primary model for reasoning and tool calls. Uses the current agent model if not set.</p>
-                <Control label={<ControlLabel label="Preset" tooltip="Select which preset to use." />}>
-                  <Select value={strongPresetId} onValueChange={(value) => saveConfig({ dualModelStrongPresetId: value })}>
-                    <SelectTrigger className="w-full sm:w-[200px]"><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {allPresets.map((preset) => <SelectItem key={preset.id} value={preset.id}>{preset.name}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Control>
-                {strongPreset && (
-                  <Control label={<ControlLabel label="Model" tooltip="Select the strong planning model." />}>
-                    <PresetModelSelector
-                      presetId={strongPresetId}
-                      baseUrl={strongPreset.baseUrl}
-                      apiKey={strongPreset.apiKey}
-                      value={config.dualModelStrongModelName || ""}
-                      onValueChange={(value) => saveConfig({ dualModelStrongModelName: value })}
-                      label="Strong Model"
-                      placeholder="Select model..."
-                    />
-                  </Control>
-                )}
-              </div>
-
-              <div className="px-3 py-3 space-y-3 border-t">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <BookOpen className="h-4 w-4 text-blue-500" />
-                  Summarization Model
-                </div>
-                <p className="text-xs text-muted-foreground">Faster, cheaper model for summarizing agent steps.</p>
-                <Control label={<ControlLabel label="Preset" tooltip="Select which preset to use." />}>
-                  <Select value={weakPresetId} onValueChange={(value) => saveConfig({ dualModelWeakPresetId: value })}>
-                    <SelectTrigger className="w-full sm:w-[200px]"><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      {allPresets.map((preset) => <SelectItem key={preset.id} value={preset.id}>{preset.name}</SelectItem>)}
-                    </SelectContent>
-                  </Select>
-                </Control>
-                {weakPreset && (
-                  <Control label={<ControlLabel label="Model" tooltip="Select the summarization model." />}>
-                    <PresetModelSelector
-                      presetId={weakPresetId}
-                      baseUrl={weakPreset.baseUrl}
-                      apiKey={weakPreset.apiKey}
-                      value={config.dualModelWeakModelName || ""}
-                      onValueChange={(value) => saveConfig({ dualModelWeakModelName: value })}
-                      label="Summarization Model"
-                      placeholder="Select model..."
-                    />
-                  </Control>
-                )}
-              </div>
-
-              <div className="px-3 py-3 space-y-3 border-t">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <Settings2 className="h-4 w-4" />
-                  Summarization Settings
-                </div>
-                <Control label={<ControlLabel label="Frequency" tooltip="How often to generate summaries." />}>
-                  <Select value={config.dualModelSummarizationFrequency || "every_response"} onValueChange={(value) => saveConfig({ dualModelSummarizationFrequency: value as "every_response" | "major_steps_only" })}>
-                    <SelectTrigger className="w-full sm:w-[180px]"><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="every_response">Every Response</SelectItem>
-                      <SelectItem value="major_steps_only">Major Steps Only</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </Control>
-                <Control label={<ControlLabel label="Detail Level" tooltip="How detailed the summaries should be." />}>
-                  <Select value={config.dualModelSummaryDetailLevel || "compact"} onValueChange={(value) => saveConfig({ dualModelSummaryDetailLevel: value as "compact" | "detailed" })}>
-                    <SelectTrigger className="w-full sm:w-[180px]"><SelectValue /></SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="compact">Compact</SelectItem>
-                      <SelectItem value="detailed">Detailed</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </Control>
-              </div>
-            </>
-          )}
+        <ControlGroup
+          title={
+            <span className="inline-flex items-center gap-2">
+              <Settings2 className="h-4 w-4 text-muted-foreground" />
+              OpenAI-Compatible Presets
+            </span>
+          }
+          collapsible
+          defaultCollapsed
+        >
+          <div className="px-3 py-3">
+            <ModelPresetManager showAgentModel={false} showTranscriptCleanupModel={false} />
+          </div>
         </ControlGroup>
       </div>
     </div>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1400,10 +1400,12 @@ export type Config = {
 
   // Dual-Model Agent Mode Configuration
   dualModelEnabled?: boolean
-  dualModelStrongPresetId?: string  // Preset ID for strong model
-  dualModelStrongModelName?: string  // Model name within the preset
+  dualModelWeakProviderId?: CHAT_PROVIDER_ID  // Provider for the summarization model
   dualModelWeakPresetId?: string  // Preset ID for weak model
-  dualModelWeakModelName?: string  // Model name within the preset
+  dualModelWeakModelName?: string  // OpenAI-compatible model name within the preset
+  dualModelWeakGroqModel?: string
+  dualModelWeakGeminiModel?: string
+  dualModelWeakChatgptWebModel?: string
   dualModelSummarizationFrequency?: "every_response" | "major_steps_only"
   dualModelSummaryDetailLevel?: "compact" | "detailed"
   dualModelSectionCollapsed?: boolean  // UI state for settings section

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -368,6 +368,7 @@ const getConfig = (): LoadedConfig => {
 
     // Dual-Model Agent Mode defaults
     dualModelEnabled: false,
+    dualModelWeakProviderId: "openai",
     dualModelSummarizationFrequency: "every_response",
     dualModelSummaryDetailLevel: "compact",
 

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -309,6 +309,12 @@ export interface Settings {
   mainAgentName?: string;
   mcpVerifyCompletionEnabled?: boolean;
   mcpFinalSummaryEnabled?: boolean;
+  dualModelEnabled?: boolean;
+  dualModelWeakProviderId?: 'openai' | 'groq' | 'gemini' | 'chatgpt-web';
+  dualModelWeakModelName?: string;
+  dualModelWeakGroqModel?: string;
+  dualModelWeakGeminiModel?: string;
+  dualModelWeakChatgptWebModel?: string;
 
   // Context Reduction & Tool Response Processing
   mcpContextReductionEnabled?: boolean;
@@ -400,9 +406,6 @@ export interface Settings {
   langfusePublicKey?: string;
   langfuseSecretKey?: string;
   langfuseBaseUrl?: string;
-
-  // Dual-Model Settings
-  dualModelEnabled?: boolean;
 
   // Streamer Mode
   streamerModeEnabled?: boolean;
@@ -437,6 +440,12 @@ export interface SettingsUpdate {
   mainAgentName?: string;
   mcpVerifyCompletionEnabled?: boolean;
   mcpFinalSummaryEnabled?: boolean;
+  dualModelEnabled?: boolean;
+  dualModelWeakProviderId?: 'openai' | 'groq' | 'gemini' | 'chatgpt-web';
+  dualModelWeakModelName?: string;
+  dualModelWeakGroqModel?: string;
+  dualModelWeakGeminiModel?: string;
+  dualModelWeakChatgptWebModel?: string;
 
   // Context Reduction & Tool Response Processing
   mcpContextReductionEnabled?: boolean;
@@ -528,9 +537,6 @@ export interface SettingsUpdate {
   langfusePublicKey?: string;
   langfuseSecretKey?: string;
   langfuseBaseUrl?: string;
-
-  // Dual-Model Settings
-  dualModelEnabled?: boolean;
 
   // Streamer Mode
   streamerModeEnabled?: boolean;


### PR DESCRIPTION
## Summary
- restructure the model settings page into job-based routing rows for Agent, Summarization, Transcript Cleanup, STT, and TTS
- support non-preset summarization providers for Groq, Gemini, and OpenAI Codex while keeping OpenAI-compatible summarization on presets
- remove the strong/main model split and prevent ModelSelector auto-select render loops

## Verification
- pnpm typecheck
- pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/model-selector.custom-input.test.tsx src/main/note-candidates.test.ts
- git diff --check

Note: pnpm lint is currently blocked in this checkout because the repo lint script cannot find eslint in apps/desktop.