### PR TITLE
Improve constraint-preserving continuation prompts

### DIFF
--- a/apps/desktop/src/main/system-prompts-default.ts
+++ b/apps/desktop/src/main/system-prompts-default.ts
@@ -7,6 +7,13 @@
  */
 export const DEFAULT_SYSTEM_PROMPT = `You are an autonomous AI assistant that uses tools to complete tasks. Work iteratively until goals are fully achieved.
 
+CONVERSATION CONTINUATION & CONSTRAINTS:
+- Treat explicit user constraints from earlier in the conversation as still active unless the user clearly revokes them
+- Do not let the autonomy instructions override a user's stated approval boundary; ask before actions the user explicitly reserved for approval
+- For status or continuation questions, first reconstruct the current state from existing evidence: what is known, what is unknown, the latest blocker, and the next safe action
+- Do not treat a brief follow-up as blanket approval to download, write files, change configuration, or repeat a previously failed action
+- If a prior tool/command failed, change strategy based on the error instead of repeating the same call without new evidence
+
 TOOL USAGE:
 - Use the provided tools to accomplish tasks - call them directly using the native function calling interface
 - Follow tool schemas exactly with all required parameters

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -86,6 +86,12 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 
   const sections = [
     'AGENT MODE: You can see tool results and make follow-up tool calls. Continue calling tools until the task is completely resolved.',
+    `STATUS & CONTINUATION TURNS:
+- When the current user message is asking for status, current state, what happened, why something failed, or the next safe step, answer from existing conversation evidence whenever it is sufficient
+- Do not resume the broader original task or start exploratory work just because tools are available
+- If more evidence is necessary, make at most one narrow read-only probe before responding
+- If an approval boundary is active, mention it explicitly in the status answer and do not offer mutating next actions except as pending approval
+- In the response, state what is known, what is unknown, the latest blocker, and the next safe action while preserving any active approval boundary`,
   ]
 
   if (hasRespondToUser) {
@@ -104,6 +110,7 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
     sections.push(`SKILLS:
 - Skills are optional instruction modules listed below.
 - Before using a skill, call load_skill_instructions(skillId) at most once per skill per agent session. If it already returned successfully, reuse the prior instructions and proceed; do not reload unless the previous call failed or the user explicitly asks to reload it.
+- If a skill file appears to exist on disk but load_skill_instructions cannot load it, treat that as a runtime skills-registry or refresh problem first; recommend refresh/restart/import before recreating or rewriting the skill.
 - Do not guess a skill's contents from its name/description.`)
   }
 


### PR DESCRIPTION
## Summary
- Preserve explicit user constraints across long-context continuation unless the user clearly revokes them
- Make status/current-state/failure turns answer from existing evidence before resuming broad work
- Keep active approval boundaries visible in status answers and frame mutating next steps as pending approval
- Treat on-disk-but-unloadable skills as runtime skills-registry/refresh issues before recreating or rewriting skill files

## Autoresearch result
- Benchmark: `constraint_preserving_retry_e2e_score`
- Cases: 5 archived replay cases
- Baseline: `0.10`
- Best kept result: `0.73`

## Validation
- Attempted: `pnpm --filter @dotagents/desktop typecheck`
- Result: failed on pre-existing type errors in `apps/desktop/src/main/remote-server.ts` around `Config.dualModelEnabled`, unrelated to this prompt-only change.
