### PR TITLE
Fix archive summary goal drift

### DIFF
--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -397,8 +397,9 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(result.appliedStrategies).toContain('archive_frontier')
     expect(result.messages.length).toBeLessThan(messages.length)
 
-    const summaryMessage = result.messages.find((msg) => msg.content.startsWith('[Session Progress Summary]'))
+    const summaryMessage = result.messages.find((msg) => msg.content.startsWith('[Archived Background Summary - not the current task]'))
     expect(summaryMessage).toBeTruthy()
+    expect(summaryMessage?.content).toContain('Prefer later live user messages when deciding what to do now.')
 
     const contextRef = summaryMessage?.content.match(/Context ref: (ctx_[a-z0-9]+)/)?.[1]
     expect(contextRef).toBeTruthy()
@@ -451,7 +452,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(makeTextCompletionWithFetchMock).toHaveBeenCalledTimes(1)
     expect(second.appliedStrategies).toContain('archive_frontier')
     expect(second.messages.length).toBeLessThan(followUpMessages.length)
-    expect(second.messages.some((msg) => msg.content.startsWith('[Session Progress Summary]'))).toBe(true)
+    expect(second.messages.some((msg) => msg.content.startsWith('[Archived Background Summary - not the current task]'))).toBe(true)
   })
 
   it('keeps search-mode excerpts within maxChars even for long queries', async () => {
@@ -588,7 +589,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(makeTextCompletionWithFetchMock).toHaveBeenCalledTimes(1)
     expect(secondPass.messages.length).toBeLessThan(messages.length)
     expect(secondPass.messages.some((msg) => msg.content.includes('live-marker-43'))).toBe(true)
-    expect(secondPass.messages.some((msg) => msg.content.startsWith('[Session Progress Summary]'))).toBe(true)
+    expect(secondPass.messages.some((msg) => msg.content.startsWith('[Archived Background Summary - not the current task]'))).toBe(true)
   })
 
   it('skips microcompact when context is comfortably under budget', async () => {
@@ -621,7 +622,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     const prompts: string[] = []
     makeTextCompletionWithFetchMock.mockImplementation(async (prompt: string) => {
       prompts.push(prompt)
-      if (prompt.includes('Summarize these AI agent conversation messages that are being archived')) {
+      if (prompt.includes('Summarize these AI agent conversation messages as archived background')) {
         return 'archived work summary'
       }
 

--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -86,6 +86,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearArchiveFrontier('session-bracket-log')
     clearArchiveFrontier('session-no-microcompact')
     clearArchiveFrontier('session-archive-reapply')
+    clearArchiveFrontier('session-latest-user')
     clearContextRefs('session-truncate')
     clearContextRefs('session-batch')
     clearContextRefs('session-archive')
@@ -95,6 +96,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearContextRefs('session-bracket-log')
     clearContextRefs('session-no-microcompact')
     clearContextRefs('session-archive-reapply')
+    clearContextRefs('session-latest-user')
     clearActualTokenUsage('session-truncate')
     clearActualTokenUsage('session-batch')
     clearActualTokenUsage('session-archive')
@@ -104,11 +106,13 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearActualTokenUsage('session-bracket-log')
     clearActualTokenUsage('session-no-microcompact')
     clearActualTokenUsage('session-archive-reapply')
+    clearActualTokenUsage('session-latest-user')
     clearIterativeSummary('session-archive')
     clearIterativeSummary('session-live-tail')
     clearIterativeSummary('session-protected-tail')
     clearIterativeSummary('session-no-microcompact')
     clearIterativeSummary('session-archive-reapply')
+    clearIterativeSummary('session-latest-user')
     Object.assign(mockConfig, {
       mcpContextReductionEnabled: true,
       mcpContextTargetRatio: 0.5,
@@ -411,6 +415,43 @@ describe('shrinkMessagesForLLM replacement policy', () => {
       kind: 'archived_history',
     }))
     expect(Number(readResult.messageCount)).toBeGreaterThan(0)
+  })
+
+  it('keeps the latest real user request raw when archive frontier trims tool-heavy history', async () => {
+    makeTextCompletionWithFetchMock.mockResolvedValue('archived work summary')
+    Object.assign(mockConfig, {
+      mcpContextTargetRatio: 0.95,
+      mcpMaxContextTokensOverride: 12000,
+    })
+
+    const oldRequest = 'list as many project names as you can that i have been working on over the past 2 years'
+    const currentRequest = 'can you open in excalidraw in chrome'
+    const messages = [
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: oldRequest },
+      ...Array.from({ length: 12 }, (_, index) => ({
+        role: index % 2 === 0 ? 'assistant' : 'user',
+        content: `older-work-${index} ${'o'.repeat(120)}`,
+      })),
+      { role: 'user', content: currentRequest },
+      ...Array.from({ length: 34 }, (_, index) => ({
+        role: 'user',
+        content: index % 2 === 0
+          ? `[playwright-extension:browser_snapshot] result-${index} ${'t'.repeat(120)}`
+          : `TOOL FAILED: playwright-extension:browser_run_code_unsafe (attempt ${index}/3)`,
+      })),
+    ]
+
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-latest-user',
+      messages,
+      lastNMessages: 3,
+    })
+
+    expect(result.appliedStrategies).toContain('archive_frontier')
+    expect(result.messages.some((msg) => msg.role === 'user' && msg.content === currentRequest)).toBe(true)
+    expect(result.messages.some((msg) => msg.role === 'user' && msg.content === oldRequest)).toBe(false)
+    expect(result.messages.some((msg) => msg.role === 'assistant' && msg.content.includes('[Earlier user request - background only]') && msg.content.includes(oldRequest))).toBe(true)
   })
 
   it('reapplies an existing archive frontier even when too few new messages arrived to advance it', async () => {

--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -56,6 +56,7 @@ vi.mock('./summarization-service', () => ({
 }))
 
 vi.mock('@dotagents/shared', () => ({
+  RESPOND_TO_USER_TOOL: 'respond_to_user',
   sanitizeMessageContentForDisplay: (content: string) => content,
 }))
 
@@ -108,6 +109,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     clearActualTokenUsage('session-archive-reapply')
     clearActualTokenUsage('session-latest-user')
     clearIterativeSummary('session-archive')
+    clearIterativeSummary('session-batch')
     clearIterativeSummary('session-live-tail')
     clearIterativeSummary('session-protected-tail')
     clearIterativeSummary('session-no-microcompact')
@@ -417,7 +419,7 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(Number(readResult.messageCount)).toBeGreaterThan(0)
   })
 
-  it('keeps the latest real user request raw when archive frontier trims tool-heavy history', async () => {
+  it('keeps recent real user request anchors raw when archive frontier trims tool-heavy history', async () => {
     makeTextCompletionWithFetchMock.mockResolvedValue('archived work summary')
     Object.assign(mockConfig, {
       mcpContextTargetRatio: 0.95,
@@ -425,16 +427,22 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     })
 
     const oldRequest = 'list as many project names as you can that i have been working on over the past 2 years'
+    const priorRequest = 'open the map in chrome'
     const currentRequest = 'can you open in excalidraw in chrome'
     const messages = [
       { role: 'system', content: 'system prompt' },
       { role: 'user', content: oldRequest },
       ...Array.from({ length: 12 }, (_, index) => ({
-        role: index % 2 === 0 ? 'assistant' : 'user',
+        role: 'assistant',
         content: `older-work-${index} ${'o'.repeat(120)}`,
       })),
+      { role: 'user', content: priorRequest },
+      ...Array.from({ length: 8 }, (_, index) => ({
+        role: 'user',
+        content: `[execute_command] intermediate tool result ${index} ${'i'.repeat(120)}`,
+      })),
       { role: 'user', content: currentRequest },
-      ...Array.from({ length: 34 }, (_, index) => ({
+      ...Array.from({ length: 26 }, (_, index) => ({
         role: 'user',
         content: index % 2 === 0
           ? `[playwright-extension:browser_snapshot] result-${index} ${'t'.repeat(120)}`
@@ -449,9 +457,9 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     })
 
     expect(result.appliedStrategies).toContain('archive_frontier')
+    expect(result.messages.some((msg) => msg.role === 'user' && msg.content === priorRequest)).toBe(true)
     expect(result.messages.some((msg) => msg.role === 'user' && msg.content === currentRequest)).toBe(true)
     expect(result.messages.some((msg) => msg.role === 'user' && msg.content === oldRequest)).toBe(false)
-    expect(result.messages.some((msg) => msg.role === 'assistant' && msg.content.includes('[Earlier user request - background only]') && msg.content.includes(oldRequest))).toBe(true)
   })
 
   it('reapplies an existing archive frontier even when too few new messages arrived to advance it', async () => {

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -943,6 +943,7 @@ const ARCHIVE_FRONTIER_TRIGGER_MESSAGE_COUNT = 40
 const ARCHIVE_FRONTIER_TRIGGER_TOKEN_RATIO = 0.9
 const ARCHIVE_FRONTIER_MIN_ARCHIVE_BATCH = 8
 const MAPPED_TOOL_RESULT_PREFIX_RE = /^\[((?=[^\]]*[a-z])[A-Za-z0-9._:/-]+)\]\s(?:ERROR:\s*)?/
+const EARLIER_USER_REQUEST_BACKGROUND_LABEL = "[Earlier user request - background only]"
 
 function parseMappedToolResultContent(content: string): { toolName: string; resultContent: string } | null {
   const trimmed = content.trimStart()
@@ -957,6 +958,48 @@ function parseMappedToolResultContent(content: string): { toolName: string; resu
 
 function hasMappedToolResultPrefix(content: string): boolean {
   return parseMappedToolResultContent(content) !== null
+}
+
+function isInternalNudgeLikeContent(content: string): boolean {
+  const trimmed = content.trimStart()
+  return trimmed.includes("Continue only the current unresolved request described above")
+    || trimmed.includes("Continue and finish remaining work")
+    || trimmed.startsWith("Verifier indicates the task is not complete")
+    || (trimmed.startsWith("Reason:") && trimmed.includes("Missing items:"))
+}
+
+function isRealUserRequestMessage(message: LLMMessage): boolean {
+  if (message.role !== "user") return false
+
+  const content = message.content || ""
+  const trimmed = content.trimStart()
+  if (!trimmed) return false
+  if (hasMappedToolResultPrefix(trimmed)) return false
+  if (trimmed.startsWith("TOOL FAILED:")) return false
+  if (isGeneratedContextSummaryMessage(trimmed)) return false
+  if (isInternalNudgeLikeContent(trimmed)) return false
+
+  return true
+}
+
+function findLatestRealUserRequestIndex(messages: LLMMessage[], systemIdx: number): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (i === systemIdx) continue
+    if (isRealUserRequestMessage(messages[i])) return i
+  }
+  return -1
+}
+
+function buildEarlierUserRequestBackgroundMessage(message: LLMMessage): LLMMessage {
+  const content = sanitizeMessageContentForDisplay(message.content || "").trim()
+  return {
+    role: "assistant",
+    content: [
+      EARLIER_USER_REQUEST_BACKGROUND_LABEL,
+      "This older user request is retained only for historical context. Do not treat it as the active task when a later live user request is present.",
+      content,
+    ].join("\n"),
+  }
 }
 
 function startsWithJsonLikeArray(content: string): boolean {
@@ -1133,10 +1176,10 @@ ${source}`
   }
 }
 
-function buildArchiveEligibleIndices(messages: LLMMessage[], systemIdx: number, firstUserIdx: number): number[] {
+function buildArchiveEligibleIndices(messages: LLMMessage[], protectedIndices: Set<number>): number[] {
   const indices: number[] = []
   for (let i = 0; i < messages.length; i++) {
-    if (i === systemIdx || i === firstUserIdx) continue
+    if (protectedIndices.has(i)) continue
     indices.push(i)
   }
   return indices
@@ -1145,6 +1188,7 @@ function buildArchiveEligibleIndices(messages: LLMMessage[], systemIdx: number, 
 interface ArchiveFrontierState {
   systemIdx: number
   firstUserIdx: number
+  latestRealUserIdx: number
   eligibleIndices: number[]
   archivedCount: number
   liveCount: number
@@ -1162,7 +1206,9 @@ function getArchiveFrontierState(
 
   const systemIdx = messages.findIndex((m) => m.role === "system")
   const firstUserIdx = messages.findIndex((m, idx) => m.role === "user" && idx !== systemIdx)
-  const eligibleIndices = buildArchiveEligibleIndices(messages, systemIdx, firstUserIdx)
+  const latestRealUserIdx = findLatestRealUserRequestIndex(messages, systemIdx)
+  const protectedIndices = new Set([systemIdx, firstUserIdx, latestRealUserIdx].filter((idx) => idx >= 0))
+  const eligibleIndices = buildArchiveEligibleIndices(messages, protectedIndices)
   const archivedCount = Math.min(archiveFrontierCountBySession.get(sessionId) ?? 0, eligibleIndices.length)
   const liveCount = Math.max(0, eligibleIndices.length - archivedCount)
   const keepLiveCount = Math.max(lastN, ARCHIVE_FRONTIER_KEEP_LIVE_MESSAGES)
@@ -1171,6 +1217,7 @@ function getArchiveFrontierState(
   return {
     systemIdx,
     firstUserIdx,
+    latestRealUserIdx,
     eligibleIndices,
     archivedCount,
     liveCount,
@@ -1573,6 +1620,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   if (sessionId && shouldApplyArchiveFrontier(archiveFrontierState, messages.length, tokens, targetTokens)) {
     const systemIdx = archiveFrontierState!.systemIdx
     const firstUserIdx = archiveFrontierState!.firstUserIdx
+    const latestRealUserIdx = archiveFrontierState!.latestRealUserIdx
     const eligibleIndices = archiveFrontierState!.eligibleIndices
     const previousArchivedCount = archiveFrontierState!.archivedCount
     const unarchivedIndices = eligibleIndices.slice(previousArchivedCount)
@@ -1596,7 +1644,6 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     if (nextArchivedCount > 0 || iterativeSummaryCache.has(sessionId)) {
       const ordered: LLMMessage[] = []
       if (systemIdx >= 0) ordered.push(messages[systemIdx])
-      if (firstUserIdx >= 0 && firstUserIdx !== systemIdx) ordered.push(messages[firstUserIdx])
 
       const summaryMessage = buildSessionProgressSummaryMessage(sessionId)
       if (summaryMessage) ordered.push(summaryMessage)
@@ -1604,6 +1651,16 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
       const progressSummary = buildContextFromSummaries(sessionId)
       if (progressSummary) {
         ordered.push({ role: "assistant", content: progressSummary })
+      }
+
+      if (firstUserIdx >= 0 && firstUserIdx !== systemIdx) {
+        ordered.push(firstUserIdx === latestRealUserIdx
+          ? messages[firstUserIdx]
+          : buildEarlierUserRequestBackgroundMessage(messages[firstUserIdx]))
+      }
+
+      if (latestRealUserIdx >= 0 && latestRealUserIdx !== systemIdx && latestRealUserIdx !== firstUserIdx) {
+        ordered.push(messages[latestRealUserIdx])
       }
 
       for (const index of eligibleIndices.slice(nextArchivedCount)) {
@@ -1624,6 +1681,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   // Tier 1: Batch-summarize oversized conversational messages.
   // Tool/payload blobs are truncated above and protected from LLM summarization here.
   const firstTierOneProtectedUserIdx = messages.findIndex((m) => m.role === "user")
+  const latestTierOneProtectedUserIdx = findLatestRealUserRequestIndex(messages, -1)
   const recentTierOneProtectedIndices = new Set<number>()
   const truncationProtectedIndices = collectTruncationProtectedIndices(messages)
   for (let k = messages.length - lastN; k < messages.length; k++) {
@@ -1646,6 +1704,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     .filter((x) => !isGeneratedContextSummaryMessage(x.contentForSummary))
     .filter((x) => !truncationProtectedIndices.has(x.i))
     .filter((x) => x.i !== firstTierOneProtectedUserIdx)
+    .filter((x) => x.i !== latestTierOneProtectedUserIdx)
     .filter((x) => !recentTierOneProtectedIndices.has(x.i))
 
   const summaryBatches = buildSummaryBatches(summaryCandidates)
@@ -1701,10 +1760,12 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
 
   const systemIdx = messages.findIndex((m) => m.role === "system")
   const firstUserIdx = messages.findIndex((m, idx) => m.role === "user" && idx !== systemIdx)
+  const latestRealUserIdx = findLatestRealUserRequestIndex(messages, systemIdx)
 
   const keptSet = new Set<number>()
   if (systemIdx >= 0) keptSet.add(systemIdx)
   if (firstUserIdx >= 0) keptSet.add(firstUserIdx)
+  if (latestRealUserIdx >= 0) keptSet.add(latestRealUserIdx)
   // Add indices for last N
   const baseLen = messages.length
   for (let k = baseLen - effectiveLastN; k < baseLen; k++) {
@@ -1743,7 +1804,6 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   // Preserve order: system -> first user -> iterative summary -> tool summary -> (chronological tail)
   const ordered: LLMMessage[] = []
   if (systemIdx >= 0) ordered.push(messages[systemIdx])
-  if (firstUserIdx >= 0 && firstUserIdx !== systemIdx) ordered.push(messages[firstUserIdx])
 
   if (opts.sessionId) {
     const summaryMessage = buildSessionProgressSummaryMessage(opts.sessionId)
@@ -1763,8 +1823,18 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   // Insert tool summary
   if (toolSummaryMessage) ordered.push(toolSummaryMessage)
 
+  if (firstUserIdx >= 0 && firstUserIdx !== systemIdx) {
+    ordered.push(firstUserIdx === latestRealUserIdx
+      ? messages[firstUserIdx]
+      : buildEarlierUserRequestBackgroundMessage(messages[firstUserIdx]))
+  }
+
+  if (latestRealUserIdx >= 0 && latestRealUserIdx !== systemIdx && latestRealUserIdx !== firstUserIdx) {
+    ordered.push(messages[latestRealUserIdx])
+  }
+
   for (let k = baseLen - effectiveLastN; k < baseLen; k++) {
-    if (k >= 0 && k !== systemIdx && k !== firstUserIdx) ordered.push(messages[k])
+    if (k >= 0 && k !== systemIdx && k !== firstUserIdx && k !== latestRealUserIdx) ordered.push(messages[k])
   }
 
   messages = ordered

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -6,6 +6,12 @@ import { constructMinimalSystemPrompt } from "./system-prompts"
 import { agentSessionStateManager } from "./state"
 import { summarizationService } from "./summarization-service"
 import { sanitizeMessageContentForDisplay } from "@dotagents/shared"
+import {
+  collectRecentRealUserRequestIndices,
+  hasMappedToolResultPrefix,
+  isGeneratedContextSummaryContent,
+  MAPPED_TOOL_RESULT_PREFIX_RE,
+} from "./conversation-history-utils"
 
 export type LLMMessage = { role: string; content: string }
 
@@ -942,8 +948,7 @@ const ARCHIVE_FRONTIER_KEEP_LIVE_MESSAGES = 20
 const ARCHIVE_FRONTIER_TRIGGER_MESSAGE_COUNT = 40
 const ARCHIVE_FRONTIER_TRIGGER_TOKEN_RATIO = 0.9
 const ARCHIVE_FRONTIER_MIN_ARCHIVE_BATCH = 8
-const MAPPED_TOOL_RESULT_PREFIX_RE = /^\[((?=[^\]]*[a-z])[A-Za-z0-9._:/-]+)\]\s(?:ERROR:\s*)?/
-const EARLIER_USER_REQUEST_BACKGROUND_LABEL = "[Earlier user request - background only]"
+const RECENT_USER_REQUEST_ANCHOR_COUNT = 2
 
 function parseMappedToolResultContent(content: string): { toolName: string; resultContent: string } | null {
   const trimmed = content.trimStart()
@@ -953,52 +958,6 @@ function parseMappedToolResultContent(content: string): { toolName: string; resu
   return {
     toolName: match[1],
     resultContent: trimmed.slice(match[0].length),
-  }
-}
-
-function hasMappedToolResultPrefix(content: string): boolean {
-  return parseMappedToolResultContent(content) !== null
-}
-
-function isInternalNudgeLikeContent(content: string): boolean {
-  const trimmed = content.trimStart()
-  return trimmed.includes("Continue only the current unresolved request described above")
-    || trimmed.includes("Continue and finish remaining work")
-    || trimmed.startsWith("Verifier indicates the task is not complete")
-    || (trimmed.startsWith("Reason:") && trimmed.includes("Missing items:"))
-}
-
-function isRealUserRequestMessage(message: LLMMessage): boolean {
-  if (message.role !== "user") return false
-
-  const content = message.content || ""
-  const trimmed = content.trimStart()
-  if (!trimmed) return false
-  if (hasMappedToolResultPrefix(trimmed)) return false
-  if (trimmed.startsWith("TOOL FAILED:")) return false
-  if (isGeneratedContextSummaryMessage(trimmed)) return false
-  if (isInternalNudgeLikeContent(trimmed)) return false
-
-  return true
-}
-
-function findLatestRealUserRequestIndex(messages: LLMMessage[], systemIdx: number): number {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (i === systemIdx) continue
-    if (isRealUserRequestMessage(messages[i])) return i
-  }
-  return -1
-}
-
-function buildEarlierUserRequestBackgroundMessage(message: LLMMessage): LLMMessage {
-  const content = sanitizeMessageContentForDisplay(message.content || "").trim()
-  return {
-    role: "assistant",
-    content: [
-      EARLIER_USER_REQUEST_BACKGROUND_LABEL,
-      "This older user request is retained only for historical context. Do not treat it as the active task when a later live user request is present.",
-      content,
-    ].join("\n"),
   }
 }
 
@@ -1124,9 +1083,7 @@ function buildSummaryMessage(batch: SummaryBatch, summary: string, contextRef?: 
 }
 
 function isGeneratedContextSummaryMessage(content: string): boolean {
-  return content.startsWith("[Earlier Context Summary:")
-    || content.startsWith("[Session Progress Summary]")
-    || content.startsWith("[Archived Background Summary")
+  return isGeneratedContextSummaryContent(content)
 }
 
 function buildBatchSummaryFallback(items: SummaryCandidate[]): string {
@@ -1187,8 +1144,7 @@ function buildArchiveEligibleIndices(messages: LLMMessage[], protectedIndices: S
 
 interface ArchiveFrontierState {
   systemIdx: number
-  firstUserIdx: number
-  latestRealUserIdx: number
+  anchorIndices: number[]
   eligibleIndices: number[]
   archivedCount: number
   liveCount: number
@@ -1201,13 +1157,18 @@ function getArchiveFrontierState(
   messages: LLMMessage[],
   sessionId: string | undefined,
   lastN: number,
+  maxAnchorContentChars: number,
 ): ArchiveFrontierState | null {
   if (!sessionId) return null
 
   const systemIdx = messages.findIndex((m) => m.role === "system")
-  const firstUserIdx = messages.findIndex((m, idx) => m.role === "user" && idx !== systemIdx)
-  const latestRealUserIdx = findLatestRealUserRequestIndex(messages, systemIdx)
-  const protectedIndices = new Set([systemIdx, firstUserIdx, latestRealUserIdx].filter((idx) => idx >= 0))
+  const anchorIndices = collectRecentRealUserRequestIndices(
+    messages,
+    RECENT_USER_REQUEST_ANCHOR_COUNT,
+    messages.length,
+    maxAnchorContentChars,
+  )
+  const protectedIndices = new Set([systemIdx, ...anchorIndices].filter((idx) => idx >= 0))
   const eligibleIndices = buildArchiveEligibleIndices(messages, protectedIndices)
   const archivedCount = Math.min(archiveFrontierCountBySession.get(sessionId) ?? 0, eligibleIndices.length)
   const liveCount = Math.max(0, eligibleIndices.length - archivedCount)
@@ -1216,8 +1177,7 @@ function getArchiveFrontierState(
 
   return {
     systemIdx,
-    firstUserIdx,
-    latestRealUserIdx,
+    anchorIndices,
     eligibleIndices,
     archivedCount,
     liveCount,
@@ -1608,7 +1568,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
 
   tokens = scaleTokensWithActual(estimateTokensFromMessages(messages))
 
-  if (tokens <= targetTokens && !shouldApplyArchiveFrontier(getArchiveFrontierState(messages, opts.sessionId, lastN), messages.length, tokens, targetTokens)) {
+  if (tokens <= targetTokens && !shouldApplyArchiveFrontier(getArchiveFrontierState(messages, opts.sessionId, lastN, summarizeThreshold), messages.length, tokens, targetTokens)) {
     if (isDebugLLM()) logLLM("ContextBudget: after microcompact and aggressive_truncate", { estTokens: tokens, count: messages.length })
     return { messages, appliedStrategies: applied, estTokensBefore, estTokensAfter: tokens, maxTokens }
   }
@@ -1616,11 +1576,10 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   // Tier 0c: Archive older raw history behind a rolling summary frontier.
   // This keeps a bounded live tail even when token count is technically under target.
   const sessionId = opts.sessionId
-  const archiveFrontierState = getArchiveFrontierState(messages, sessionId, lastN)
+  const archiveFrontierState = getArchiveFrontierState(messages, sessionId, lastN, summarizeThreshold)
   if (sessionId && shouldApplyArchiveFrontier(archiveFrontierState, messages.length, tokens, targetTokens)) {
     const systemIdx = archiveFrontierState!.systemIdx
-    const firstUserIdx = archiveFrontierState!.firstUserIdx
-    const latestRealUserIdx = archiveFrontierState!.latestRealUserIdx
+    const anchorIndices = archiveFrontierState!.anchorIndices
     const eligibleIndices = archiveFrontierState!.eligibleIndices
     const previousArchivedCount = archiveFrontierState!.archivedCount
     const unarchivedIndices = eligibleIndices.slice(previousArchivedCount)
@@ -1653,14 +1612,8 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
         ordered.push({ role: "assistant", content: progressSummary })
       }
 
-      if (firstUserIdx >= 0 && firstUserIdx !== systemIdx) {
-        ordered.push(firstUserIdx === latestRealUserIdx
-          ? messages[firstUserIdx]
-          : buildEarlierUserRequestBackgroundMessage(messages[firstUserIdx]))
-      }
-
-      if (latestRealUserIdx >= 0 && latestRealUserIdx !== systemIdx && latestRealUserIdx !== firstUserIdx) {
-        ordered.push(messages[latestRealUserIdx])
+      for (const index of anchorIndices) {
+        if (index >= 0 && index !== systemIdx) ordered.push(messages[index])
       }
 
       for (const index of eligibleIndices.slice(nextArchivedCount)) {
@@ -1680,8 +1633,12 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
 
   // Tier 1: Batch-summarize oversized conversational messages.
   // Tool/payload blobs are truncated above and protected from LLM summarization here.
-  const firstTierOneProtectedUserIdx = messages.findIndex((m) => m.role === "user")
-  const latestTierOneProtectedUserIdx = findLatestRealUserRequestIndex(messages, -1)
+  const protectedAnchorIndices = new Set(collectRecentRealUserRequestIndices(
+    messages,
+    RECENT_USER_REQUEST_ANCHOR_COUNT,
+    messages.length,
+    summarizeThreshold,
+  ))
   const recentTierOneProtectedIndices = new Set<number>()
   const truncationProtectedIndices = collectTruncationProtectedIndices(messages)
   for (let k = messages.length - lastN; k < messages.length; k++) {
@@ -1703,8 +1660,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     .filter((x) => x.role !== "tool")
     .filter((x) => !isGeneratedContextSummaryMessage(x.contentForSummary))
     .filter((x) => !truncationProtectedIndices.has(x.i))
-    .filter((x) => x.i !== firstTierOneProtectedUserIdx)
-    .filter((x) => x.i !== latestTierOneProtectedUserIdx)
+    .filter((x) => !protectedAnchorIndices.has(x.i))
     .filter((x) => !recentTierOneProtectedIndices.has(x.i))
 
   const summaryBatches = buildSummaryBatches(summaryCandidates)
@@ -1754,18 +1710,22 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     return { messages, appliedStrategies: applied, estTokensBefore, estTokensAfter: tokens, maxTokens }
   }
 
-  // Tier 2: Remove middle messages (keep system, first user, last N)
+  // Tier 2: Remove middle messages (keep system, recent real user request anchors, last N)
   // If still over budget, reduce lastN to be more aggressive
   const effectiveLastN = tokens > targetTokens * 1.5 ? Math.max(1, Math.floor(lastN / 2)) : lastN
 
   const systemIdx = messages.findIndex((m) => m.role === "system")
-  const firstUserIdx = messages.findIndex((m, idx) => m.role === "user" && idx !== systemIdx)
-  const latestRealUserIdx = findLatestRealUserRequestIndex(messages, systemIdx)
+  const anchorIndices = collectRecentRealUserRequestIndices(
+    messages,
+    RECENT_USER_REQUEST_ANCHOR_COUNT,
+    messages.length,
+    summarizeThreshold,
+  )
+  const anchorSet = new Set(anchorIndices)
 
   const keptSet = new Set<number>()
   if (systemIdx >= 0) keptSet.add(systemIdx)
-  if (firstUserIdx >= 0) keptSet.add(firstUserIdx)
-  if (latestRealUserIdx >= 0) keptSet.add(latestRealUserIdx)
+  for (const index of anchorIndices) keptSet.add(index)
   // Add indices for last N
   const baseLen = messages.length
   for (let k = baseLen - effectiveLastN; k < baseLen; k++) {
@@ -1801,7 +1761,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     upsertArchiveHistoryRef(opts.sessionId, droppedMessages)
   }
 
-  // Preserve order: system -> first user -> iterative summary -> tool summary -> (chronological tail)
+  // Preserve order: system -> summaries -> recent real user request anchors -> chronological tail
   const ordered: LLMMessage[] = []
   if (systemIdx >= 0) ordered.push(messages[systemIdx])
 
@@ -1823,18 +1783,12 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
   // Insert tool summary
   if (toolSummaryMessage) ordered.push(toolSummaryMessage)
 
-  if (firstUserIdx >= 0 && firstUserIdx !== systemIdx) {
-    ordered.push(firstUserIdx === latestRealUserIdx
-      ? messages[firstUserIdx]
-      : buildEarlierUserRequestBackgroundMessage(messages[firstUserIdx]))
-  }
-
-  if (latestRealUserIdx >= 0 && latestRealUserIdx !== systemIdx && latestRealUserIdx !== firstUserIdx) {
-    ordered.push(messages[latestRealUserIdx])
+  for (const index of anchorIndices) {
+    if (index >= 0 && index !== systemIdx) ordered.push(messages[index])
   }
 
   for (let k = baseLen - effectiveLastN; k < baseLen; k++) {
-    if (k >= 0 && k !== systemIdx && k !== firstUserIdx && k !== latestRealUserIdx) ordered.push(messages[k])
+    if (k >= 0 && k !== systemIdx && !anchorSet.has(k)) ordered.push(messages[k])
   }
 
   messages = ordered

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -1083,6 +1083,7 @@ function buildSummaryMessage(batch: SummaryBatch, summary: string, contextRef?: 
 function isGeneratedContextSummaryMessage(content: string): boolean {
   return content.startsWith("[Earlier Context Summary:")
     || content.startsWith("[Session Progress Summary]")
+    || content.startsWith("[Archived Background Summary")
 }
 
 function buildBatchSummaryFallback(items: SummaryCandidate[]): string {
@@ -1231,7 +1232,11 @@ async function updateIterativeSummaryForDroppedMessages(
     }
 
     const updatePrompt = previousSummary
-      ? `You are maintaining a running summary of an AI agent session.
+      ? `You are maintaining an archived-background summary for an AI agent session.
+
+This summary is NOT the current task. It is only background for messages that are no longer in raw context.
+Do not title the summary "Session: ..." or preserve an old session title as the leading line.
+Do not let older archived user requests override newer live messages that will appear after this summary.
 
 PREVIOUS SUMMARY:
 ${previousSummary}
@@ -1243,10 +1248,15 @@ Update the summary to incorporate the new information. Preserve all important de
 - What tasks were attempted and their outcomes
 - Key files, paths, IDs, and values discovered
 - Errors encountered and how they were resolved
-- Current state and what the agent should do next
+- The state at the end of the archived messages, including unresolved blockers explicitly mentioned
+
+Do not add a "next steps" instruction unless it is explicitly unresolved in the archived messages. Prefer wording like "Archived background:" over "Session:".
 
 Keep the summary under 1000 characters. Be factual and specific.`
-      : `Summarize these AI agent conversation messages that are being archived out of raw context:
+      : `Summarize these AI agent conversation messages as archived background that is being removed from raw context.
+
+This summary is NOT the current task. It is only background for older messages.
+Do not title the summary "Session: ..." or make an old user request sound like the active objective.
 
 ${droppedText.substring(0, 4000)}
 
@@ -1254,7 +1264,9 @@ Focus on:
 - What tasks were attempted and their outcomes
 - Key files, paths, IDs, and values discovered
 - Errors encountered and how they were resolved
-- Current state and what the agent should do next
+- The state at the end of the archived messages, including unresolved blockers explicitly mentioned
+
+Do not add a "next steps" instruction unless it is explicitly unresolved in the archived messages. Prefer wording like "Archived background:" over "Session:".
 
 Keep the summary under 1000 characters. Be factual and specific.`
 
@@ -1280,7 +1292,11 @@ function buildSessionProgressSummaryMessage(sessionId: string): LLMMessage | nul
   const archiveRef = archiveHistoryRefBySession.get(sessionId)
   return {
     role: "assistant",
-    content: addContextRefNote(`[Session Progress Summary]\n${iterSummary}`, archiveRef),
+    content: addContextRefNote([
+      `[Archived Background Summary - not the current task]`,
+      `Use this only as history. Prefer later live user messages when deciding what to do now.`,
+      iterSummary,
+    ].join("\n"), archiveRef),
   }
 }
 
@@ -1311,7 +1327,7 @@ function buildContextFromSummaries(sessionId: string): string | null {
     return `${status} Step ${s.stepNumber}: ${truncatedSummary}`
   })
 
-  const result = `[Session Progress Summary]\n${lines.join("\n")}`
+  const result = `[Archived Background Summary - not the current task]\nUse this only as history. Prefer later live user messages when deciding what to do now.\n${lines.join("\n")}`
 
   // Truncate total summary if it exceeds max length
   if (result.length > MAX_TOTAL_SUMMARY_LENGTH) {

--- a/apps/desktop/src/main/conversation-history-utils.test.ts
+++ b/apps/desktop/src/main/conversation-history-utils.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest"
 import { INTERNAL_COMPLETION_NUDGE_TEXT } from "../shared/runtime-tool-names"
 import {
+  collectRecentRealUserRequestIndices,
   filterEphemeralMessages,
+  hasMappedToolResultPrefix,
+  isGeneratedContextSummaryContent,
   isInternalNudgeContent,
+  isRealUserRequestContent,
   type ConversationMessage,
 } from "./conversation-history-utils"
 
@@ -62,6 +66,34 @@ describe("conversation-history-utils", () => {
 
     it("does not classify normal user messages as internal nudges", () => {
       expect(isInternalNudgeContent("continue with my tax prep")).toBe(false)
+    })
+  })
+
+  describe("real user request detection", () => {
+    it("distinguishes real requests from tool results, summaries, and internal nudges", () => {
+      expect(isRealUserRequestContent("can you open in excalidraw in chrome")).toBe(true)
+      expect(isRealUserRequestContent("[execute_command] output")).toBe(false)
+      expect(isRealUserRequestContent("TOOL FAILED: execute_command (attempt 1/3)")).toBe(false)
+      expect(isRealUserRequestContent("[Archived Background Summary - not the current task]\nold work")).toBe(false)
+      expect(isRealUserRequestContent("Reason: incomplete\nMissing items:\n- x\nContinue only the current unresolved request described above.")).toBe(false)
+    })
+
+    it("collects the latest real user anchors while skipping tool-like user messages", () => {
+      const history = [
+        { role: "user", content: "old unrelated task" },
+        { role: "user", content: "[execute_command] noisy output" },
+        { role: "assistant", content: "done" },
+        { role: "user", content: "open the map in chrome" },
+        { role: "user", content: "TOOL FAILED: browser_drop" },
+        { role: "user", content: "can you open in excalidraw in chrome" },
+      ]
+
+      expect(collectRecentRealUserRequestIndices(history, 2)).toEqual([3, 5])
+    })
+
+    it("recognizes shared tool and summary markers", () => {
+      expect(hasMappedToolResultPrefix("[playwright-extension:browser_snapshot] result")).toBe(true)
+      expect(isGeneratedContextSummaryContent("[Session Progress Summary]\nsummary")).toBe(true)
     })
   })
 

--- a/apps/desktop/src/main/conversation-history-utils.test.ts
+++ b/apps/desktop/src/main/conversation-history-utils.test.ts
@@ -43,6 +43,14 @@ describe("conversation-history-utils", () => {
     it("detects verification nudges", () => {
       expect(
         isInternalNudgeContent(
+          "Reason: Completion criteria not met.\nMissing items:\n- add the next checklist item\nContinue only the current unresolved request described above. Do not resume older/background tasks unless they are explicitly required to satisfy these missing items."
+        )
+      ).toBe(true)
+    })
+
+    it("keeps detecting legacy verification nudges", () => {
+      expect(
+        isInternalNudgeContent(
           "Reason: Completion criteria not met.\nMissing items:\n- add the next checklist item\nContinue and finish remaining work."
         )
       ).toBe(true)

--- a/apps/desktop/src/main/conversation-history-utils.ts
+++ b/apps/desktop/src/main/conversation-history-utils.ts
@@ -39,6 +39,7 @@ const INTERNAL_NUDGE_PATTERNS = [
   "Your last response was not a final deliverable",
   "Your last response was empty or non-deliverable",
   "Continue and finish remaining work",
+  "Continue only the current unresolved request described above",
   "Your previous response only described the next step instead of actually doing it.",
   "Your previous response contained text like \"[Calling tools: ...]\" instead of an actual tool call.",
 ] as const

--- a/apps/desktop/src/main/conversation-history-utils.ts
+++ b/apps/desktop/src/main/conversation-history-utils.ts
@@ -22,6 +22,15 @@ export interface ConversationMessage {
 }
 
 type WithEphemeralFlag = { ephemeral?: boolean }
+type ConversationLike = { role: string; content?: string }
+
+export const MAPPED_TOOL_RESULT_PREFIX_RE = /^\[((?=[^\]]*[a-z])[A-Za-z0-9._:/-]+)\]\s(?:ERROR:\s*)?/
+
+const GENERATED_CONTEXT_SUMMARY_PREFIXES = [
+  "[Earlier Context Summary:",
+  "[Session Progress Summary]",
+  "[Archived Background Summary",
+] as const
 
 const INTERNAL_NUDGE_EXACT_MATCHES = [
   INTERNAL_COMPLETION_NUDGE_TEXT,
@@ -53,6 +62,48 @@ export function isInternalNudgeContent(content?: string): boolean {
   }
 
   return INTERNAL_NUDGE_PATTERNS.some((pattern) => trimmed.includes(pattern))
+}
+
+export function hasMappedToolResultPrefix(content?: string): boolean {
+  return typeof content === "string" && MAPPED_TOOL_RESULT_PREFIX_RE.test(content.trimStart())
+}
+
+export function isGeneratedContextSummaryContent(content?: string): boolean {
+  const trimmed = typeof content === "string" ? content.trimStart() : ""
+  return GENERATED_CONTEXT_SUMMARY_PREFIXES.some((prefix) => trimmed.startsWith(prefix))
+}
+
+export function isRealUserRequestContent(content?: string): boolean {
+  const trimmed = typeof content === "string" ? content.trimStart() : ""
+  if (!trimmed) return false
+  if (hasMappedToolResultPrefix(trimmed)) return false
+  if (trimmed.startsWith("TOOL FAILED:")) return false
+  if (isGeneratedContextSummaryContent(trimmed)) return false
+  if (isInternalNudgeContent(trimmed)) return false
+  return true
+}
+
+export function collectRecentRealUserRequestIndices<T extends ConversationLike>(
+  messages: T[],
+  limit = 2,
+  beforeIndex = messages.length,
+  maxContentChars = Number.POSITIVE_INFINITY,
+): number[] {
+  const indices: number[] = []
+  const end = Math.max(0, Math.min(beforeIndex, messages.length))
+
+  for (let index = end - 1; index >= 0 && indices.length < limit; index--) {
+    const message = messages[index]
+    if (
+      message?.role === "user"
+      && (message.content?.length ?? 0) <= maxContentChars
+      && isRealUserRequestContent(message.content)
+    ) {
+      indices.push(index)
+    }
+  }
+
+  return indices.reverse()
 }
 
 /**

--- a/apps/desktop/src/main/llm-verification-replay.test.ts
+++ b/apps/desktop/src/main/llm-verification-replay.test.ts
@@ -35,6 +35,29 @@ describe("llm-verification-replay", () => {
     expect(messages.map((message) => message.content).join("\n")).not.toContain("[Calling tools: respond_to_user]")
   })
 
+  it("includes prior real user requests to resolve referential follow-ups without reviving tool noise", () => {
+    const messages = buildVerificationMessagesFromAgentState(makeAgentStateFixture({
+      transcript: "can you open in excalidraw in chrome",
+      finalAssistantText: "Excalidraw is open.",
+      sinceIndex: 5,
+      conversationHistory: [
+        { role: "user", content: "list as many project names as you can" },
+        { role: "assistant", content: "I made a project inventory." },
+        { role: "user", content: "open the map in chrome" },
+        { role: "user", content: "[execute_command] noisy tool result" },
+        { role: "user", content: "TOOL FAILED: playwright-extension:browser_drop" },
+        { role: "user", content: "can you open in excalidraw in chrome" },
+        { role: "assistant", content: "Excalidraw is open." },
+      ],
+    }))
+
+    const priorContext = messages.find((message) => message.content.startsWith("Relevant prior user context"))?.content || ""
+    expect(priorContext).toContain("open the map in chrome")
+    expect(priorContext).not.toContain("list as many project names")
+    expect(priorContext).not.toContain("[execute_command]")
+    expect(priorContext).not.toContain("TOOL FAILED")
+  })
+
   it("adds retry notes to the final verifier request only after a failed attempt", () => {
     const initialRequest = buildVerificationMessagesFromAgentState(
       makeAgentStateFixture({ verificationFailCount: 0 }),

--- a/apps/desktop/src/main/llm-verification-replay.ts
+++ b/apps/desktop/src/main/llm-verification-replay.ts
@@ -1,5 +1,6 @@
 import type { AgentConversationState, AgentUserResponseEvent } from "@dotagents/shared"
 import { sanitizeMessageContentForDisplay } from "@dotagents/shared"
+import { collectRecentRealUserRequestIndices } from "./conversation-history-utils"
 import { resolveLatestUserFacingResponse } from "./respond-to-user-utils"
 
 type ToolCallLike = {
@@ -99,25 +100,6 @@ Return ONLY JSON with this schema:
 Set isComplete=false only when conversationState=running. Set isComplete=true for complete, needs_input, or blocked.`
 
 const VERIFICATION_JSON_REQUEST_BASE = "Return JSON only. Remember: if the assistant is waiting on the user, use conversationState=needs_input; if it cannot continue because of a blocker, use conversationState=blocked; otherwise use running or complete. Do not treat optional preference/approval questions after unfinished work as needs_input; those should stay running."
-const MAPPED_TOOL_RESULT_PREFIX_RE = /^\[((?=[^\]]*[a-z])[A-Za-z0-9._:/-]+)\]\s(?:ERROR:\s*)?/
-
-function isInternalNudgeLikeContent(content: string): boolean {
-  const trimmed = content.trimStart()
-  return trimmed.includes("Continue only the current unresolved request described above")
-    || trimmed.includes("Continue and finish remaining work")
-    || trimmed.startsWith("Verifier indicates the task is not complete")
-    || (trimmed.startsWith("Reason:") && trimmed.includes("Missing items:"))
-}
-
-function isRealUserRequestContent(content: string): boolean {
-  const trimmed = content.trimStart()
-  if (!trimmed) return false
-  if (MAPPED_TOOL_RESULT_PREFIX_RE.test(trimmed)) return false
-  if (trimmed.startsWith("TOOL FAILED:")) return false
-  if (trimmed.startsWith("Original request:")) return false
-  if (isInternalNudgeLikeContent(trimmed)) return false
-  return true
-}
 
 function collectRelevantPriorUserRequests(
   conversationHistory: ReplayConversationHistoryEntry[],
@@ -128,20 +110,12 @@ function collectRelevantPriorUserRequests(
     ? Math.max(0, Math.min(sinceIndex, conversationHistory.length))
     : conversationHistory.length
   const currentRequest = sanitizeMessageContentForDisplay(transcript).trim()
-  const priorRequests: string[] = []
 
-  for (let i = searchEnd - 1; i >= 0 && priorRequests.length < 1; i--) {
-    const entry = conversationHistory[i]
-    if (entry?.role !== "user") continue
+  const candidates = collectRecentRealUserRequestIndices(conversationHistory, 2, searchEnd)
+    .map((index) => sanitizeMessageContentForDisplay(conversationHistory[index]?.content || "").trim())
+    .filter((request) => request.length > 0 && request !== currentRequest)
 
-    const text = sanitizeMessageContentForDisplay(entry.content || "").trim()
-    if (!isRealUserRequestContent(text)) continue
-    if (currentRequest && text === currentRequest) continue
-
-    priorRequests.unshift(text)
-  }
-
-  return priorRequests
+  return candidates.slice(-1)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/main/llm-verification-replay.ts
+++ b/apps/desktop/src/main/llm-verification-replay.ts
@@ -84,6 +84,7 @@ Rules:
 - If the assistant only gathered context, prepared, or summarized next steps but did not create the main requested artifact, return running even if it asks a style/preference question.
 - If the assistant clearly says it cannot proceed because of a blocker outside its control, return blocked.
 - If the user already has the final answer, requested artifact, or requested summary, return complete.
+- If the current request is a short or referential follow-up, use the provided prior user context only to resolve references like "it", "this", or "the map"; do not replace the current request with an older background task.
 - Empty, vague, or purely procedural replies should return running.
 
 Return ONLY JSON with this schema:
@@ -98,6 +99,50 @@ Return ONLY JSON with this schema:
 Set isComplete=false only when conversationState=running. Set isComplete=true for complete, needs_input, or blocked.`
 
 const VERIFICATION_JSON_REQUEST_BASE = "Return JSON only. Remember: if the assistant is waiting on the user, use conversationState=needs_input; if it cannot continue because of a blocker, use conversationState=blocked; otherwise use running or complete. Do not treat optional preference/approval questions after unfinished work as needs_input; those should stay running."
+const MAPPED_TOOL_RESULT_PREFIX_RE = /^\[((?=[^\]]*[a-z])[A-Za-z0-9._:/-]+)\]\s(?:ERROR:\s*)?/
+
+function isInternalNudgeLikeContent(content: string): boolean {
+  const trimmed = content.trimStart()
+  return trimmed.includes("Continue only the current unresolved request described above")
+    || trimmed.includes("Continue and finish remaining work")
+    || trimmed.startsWith("Verifier indicates the task is not complete")
+    || (trimmed.startsWith("Reason:") && trimmed.includes("Missing items:"))
+}
+
+function isRealUserRequestContent(content: string): boolean {
+  const trimmed = content.trimStart()
+  if (!trimmed) return false
+  if (MAPPED_TOOL_RESULT_PREFIX_RE.test(trimmed)) return false
+  if (trimmed.startsWith("TOOL FAILED:")) return false
+  if (trimmed.startsWith("Original request:")) return false
+  if (isInternalNudgeLikeContent(trimmed)) return false
+  return true
+}
+
+function collectRelevantPriorUserRequests(
+  conversationHistory: ReplayConversationHistoryEntry[],
+  sinceIndex: number | undefined,
+  transcript: string,
+): string[] {
+  const searchEnd = typeof sinceIndex === "number"
+    ? Math.max(0, Math.min(sinceIndex, conversationHistory.length))
+    : conversationHistory.length
+  const currentRequest = sanitizeMessageContentForDisplay(transcript).trim()
+  const priorRequests: string[] = []
+
+  for (let i = searchEnd - 1; i >= 0 && priorRequests.length < 1; i--) {
+    const entry = conversationHistory[i]
+    if (entry?.role !== "user") continue
+
+    const text = sanitizeMessageContentForDisplay(entry.content || "").trim()
+    if (!isRealUserRequestContent(text)) continue
+    if (currentRequest && text === currentRequest) continue
+
+    priorRequests.unshift(text)
+  }
+
+  return priorRequests
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
@@ -157,11 +202,23 @@ export function buildVerificationMessagesFromAgentState(
     conversationHistory: fixture.conversationHistory,
     sinceIndex: fixture.sinceIndex,
   })
+  const relevantPriorUserRequests = collectRelevantPriorUserRequests(
+    fixture.conversationHistory,
+    fixture.sinceIndex,
+    fixture.transcript,
+  )
 
   const messages: VerificationMessage[] = [
     { role: "system", content: VERIFICATION_SYSTEM_PROMPT },
     { role: "user", content: `Original request:\n${sanitizeMessageContentForDisplay(fixture.transcript)}` },
   ]
+
+  if (relevantPriorUserRequests.length > 0) {
+    messages.push({
+      role: "user",
+      content: `Relevant prior user context for resolving references only; these are not the active request unless the current request depends on them:\n${relevantPriorUserRequests.map((request) => `- ${request}`).join("\n")}`,
+    })
+  }
 
   if (latestUserFacingResponse?.trim()) {
     messages.push({

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1595,7 +1595,7 @@ export async function processTranscriptWithAgentMode(
     const reason = verificationReason
       ? `Reason: ${verificationReason}`
       : "Reason: Completion criteria not met."
-    const userNudge = `${reason}\n${missing ? `Missing items:\n${missing}` : ""}\nContinue and finish remaining work.`
+    const userNudge = `${reason}\n${missing ? `Missing items:\n${missing}` : ""}\nContinue only the current unresolved request described above. Do not resume older/background tasks unless they are explicitly required to satisfy these missing items.`
     addEphemeralMessage("user", userNudge)
     maybeNudgeToolUsage(newFailCount)
 


### PR DESCRIPTION
## Summary
- Reframe archive-frontier summaries as background context, not current task state
- Rename inserted summary labels from session progress to archived background and instruct the model to prefer later live user messages
- Make verifier recovery nudges continue only the current unresolved request instead of vague remaining work
- Keep new and legacy verifier nudges classified as internal/ephemeral

## Tests
- pnpm --filter @dotagents/desktop exec vitest run src/main/context-budget.test.ts src/main/conversation-history-utils.test.ts