### PR TITLE
Stream early ChatGPT reasoning progress

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const tempDirs: string[] = []
 
-async function setupChatGptWebProviderTest() {
+async function setupChatGptWebProviderTest(configOverrides: Record<string, unknown> = {}) {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-chatgpt-web-images-"))
   tempDirs.push(tempDir)
 
@@ -14,6 +14,7 @@ async function setupChatGptWebProviderTest() {
       get: vi.fn(() => ({
         chatgptWebBaseUrl: "https://chatgpt.test",
         mcpToolsChatgptWebModel: "gpt-test",
+        ...configOverrides,
       })),
       save: vi.fn(),
     },
@@ -40,6 +41,7 @@ async function setupChatGptWebProviderTest() {
 afterEach(async () => {
   vi.resetModules()
   vi.clearAllMocks()
+  vi.restoreAllMocks()
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
 })
 
@@ -147,6 +149,50 @@ describe("chatgpt-web Codex options", () => {
     await setupCodexOptionsTest({ codexTextVerbosity: "verbose" })
     const { getCodexTextVerbosity } = await import("./chatgpt-web-provider")
     expect(getCodexTextVerbosity()).toBe("medium")
+  })
+})
+
+describe("chatgpt-web response streaming", () => {
+  it("surfaces reasoning start and reasoning summary deltas through the streaming callback", async () => {
+    await setupChatGptWebProviderTest({ chatgptWebAccessToken: "test-access-token" })
+    const encoder = new TextEncoder()
+    const events = [
+      { type: "response.created" },
+      { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+      { type: "response.output_text.delta", delta: "\n" },
+      { type: "response.reasoning_summary_text.delta", delta: "Plan" },
+      { type: "response.reasoning_summary_text.delta", delta: " next" },
+      { type: "response.completed", response: { output: [] } },
+    ]
+    const body = new ReadableStream({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
+        }
+        controller.close()
+      },
+    })
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(body, { status: 200 }) as any)
+
+    const { makeChatGptWebResponse } = await import("./chatgpt-web-provider")
+    const chunks: Array<{ chunk: string; accumulated: string }> = []
+
+    const response = await makeChatGptWebResponse([
+      { role: "system", content: "System prompt" },
+      { role: "user", content: "Hello" },
+    ], {
+      onTextChunk: (chunk, accumulated) => chunks.push({ chunk, accumulated }),
+    })
+
+    expect(chunks).toEqual([
+      { chunk: "Thinking...", accumulated: "Thinking..." },
+      { chunk: "\n\nPlan", accumulated: "Thinking...\n\nPlan" },
+      { chunk: " next", accumulated: "Thinking...\n\nPlan next" },
+    ])
+    expect(response).toMatchObject({
+      text: "",
+      reasoningSummary: "Plan next",
+    })
   })
 })
 

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -838,7 +838,9 @@ export async function makeChatGptWebResponse(
   let buffer = ""
   let accumulatedText = ""
   let accumulatedReasoningSummary = ""
+  let streamedDisplayText = ""
   let completedResponse: ChatGptWebCompletedEventResponse | undefined
+  let sentReasoningProgress = false
   const pendingToolArguments = new Map<string, string>()
   const completedToolCalls = new Map<string, ChatGptWebToolCall>()
 
@@ -867,17 +869,38 @@ export async function makeChatGptWebResponse(
 
       const event = parseJsonObject(data)
       const eventType = typeof event.type === "string" ? event.type : ""
+      const appendDisplayChunk = (chunk: string) => {
+        if (!chunk) return
+        streamedDisplayText += chunk
+        options.onTextChunk?.(chunk, streamedDisplayText)
+      }
 
       if (eventType === "response.output_text.delta") {
         const delta = typeof event.delta === "string" ? event.delta : ""
         if (delta) {
+          const hadVisibleText = accumulatedText.trim().length > 0
           accumulatedText += delta
-          options.onTextChunk?.(delta, accumulatedText)
+          if (hadVisibleText || accumulatedText.trim().length > 0) {
+            appendDisplayChunk(delta)
+          }
+        }
+      } else if (eventType === "response.output_item.added") {
+        const item = event.item
+        const itemType = item && typeof item === "object"
+          ? (item as { type?: unknown }).type
+          : undefined
+        if (itemType === "reasoning" && !sentReasoningProgress && !accumulatedText.trim() && !accumulatedReasoningSummary) {
+          sentReasoningProgress = true
+          appendDisplayChunk("Thinking...")
         }
       } else if (eventType === "response.reasoning_summary_text.delta") {
         const delta = typeof event.delta === "string" ? event.delta : ""
         if (delta) {
+          const hadReasoningSummary = accumulatedReasoningSummary.length > 0
           accumulatedReasoningSummary += delta
+          if (!accumulatedText.trim()) {
+            appendDisplayChunk(sentReasoningProgress && !hadReasoningSummary ? `\n\n${delta}` : delta)
+          }
         }
       } else if (eventType === "response.function_call_arguments.delta") {
         const itemId = typeof event.item_id === "string" ? event.item_id : ""

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1833,6 +1833,10 @@ export async function processTranscriptWithAgentMode(
         const now = Date.now()
         // Update the thinking step with streaming content (always)
         thinkingStep.llmContent = accumulated
+        if (accumulated.trim()) {
+          thinkingStep.title = "Agent response"
+          thinkingStep.description = "Generating response..."
+        }
 
         // Throttle emit calls to reduce log spam
         if (now - lastStreamEmitTime < STREAM_EMIT_THROTTLE_MS) {


### PR DESCRIPTION
## Summary
- surface ChatGPT/Codex reasoning output-item start as an immediate display-only `Thinking...` streaming update
- stream reasoning-summary deltas through the existing progress callback before final tool calls complete
- relabel the active thinking step to `Agent response` once streamed content arrives
- add a focused provider streaming test

## Autoresearch result
Best kept run: `ui_analyzing_penalty_ms` improved from `25,860ms` to `726ms`.
- p75 placeholder wait: `7,620ms → 726ms`
- max placeholder wait: `9,621ms → 790ms`
- effectiveness score: `0.674` (above `0.65` floor)

## Validation
- from worktree root: `../../node_modules/.bin/vitest run apps/desktop/src/main/chatgpt-web-provider.test.ts`
- from `apps/desktop` in the worktree: `../../../../node_modules/.bin/tsc --noEmit -p tsconfig.node.json --composite false`