### PR TITLE
Bound agent loop defaults for efficient task completion

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -370,7 +370,7 @@ async function executeToolWithRetries(
   executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void) => Promise<MCPToolResult>,
   currentSessionId: string,
   onToolProgress: (message: string) => void,
-  maxRetries: number = 2,
+  maxRetries: number = 1,
 ): Promise<ToolExecutionResult> {
   // Check for stop signal before starting
   if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
@@ -1416,15 +1416,15 @@ export async function processTranscriptWithAgentMode(
   // between), end as incomplete. Scales with iteration budget; the high upper
   // clamp keeps long deep-research runs from being killed by a verifier that
   // is correctly saying "still more work to do".
-  const VERIFICATION_FAIL_LIMIT = clamp(Math.ceil(effectiveIterationBudget * 0.8), 5, 1000)
+  const VERIFICATION_FAIL_LIMIT = clamp(Math.ceil(effectiveIterationBudget * 0.6), 5, 1000)
 
   // Max consecutive nudges before forcing an incomplete fallback. Resets on
   // any successful tool batch (see `totalNudgeCount = 0` reset paths below),
   // so this only caps "how stuck can the agent be in one segment".
-  const MAX_NUDGES = clamp(Math.ceil(effectiveIterationBudget * 0.6), 3, 1000)
+  const MAX_NUDGES = clamp(Math.ceil(effectiveIterationBudget * 0.4), 3, 1000)
 
   // Empty response retry limit - after this many retries, break to prevent infinite loops
-  const MAX_EMPTY_RESPONSE_RETRIES = 3
+  const MAX_EMPTY_RESPONSE_RETRIES = 2
 
   /**
    * Result of running verification and handling the outcome
@@ -1635,7 +1635,7 @@ export async function processTranscriptWithAgentMode(
   let totalNudgeCount = 0
   let garbledToolCallCount = 0 // Track consecutive garbled tool-call-as-text responses
   let completionSignalHintCount = 0 // Avoid repeatedly injecting explicit-completion hints
-  const MAX_COMPLETION_SIGNAL_HINTS = 2
+  const MAX_COMPLETION_SIGNAL_HINTS = 1
   // Count *consecutive* verification failures. Resets to 0 on any verifier
   // "yes" (handled inside runVerificationAndHandleResult by returning
   // newFailCount: 0) and on any successful tool batch (see the reset right
@@ -1649,7 +1649,7 @@ export async function processTranscriptWithAgentMode(
   // is critical for experiment-style flows where the agent legitimately needs
   // to retry the same tool with progressively refined inputs.
   const toolFailureCount = new Map<string, number>()
-  const MAX_TOOL_FAILURES = 3 // Max consecutive failures of a tool before excluding it
+  const MAX_TOOL_FAILURES = 2 // Max consecutive failures of a tool before excluding it
   let lastExcludedToolCount = 0 // Track previous excluded count to avoid unnecessary system prompt rebuilds
   let cachedSystemPrompt: string | undefined // Cached rebuilt prompt when tools are excluded
 
@@ -2377,7 +2377,7 @@ export async function processTranscriptWithAgentMode(
         } else {
           garbledToolCallCount = 0
         }
-        const MAX_GARBLED_TOOL_CALL_RETRIES = 3
+        const MAX_GARBLED_TOOL_CALL_RETRIES = 2
         if (totalNudgeCount >= MAX_NUDGES || garbledToolCallCount >= MAX_GARBLED_TOOL_CALL_RETRIES) {
           finalContent = buildIncompleteTaskFallback(contentText)
           addMessage("assistant", finalContent)
@@ -2541,7 +2541,7 @@ export async function processTranscriptWithAgentMode(
           executeToolCall,
           currentSessionId,
           onToolProgress,
-          2, // maxRetries
+          1, // maxRetries
         )
 
         // Update the progress step with the result
@@ -2659,7 +2659,7 @@ export async function processTranscriptWithAgentMode(
           executeToolCall,
           currentSessionId,
           onToolProgress,
-          2, // maxRetries
+          1, // maxRetries
         )
 
         if (execResult.cancelledByKill) {

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -30,7 +30,7 @@ export interface RuntimeToolDefinition {
 export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
   {
     name: "list_running_agents",
-    description: "List all currently running agent sessions with their status, iteration count, and activity. Useful for monitoring active agents before terminating them.",
+    description: "Return a single snapshot of currently running agent sessions with their status, iteration count, and activity. Use it at most once for a progress/status check; do not poll repeatedly. Useful for monitoring active agents before terminating them.",
     inputSchema: {
       type: "object",
       properties: {},
@@ -170,13 +170,13 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
   },
   {
     name: "execute_command",
-    description: "Execute any shell command. This is the primary tool for file operations, running scripts, and automation. Use for: reading files (cat), writing files (cat/echo with redirection), listing directories (ls), creating directories (mkdir -p), git operations, package-manager/python/node commands, and any shell command. Respect the repo's lockfile/package-manager conventions: pnpm-lock.yaml => pnpm, package-lock.json => npm, yarn.lock => yarn, bun.lock/bun.lockb => bun. Prefer read-only inspection commands first for planning/context tasks. Only run package-manager install/test/build/lint/typecheck commands when the user explicitly asks for verification/package work, or when validating code changes you already made. Omit skillId for normal workspace or repository commands. Only provide skillId when you need to run inside an exact loaded skill ID from Available Skills.",
+    description: "Execute shell/file/git/package commands. Respect lockfiles (pnpm-lock => pnpm, package-lock => npm, yarn.lock => yarn, bun.lock/bun.lockb => bun). For planning, start with one targeted read-only inspection and batch related reads/status checks when safe. For exactly-one experiment/candidate tasks, use one candidate only: run one combined read-only inspection command only, with the first pass limited to program.md, git status, logs, and results (or the task's equivalent state sources), then one candidate change and one validation run; if validation fails, stop and report the blocker instead of trying alternates. Avoid repeated unchanged commands or polling; obey the task budget/stop condition. If a command errors twice, change approach or report the blocker. Run install/test/build/lint/typecheck only when asked or validating your code changes. Omit skillId unless running inside an exact loaded skill ID.",
     inputSchema: {
       type: "object",
       properties: {
         command: {
           type: "string",
-          description: "The shell command to execute. Examples: 'cat file.txt' (read), 'echo content > file.txt' (write), 'ls -la' (list), 'mkdir -p dir' (create dir), 'git status', 'rg TODO apps/desktop/src', 'python script.py'. Prefer read-only inspection commands unless the user asked you to run verification/package-manager work.",
+          description: "Shell command to execute. Examples: 'git status', 'rg TODO apps/desktop/src', 'sed -n 1,120p file', 'python script.py'. Prefer read-only inspection first; for exactly-one experiment/candidate work, use one candidate only and one combined read-only inspection command only, with the first pass limited to program.md, git status, logs, and results (or the task's equivalent state sources), then one candidate change and one validation run; if validation fails, stop and report the blocker instead of trying alternates. Combine related checks, cap output, and do not re-run unchanged commands unless inputs changed.",
         },
         skillId: {
           type: "string",

--- a/apps/desktop/src/main/system-prompts-default.ts
+++ b/apps/desktop/src/main/system-prompts-default.ts
@@ -5,66 +5,49 @@
  * - Keep this file free of imports to avoid circular dependencies.
  * - Other modules (config, TIPC, renderer-facing defaults) may import this.
  */
-export const DEFAULT_SYSTEM_PROMPT = `You are an autonomous AI assistant that uses tools to complete tasks. Work iteratively until goals are fully achieved.
+export const DEFAULT_SYSTEM_PROMPT = `You are an autonomous AI assistant that uses tools to complete tasks. Work iteratively, but keep every task bounded by the user's requested outcome.
 
-TOOL USAGE:
-- Use the provided tools to accomplish tasks - call them directly using the native function calling interface
-- Follow tool schemas exactly with all required parameters
-- Use exact tool names from the available list (including server prefixes like "server:tool_name")
-- Prefer tools over asking users for information you can gather yourself
-- You are highly autonomous and proactive. Make as many tool calls as needed to completely finish the task.
-- Do NOT stop to ask the user for permission or confirmation. Keep working, verifying, and checking your own work until you are certain it is done.
-- Try tools before refusing—only refuse after multiple genuine attempts fail and you've tried all alternate ways
-- You can call multiple tools in a single response in parallel for efficiency
+CORE TOOL POLICY:
+- Use tools directly with exact names/schemas, including server prefixes like "server:tool_name".
+- Prefer tools over asking for information you can gather yourself, but choose a small tool budget and stop condition before acting.
+- Minimize assistant messages and tool calls. Finish as soon as the stop condition is met.
+- For bounded requests (status checks, progress checks, context gathering, exactly one experiment, at most one candidate, one render, one topic inventory), do only that requested unit of work; for experiment tasks, run one combined read-only inspection command only, with the first pass limited to program.md, git status, logs, and results (or the task's equivalent state sources), then stop reopening state files or trying alternate candidates.
+- Use parallel tool calls when independent. Batch related shell/file reads into one command when safe.
+- On error: read the error, do not retry the same call blindly. After two failed attempts, change approach or report the blocker instead of looping.
+- Do not ask for permission when the next step is clear; do stop tool use once you can give a correct final answer.
 
-TOOL RELIABILITY:
-- Check the available tool descriptions and schemas before use
-- Work incrementally - verify each step before continuing
-- On failure: read the error, don't retry the same call blindly
-- After multiple failures: try a different approach. Exhaust all possible solutions before giving up.
-- If a tool-inspection helper is available, use it to confirm exact parameters before retrying
+SHELL / FILES:
+- Use shell/file tools for git, package-manager commands, python/node scripts, curl, and filesystem reads/writes.
+- Respect lockfiles: pnpm-lock.yaml => pnpm, package-lock.json => npm, yarn.lock => yarn, bun.lock/bun.lockb => bun.
+- For planning or context, do a single pass of targeted read-only inspection first (git status, ls/find/rg, sed/head/tail/cat).
+- Avoid re-running unchanged tests, renders, polls, searches, or commands unless new information changes the expected result.
+- Do not run install/test/build/lint/typecheck commands unless explicitly requested or needed to validate code changes.
 
-SHELL COMMANDS & FILE OPERATIONS:
-- If a shell/file execution tool is available, use it for running shell commands, scripts, file operations, and automation
-- Typical examples include git, the repo's actual package manager (pnpm/npm/yarn/bun based on lockfile), python, node, curl, and filesystem reads/writes
-- For planning/context-gathering requests, prefer read-only inspection commands first (git status, ls, find, rg, sed, head, tail, cat)
-- Do not run package-manager install/test/build/lint/typecheck commands unless the user explicitly asked for verification/package work or you need targeted validation after making code changes
+FILE READING:
+- Before reading a large file, check size with wc -l; then read targeted ranges with sed/head/tail.
+- For files over 200 lines, read chunks of 100-200 lines.
+- Read once, keep notes mentally, and avoid re-reading unchanged files unless a later error requires it.
+- Output over 10K chars may be truncated.
 
-FILE READING (important - avoid reading entire large files):
-- Before reading a file, check its size: wc -l file.txt
-- Read specific line ranges: sed -n '1,100p' file.txt (lines 1-100)
-- Read the beginning: head -n 100 file.txt
-- Read the end: tail -n 100 file.txt
-- Read a middle section: sed -n '200,300p' file.txt
-- For large files (>200 lines), read in chunks of 100-200 lines at a time
-- Prefer targeted reads over cat for any file that might be large
-- Output over 10K chars will be automatically truncated (first 5K + last 5K)
-
-KNOWLEDGE NOTES:
-- Durable project/user knowledge lives in ~/.agents/knowledge/ and ./.agents/knowledge/
-- Prefer direct file editing there to create or update notes
-- Store each note at .agents/knowledge/<slug>/<slug>.md using a human-readable slug
-- Related assets such as images or documents may live in the same note folder
-- Use canonical note frontmatter: kind: note, id, title, context, numeric createdAt/updatedAt millisecond timestamps, and comma-separated tags
-- Default most notes to context: search-only
-- Use context: auto only for a tiny curated subset of high-signal notes
-
-PAST CONVERSATIONS:
-- Prior DotAgents conversations are stored as JSON in the app-data conversations folder: <appData>/<appId>/conversations/
-- Common locations are ~/Library/Application Support/<appId>/conversations/ on macOS, %APPDATA%/<appId>/conversations/ on Windows, and ~/.config/<appId>/conversations/ on Linux
-- <appId> is usually dotagents, but some installs may use app.dotagents; infer the real local folder when needed instead of assuming one OS-specific path
-- Use index.json to discover relevant conversations, then open matching conv_*.json files for full message history when prior chat context would help
-- Before asking the user for facts that may already be known, check relevant knowledge notes and prior conversations first
+KNOWLEDGE / HISTORY:
+- Knowledge notes live in ~/.agents/knowledge/ and ./.agents/knowledge/.
+- Store notes at .agents/knowledge/<slug>/<slug>.md with frontmatter: kind, id, title, context, createdAt, updatedAt, tags.
+- Default notes to context: search-only; use context: auto only for tiny high-signal notes.
+- Prior conversations live in the app-data conversations folder. Use index.json first, then open specific conv_*.json files only when prior context is needed.
+- Before asking for facts that may already be known, check relevant knowledge notes and prior conversations.
 
 DOTAGENTS CONFIG:
-- DotAgents configuration lives in the layered ~/.agents/ and ./.agents/ filesystem
-- Global ~/.agents/ is the default editable layer
-- Workspace ./.agents/ only overrides global ~/.agents/ when DOTAGENTS_WORKSPACE_DIR is explicitly set
-- Prefer direct file editing for DotAgents config instead of narrow app-specific config tools
-- For exact file locations and edit recipes, load the dotagents-config-admin skill before changing unfamiliar DotAgents config
-- Common config files include dotagents-settings.json, mcp.json, models.json, system-prompt.md, agents.md, agents/<id>/agent.md, agents/<id>/config.json, skills/<id>/skill.md, and tasks/<id>/task.md
+- DotAgents config is layered: global ~/.agents/ plus optional workspace ./.agents/ when DOTAGENTS_WORKSPACE_DIR is set.
+- Prefer direct file edits for config. For unfamiliar config changes, load the dotagents-config-admin skill.
+- Common files: dotagents-settings.json, mcp.json, models.json, system-prompt.md, agents.md, agents/<id>/agent.md, agents/<id>/config.json, skills/<id>/skill.md, tasks/<id>/task.md.
 
-WHEN TO ASK: ONLY when the request is completely ambiguous or you absolutely need credentials you cannot find. Do not ask for permission to proceed.
-WHEN TO ACT: Always bias towards action. Execute tools, verify results, and complete the work autonomously.
+EFFICIENCY PATTERNS:
+- Autoresearch: for exactly one experiment or one candidate, use one candidate only: run one combined read-only inspection command only, with the first pass limited to program.md, git status, logs, and results (or the task's equivalent state sources), then one candidate change and one validation run; if validation fails, report the blocker instead of trying alternate candidates, then log/commit/revert as required and stop with a concise receipt.
+- Progress check: take one running-agent snapshot at most once. If it already answers the question, stop; only if essential details are still missing, do one targeted log/status read, then answer with current status and next action.
+- Knowledge cleanup: make a bounded inventory and cleanup proposal first; do not scan every note unless asked.
+- Topic extraction: load stream-topic-inventory once, find the latest relevant transcript/media once, process bounded chunks, then stop after the requested inventory or clip list.
+- Video render: load video-editing once (use video-frames only if frame extraction is needed), inspect assets once, render one preview candidate, report preview path and blockers; avoid render/search/frame-extraction churn.
 
+WHEN TO ASK: Only when the request is completely ambiguous or you need credentials you cannot find.
+WHEN TO ACT: Bias toward the smallest targeted action that satisfies the prompt. Verify once, then complete.
 TONE: Be extremely concise. No preamble or postamble. Prefer 1-3 sentences unless detail is requested.`

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -85,7 +85,7 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
   const hasReadMoreContext = hasPromptTool(availableTools, 'read_more_context')
 
   const sections = [
-    'AGENT MODE: You can see tool results and make follow-up tool calls. Continue calling tools until the task is completely resolved.',
+    'AGENT MODE: You can see tool results and make follow-up tool calls. Continue only while needed to satisfy the user\'s request, and stop as soon as the requested outcome is clear. For status and progress checks, take one snapshot and answer from it; do not keep polling once the answer is clear. For exactly-one experiment/candidate tasks, run one combined read-only inspection command only, with the first pass limited to program.md, git status, logs, and results (or the task\'s equivalent state sources), then stop reopening state files or trying alternate candidates.',
   ]
 
   if (hasRespondToUser) {
@@ -110,23 +110,26 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
   if (hasRespondToUser && hasMarkWorkComplete) {
     sections.push(`COMPLETION SIGNAL:
 - When all requested work is fully complete:
-  1. ALWAYS call respond_to_user with the final user-facing response FIRST
+  1. ALWAYS call respond_to_user with a concise final receipt FIRST
   2. Then call mark_work_complete with a concise internal completion summary
-- IMPORTANT: Never put the final user-facing answer in plain assistant text — always use respond_to_user
+- IMPORTANT: Keep the user-facing receipt short: changed files, validation result, blocker, next step
+- Do not paste tool traces, raw command output, or long logs
 - Do not send a second recap or post-completion summary unless the user explicitly asked for one
 - Do not call mark_work_complete while work is still in progress or partially done`)
   } else if (hasRespondToUser) {
     sections.push(`COMPLETION SIGNAL:
-- When all requested work is fully complete, call respond_to_user with the final user-facing response.
+- When all requested work is fully complete, call respond_to_user with a concise final receipt.
 - There is no separate completion tool in this run, so do not continue looping after that final response.`)
   } else if (hasMarkWorkComplete) {
     sections.push(`COMPLETION SIGNAL:
- - When all requested work is fully complete, provide the complete final user-facing answer in normal assistant text, then call mark_work_complete with a concise internal completion summary.
+ - When all requested work is fully complete, provide a concise final receipt in normal assistant text, then call mark_work_complete with a concise internal completion summary.
+ - Keep the user-facing receipt short: changed files, validation result, blocker, next step.
+ - Do not paste tool traces, raw command output, or long logs.
  - Do not send a second recap or post-completion summary unless the user explicitly asked for one.
 - Do not call mark_work_complete while work is still in progress or partially done.`)
   } else {
     sections.push(`COMPLETION SIGNAL:
-- When all requested work is fully complete, provide the complete final user-facing answer in normal assistant text and stop.`)
+- When all requested work is fully complete, provide a concise final receipt in normal assistant text and stop. Keep it short: changed files, validation result, blocker, next step. Do not paste tool traces, raw command output, or long logs.`)
   }
 
   if (hasExecuteCommand) {
@@ -135,6 +138,7 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 - For JS/TS repos, infer the package manager from lockfiles before running commands: pnpm-lock.yaml => pnpm, package-lock.json => npm, yarn.lock => yarn, bun.lock/bun.lockb => bun
 - Do not default to npm when a repo lockfile indicates pnpm, yarn, or bun
 - For planning/context-gathering or “what's next” requests, prefer read-only inspection commands like git status, ls, find, rg, sed, head, tail, and cat
+- For exactly-one experiment/candidate tasks, run one combined read-only inspection command only (e.g. program.md, git status, logs, results or the task's equivalent state sources in one shell command), then stop rerunning inspection commands or reopening files.
 - Do not run package-manager install/test/build/lint/typecheck commands unless the user explicitly asked for verification/package work or you need targeted validation after making code changes
 - Read files: check size first with "wc -l file", then read in chunks with "sed -n '1,100p' file" or "head -n 100 file"
 - For small files (<200 lines): "cat path/to/file" is fine
@@ -489,15 +493,17 @@ export function constructMinimalSystemPrompt(
   // - Work iteratively until goals are fully achieved
   // - Preserve skills discoverability (IDs) so skills aren't silently dropped
   let prompt =
-    "You are an autonomous AI assistant that uses tools to complete tasks. Work iteratively until goals are fully achieved. " +
+    "You are an autonomous AI assistant that uses tools to complete tasks. Work iteratively, but keep every task bounded by the user's requested outcome. " +
+    "Use the smallest tool budget that can still finish the task. Stop once the stop condition is met. Batch independent tool calls when possible, and do not re-run unchanged commands or polls. " +
     "Use tools proactively - prefer tools over asking users for information you can gather yourself. " +
-    "When calling tools, use exact tool names and parameter keys. Be concise. Batch independent tool calls when possible. " +
-    "You are highly autonomous and proactive. Make as many tool calls as needed to completely finish the task. Do NOT stop to ask the user for permission or confirmation. Keep working, verifying, and checking your own work until you are certain it is done. " +
+    "When calling tools, use exact tool names and parameter keys. Be concise. " +
+    "You are autonomous, but continue only while needed to satisfy the user's request, and stop as soon as the outcome is clear. " +
+    "Autoresearch: for exactly one experiment or one candidate, use one candidate only: run one combined read-only inspection command only, with the first pass limited to program.md, git status, logs, and results (or the task's equivalent state sources), then one candidate change and one validation run; if validation fails, report the blocker instead of trying alternate candidates, then log/commit/revert as required and stop with a concise receipt. Progress check: take one running-agent snapshot at most once and answer from it. Knowledge cleanup: make a bounded inventory and cleanup proposal first; do not scan every note unless asked. Topic extraction: load stream-topic-inventory once, find the latest relevant transcript/media once, process bounded chunks, then stop after the requested inventory or clip list. Video render: load video-editing once (use video-frames only if frame extraction is needed), inspect assets once, render one preview candidate, report path and blockers; avoid render/search churn. " +
     "Before asking the user for facts, check relevant knowledge notes and prior conversations first; if user/project-specific facts are still missing, do not ask for permission, only ask the minimum high-signal follow-ups. " +
     "Durable knowledge lives in ~/.agents/knowledge/ and ./.agents/knowledge/ as notes at .agents/knowledge/<slug>/<slug>.md; use human-readable slugs, keep related assets in the same folder, default notes to context: search-only, reserve context: auto for a tiny curated subset, and prefer direct file editing. Prior DotAgents conversations are stored as JSON in <appData>/<appId>/conversations/; common locations are ~/Library/Application Support/<appId>/conversations/ on macOS, %APPDATA%/<appId>/conversations/ on Windows, and ~/.config/<appId>/conversations/ on Linux; <appId> is usually dotagents but some installs may use app.dotagents, so infer the real local folder when needed; use index.json to find relevant conversations and open matching conv_*.json files for full history. DotAgents configuration lives in the layered ~/.agents/ and ./.agents/ filesystem; workspace overrides global on conflicts; prefer direct file editing for settings, models, prompts, agents, skills, tasks, and knowledge notes; and when available load the dotagents-config-admin skill before changing unfamiliar DotAgents config."
 
   if (isAgentMode) {
-    prompt += " Agent mode: continue calling tools until the task is completely resolved. If a tool fails, try alternative approaches before giving up. If AJ says to pick up where you left off or find a prior conversation, proactively search the conversation store with python3 or shell tools, read the last relevant messages, and summarize recovered state before asking follow-up questions."
+    prompt += " Agent mode: continue only while needed to satisfy the user's request, and stop as soon as the outcome is clear. If a tool fails, read the error once; for exactly-one experiment/candidate tasks, run one combined read-only inspection command only (e.g. program.md, git status, logs, results or the task's equivalent state sources in one shell command), then stop rerunning inspection commands or reopening files. If AJ says to pick up where you left off or find a prior conversation, proactively search the conversation store with python3 or shell tools, read the last relevant messages, and summarize recovered state before asking follow-up questions."
   }
 
   // Preserve skills policy + IDs under Tier-3 shrinking (only if skills exist).

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -196,8 +196,8 @@ const getConfig = (): LoadedConfig => {
     mcpRequireApprovalBeforeToolCall: false,
     mcpAutoPasteEnabled: false,
     mcpAutoPasteDelay: 1000, // 1 second delay by default
-    mcpMaxIterations: 10, // Default max iterations for agent mode
-    mcpUnlimitedIterations: true, // Default to unlimited iterations
+    mcpMaxIterations: 8, // Default max iterations for agent mode
+    mcpUnlimitedIterations: false, // Default to a finite iteration budget to prevent runaway agent loops
     textInputEnabled: true,
 
     // Text input: On Windows, use Ctrl+Shift+T to avoid browser new tab conflict
@@ -314,7 +314,7 @@ const getConfig = (): LoadedConfig => {
 
     // Completion verification defaults
     mcpVerifyCompletionEnabled: true,
-    mcpVerifyContextMaxItems: 10,
+    mcpVerifyContextMaxItems: 8,
     mcpVerifyRetryCount: 1,
 
     // Final summary defaults - off unless explicitly enabled
@@ -507,10 +507,10 @@ export class ConfigStore {
     // Sync active preset credentials to legacy fields on startup
     this.config = syncPresetToLegacyFields(loaded.config) as Config
 
-    // Migration: ensure mcpVerifyCompletionEnabled and mcpUnlimitedIterations
-    // default to true. These were previously false by default and may have been
-    // persisted to ~/.agents/mcp.json, overriding config.json changes.
-    // This is a one-time fix: once the values are true, this is a no-op.
+    // Migration: ensure mcpVerifyCompletionEnabled defaults to true. It was
+    // previously false by default and may have been persisted to ~/.agents/mcp.json,
+    // overriding config.json changes. Do not force mcpUnlimitedIterations back to
+    // true: finite defaults prevent runaway agent loops in bounded tasks.
     try {
       const globalLayer = getAgentsLayerPaths(globalAgentsFolder)
       const mcpJson = safeReadJsonFileSync<Record<string, unknown>>(globalLayer.mcpJsonPath, {
@@ -522,10 +522,6 @@ export class ConfigStore {
         mcpJson.mcpVerifyCompletionEnabled = true
         mcpDirty = true
       }
-      if (mcpJson.mcpUnlimitedIterations === false) {
-        mcpJson.mcpUnlimitedIterations = true
-        mcpDirty = true
-      }
       if (mcpDirty) {
         safeWriteJsonFileSync(globalLayer.mcpJsonPath, mcpJson, {
           backupDir: globalLayer.backupsDir,
@@ -534,7 +530,6 @@ export class ConfigStore {
         })
         // Also update the in-memory config
         this.config.mcpVerifyCompletionEnabled = true
-        this.config.mcpUnlimitedIterations = true
       }
     } catch {
       // best-effort


### PR DESCRIPTION
## Summary
- Make default agent mode bounded by finite iteration limits instead of unlimited loops
- Tighten retry, nudge, and failure budgets in the agent loop to reduce repeated recovery churn
- Update default and agent-mode prompts plus runtime tool descriptions to favor one-shot progress checks, exactly-one-candidate workflows, concise receipts, and fewer repeated commands or polls

## Source-only scope
This PR intentionally includes only product source changes from the autoresearch branch:
- apps/desktop/src/main/llm.ts
- apps/desktop/src/main/runtime-tool-definitions.ts
- apps/desktop/src/main/system-prompts-default.ts
- apps/desktop/src/main/system-prompts.ts
- packages/core/src/config.ts

It excludes autoresearch docs, benchmark fixtures/scripts, run artifacts, and logs.

## Validation
- PASS: pnpm --filter @dotagents/core test -- src/config.test.ts
- NOTE: pnpm --filter @dotagents/desktop typecheck:node fails on existing dualModelEnabled type errors in apps/desktop/src/main/remote-server.ts, which is outside this PR source-only diff and also present on origin/main.
