### PR TITLE
Limit sidebar sessions to five by default

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
@@ -91,6 +91,15 @@ describe("active agents sidebar task section", () => {
     expect(sidebarSource).toContain("mt-1 space-y-0.5 overflow-visible")
   })
 
+  it("defaults regular sessions to five rows and only expands from the explicit show more action", () => {
+    expect(sidebarSource).toContain("const DEFAULT_VISIBLE_SIDEBAR_SESSIONS = 5")
+    expect(sidebarSource).toContain("const SIDEBAR_PAST_SESSIONS_PAGE_SIZE = 5")
+    expect(sidebarSource).toContain("DEFAULT_VISIBLE_SIDEBAR_SESSIONS - activeUserSidebarSessionCount")
+    expect(sidebarSource).toContain("prev > 0 ? prev : defaultSavedConversationRows")
+    expect(sidebarSource).not.toContain("handleSidebarSessionsScroll")
+    expect(sidebarSource).not.toContain("onScroll=")
+  })
+
   it("renders show less to the right of show more", () => {
     const showMoreIndex = sidebarSource.indexOf("Show more")
     const showLessIndex = sidebarSource.indexOf("Show less")

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -160,8 +160,8 @@ function isAnalyzingOrPlanningProgress(progress?: AgentProgressUpdate | null): b
   return activeStepText.includes("analyzing") || activeStepText.includes("planning")
 }
 
-const MIN_VISIBLE_SIDEBAR_SESSIONS = 8
-const SIDEBAR_PAST_SESSIONS_PAGE_SIZE = 10
+const DEFAULT_VISIBLE_SIDEBAR_SESSIONS = 5
+const SIDEBAR_PAST_SESSIONS_PAGE_SIZE = 5
 
 const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac")
 const SHORTCUT_MOD_SYMBOL = IS_MAC ? "⌘" : "Ctrl"
@@ -511,17 +511,17 @@ export function ActiveAgentsSidebar({
     [allUserSidebarSessions],
   )
 
-  const minimumSavedConversationRowsNeeded = useMemo(
-    () => Math.max(MIN_VISIBLE_SIDEBAR_SESSIONS - activeUserSidebarSessionCount, 0),
+  const defaultSavedConversationRows = useMemo(
+    () => Math.max(DEFAULT_VISIBLE_SIDEBAR_SESSIONS - activeUserSidebarSessionCount, 0),
     [activeUserSidebarSessionCount],
   )
 
-  const displayedSavedConversationCount = Math.max(
-    visibleSavedConversationCount,
-    minimumSavedConversationRowsNeeded,
-  )
+  const displayedSavedConversationCount =
+    visibleSavedConversationCount > 0
+      ? visibleSavedConversationCount
+      : defaultSavedConversationRows
   const canShowLessSavedConversations =
-    visibleSavedConversationCount > minimumSavedConversationRowsNeeded
+    visibleSavedConversationCount > defaultSavedConversationRows
 
   const {
     visibleEntries: userSidebarSessions,
@@ -587,12 +587,6 @@ export function ActiveAgentsSidebar({
   )
 
   const hasAnySessions = sidebarSessions.length > 0
-
-  useEffect(() => {
-    setVisibleSavedConversationCount((prev) =>
-      Math.max(prev, minimumSavedConversationRowsNeeded),
-    )
-  }, [minimumSavedConversationRowsNeeded])
 
   useEffect(() => {
     logStateChange("ActiveAgentsSidebar", "isExpanded", !isExpanded, isExpanded)
@@ -867,41 +861,23 @@ export function ActiveAgentsSidebar({
 
   const loadMoreSavedConversations = useCallback(() => {
     setVisibleSavedConversationCount((prev) =>
-      Math.max(prev, minimumSavedConversationRowsNeeded) +
+      (prev > 0 ? prev : defaultSavedConversationRows) +
         SIDEBAR_PAST_SESSIONS_PAGE_SIZE,
     )
-  }, [minimumSavedConversationRowsNeeded])
+  }, [defaultSavedConversationRows])
 
   const showLessSavedConversations = useCallback(() => {
-    setVisibleSavedConversationCount((prev) =>
-      Math.max(
-        prev - SIDEBAR_PAST_SESSIONS_PAGE_SIZE,
-        minimumSavedConversationRowsNeeded,
-      ),
-    )
-  }, [minimumSavedConversationRowsNeeded])
+    setVisibleSavedConversationCount((prev) => {
+      const next = prev - SIDEBAR_PAST_SESSIONS_PAGE_SIZE
+      return next > defaultSavedConversationRows ? next : 0
+    })
+  }, [defaultSavedConversationRows])
 
   const loadMoreTaskConversations = useCallback(() => {
     setVisibleTaskConversationCount((prev) =>
       prev + SIDEBAR_PAST_SESSIONS_PAGE_SIZE,
     )
   }, [])
-
-  const handleSidebarSessionsScroll = useCallback(
-    (e: React.UIEvent<HTMLDivElement>) => {
-      if (!hasMoreSavedConversations) return
-
-      const container = e.currentTarget
-      const nearBottom =
-        container.scrollTop + container.clientHeight >=
-        container.scrollHeight - 32
-
-      if (!nearBottom) return
-
-      loadMoreSavedConversations()
-    },
-    [hasMoreSavedConversations, loadMoreSavedConversations],
-  )
 
   const hasLaunchControls =
     !!onStartTextSession || !!onStartVoiceSession || !!onStartPromptSession
@@ -973,10 +949,7 @@ export function ActiveAgentsSidebar({
       )}
 
       {hasAnySessions && (
-        <div
-          className="mt-1 space-y-0.5 overflow-visible pl-2 pr-1"
-          onScroll={handleSidebarSessionsScroll}
-        >
+        <div className="mt-1 space-y-0.5 overflow-visible pl-2 pr-1">
           {(() => {
             const renderSessionRow = (
               {

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
@@ -475,7 +475,7 @@ describe("dedupeTaskEntriesByTitle", () => {
 })
 
 describe("paginateSidebarEntries", () => {
-  it("always keeps active and pinned entries while paginating unpinned saved entries", () => {
+  it("always keeps active entries while counting pinned saved entries toward the saved limit", () => {
     const entries = [
       { session: { id: "active", conversationId: "active-c" }, isSavedConversation: false },
       { session: { id: "pinned", conversationId: "pinned-c" }, isSavedConversation: true },
@@ -488,23 +488,48 @@ describe("paginateSidebarEntries", () => {
     expect(paginated.visibleEntries.map((entry) => entry.session.id)).toEqual([
       "active",
       "pinned",
-      "saved-1",
     ])
     expect(paginated.hasMoreEntries).toBe(true)
   })
 
-  it("keeps saved subagents visible with their pinned parent", () => {
+  it("does not show pinned saved entries when active rows fill the default page", () => {
+    const entries = [
+      { session: { id: "active-1", conversationId: "active-c-1" }, isSavedConversation: false },
+      { session: { id: "active-2", conversationId: "active-c-2" }, isSavedConversation: false },
+      { session: { id: "active-3", conversationId: "active-c-3" }, isSavedConversation: false },
+      { session: { id: "active-4", conversationId: "active-c-4" }, isSavedConversation: false },
+      { session: { id: "active-pin", conversationId: "active-pin-c" }, isSavedConversation: false },
+      { session: { id: "pinned-1", conversationId: "pinned-c-1" }, isSavedConversation: true },
+      { session: { id: "pinned-2", conversationId: "pinned-c-2" }, isSavedConversation: true },
+    ]
+
+    const paginated = paginateSidebarEntries(
+      entries,
+      new Set(["active-pin-c", "pinned-c-1", "pinned-c-2"]),
+      0,
+    )
+
+    expect(paginated.visibleEntries.map((entry) => entry.session.id)).toEqual([
+      "active-1",
+      "active-2",
+      "active-3",
+      "active-4",
+      "active-pin",
+    ])
+    expect(paginated.hasMoreEntries).toBe(true)
+  })
+
+  it("counts saved subagents with their pinned parent against the saved limit", () => {
     const entries = [
       { session: { id: "parent", conversationId: "parent-c" }, isSavedConversation: true },
       { session: { id: "child", parentSessionId: "parent" }, isSavedConversation: true },
       { session: { id: "saved", conversationId: "saved-c" }, isSavedConversation: true },
     ]
 
-    const paginated = paginateSidebarEntries(entries, new Set(["parent-c"]), 0)
+    const paginated = paginateSidebarEntries(entries, new Set(["parent-c"]), 1)
 
     expect(paginated.visibleEntries.map((entry) => entry.session.id)).toEqual([
       "parent",
-      "child",
     ])
     expect(paginated.hasMoreEntries).toBe(true)
   })

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
@@ -152,36 +152,20 @@ export function paginateSidebarEntries<
   T extends { session: ParentSessionLike; isSavedConversation: boolean },
 >(
   entries: T[],
-  pinnedSessionIds: ReadonlySet<string>,
-  visibleUnpinnedSavedEntryCount: number,
+  _pinnedSessionIds: ReadonlySet<string>,
+  visibleSavedEntryCount: number,
 ): { visibleEntries: T[]; hasMoreEntries: boolean } {
-  const pinnedSavedSessionIds = new Set(
-    entries
-      .filter((entry) => {
-        const conversationId = entry.session.conversationId
-        return entry.isSavedConversation && !!conversationId && pinnedSessionIds.has(conversationId)
-      })
-      .map((entry) => entry.session.id),
-  )
-
   const alwaysVisibleEntries: T[] = []
   const pageableEntries: T[] = []
   for (const entry of entries) {
-    const conversationId = entry.session.conversationId
-    const parentSessionId = entry.session.parentSessionId?.trim()
-    const isPinnedSavedEntry =
-      entry.isSavedConversation && !!conversationId && pinnedSessionIds.has(conversationId)
-    const isChildOfPinnedSavedEntry =
-      entry.isSavedConversation && !!parentSessionId && pinnedSavedSessionIds.has(parentSessionId)
-
-    if (!entry.isSavedConversation || isPinnedSavedEntry || isChildOfPinnedSavedEntry) {
+    if (!entry.isSavedConversation) {
       alwaysVisibleEntries.push(entry)
     } else {
       pageableEntries.push(entry)
     }
   }
 
-  const sliceCount = Math.max(visibleUnpinnedSavedEntryCount, 0)
+  const sliceCount = Math.max(visibleSavedEntryCount, 0)
   return {
     visibleEntries: [
       ...alwaysVisibleEntries,


### PR DESCRIPTION
## Summary
- cap the default visible sidebar sessions at five
- prevent scroll from auto-loading more sessions
- count inactive pinned saved sessions toward the saved-session limit so they only appear after Show more

## Tests
- pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/lib/sidebar-sessions.test.ts src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
- pnpm --filter @dotagents/desktop run typecheck:web