### PR TITLE
Add Codex thinking/verbosity controls and surface GPT-5.5

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -110,6 +110,46 @@ describe("chatgpt-web provider image input", () => {
   })
 })
 
+describe("chatgpt-web Codex options", () => {
+  async function setupCodexOptionsTest(config: Record<string, unknown>) {
+    vi.doMock("./config", () => ({
+      configStore: {
+        get: vi.fn(() => config),
+        save: vi.fn(),
+      },
+    }))
+    vi.doMock("./oauth-storage", () => ({
+      oauthStorage: {
+        getTokens: vi.fn(),
+        storeTokens: vi.fn(),
+        clearTokens: vi.fn(),
+      },
+    }))
+    vi.doMock("./conversation-image-assets", () => ({
+      CONVERSATION_IMAGE_ASSET_HOST: "conversation-image",
+      getConversationImageAssetPath: vi.fn(),
+    }))
+  }
+
+  it("defaults Codex text verbosity to medium when unset", async () => {
+    await setupCodexOptionsTest({})
+    const { getCodexTextVerbosity } = await import("./chatgpt-web-provider")
+    expect(getCodexTextVerbosity()).toBe("medium")
+  })
+
+  it("returns the configured Codex text verbosity override", async () => {
+    await setupCodexOptionsTest({ codexTextVerbosity: "high" })
+    const { getCodexTextVerbosity } = await import("./chatgpt-web-provider")
+    expect(getCodexTextVerbosity()).toBe("high")
+  })
+
+  it("ignores invalid Codex text verbosity values and falls back to medium", async () => {
+    await setupCodexOptionsTest({ codexTextVerbosity: "verbose" })
+    const { getCodexTextVerbosity } = await import("./chatgpt-web-provider")
+    expect(getCodexTextVerbosity()).toBe("medium")
+  })
+})
+
 describe("chatgpt-web Codex CLI auth fallback", () => {
   it("reads ChatGPT tokens from a Codex CLI auth cache", async () => {
     const { tempDir } = await setupChatGptWebProviderTest()

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -164,6 +164,16 @@ export function getCodexReasoningOptions(model: string): { effort: CodexReasonin
   return { effort, summary: "auto" }
 }
 
+type CodexTextVerbosity = "low" | "medium" | "high"
+
+export function getCodexTextVerbosity(): CodexTextVerbosity {
+  const override = configStore.get().codexTextVerbosity
+  if (override === "low" || override === "medium" || override === "high") {
+    return override
+  }
+  return "medium"
+}
+
 function normalizeChatGptWebBaseUrl(baseUrl: string | undefined): string {
   const raw = (baseUrl || DEFAULT_CHATGPT_WEB_BASE_URL).trim()
   if (!raw) return DEFAULT_CHATGPT_WEB_BASE_URL
@@ -779,7 +789,7 @@ export async function makeChatGptWebResponse(
     store: false,
     stream: true,
     input: buildCodexInput(messages),
-    text: { verbosity: "medium" },
+    text: { verbosity: getCodexTextVerbosity() },
     include: ["reasoning.encrypted_content"],
     parallel_tool_calls: true,
   }

--- a/apps/desktop/src/main/models-service.ts
+++ b/apps/desktop/src/main/models-service.ts
@@ -47,6 +47,7 @@ function mapToModelsDevProviderId(providerId: string, baseUrl?: string): string 
 }
 
 const CHATGPT_WEB_FALLBACK_MODELS: ModelInfo[] = [
+  { id: "gpt-5.5", name: "GPT-5.5" },
   { id: "gpt-5.4", name: "GPT-5.4" },
   { id: "gpt-5.4-mini", name: "GPT-5.4 Mini" },
   { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -222,6 +222,62 @@ export function Component() {
             </div>
           )}
 
+          {agentProviderId === "chatgpt-web" && (
+            <div className="border-t px-3 py-2">
+              <div className="pb-2">
+                <span className="text-sm font-medium">Codex options</span>
+                <p className="text-xs text-muted-foreground">
+                  Tune how the Codex (ChatGPT Web) model thinks and how verbose its replies are.
+                </p>
+              </div>
+              <Control
+                label={<ControlLabel label="Thinking level" tooltip="Reasoning effort sent to Codex reasoning models. 'None' lets the provider answer instantly with no extra reasoning." />}
+              >
+                <Select
+                  value={config.openaiReasoningEffort || "medium"}
+                  onValueChange={(value) =>
+                    saveConfig({
+                      openaiReasoningEffort: value as Config["openaiReasoningEffort"],
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-full sm:w-[220px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">None</SelectItem>
+                    <SelectItem value="minimal">Minimal</SelectItem>
+                    <SelectItem value="low">Low</SelectItem>
+                    <SelectItem value="medium">Medium (default)</SelectItem>
+                    <SelectItem value="high">High</SelectItem>
+                    <SelectItem value="xhigh">Extra high</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Control>
+              <Control
+                label={<ControlLabel label="Verbosity" tooltip="Output verbosity passed as text.verbosity in the Codex responses payload." />}
+              >
+                <Select
+                  value={config.codexTextVerbosity || "medium"}
+                  onValueChange={(value) =>
+                    saveConfig({
+                      codexTextVerbosity: value as Config["codexTextVerbosity"],
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-full sm:w-[220px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="low">Low</SelectItem>
+                    <SelectItem value="medium">Medium (default)</SelectItem>
+                    <SelectItem value="high">High</SelectItem>
+                  </SelectContent>
+                </Select>
+              </Control>
+            </div>
+          )}
+
           {!usesOpenAiCompatiblePreset && agentProviderId === "openai" && (
             <p className="px-3 py-2 text-sm text-muted-foreground">
               OpenAI-compatible preset controls appear here when Agent or Transcript Processing uses that provider.

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1207,6 +1207,12 @@ export type Config = {
    * this override is set.
    */
   openaiReasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+  /**
+   * Output verbosity for Codex (ChatGPT Web) responses. Passed through as
+   * `text.verbosity` on the Codex responses payload. Defaults to "medium"
+   * when unset.
+   */
+  codexTextVerbosity?: "low" | "medium" | "high"
   /** @deprecated Use agentSystemPrompt instead; legacy field is ignored. */
   mcpToolsSystemPrompt?: string
   /** @deprecated Kept for backward compatibility but ignored */


### PR DESCRIPTION
## Summary

Closes #421.

- Adds **Models settings** UI controls for the Codex (ChatGPT Web) provider so users can pick a thinking level and an output verbosity from the Agent Models section. The controls only render when the Agent provider is Codex.
- Wires the new `codexTextVerbosity` config field through the ChatGPT Web provider so it is sent as `text.verbosity` on the Codex responses payload (was hard-coded `"medium"` before). Thinking level reuses the existing `openaiReasoningEffort` field that the provider already honors.
- Adds **GPT-5.5** to the ChatGPT Web fallback model list so it is selectable from Models settings (the upstream model list endpoint isn't reliable, so the fallback is what users see).

## Files changed

- `apps/desktop/src/shared/types.ts` — adds `codexTextVerbosity?: "low" | "medium" | "high"` next to `openaiReasoningEffort`.
- `apps/desktop/src/main/chatgpt-web-provider.ts` — exports `getCodexTextVerbosity()` and uses it in the responses payload.
- `apps/desktop/src/main/chatgpt-web-provider.test.ts` — covers default, override, and invalid-value behavior for `getCodexTextVerbosity()`.
- `apps/desktop/src/main/models-service.ts` — adds `gpt-5.5` to `CHATGPT_WEB_FALLBACK_MODELS`.
- `apps/desktop/src/renderer/src/pages/settings-models.tsx` — renders the **Codex options** panel (thinking level + verbosity) when `agentProviderId === "chatgpt-web"`.

## Test plan

- [x] `pnpm exec vitest run src/main/chatgpt-web-provider.test.ts` — 8 passing (3 new)
- [x] `pnpm exec vitest run src/main/ai-sdk-provider.test.ts` — 23 passing (existing reasoning-effort coverage still green)
- [x] `pnpm --filter @dotagents/desktop typecheck` — no new type errors in the touched files (the only failures are pre-existing `dualModelEnabled` references on `main`, unrelated to this PR)
- [ ] Manual: open Models settings with Agent set to Codex, change thinking level / verbosity, confirm settings persist and the next Codex request includes the chosen `text.verbosity` and `reasoning.effort`
- [ ] Manual: confirm GPT-5.5 appears in the model picker for Codex

https://claude.ai/code/session_01TKUcvbqdZABZETquVdjviE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKUcvbqdZABZETquVdjviE)_