### PR TITLE
Allow plain text agent responses

### DIFF
--- a/apps/desktop/src/main/acp-main-agent.test.ts
+++ b/apps/desktop/src/main/acp-main-agent.test.ts
@@ -23,9 +23,11 @@ vi.mock("./acp-service", () => ({
 vi.mock("./acp-session-state", () => ({
   getMainAcpxSessionName: vi.fn((conversationId: string) => `dotagents:main:${conversationId}`),
   getSessionForConversation: vi.fn(() => undefined),
+  registerKnownAppSessionId: vi.fn(),
   setSessionForConversation: vi.fn(),
   touchSession: vi.fn(),
   setAcpToAppSessionMapping: vi.fn(),
+  updateConversationRuntimeSessionId: vi.fn(),
 }))
 
 vi.mock("./emit-agent-progress", () => ({
@@ -173,9 +175,9 @@ describe("acp-main-agent", () => {
     )
 
     const promptContext = mockSendPrompt.mock.calls[0]?.[3]
-    expect(promptContext).toContain("If injected DotAgents runtime tools are available")
-    expect(promptContext).toContain('call "respond_to_user" first with the final user-facing answer')
-    expect(promptContext).toContain('then call "mark_work_complete" with a concise internal completion summary')
+    expect(promptContext).toContain("Plain assistant text is valid user-facing output")
+    expect(promptContext).toContain('If "respond_to_user" is available')
+    expect(promptContext).toContain('call it only when an explicit internal completion signal is useful')
     expect(promptContext).toContain("System Prompt: Be helpful")
     expect(promptContext).toContain("Guidelines: Stay concise")
   })

--- a/apps/desktop/src/main/acp-main-agent.test.ts
+++ b/apps/desktop/src/main/acp-main-agent.test.ts
@@ -177,7 +177,8 @@ describe("acp-main-agent", () => {
     const promptContext = mockSendPrompt.mock.calls[0]?.[3]
     expect(promptContext).toContain("Plain assistant text is valid user-facing output")
     expect(promptContext).toContain('If "respond_to_user" is available')
-    expect(promptContext).toContain('call it only when an explicit internal completion signal is useful')
+    expect(promptContext).toContain('first provide the final user-facing answer in plain assistant text or via "respond_to_user"')
+    expect(promptContext).toContain('Only then call "mark_work_complete"')
     expect(promptContext).toContain("System Prompt: Be helpful")
     expect(promptContext).toContain("Guidelines: Stay concise")
   })

--- a/apps/desktop/src/main/acp-main-agent.ts
+++ b/apps/desktop/src/main/acp-main-agent.ts
@@ -33,10 +33,9 @@ import { resolveMessageTimestamps, type AgentConversationState, type AgentUserRe
 type ConversationHistoryMessage = NonNullable<AgentProgressUpdate["conversationHistory"]>[number]
 
 const ACP_RUNTIME_TOOL_PROMPT_CONTEXT = [
-  `If injected DotAgents runtime tools are available, prefer them for user-facing communication and completion signaling.`,
-  `When "${RESPOND_TO_USER_TOOL}" is available, use it for every user-facing response instead of plain assistant text.`,
-  `When the task is fully complete and "${MARK_WORK_COMPLETE_TOOL}" is available, call "${RESPOND_TO_USER_TOOL}" first with the final user-facing answer, then call "${MARK_WORK_COMPLETE_TOOL}" with a concise internal completion summary. Do not send a second recap unless the user explicitly asked for one.`,
-  `Only fall back to plain assistant text if those runtime tools are unavailable or fail repeatedly.`,
+  `Plain assistant text is valid user-facing output for ordinary chat, simple questions, and final answers.`,
+  `If "${RESPOND_TO_USER_TOOL}" is available, use it when explicit voice/messaging delivery semantics or attachments are needed; do not duplicate the same answer in plain text.`,
+  `When the task is fully complete and "${MARK_WORK_COMPLETE_TOOL}" is available, call it only when an explicit internal completion signal is useful, with a concise internal completion summary. Do not send a second recap unless the user explicitly asked for one.`,
 ].join("\n")
 
 const ACP_SETUP_STAGE_META: Record<ACPGetOrCreateSessionStage, { stepId: string; title: (agentName: string) => string }> = {

--- a/apps/desktop/src/main/acp-main-agent.ts
+++ b/apps/desktop/src/main/acp-main-agent.ts
@@ -35,7 +35,7 @@ type ConversationHistoryMessage = NonNullable<AgentProgressUpdate["conversationH
 const ACP_RUNTIME_TOOL_PROMPT_CONTEXT = [
   `Plain assistant text is valid user-facing output for ordinary chat, simple questions, and final answers.`,
   `If "${RESPOND_TO_USER_TOOL}" is available, use it when explicit voice/messaging delivery semantics or attachments are needed; do not duplicate the same answer in plain text.`,
-  `When the task is fully complete and "${MARK_WORK_COMPLETE_TOOL}" is available, call it only when an explicit internal completion signal is useful, with a concise internal completion summary. Do not send a second recap unless the user explicitly asked for one.`,
+  `When the task is fully complete and "${MARK_WORK_COMPLETE_TOOL}" is available, first provide the final user-facing answer in plain assistant text or via "${RESPOND_TO_USER_TOOL}". Only then call "${MARK_WORK_COMPLETE_TOOL}" when an explicit internal completion signal is useful, with a concise internal completion summary. Do not send a second recap unless the user explicitly asked for one.`,
 ].join("\n")
 
 const ACP_SETUP_STAGE_META: Record<ACPGetOrCreateSessionStage, { stepId: string; title: (agentName: string) => string }> = {

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -246,6 +246,31 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
     expect(mocks.makeLLMCallWithStreamingAndTools).toHaveBeenCalledTimes(1)
   })
 
+  it("accepts verified plain assistant text without nudging for a response tool first", async () => {
+    currentConfig.mcpVerifyCompletionEnabled = true
+    const { processTranscriptWithAgentMode } = await import("./llm")
+    const progressUpdates: any[] = []
+
+    mocks.makeLLMCallWithStreamingAndTools.mockResolvedValueOnce({ content: "Yes — that will work.", toolCalls: [] })
+    mocks.verifyCompletionWithFetch.mockResolvedValue({ isComplete: true, conversationState: "complete", confidence: 0.96, missingItems: [] })
+
+    const result = await processTranscriptWithAgentMode("Will this approach work?", availableTools as any, makeExecuteToolCall("session-plain-text", 1), 4, [], "conv-plain-text", "session-plain-text", (update) => progressUpdates.push(update), undefined, 1)
+
+    expect(result.content).toBe("Yes — that will work.")
+    expect(mocks.makeLLMCallWithStreamingAndTools).toHaveBeenCalledTimes(1)
+    expect(mocks.verifyCompletionWithFetch).toHaveBeenCalledTimes(1)
+
+    const promptText = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[0]?.[0] ?? [])
+      .map((message: any) => message.content)
+      .join("\n")
+    expect(promptText).not.toContain(INTERNAL_COMPLETION_NUDGE_TEXT)
+
+    const completedUpdate = progressUpdates.find((update) => update.isComplete)
+    expect(completedUpdate?.finalContent).toBe("Yes — that will work.")
+    expect(completedUpdate?.userResponse).toBeUndefined()
+    expect(completedUpdate?.responseEvents).toBeUndefined()
+  })
+
   it("asks for the missing final answer instead of auto-generating a summary after bare mark_work_complete", async () => {
     currentConfig.mcpVerifyCompletionEnabled = true
     currentConfig.mcpFinalSummaryEnabled = false

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -603,10 +603,6 @@ export async function processTranscriptWithAgentMode(
       storedResponse: storedUserResponse,
       responseEvents,
     })
-    const isKillSwitchCompletion =
-      update.isComplete &&
-      typeof update.finalContent === "string" &&
-      update.finalContent.includes("emergency kill switch")
     const conversationState = resolveProgressConversationState({
       conversationState: update.conversationState,
       isComplete: update.isComplete,
@@ -615,17 +611,12 @@ export async function processTranscriptWithAgentMode(
     })
     const userResponseForUpdate =
       update.userResponse ??
-      normalizedStoredUserResponse ??
-      (update.isComplete && !isKillSwitchCompletion
-        ? update.finalContent
-        : undefined)
+      normalizedStoredUserResponse
     const userResponseSource =
       update.userResponse !== undefined
         ? "update"
         : normalizedStoredUserResponse !== undefined
         ? "store"
-        : update.isComplete && !isKillSwitchCompletion
-        ? "finalContent"
         : "none"
     const shouldEmitUserResponse =
       userResponseForUpdate !== undefined &&
@@ -1138,7 +1129,7 @@ export async function processTranscriptWithAgentMode(
   }
 
   const buildMissingFinalAnswerAfterCompletionNudge = () => {
-    return `You called ${MARK_WORK_COMPLETE_TOOL} without first providing the final user-facing answer. Provide that answer now. If ${RESPOND_TO_USER_TOOL} is available, use it for the final user-facing answer and then call ${MARK_WORK_COMPLETE_TOOL} again only if needed. Do not add a second recap or summary unless the user explicitly asked for one.`
+    return `You called ${MARK_WORK_COMPLETE_TOOL} without first providing the final user-facing answer. Provide that answer now in normal assistant text, or use ${RESPOND_TO_USER_TOOL} only if explicit delivery semantics are needed. Call ${MARK_WORK_COMPLETE_TOOL} again only if needed. Do not add a second recap or summary unless the user explicitly asked for one.`
   }
 
   const extractLatestSelectorRefFromHistory = () => {
@@ -1634,8 +1625,6 @@ export async function processTranscriptWithAgentMode(
   // segment is what's bounded, not the lifetime of the run.
   let totalNudgeCount = 0
   let garbledToolCallCount = 0 // Track consecutive garbled tool-call-as-text responses
-  let completionSignalHintCount = 0 // Avoid repeatedly injecting explicit-completion hints
-  const MAX_COMPLETION_SIGNAL_HINTS = 2
   // Count *consecutive* verification failures. Resets to 0 on any verifier
   // "yes" (handled inside runVerificationAndHandleResult by returning
   // newFailCount: 0) and on any successful tool batch (see the reset right
@@ -2101,9 +2090,6 @@ export async function processTranscriptWithAgentMode(
       noOpCount++
 
       const hasToolsAvailable = activeTools.length > 0
-      const hasCompletionSignalTool = activeTools.some(
-        (tool) => tool.name === MARK_WORK_COMPLETE_TOOL,
-      )
       const contentText = llmResponse.content || ""
       const trimmedContent = contentText.trim()
       const hasToolMarkers = /<\|tool_calls_section_begin\|>|<\|tool_call_begin\|>/i.test(contentText)
@@ -2165,42 +2151,11 @@ export async function processTranscriptWithAgentMode(
           break
         }
 
-        if (hasCompletionSignalTool) {
-          // When tools have already been executed in this session and the agent is
-          // giving a substantive text summary, skip the completion-hint loop and go
-          // straight to verification. The work is done -- nudging for mark_work_complete
-          // just wastes iterations and risks the nudge/fallback path producing a
-          // generic "couldn't complete" error for tasks that are already finished.
-          const noOpThresholdReached = noOpCount >= 2
-          if (completionSignalHintCount < MAX_COMPLETION_SIGNAL_HINTS && !noOpThresholdReached && !toolsExecutedInSession) {
-            // No tools executed yet: substantive text is likely a progress/status update.
-            // Keep iterating and reserve verifier calls for explicit completion signals.
-            if (trimmedContent.length > 0) {
-              addMessage("assistant", contentText, undefined, undefined, undefined, displayOnlyMessageOptions)
-            }
-            addEphemeralMessage("user", INTERNAL_COMPLETION_NUDGE_TEXT)
-            completionSignalHintCount++
-            // Do NOT reset noOpCount here. Substantive text without tool calls or explicit
-            // completion in a tool-driven task is still a no-op from a progress standpoint.
-            // The single increment at the top of the !hasToolCalls block already counted
-            // this iteration (there is no second increment), so the noOpThresholdReached
-            // check above will trigger the fallthrough naturally.
-            continue
-          }
-
-          // Fall through to the verification/fallback path when:
-          // - tools were already executed (agent is summarizing completed work), or
-          // - hints exhausted / noOp threshold reached without mark_work_complete.
-          // The fallback path will treat the substantive text as a completion candidate
-          // and run verification, which may either continue the loop or finalize.
-        }
-
-        // Fallback/verification path: reached when either (a) the completion signal
-        // tool is unavailable for this session/profile, or (b) the tool is available
-        // but all completion-signal hints have been exhausted without the model calling
-        // mark_work_complete. In case (b) this acts as a safety valve so we don't spin
-        // until maxIterations — we treat the substantive text as a completion candidate
-        // and run verification, which may either continue the loop or finalize.
+        // Treat substantive plain assistant text as a legitimate completion candidate
+        // even when runtime communication/completion tools are available. Older models
+        // needed a completion-tool nudge here, but forcing that extra loop degrades
+        // simple question/answer turns. Verification below still catches genuinely
+        // incomplete work and asks the model to continue when necessary.
         finalContent = contentText
         const noToolsCalledYet = !conversationHistory.some((e) => e.role === "tool")
         let skipPostVerifySummary =
@@ -2250,7 +2205,6 @@ export async function processTranscriptWithAgentMode(
             noOpCount = 0
             totalNudgeCount = 0
             garbledToolCallCount = 0
-            completionSignalHintCount = 0
             continue
           }
         }
@@ -2368,7 +2322,6 @@ export async function processTranscriptWithAgentMode(
         const followsSuccessfulToolResult = lastConversationMessage?.role === "tool" && !/\bERROR:\b/i.test(lastConversationMessage.content || "")
         if (followsSuccessfulToolResult) {
           totalNudgeCount = 0
-          completionSignalHintCount = 0
         }
 
         const isGarbledToolCallTextResponse = isGarbledToolCallText(contentText)
@@ -2452,7 +2405,6 @@ export async function processTranscriptWithAgentMode(
         // nudging to work per "stuck segment" rather than globally across the run.
         // If the agent gets stuck again later, it should have a fresh nudge budget.
         totalNudgeCount = 0
-        completionSignalHintCount = 0
       }
     }
 
@@ -2903,7 +2855,6 @@ export async function processTranscriptWithAgentMode(
           noOpCount = 0
           totalNudgeCount = 0
           garbledToolCallCount = 0
-          completionSignalHintCount = 0
           continue
         }
 
@@ -3108,7 +3059,6 @@ export async function processTranscriptWithAgentMode(
         noOpCount = 0
         totalNudgeCount = 0
         garbledToolCallCount = 0
-        completionSignalHintCount = 0
         continue
       }
 
@@ -3160,7 +3110,6 @@ export async function processTranscriptWithAgentMode(
 		          noOpCount = 0
 		          totalNudgeCount = 0
 		          garbledToolCallCount = 0
-		          completionSignalHintCount = 0
 	          continue
 	        }
 	      }

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -76,7 +76,7 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
   {
     name: "respond_to_user",
     description:
-      "Send a response directly to the user. On voice interfaces this will be spoken aloud via TTS; on messaging channels (mobile, WhatsApp, etc.) it will be sent as a message. Regular assistant text is internal and not guaranteed to reach the user; use this tool to explicitly communicate with them. Provide at least one of: non-empty text, one/more images, or one/more videos.",
+      "Send a response through DotAgents' explicit delivery channel. Normal assistant text is valid for ordinary chat and simple final answers; use this tool when you specifically need voice/TTS or messaging-channel delivery semantics, or when sending images/videos. Provide at least one of: non-empty text, one/more images, or one/more videos.",
     inputSchema: {
       type: "object",
       properties: {

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -125,7 +125,21 @@ describe("constructSystemPrompt", () => {
     expect(prompt).toContain("- respond_to_user — Send a user-facing response")
     expect(prompt).toContain("- load_skill_instructions — Load a skill")
     expect(prompt).not.toContain("AVAILABLE MCP SERVERS")
-    expect(prompt).not.toContain("unknown")
+    expect(prompt).not.toContain("- unknown (")
+  })
+
+  it("allows plain assistant text even when response runtime tools are available", async () => {
+    const { constructSystemPrompt } = await import("./system-prompts")
+
+    const prompt = constructSystemPrompt([
+      { name: "respond_to_user", description: "Send a user-facing response", inputSchema: { type: "object", properties: {} } },
+      { name: "mark_work_complete", description: "Mark work complete", inputSchema: { type: "object", properties: {} } },
+    ] as any, undefined, true)
+
+    expect(prompt).toContain("Normal assistant text is valid user-facing output")
+    expect(prompt).toContain("a normal assistant text final answer is valid and may be the only response")
+    expect(prompt).not.toContain("Never put the final user-facing answer in plain assistant text")
+    expect(prompt).not.toContain("ALWAYS call respond_to_user")
   })
 
   it("only advertises discovery helpers that are actually available", async () => {

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -138,8 +138,22 @@ describe("constructSystemPrompt", () => {
 
     expect(prompt).toContain("Normal assistant text is valid user-facing output")
     expect(prompt).toContain("a normal assistant text final answer is valid and may be the only response")
+    expect(prompt).toContain("call mark_work_complete with a concise internal completion summary after delivering the final answer")
     expect(prompt).not.toContain("Never put the final user-facing answer in plain assistant text")
     expect(prompt).not.toContain("ALWAYS call respond_to_user")
+  })
+
+  it("keeps mark_work_complete-only completion guidance as consistently formatted list items", async () => {
+    const { constructSystemPrompt } = await import("./system-prompts")
+
+    const prompt = constructSystemPrompt([
+      { name: "mark_work_complete", description: "Mark work complete", inputSchema: { type: "object", properties: {} } },
+    ] as any, undefined, true)
+
+    expect(prompt).toContain("provide the complete final user-facing answer in normal assistant text first")
+    expect(prompt).toContain("may then call mark_work_complete")
+    expect(prompt).not.toContain("\n - When all requested work")
+    expect(prompt).not.toContain("\n - Do not send a second recap")
   })
 
   it("only advertises discovery helpers that are actually available", async () => {

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -128,8 +128,8 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 - There is no separate completion tool in this run, so do not continue looping after that final response.`)
   } else if (hasMarkWorkComplete) {
     sections.push(`COMPLETION SIGNAL:
- - When all requested work is fully complete, provide the complete final user-facing answer in normal assistant text. For tool-driven work, you may then call mark_work_complete with a concise internal completion summary.
- - Do not send a second recap or post-completion summary unless the user explicitly asked for one.
+- When all requested work is fully complete, provide the complete final user-facing answer in normal assistant text first. For tool-driven work, you may then call mark_work_complete with a concise internal completion summary.
+- Do not send a second recap or post-completion summary unless the user explicitly asked for one.
 - Do not call mark_work_complete while work is still in progress or partially done.`)
   } else {
     sections.push(`COMPLETION SIGNAL:

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -96,7 +96,8 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 
   if (hasRespondToUser) {
     sections.push(`RESPONDING TO USER:
-- Use respond_to_user whenever you want to communicate directly with the user
+- Normal assistant text is valid user-facing output for ordinary chat, simple questions, and final answers
+- Use respond_to_user when you specifically need explicit voice/messaging delivery semantics or need to attach images/videos
 - On voice interfaces this will be spoken aloud; on messaging channels (mobile, WhatsApp) it will be sent as a message
 - Write respond_to_user content naturally and conversationally
 - Markdown is allowed when useful (for example links or image captions)
@@ -116,19 +117,18 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 
   if (hasRespondToUser && hasMarkWorkComplete) {
     sections.push(`COMPLETION SIGNAL:
-- When all requested work is fully complete:
-  1. ALWAYS call respond_to_user with the final user-facing response FIRST
-  2. Then call mark_work_complete with a concise internal completion summary
-- IMPORTANT: Never put the final user-facing answer in plain assistant text — always use respond_to_user
+- When all requested work is fully complete, a normal assistant text final answer is valid and may be the only response
+- For tool-driven work where an explicit completion signal is useful, call mark_work_complete with a concise internal completion summary after delivering the final answer
+- If you use respond_to_user for the final answer, do not duplicate that same answer in plain assistant text
 - Do not send a second recap or post-completion summary unless the user explicitly asked for one
 - Do not call mark_work_complete while work is still in progress or partially done`)
   } else if (hasRespondToUser) {
     sections.push(`COMPLETION SIGNAL:
-- When all requested work is fully complete, call respond_to_user with the final user-facing response.
+- When all requested work is fully complete, provide the final user-facing response in normal assistant text or via respond_to_user when explicit delivery semantics are needed.
 - There is no separate completion tool in this run, so do not continue looping after that final response.`)
   } else if (hasMarkWorkComplete) {
     sections.push(`COMPLETION SIGNAL:
- - When all requested work is fully complete, provide the complete final user-facing answer in normal assistant text, then call mark_work_complete with a concise internal completion summary.
+ - When all requested work is fully complete, provide the complete final user-facing answer in normal assistant text. For tool-driven work, you may then call mark_work_complete with a concise internal completion summary.
  - Do not send a second recap or post-completion summary unless the user explicitly asked for one.
 - Do not call mark_work_complete while work is still in progress or partially done.`)
   } else {


### PR DESCRIPTION
## Summary
- Relax agent/ACP prompt guidance so normal assistant text is valid for simple questions and final answers
- Stop nudging verified plain-text answers into respond_to_user / mark_work_complete flow
- Prevent plain finalContent from being emitted as userResponse, avoiding duplicate visible/TTS responses
- Keep respond_to_user for explicit delivery semantics and attachments

## Tests
- pnpm --filter @dotagents/desktop exec vitest run src/main/llm.respond-to-user-history.test.ts src/main/system-prompts.test.ts src/main/acp-main-agent.test.ts src/main/runtime-tools.respond-to-user.test.ts src/main/llm.continuation-guards.test.ts src/renderer/src/components/agent-progress.response-history.test.ts
- git diff --check

## Notes
- Attempted pnpm --filter @dotagents/desktop typecheck:node, but it is currently blocked by unrelated existing remote-server.ts Config.dualModelEnabled type errors.