### PR TITLE
Fix streamed response disappearing during verification

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -324,6 +324,41 @@ afterEach(() => {
 })
 
 describe("agent progress response history", () => {
+  it("keeps the completed streamed response visible while verification is running", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const progress = {
+      sessionId: "session-verifying-stream",
+      conversationId: "conversation-verifying-stream",
+      currentIteration: 1,
+      maxIterations: 2,
+      steps: [
+        {
+          id: "verify-1",
+          type: "thinking",
+          title: "Verifying completion",
+          status: "in_progress",
+          timestamp: 200,
+        },
+      ],
+      isComplete: false,
+      finalContent: "",
+      conversationHistory: [
+        { role: "user", content: "Question", timestamp: 100 },
+      ],
+      streamingContent: {
+        text: "Streamed answer awaiting verification",
+        isStreaming: false,
+      },
+    }
+
+    const tree = runtime.render(AgentProgress, { progress })
+    const text = getTextContent(tree)
+
+    expect(text).toContain("Streamed answer awaiting verification")
+    expect(text).toContain("Response")
+  })
+
   it("keeps unresolved mid-turn responses in chronological order within the conversation", async () => {
     const runtime = createHookRuntime()
     const { AgentProgress } = await loadAgentProgress(runtime)

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -3900,7 +3900,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       })
     }
 
-    if (progress.streamingContent?.isStreaming && progress.streamingContent.text) {
+    if (!progress.isComplete && progress.streamingContent?.text) {
       let latestAssistantText: (typeof enrichedMessages)[number] | undefined
       for (let i = enrichedMessages.length - 1; i >= 0; i--) {
         const message = enrichedMessages[i]


### PR DESCRIPTION
## Summary
- keep the completed streamed response visible while the agent is still verifying/finalizing
- preserve existing de-dupe behavior once the response lands in conversation history
- add a renderer regression test for the verification gap

## Tests
- pnpm exec vitest run src/renderer/src/components/agent-progress.response-history.test.ts
- pnpm --filter @dotagents/desktop typecheck:web