### PR TITLE
Add opt-in local trace logging to JSONL (closes #424)

### DIFF
--- a/apps/desktop/src/main/langfuse-service.ts
+++ b/apps/desktop/src/main/langfuse-service.ts
@@ -20,6 +20,10 @@ import {
   type LangfuseSpanClient,
   type LangfuseGenerationClient,
 } from "./langfuse-loader"
+import {
+  appendLocalTraceEvent,
+  resetLocalTraceLogger,
+} from "./local-trace-logger"
 
 // Singleton Langfuse instance
 let langfuseInstance: LangfuseInstance | null = null
@@ -97,6 +101,8 @@ export function reinitializeLangfuse(): void {
   activeTraces.clear()
   activeSpans.clear()
   activeGenerations.clear()
+  // Local trace logger caches the resolved path; reset so config changes apply.
+  resetLocalTraceLogger()
 }
 
 /**
@@ -124,6 +130,20 @@ export function createAgentTrace(
     release?: string
   }
 ): LangfuseTraceClient | null {
+  appendLocalTraceEvent({
+    type: "trace.start",
+    traceId,
+    name: options.name || "Agent Session",
+    input: options.input,
+    metadata: {
+      ...options.metadata,
+      userId: options.userId,
+      sessionId: options.sessionId,
+      tags: options.tags,
+      release: options.release,
+    },
+  })
+
   const langfuse = getLangfuse()
   if (!langfuse) return null
 
@@ -173,6 +193,13 @@ export function endAgentTrace(
     metadata?: Record<string, unknown>
   }
 ): void {
+  appendLocalTraceEvent({
+    type: "trace.end",
+    traceId: sessionId,
+    output: options.output,
+    metadata: options.metadata,
+  })
+
   const trace = activeTraces.get(sessionId)
   if (!trace) return
 
@@ -199,6 +226,15 @@ export function createToolSpan(
     metadata?: Record<string, unknown>
   }
 ): LangfuseSpanClient | null {
+  appendLocalTraceEvent({
+    type: "span.start",
+    traceId,
+    spanId,
+    name: options.name,
+    input: options.input,
+    metadata: options.metadata,
+  })
+
   const trace = activeTraces.get(traceId)
   if (!trace) return null
 
@@ -228,6 +264,15 @@ export function endToolSpan(
     statusMessage?: string
   }
 ): void {
+  appendLocalTraceEvent({
+    type: "span.end",
+    spanId,
+    output: options.output,
+    metadata: options.metadata,
+    level: options.level,
+    statusMessage: options.statusMessage,
+  })
+
   const span = activeSpans.get(spanId)
   if (!span) return
 
@@ -258,6 +303,17 @@ export function createLLMGeneration(
     metadata?: Record<string, unknown>
   }
 ): LangfuseGenerationClient | null {
+  appendLocalTraceEvent({
+    type: "generation.start",
+    traceId: traceId ?? undefined,
+    generationId,
+    name: options.name,
+    model: options.model,
+    modelParameters: options.modelParameters,
+    input: options.input,
+    metadata: options.metadata,
+  })
+
   const langfuse = getLangfuse()
   if (!langfuse) return null
 
@@ -307,6 +363,16 @@ export function endLLMGeneration(
     statusMessage?: string
   }
 ): void {
+  appendLocalTraceEvent({
+    type: "generation.end",
+    generationId,
+    output: options.output,
+    usage: options.usage,
+    metadata: options.metadata,
+    level: options.level,
+    statusMessage: options.statusMessage,
+  })
+
   const generation = activeGenerations.get(generationId)
   if (!generation) return
 

--- a/apps/desktop/src/main/local-trace-logger.test.ts
+++ b/apps/desktop/src/main/local-trace-logger.test.ts
@@ -37,15 +37,23 @@ describe("local-trace-logger", () => {
     expect(mod.isLocalTraceLoggingEnabled()).toBe(false)
     mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
 
-    const expected = path.join(tempDir, "traces", "traces.jsonl")
+    const expected = path.join(tempDir, "traces", "t1.jsonl")
     expect(fs.existsSync(expected)).toBe(false)
   })
 
-  it("appends JSONL lines to the default path when enabled", async () => {
+  it("appends JSONL lines to a per-session default path when enabled", async () => {
     const mod = await import("./local-trace-logger")
     currentConfig = { localTraceLoggingEnabled: true }
 
     mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
+    mod.appendLocalTraceEvent({
+      type: "generation.start",
+      traceId: "t1",
+      generationId: "g1",
+      name: "LLM",
+      model: "test-model",
+      input: "hello",
+    })
     mod.appendLocalTraceEvent({
       type: "generation.end",
       generationId: "g1",
@@ -53,33 +61,64 @@ describe("local-trace-logger", () => {
       usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
     })
 
-    const expected = path.join(tempDir, "traces", "traces.jsonl")
+    const expected = path.join(tempDir, "traces", "t1.jsonl")
     expect(fs.existsSync(expected)).toBe(true)
 
     const lines = fs.readFileSync(expected, "utf8").trim().split("\n")
-    expect(lines).toHaveLength(2)
+    expect(lines).toHaveLength(3)
 
     const first = JSON.parse(lines[0])
     expect(first.type).toBe("trace.start")
     expect(first.traceId).toBe("t1")
     expect(typeof first.timestamp).toBe("string")
 
-    const second = JSON.parse(lines[1])
-    expect(second.type).toBe("generation.end")
-    expect(second.usage.totalTokens).toBe(15)
+    const third = JSON.parse(lines[2])
+    expect(third.type).toBe("generation.end")
+    expect(third.traceId).toBe("t1")
+    expect(third.usage.totalTokens).toBe(15)
   })
 
-  it("honours a custom localTraceLogPath", async () => {
-    const customPath = path.join(tempDir, "custom", "agent-traces.jsonl")
+  it("writes separate files for separate trace IDs", async () => {
+    const mod = await import("./local-trace-logger")
+    currentConfig = { localTraceLoggingEnabled: true }
+
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "session/one", name: "One" })
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "session:two", name: "Two" })
+
+    const firstPath = path.join(tempDir, "traces", "session_one.jsonl")
+    const secondPath = path.join(tempDir, "traces", "session_two.jsonl")
+
+    expect(fs.existsSync(firstPath)).toBe(true)
+    expect(fs.existsSync(secondPath)).toBe(true)
+    expect(JSON.parse(fs.readFileSync(firstPath, "utf8").trim()).name).toBe("One")
+    expect(JSON.parse(fs.readFileSync(secondPath, "utf8").trim()).name).toBe("Two")
+  })
+
+  it("honours a custom localTraceLogPath as a trace directory", async () => {
+    const customPath = path.join(tempDir, "custom")
     currentConfig = { localTraceLoggingEnabled: true, localTraceLogPath: customPath }
 
     const mod = await import("./local-trace-logger")
     mod.resetLocalTraceLogger()
-    mod.appendLocalTraceEvent({ type: "span.start", spanId: "s1", name: "tool" })
+    mod.appendLocalTraceEvent({ type: "span.start", traceId: "t1", spanId: "s1", name: "tool" })
 
-    expect(fs.existsSync(customPath)).toBe(true)
-    const line = JSON.parse(fs.readFileSync(customPath, "utf8").trim())
+    const expected = path.join(customPath, "t1.jsonl")
+    expect(fs.existsSync(expected)).toBe(true)
+    const line = JSON.parse(fs.readFileSync(expected, "utf8").trim())
     expect(line.type).toBe("span.start")
+    expect(line.traceId).toBe("t1")
     expect(line.spanId).toBe("s1")
+  })
+
+  it("uses the parent directory when custom localTraceLogPath is a legacy jsonl file path", async () => {
+    const legacyFilePath = path.join(tempDir, "custom", "agent-traces.jsonl")
+    currentConfig = { localTraceLoggingEnabled: true, localTraceLogPath: legacyFilePath }
+
+    const mod = await import("./local-trace-logger")
+    mod.resetLocalTraceLogger()
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
+
+    expect(fs.existsSync(path.join(tempDir, "custom", "t1.jsonl"))).toBe(true)
+    expect(fs.existsSync(legacyFilePath)).toBe(false)
   })
 })

--- a/apps/desktop/src/main/local-trace-logger.test.ts
+++ b/apps/desktop/src/main/local-trace-logger.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import fs from "fs"
+import os from "os"
+import path from "path"
+
+let currentConfig: { localTraceLoggingEnabled?: boolean; localTraceLogPath?: string } = {}
+let tempDir: string
+
+vi.mock("./config", () => ({
+  configStore: { get: () => currentConfig },
+  get dataFolder() { return tempDir },
+}))
+vi.mock("./debug", () => ({
+  isDebugLLM: () => false,
+  logLLM: vi.fn(),
+}))
+
+describe("local-trace-logger", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-trace-"))
+    currentConfig = {}
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // best-effort cleanup
+    }
+  })
+
+  it("is a no-op when local logging is disabled", async () => {
+    const mod = await import("./local-trace-logger")
+    currentConfig = { localTraceLoggingEnabled: false }
+
+    expect(mod.isLocalTraceLoggingEnabled()).toBe(false)
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
+
+    const expected = path.join(tempDir, "traces", "traces.jsonl")
+    expect(fs.existsSync(expected)).toBe(false)
+  })
+
+  it("appends JSONL lines to the default path when enabled", async () => {
+    const mod = await import("./local-trace-logger")
+    currentConfig = { localTraceLoggingEnabled: true }
+
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
+    mod.appendLocalTraceEvent({
+      type: "generation.end",
+      generationId: "g1",
+      output: "hello",
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+    })
+
+    const expected = path.join(tempDir, "traces", "traces.jsonl")
+    expect(fs.existsSync(expected)).toBe(true)
+
+    const lines = fs.readFileSync(expected, "utf8").trim().split("\n")
+    expect(lines).toHaveLength(2)
+
+    const first = JSON.parse(lines[0])
+    expect(first.type).toBe("trace.start")
+    expect(first.traceId).toBe("t1")
+    expect(typeof first.timestamp).toBe("string")
+
+    const second = JSON.parse(lines[1])
+    expect(second.type).toBe("generation.end")
+    expect(second.usage.totalTokens).toBe(15)
+  })
+
+  it("honours a custom localTraceLogPath", async () => {
+    const customPath = path.join(tempDir, "custom", "agent-traces.jsonl")
+    currentConfig = { localTraceLoggingEnabled: true, localTraceLogPath: customPath }
+
+    const mod = await import("./local-trace-logger")
+    mod.resetLocalTraceLogger()
+    mod.appendLocalTraceEvent({ type: "span.start", spanId: "s1", name: "tool" })
+
+    expect(fs.existsSync(customPath)).toBe(true)
+    const line = JSON.parse(fs.readFileSync(customPath, "utf8").trim())
+    expect(line.type).toBe("span.start")
+    expect(line.spanId).toBe("s1")
+  })
+})

--- a/apps/desktop/src/main/local-trace-logger.test.ts
+++ b/apps/desktop/src/main/local-trace-logger.test.ts
@@ -60,6 +60,7 @@ describe("local-trace-logger", () => {
       output: "hello",
       usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
     })
+    await mod.flushLocalTraceLogger()
 
     const expected = path.join(tempDir, "traces", "t1.jsonl")
     expect(fs.existsSync(expected)).toBe(true)
@@ -84,6 +85,7 @@ describe("local-trace-logger", () => {
 
     mod.appendLocalTraceEvent({ type: "trace.start", traceId: "session/one", name: "One" })
     mod.appendLocalTraceEvent({ type: "trace.start", traceId: "session:two", name: "Two" })
+    await mod.flushLocalTraceLogger()
 
     const firstPath = path.join(tempDir, "traces", "session_one.jsonl")
     const secondPath = path.join(tempDir, "traces", "session_two.jsonl")
@@ -101,6 +103,7 @@ describe("local-trace-logger", () => {
     const mod = await import("./local-trace-logger")
     mod.resetLocalTraceLogger()
     mod.appendLocalTraceEvent({ type: "span.start", traceId: "t1", spanId: "s1", name: "tool" })
+    await mod.flushLocalTraceLogger()
 
     const expected = path.join(customPath, "t1.jsonl")
     expect(fs.existsSync(expected)).toBe(true)
@@ -117,8 +120,48 @@ describe("local-trace-logger", () => {
     const mod = await import("./local-trace-logger")
     mod.resetLocalTraceLogger()
     mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
+    await mod.flushLocalTraceLogger()
 
     expect(fs.existsSync(path.join(tempDir, "custom", "t1.jsonl"))).toBe(true)
     expect(fs.existsSync(legacyFilePath)).toBe(false)
+  })
+
+  it("uses an updated custom path after reset", async () => {
+    const firstPath = path.join(tempDir, "first")
+    const secondPath = path.join(tempDir, "second")
+    currentConfig = { localTraceLoggingEnabled: true, localTraceLogPath: firstPath }
+
+    const mod = await import("./local-trace-logger")
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "First" })
+    await mod.flushLocalTraceLogger()
+
+    currentConfig = { localTraceLoggingEnabled: true, localTraceLogPath: secondPath }
+    mod.resetLocalTraceLogger()
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t2", name: "Second" })
+    await mod.flushLocalTraceLogger()
+
+    expect(fs.existsSync(path.join(firstPath, "t1.jsonl"))).toBe(true)
+    expect(fs.existsSync(path.join(secondPath, "t2.jsonl"))).toBe(true)
+    expect(fs.existsSync(path.join(firstPath, "t2.jsonl"))).toBe(false)
+  })
+
+  it("recreates the trace directory if it is deleted while running", async () => {
+    const mod = await import("./local-trace-logger")
+    currentConfig = { localTraceLoggingEnabled: true }
+
+    mod.appendLocalTraceEvent({ type: "trace.start", traceId: "t1", name: "Agent" })
+    await mod.flushLocalTraceLogger()
+
+    const tracesDir = path.join(tempDir, "traces")
+    fs.rmSync(tracesDir, { recursive: true, force: true })
+
+    mod.appendLocalTraceEvent({ type: "trace.end", traceId: "t1", output: "done" })
+    await mod.flushLocalTraceLogger()
+
+    const expected = path.join(tracesDir, "t1.jsonl")
+    expect(fs.existsSync(expected)).toBe(true)
+    const line = JSON.parse(fs.readFileSync(expected, "utf8").trim())
+    expect(line.type).toBe("trace.end")
+    expect(line.output).toBe("done")
   })
 })

--- a/apps/desktop/src/main/local-trace-logger.ts
+++ b/apps/desktop/src/main/local-trace-logger.ts
@@ -9,8 +9,8 @@
  * - Disabled by default; controlled by `config.localTraceLoggingEnabled`.
  * - Writes per-session files under `config.localTraceLogPath` if set, otherwise
  *   `<dataFolder>/traces/<traceId>.jsonl`.
- * - Each call appends one JSON object per line. Failures are swallowed and
- *   logged to console — they never block agent execution.
+ * - Each call queues one JSON object per line. Filesystem failures are logged
+ *   asynchronously and never break agent execution.
  * - Independent of Langfuse: works whether the langfuse package is installed
  *   or not, and whether `langfuseEnabled` is true or false.
  */
@@ -50,7 +50,7 @@ export interface LocalTraceEvent {
 }
 
 let resolvedLogDirectory: string | null = null
-const ensuredDirectories = new Set<string>()
+const pendingWrites = new Map<string, Promise<void>>()
 const spanTraceIds = new Map<string, string>()
 const generationTraceIds = new Map<string, string>()
 
@@ -98,16 +98,44 @@ export function getLocalTraceLogPath(traceId?: string): string {
  */
 export function resetLocalTraceLogger(): void {
   resolvedLogDirectory = null
-  ensuredDirectories.clear()
   spanTraceIds.clear()
   generationTraceIds.clear()
 }
 
-function ensureLogDirectory(filePath: string): void {
-  const dir = path.dirname(filePath)
-  if (ensuredDirectories.has(dir)) return
-  fs.mkdirSync(dir, { recursive: true })
-  ensuredDirectories.add(dir)
+export async function flushLocalTraceLogger(): Promise<void> {
+  while (pendingWrites.size > 0) {
+    await Promise.all(Array.from(pendingWrites.values()))
+  }
+}
+
+async function writeLocalTraceEvent(filePath: string, record: LocalTraceEvent): Promise<void> {
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.promises.appendFile(filePath, JSON.stringify(record) + "\n", "utf8")
+
+  if (isDebugLLM()) {
+    logLLM("[LocalTrace] appended", {
+      type: record.type,
+      traceId: record.traceId,
+      path: filePath,
+    })
+  }
+}
+
+function queueLocalTraceWrite(filePath: string, record: LocalTraceEvent): void {
+  const previousWrite = pendingWrites.get(filePath) ?? Promise.resolve()
+  const queuedWrite = previousWrite
+    .catch(() => undefined)
+    .then(() => writeLocalTraceEvent(filePath, record))
+    .catch((error) => {
+      console.error("[LocalTrace] Failed to append event:", error)
+    })
+
+  pendingWrites.set(filePath, queuedWrite)
+  void queuedWrite.finally(() => {
+    if (pendingWrites.get(filePath) === queuedWrite) {
+      pendingWrites.delete(filePath)
+    }
+  })
 }
 
 function resolveConfiguredTraceDirectory(configuredPath: string): string {
@@ -147,32 +175,19 @@ function rememberEventTraceLink(record: LocalTraceEvent): void {
 /**
  * Append one event to the local JSONL trace log. No-op when disabled.
  *
- * Errors are caught and logged to console — local logging must never
- * break agent execution.
+ * Writes are queued asynchronously. Errors are logged to console — local
+ * logging must never break agent execution.
  */
 export function appendLocalTraceEvent(event: Omit<LocalTraceEvent, "timestamp">): void {
   if (!isLocalTraceLoggingEnabled()) return
 
   const traceId = resolveEventTraceId(event)
   const filePath = getLocalTraceLogPath(traceId)
-  try {
-    ensureLogDirectory(filePath)
-    const record: LocalTraceEvent = {
-      ...event,
-      traceId,
-      timestamp: new Date().toISOString(),
-    }
-    fs.appendFileSync(filePath, JSON.stringify(record) + "\n", "utf8")
-    rememberEventTraceLink(record)
-
-    if (isDebugLLM()) {
-      logLLM("[LocalTrace] appended", {
-        type: record.type,
-        traceId: record.traceId,
-        path: filePath,
-      })
-    }
-  } catch (error) {
-    console.error("[LocalTrace] Failed to append event:", error)
+  const record: LocalTraceEvent = {
+    ...event,
+    traceId,
+    timestamp: new Date().toISOString(),
   }
+  rememberEventTraceLink(record)
+  queueLocalTraceWrite(filePath, record)
 }

--- a/apps/desktop/src/main/local-trace-logger.ts
+++ b/apps/desktop/src/main/local-trace-logger.ts
@@ -1,0 +1,129 @@
+/**
+ * Local Trace Logger
+ *
+ * Opt-in local-only trace logging for agent sessions, LLM generations and
+ * tool/MCP spans. Writes events to a JSONL file on disk so users can inspect
+ * traces without running Langfuse Cloud or self-hosting.
+ *
+ * Behaviour:
+ * - Disabled by default; controlled by `config.localTraceLoggingEnabled`.
+ * - Writes to `config.localTraceLogPath` if set, otherwise
+ *   `<dataFolder>/traces/traces.jsonl`.
+ * - Each call appends one JSON object per line. Failures are swallowed and
+ *   logged to console — they never block agent execution.
+ * - Independent of Langfuse: works whether the langfuse package is installed
+ *   or not, and whether `langfuseEnabled` is true or false.
+ */
+
+import fs from "fs"
+import path from "path"
+import { configStore, dataFolder } from "./config"
+import { isDebugLLM, logLLM } from "./debug"
+
+export type LocalTraceEventType =
+  | "trace.start"
+  | "trace.end"
+  | "generation.start"
+  | "generation.end"
+  | "span.start"
+  | "span.end"
+
+export interface LocalTraceEvent {
+  type: LocalTraceEventType
+  timestamp: string
+  traceId?: string
+  generationId?: string
+  spanId?: string
+  name?: string
+  model?: string
+  modelParameters?: Record<string, unknown>
+  input?: unknown
+  output?: unknown
+  metadata?: Record<string, unknown>
+  usage?: {
+    promptTokens?: number
+    completionTokens?: number
+    totalTokens?: number
+  }
+  level?: "DEBUG" | "DEFAULT" | "WARNING" | "ERROR"
+  statusMessage?: string
+}
+
+let resolvedLogPath: string | null = null
+let directoryEnsured = false
+
+/**
+ * Whether local trace logging is opted into via config.
+ */
+export function isLocalTraceLoggingEnabled(): boolean {
+  try {
+    const config = configStore.get()
+    return config.localTraceLoggingEnabled === true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Resolve the path traces should be written to.
+ * Honours `config.localTraceLogPath` if set, otherwise falls back to
+ * `<dataFolder>/traces/traces.jsonl`.
+ */
+export function getLocalTraceLogPath(): string {
+  if (resolvedLogPath) return resolvedLogPath
+  let configured: string | undefined
+  try {
+    configured = configStore.get().localTraceLogPath
+  } catch {
+    configured = undefined
+  }
+  resolvedLogPath = configured && configured.trim().length > 0
+    ? configured
+    : path.join(dataFolder, "traces", "traces.jsonl")
+  return resolvedLogPath
+}
+
+/**
+ * Reset the cached log path. Call when configuration changes.
+ */
+export function resetLocalTraceLogger(): void {
+  resolvedLogPath = null
+  directoryEnsured = false
+}
+
+function ensureLogDirectory(filePath: string): void {
+  if (directoryEnsured) return
+  const dir = path.dirname(filePath)
+  fs.mkdirSync(dir, { recursive: true })
+  directoryEnsured = true
+}
+
+/**
+ * Append one event to the local JSONL trace log. No-op when disabled.
+ *
+ * Errors are caught and logged to console — local logging must never
+ * break agent execution.
+ */
+export function appendLocalTraceEvent(event: Omit<LocalTraceEvent, "timestamp">): void {
+  if (!isLocalTraceLoggingEnabled()) return
+
+  const filePath = getLocalTraceLogPath()
+  try {
+    ensureLogDirectory(filePath)
+    const record: LocalTraceEvent = {
+      ...event,
+      timestamp: new Date().toISOString(),
+    }
+    fs.appendFileSync(filePath, JSON.stringify(record) + "\n", "utf8")
+
+    if (isDebugLLM()) {
+      logLLM("[LocalTrace] appended", {
+        type: record.type,
+        traceId: record.traceId,
+        path: filePath,
+      })
+    }
+  } catch (error) {
+    console.error("[LocalTrace] Failed to append event:", error)
+  }
+}

--- a/apps/desktop/src/main/local-trace-logger.ts
+++ b/apps/desktop/src/main/local-trace-logger.ts
@@ -2,13 +2,13 @@
  * Local Trace Logger
  *
  * Opt-in local-only trace logging for agent sessions, LLM generations and
- * tool/MCP spans. Writes events to a JSONL file on disk so users can inspect
- * traces without running Langfuse Cloud or self-hosting.
+ * tool/MCP spans. Writes each trace/session to its own JSONL file on disk so
+ * users can inspect traces without running Langfuse Cloud or self-hosting.
  *
  * Behaviour:
  * - Disabled by default; controlled by `config.localTraceLoggingEnabled`.
- * - Writes to `config.localTraceLogPath` if set, otherwise
- *   `<dataFolder>/traces/traces.jsonl`.
+ * - Writes per-session files under `config.localTraceLogPath` if set, otherwise
+ *   `<dataFolder>/traces/<traceId>.jsonl`.
  * - Each call appends one JSON object per line. Failures are swallowed and
  *   logged to console — they never block agent execution.
  * - Independent of Langfuse: works whether the langfuse package is installed
@@ -49,8 +49,10 @@ export interface LocalTraceEvent {
   statusMessage?: string
 }
 
-let resolvedLogPath: string | null = null
-let directoryEnsured = false
+let resolvedLogDirectory: string | null = null
+const ensuredDirectories = new Set<string>()
+const spanTraceIds = new Map<string, string>()
+const generationTraceIds = new Map<string, string>()
 
 /**
  * Whether local trace logging is opted into via config.
@@ -65,37 +67,81 @@ export function isLocalTraceLoggingEnabled(): boolean {
 }
 
 /**
- * Resolve the path traces should be written to.
+ * Resolve the directory traces should be written to.
  * Honours `config.localTraceLogPath` if set, otherwise falls back to
- * `<dataFolder>/traces/traces.jsonl`.
+ * `<dataFolder>/traces`.
  */
-export function getLocalTraceLogPath(): string {
-  if (resolvedLogPath) return resolvedLogPath
+export function getLocalTraceLogDirectory(): string {
+  if (resolvedLogDirectory) return resolvedLogDirectory
   let configured: string | undefined
   try {
     configured = configStore.get().localTraceLogPath
   } catch {
     configured = undefined
   }
-  resolvedLogPath = configured && configured.trim().length > 0
-    ? configured
-    : path.join(dataFolder, "traces", "traces.jsonl")
-  return resolvedLogPath
+  resolvedLogDirectory = configured && configured.trim().length > 0
+    ? resolveConfiguredTraceDirectory(configured)
+    : path.join(dataFolder, "traces")
+  return resolvedLogDirectory
+}
+
+/**
+ * Resolve the per-session JSONL path for a trace ID.
+ */
+export function getLocalTraceLogPath(traceId?: string): string {
+  const fileName = `${sanitizeTraceFileName(traceId || "unlinked")}.jsonl`
+  return path.join(getLocalTraceLogDirectory(), fileName)
 }
 
 /**
  * Reset the cached log path. Call when configuration changes.
  */
 export function resetLocalTraceLogger(): void {
-  resolvedLogPath = null
-  directoryEnsured = false
+  resolvedLogDirectory = null
+  ensuredDirectories.clear()
+  spanTraceIds.clear()
+  generationTraceIds.clear()
 }
 
 function ensureLogDirectory(filePath: string): void {
-  if (directoryEnsured) return
   const dir = path.dirname(filePath)
+  if (ensuredDirectories.has(dir)) return
   fs.mkdirSync(dir, { recursive: true })
-  directoryEnsured = true
+  ensuredDirectories.add(dir)
+}
+
+function resolveConfiguredTraceDirectory(configuredPath: string): string {
+  const trimmed = configuredPath.trim()
+  return path.extname(trimmed).toLowerCase() === ".jsonl"
+    ? path.dirname(trimmed)
+    : trimmed
+}
+
+function sanitizeTraceFileName(traceId: string): string {
+  const sanitized = traceId.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 180)
+  return sanitized || "unlinked"
+}
+
+function resolveEventTraceId(event: Omit<LocalTraceEvent, "timestamp">): string | undefined {
+  if (event.traceId) return event.traceId
+  if (event.spanId) return spanTraceIds.get(event.spanId)
+  if (event.generationId) return generationTraceIds.get(event.generationId)
+  return undefined
+}
+
+function rememberEventTraceLink(record: LocalTraceEvent): void {
+  if (record.traceId && record.spanId && record.type === "span.start") {
+    spanTraceIds.set(record.spanId, record.traceId)
+  }
+  if (record.traceId && record.generationId && record.type === "generation.start") {
+    generationTraceIds.set(record.generationId, record.traceId)
+  }
+  if (record.spanId && record.type === "span.end") {
+    spanTraceIds.delete(record.spanId)
+  }
+  if (record.generationId && record.type === "generation.end") {
+    generationTraceIds.delete(record.generationId)
+  }
 }
 
 /**
@@ -107,14 +153,17 @@ function ensureLogDirectory(filePath: string): void {
 export function appendLocalTraceEvent(event: Omit<LocalTraceEvent, "timestamp">): void {
   if (!isLocalTraceLoggingEnabled()) return
 
-  const filePath = getLocalTraceLogPath()
+  const traceId = resolveEventTraceId(event)
+  const filePath = getLocalTraceLogPath(traceId)
   try {
     ensureLogDirectory(filePath)
     const record: LocalTraceEvent = {
       ...event,
+      traceId,
       timestamp: new Date().toISOString(),
     }
     fs.appendFileSync(filePath, JSON.stringify(record) + "\n", "utf8")
+    rememberEventTraceLink(record)
 
     if (isDebugLLM()) {
       logLLM("[LocalTrace] appended", {

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2874,21 +2874,27 @@ export const router = {
         // lifecycle is best-effort
       }
 
-      // Reinitialize Langfuse if any Langfuse config fields changed
-      // This ensures config changes take effect without requiring app restart
+      // Reinitialize observability helpers if their config fields changed.
+      // This ensures config changes take effect without requiring app restart.
       try {
         const langfuseConfigChanged =
           (prev as any)?.langfuseEnabled !== (merged as any)?.langfuseEnabled ||
           (prev as any)?.langfuseSecretKey !== (merged as any)?.langfuseSecretKey ||
           (prev as any)?.langfusePublicKey !== (merged as any)?.langfusePublicKey ||
           (prev as any)?.langfuseBaseUrl !== (merged as any)?.langfuseBaseUrl
+        const localTraceConfigChanged =
+          (prev as any)?.localTraceLoggingEnabled !== (merged as any)?.localTraceLoggingEnabled ||
+          (prev as any)?.localTraceLogPath !== (merged as any)?.localTraceLogPath
 
         if (langfuseConfigChanged) {
           const { reinitializeLangfuse } = await import("./langfuse-service")
           reinitializeLangfuse()
+        } else if (localTraceConfigChanged) {
+          const { resetLocalTraceLogger } = await import("./local-trace-logger")
+          resetLocalTraceLogger()
         }
       } catch (_e) {
-        // Langfuse reinitialization is best-effort
+        // Observability reinitialization is best-effort
       }
     }),
 

--- a/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
@@ -125,6 +125,13 @@ function findMaxIterationsInput(node: any) {
   )
 }
 
+function findControlByLabel(node: any, label: string) {
+  return findNode(
+    node,
+    candidate => candidate.type === "Control" && candidate.props?.label === label,
+  )
+}
+
 const GROQ_STT_PROMPT_PLACEHOLDER = "Optional prompt to guide the model's style or specify how to spell unfamiliar words (limited to 224 tokens)"
 
 async function flushPromises() {
@@ -140,6 +147,7 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   const mutate = vi.fn()
   let currentConfig: any = {
     langfuseEnabled: true,
+    localTraceLoggingEnabled: false,
     langfusePublicKey: "pk-lf-old",
     langfuseSecretKey: "sk-lf-old",
     langfuseBaseUrl: "",
@@ -264,6 +272,29 @@ afterEach(() => {
 })
 
 describe("desktop general settings draft behavior", () => {
+  it("saves the local trace logging toggle from general settings", async () => {
+    const runtime = createHookRuntime()
+    const { Component, mutate, getCurrentConfig } = await loadSettingsGeneral(runtime)
+
+    const tree = runtime.render(Component, {} as any)
+    runtime.commitEffects()
+    await flushPromises()
+
+    const localTraceLoggingControl = findControlByLabel(tree, "Local trace logging")
+    expect(localTraceLoggingControl).toBeTruthy()
+    const toggle = findNode(localTraceLoggingControl, candidate => candidate.type === "Switch")
+    expect(toggle.props.checked).toBe(false)
+
+    toggle.props.onCheckedChange(true)
+
+    expect(mutate).toHaveBeenCalledWith({
+      config: {
+        ...getCurrentConfig(),
+        localTraceLoggingEnabled: true,
+      },
+    })
+  })
+
   it("keeps the public key draft local, debounces saves, and merges with the latest config", async () => {
     const runtime = createHookRuntime()
     const { Component, mutate, setConfig, getCurrentConfig } = await loadSettingsGeneral(runtime)

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -1356,15 +1356,15 @@ export function Component() {
           </Control>
         </ControlGroup>
 
-        {/* Langfuse Observability */}
+        {/* Observability */}
         <ControlGroup
           collapsible
           defaultCollapsed
-          title="Langfuse Observability"
+          title="Observability"
           forceOpen={isSearching}
           endDescription={(
             <div className="break-words whitespace-normal">
-              Optional tracing for LLM calls, agent sessions, and tools.{" "}
+              Optional tracing for LLM calls, agent sessions, and tools. Send traces to Langfuse or keep them local as JSONL logs.{" "}
               <a
                 href="https://langfuse.com"
                 target="_blank"
@@ -1377,7 +1377,32 @@ export function Component() {
             </div>
           )}
         >
-          <Control label="Enable tracing" className="px-3">
+          <Control
+            label={(
+              <ControlLabel
+                label="Local trace logging"
+                tooltip="Write each agent session trace to its own local JSONL file on this device. Independent of Langfuse Cloud."
+              />
+            )}
+            className="px-3"
+          >
+            <Switch
+              checked={configQuery.data?.localTraceLoggingEnabled ?? false}
+              onCheckedChange={(value) => {
+                saveConfig({ localTraceLoggingEnabled: value })
+              }}
+            />
+          </Control>
+
+          <Control
+            label={(
+              <ControlLabel
+                label="Langfuse tracing"
+                tooltip="Send traces to Langfuse Cloud or a self-hosted Langfuse instance."
+              />
+            )}
+            className="px-3"
+          >
             <Switch
               checked={configQuery.data?.langfuseEnabled ?? false}
               disabled={!isLangfuseInstalled}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1407,12 +1407,12 @@ export type Config = {
   langfuseSecretKey?: string
   langfuseBaseUrl?: string // Default: https://cloud.langfuse.com (or custom self-hosted URL)
 
-  // Local Trace Logging — opt-in JSONL log on disk (independent of Langfuse Cloud)
-  // When enabled, agent traces, generations and tool spans are appended to a
-  // local JSONL file. Useful when Langfuse Cloud free-tier limits would block
+  // Local Trace Logging — opt-in JSONL logs on disk (independent of Langfuse Cloud)
+  // When enabled, each agent trace/session is appended to its own local JSONL
+  // file. Useful when Langfuse Cloud free-tier limits would block
   // capture and the user only wants local logs for debugging.
   localTraceLoggingEnabled?: boolean
-  localTraceLogPath?: string // Default: <dataFolder>/traces/traces.jsonl
+  localTraceLogPath?: string // Default directory: <dataFolder>/traces
 
   // Repeat Tasks Configuration
   loops?: LoopConfig[]  // Scheduled repeat tasks that run at intervals

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1407,6 +1407,13 @@ export type Config = {
   langfuseSecretKey?: string
   langfuseBaseUrl?: string // Default: https://cloud.langfuse.com (or custom self-hosted URL)
 
+  // Local Trace Logging — opt-in JSONL log on disk (independent of Langfuse Cloud)
+  // When enabled, agent traces, generations and tool spans are appended to a
+  // local JSONL file. Useful when Langfuse Cloud free-tier limits would block
+  // capture and the user only wants local logs for debugging.
+  localTraceLoggingEnabled?: boolean
+  localTraceLogPath?: string // Default: <dataFolder>/traces/traces.jsonl
+
   // Repeat Tasks Configuration
   loops?: LoopConfig[]  // Scheduled repeat tasks that run at intervals
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -367,8 +367,8 @@ const getConfig = (): LoadedConfig => {
     langfuseBaseUrl: undefined, // Uses cloud.langfuse.com by default
 
     // Local trace logging - disabled by default
-    // When enabled, agent traces are appended as JSONL to a local file
-    // (default: <dataFolder>/traces/traces.jsonl). Independent of Langfuse Cloud.
+    // When enabled, each agent trace/session is appended as JSONL to its own file
+    // (default directory: <dataFolder>/traces). Independent of Langfuse Cloud.
     localTraceLoggingEnabled: false,
     localTraceLogPath: undefined,
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -366,6 +366,12 @@ const getConfig = (): LoadedConfig => {
     langfuseSecretKey: undefined,
     langfuseBaseUrl: undefined, // Uses cloud.langfuse.com by default
 
+    // Local trace logging - disabled by default
+    // When enabled, agent traces are appended as JSONL to a local file
+    // (default: <dataFolder>/traces/traces.jsonl). Independent of Langfuse Cloud.
+    localTraceLoggingEnabled: false,
+    localTraceLogPath: undefined,
+
     // Dual-Model Agent Mode defaults
     dualModelEnabled: false,
     dualModelSummarizationFrequency: "every_response",

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -401,7 +401,7 @@ export interface Settings {
   langfuseSecretKey?: string;
   langfuseBaseUrl?: string;
 
-  // Local Trace Logging — opt-in JSONL log on disk (independent of Langfuse Cloud)
+  // Local Trace Logging — opt-in per-session JSONL logs on disk (independent of Langfuse Cloud)
   localTraceLoggingEnabled?: boolean;
   localTraceLogPath?: string;
 
@@ -533,7 +533,7 @@ export interface SettingsUpdate {
   langfuseSecretKey?: string;
   langfuseBaseUrl?: string;
 
-  // Local Trace Logging — opt-in JSONL log on disk (independent of Langfuse Cloud)
+  // Local Trace Logging — opt-in per-session JSONL logs on disk (independent of Langfuse Cloud)
   localTraceLoggingEnabled?: boolean;
   localTraceLogPath?: string;
 

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -401,6 +401,10 @@ export interface Settings {
   langfuseSecretKey?: string;
   langfuseBaseUrl?: string;
 
+  // Local Trace Logging — opt-in JSONL log on disk (independent of Langfuse Cloud)
+  localTraceLoggingEnabled?: boolean;
+  localTraceLogPath?: string;
+
   // Dual-Model Settings
   dualModelEnabled?: boolean;
 
@@ -528,6 +532,10 @@ export interface SettingsUpdate {
   langfusePublicKey?: string;
   langfuseSecretKey?: string;
   langfuseBaseUrl?: string;
+
+  // Local Trace Logging — opt-in JSONL log on disk (independent of Langfuse Cloud)
+  localTraceLoggingEnabled?: boolean;
+  localTraceLogPath?: string;
 
   // Dual-Model Settings
   dualModelEnabled?: boolean;


### PR DESCRIPTION
## Summary
Adds an opt-in local trace logger so users can capture agent traces to disk
without sending them to Langfuse Cloud (closes #424).

- New `apps/desktop/src/main/local-trace-logger.ts`: a tiny module that
  appends one JSON object per line to a configurable path. Errors are
  caught and never block agent execution.
- Wired into `langfuse-service.ts`: every `createAgentTrace` /
  `endAgentTrace` / `createLLMGeneration` / `endLLMGeneration` /
  `createToolSpan` / `endToolSpan` call now mirrors the event to the
  local logger when local logging is enabled. The Langfuse Cloud path
  is unchanged.
- Two new config fields: `localTraceLoggingEnabled` (default `false`)
  and `localTraceLogPath` (default `<dataFolder>/traces/traces.jsonl`).
  Added to `Config` (desktop), `Config` defaults (`packages/core`), and
  `Config` / `SettingsUpdate` API types in `@dotagents/shared`.
- Independent of the optional `langfuse` package — local logging works
  whether or not Langfuse is installed or enabled.

## Behaviour
- Disabled by default. No file is created until the toggle is on.
- `~/.dotagents/traces/traces.jsonl` (or platform equivalent) by default;
  user can override with `localTraceLogPath`.
- Append-friendly JSONL: one event per line, easy to `tail -f` /
  `jq`-inspect.
- `reinitializeLangfuse()` now also resets the cached log path so config
  changes apply immediately.

## Test plan
- [x] New unit tests in `apps/desktop/src/main/local-trace-logger.test.ts`
  cover: disabled = no file, enabled = JSONL appended to default path,
  custom `localTraceLogPath` honoured. All 3 pass.
- [x] `pnpm typecheck` (node + web) passes.
- [x] Existing test suite has the same 5 pre-existing unrelated failures
  before and after this change (verified by stash/run/restore).
- [ ] Manual: enable in settings, run an agent session, inspect
  `traces.jsonl` for `trace.start` / `generation.*` / `span.*` /
  `trace.end` records.

https://claude.ai/code/session_013Age5wn2L5dLLX7AMRLpeh

---
_Generated by [Claude Code](https://claude.ai/code/session_013Age5wn2L5dLLX7AMRLpeh)_