### PR TITLE
Speed up agent continuation responses

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -133,6 +133,23 @@ describe("chatgpt-web Codex options", () => {
     }))
   }
 
+  it("defaults Codex reasoning effort to low without requesting summaries", async () => {
+    await setupCodexOptionsTest({})
+    const { getCodexReasoningOptions } = await import("./chatgpt-web-provider")
+    expect(getCodexReasoningOptions("gpt-5.1-codex")).toEqual({ effort: "low" })
+  })
+
+  it("honors disabled and explicit Codex reasoning effort overrides", async () => {
+    await setupCodexOptionsTest({ openaiReasoningEffort: "none" })
+    let provider = await import("./chatgpt-web-provider")
+    expect(provider.getCodexReasoningOptions("gpt-5.1-codex")).toBeUndefined()
+
+    vi.resetModules()
+    await setupCodexOptionsTest({ openaiReasoningEffort: "xhigh" })
+    provider = await import("./chatgpt-web-provider")
+    expect(provider.getCodexReasoningOptions("gpt-5.1-codex")).toEqual({ effort: "high" })
+  })
+
   it("defaults Codex text verbosity to medium when unset", async () => {
     await setupCodexOptionsTest({})
     const { getCodexTextVerbosity } = await import("./chatgpt-web-provider")

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -145,7 +145,7 @@ function normalizeCodexReasoningEffort(effort: unknown): CodexReasoningEffort | 
   return undefined
 }
 
-export function getCodexReasoningOptions(model: string): { effort: CodexReasoningEffort; summary?: "auto" } | undefined {
+export function getCodexReasoningOptions(model: string): { effort: CodexReasoningEffort } | undefined {
   if (!isCodexReasoningModel(model)) return undefined
 
   const override = configStore.get().openaiReasoningEffort
@@ -156,7 +156,6 @@ export function getCodexReasoningOptions(model: string): { effort: CodexReasonin
     logLLM("Applying ChatGPT Codex reasoning effort", {
       model,
       effort,
-      summary: undefined,
       source: override ? "user-config" : "default",
     })
   }

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -145,23 +145,23 @@ function normalizeCodexReasoningEffort(effort: unknown): CodexReasoningEffort | 
   return undefined
 }
 
-export function getCodexReasoningOptions(model: string): { effort: CodexReasoningEffort; summary: "auto" } | undefined {
+export function getCodexReasoningOptions(model: string): { effort: CodexReasoningEffort; summary?: "auto" } | undefined {
   if (!isCodexReasoningModel(model)) return undefined
 
   const override = configStore.get().openaiReasoningEffort
   if (override === "none") return undefined
 
-  const effort = normalizeCodexReasoningEffort(override) || "medium"
+  const effort = normalizeCodexReasoningEffort(override) || "low"
   if (isDebugLLM()) {
     logLLM("Applying ChatGPT Codex reasoning effort", {
       model,
       effort,
-      summary: "auto",
+      summary: undefined,
       source: override ? "user-config" : "default",
     })
   }
 
-  return { effort, summary: "auto" }
+  return { effort }
 }
 
 type CodexTextVerbosity = "low" | "medium" | "high"

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -130,6 +130,7 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       "session-windowed-progress",
       "session-reasoning-stub",
       "session-reasoning-only-empty-retry",
+      "session-latest-completion-summary",
     )
   })
 
@@ -308,6 +309,33 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       .join("\n")
     expect(secondPrompt).toContain("without first providing the final user-facing answer")
     expect(secondPrompt).toContain("Do not add a second recap or summary")
+  })
+
+  it("uses the latest completion summary when promoting mark_work_complete summary to final content", async () => {
+    currentConfig.mcpVerifyCompletionEnabled = false
+    currentConfig.mcpFinalSummaryEnabled = false
+    const { processTranscriptWithAgentMode } = await import("./llm")
+
+    mocks.makeLLMCallWithStreamingAndTools.mockResolvedValueOnce({ content: "", toolCalls: [
+      { name: "mark_work_complete", arguments: { summary: "Earlier stale answer." } },
+      { name: "mark_work_complete", arguments: { summary: "Latest authoritative answer." } },
+    ] })
+
+    const result = await processTranscriptWithAgentMode(
+      "Finish this",
+      availableTools as any,
+      makeExecuteToolCall("session-latest-completion-summary", 1),
+      4,
+      [],
+      "conv-latest-completion-summary",
+      "session-latest-completion-summary",
+      undefined,
+      undefined,
+      1,
+    )
+
+    expect(result.content).toBe("Latest authoritative answer.")
+    expect(mocks.makeLLMCallWithStreamingAndTools).toHaveBeenCalledTimes(1)
   })
 
   it("does not finalize with a reasoning summary as the user-facing answer", async () => {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -74,6 +74,12 @@ import {
 } from "@dotagents/shared"
 
 const AGENT_PROGRESS_CONVERSATION_HISTORY_WINDOW_SIZE = 120
+const INTERNAL_COMPLETION_SUMMARY_REGEX = /^(?:internal\b|completion metadata\b|internal completion\b|internal stop\b)/i
+
+function isDeliverableCompletionSummary(summary: string): boolean {
+  const trimmed = summary.trim()
+  return isDeliverableResponseContent(trimmed) && !INTERNAL_COMPLETION_SUMMARY_REGEX.test(trimmed)
+}
 
 /**
  * Clean error message by removing stack traces and noise
@@ -3136,12 +3142,18 @@ export async function processTranscriptWithAgentMode(
       }
 
       if (!finalContent.trim() && !existingUserResponse?.trim().length && !forceFinalSummary) {
-        const completionSummary = toolCallsArray
-          .map((toolCall) => toolCall.name === MARK_WORK_COMPLETE_TOOL && typeof (toolCall.arguments as any)?.summary === "string"
+        let completionSummary = ""
+        for (let toolCallIndex = toolCallsArray.length - 1; toolCallIndex >= 0; toolCallIndex--) {
+          const toolCall = toolCallsArray[toolCallIndex]
+          const summary = toolCall?.name === MARK_WORK_COMPLETE_TOOL && typeof (toolCall.arguments as any)?.summary === "string"
             ? (toolCall.arguments as any).summary.trim()
-            : "")
-          .find((summary) => summary.length > 0)
-        if (completionSummary && isDeliverableResponseContent(completionSummary)) {
+            : ""
+          if (summary.length > 0) {
+            completionSummary = summary
+            break
+          }
+        }
+        if (completionSummary && isDeliverableCompletionSummary(completionSummary)) {
           finalContent = completionSummary
         }
       }

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -194,6 +194,59 @@ function isInvalidExecuteCommandSkillIdFailure(toolName: string | undefined, res
     || (errorText.includes("skill not found") && errorText.includes("omit skillid"))
 }
 
+function isLikelyAnswerOnlyContinuationTurn(
+  transcript: string,
+  previousConversationHistory?: Array<{ role: string; content?: string; toolCalls?: unknown[]; toolResults?: unknown[] }>,
+): boolean {
+  const priorHistory = previousConversationHistory || []
+  const hasPriorEvidence = priorHistory.some((entry) =>
+    entry.role === "tool"
+    || (Array.isArray(entry.toolCalls) && entry.toolCalls.length > 0)
+    || (Array.isArray(entry.toolResults) && entry.toolResults.length > 0),
+  )
+  if (!hasPriorEvidence) return false
+
+  const normalized = transcript.toLowerCase().replace(/\s+/g, " ").trim()
+  if (!normalized) return false
+
+  const words = normalized.split(" ").filter(Boolean)
+  const startsAsQuestionOrStatus = /^(what|why|how|did|does|is|are|can|should|summarize|summary|status|current|continue|next|explain|check|test)\b/.test(normalized)
+  const containsStatusCue = /\b(current state|next safest action|next safe action|what happened|what should|status|summarize|summary|blocker|known|unknown|confirmed|worked|works|failed|done|complete)\b/.test(normalized)
+
+  return words.length <= 40 && (normalized.endsWith("?") || startsAsQuestionOrStatus || containsStatusCue)
+}
+
+function buildAnswerOnlyContinuationDigest(
+  omittedHistory: Array<{ role: string; content?: string }>,
+): string {
+  const formatSnippet = (entry: { role: string; content?: string }) => {
+    const text = sanitizeMessageContentForDisplay(entry.content || "")
+      .replace(/\s+/g, " ")
+      .trim()
+      .slice(0, 240)
+    return text ? `- ${entry.role}: ${text}` : ""
+  }
+
+  const userSnippets = omittedHistory
+    .filter((entry) => entry.role === "user")
+    .slice(-3)
+    .map(formatSnippet)
+    .filter(Boolean)
+
+  const evidenceSnippets = omittedHistory
+    .filter((entry) => entry.role === "assistant" || entry.role === "tool")
+    .slice(-5)
+    .map(formatSnippet)
+    .filter(Boolean)
+
+  return [
+    `[Earlier context compacted for this status/continuation turn: ${omittedHistory.length} older messages omitted.]`,
+    `Use this only as background; answer from the recent live messages below when possible.`,
+    userSnippets.length ? `Older user goals/constraints:\n${userSnippets.join("\n")}` : "",
+    evidenceSnippets.length ? `Older evidence snippets:\n${evidenceSnippets.join("\n")}` : "",
+  ].filter(Boolean).join("\n")
+}
+
 export async function postProcessTranscript(transcript: string) {
   const config = configStore.get()
 
@@ -1004,7 +1057,10 @@ export async function processTranscriptWithAgentMode(
       index === self.findIndex((t) => t.name === tool.name),
   )
 
-  const baseAvailableTools = uniqueAvailableTools
+  const hideCompletionSignalTool = isLikelyAnswerOnlyContinuationTurn(transcript, previousConversationHistory)
+  const baseAvailableTools = hideCompletionSignalTool
+    ? uniqueAvailableTools.filter((tool) => tool.name !== MARK_WORK_COMPLETE_TOOL)
+    : uniqueAvailableTools
 
   const { agentProfileService } = await import("./agent-profile-service")
   const mainAgent = agentProfileService.getCurrentProfile()
@@ -1091,6 +1147,27 @@ export async function processTranscriptWithAgentMode(
     ? undefined
     : previousBranchMessageIndex + 1
 
+  const preparedPreviousConversationHistory = (() => {
+    if (!hideCompletionSignalTool || sanitizedPreviousConversationHistory.length <= 10) {
+      return sanitizedPreviousConversationHistory
+    }
+
+    const tailCount = 6
+    const splitIndex = Math.max(0, sanitizedPreviousConversationHistory.length - tailCount)
+    const omittedHistory = sanitizedPreviousConversationHistory.slice(0, splitIndex)
+    const recentHistory = sanitizedPreviousConversationHistory.slice(splitIndex)
+    return [
+      ...omittedHistory.map((entry) => ({ ...entry, skipModelReplay: true })),
+      {
+        role: "assistant" as const,
+        content: buildAnswerOnlyContinuationDigest(omittedHistory),
+        timestamp: Date.now(),
+        ephemeral: true,
+      },
+      ...recentHistory,
+    ]
+  })()
+
   const conversationHistory: Array<{
     role: "user" | "assistant" | "tool"
     content: string
@@ -1103,7 +1180,7 @@ export async function processTranscriptWithAgentMode(
     /** Renderer-only content override; never persisted or replayed to the model. */
     displayContent?: string
   }> = [
-    ...sanitizedPreviousConversationHistory,
+    ...preparedPreviousConversationHistory,
     {
       role: "user",
       content: transcript,
@@ -1118,7 +1195,7 @@ export async function processTranscriptWithAgentMode(
 
   // Track the index where the current user prompt was added
   // This is used to scope tool result checks to only the current turn
-  const currentPromptIndex = sanitizedPreviousConversationHistory.length
+  const currentPromptIndex = preparedPreviousConversationHistory.length
 
   const buildIntentOnlyToolUsageNudge = (contentText: string) => {
     const selectorRef = contentText.match(/@[a-z][0-9]+/i)?.[0]
@@ -1273,6 +1350,8 @@ export async function processTranscriptWithAgentMode(
   ): Array<{ role: "user" | "assistant"; content: string }> => {
     const mapped = conversationHistory
       .map((entry) => {
+        if (entry.skipModelReplay) return null
+
         const rawContent = typeof entry.content === "string" ? entry.content : ""
         const content = sanitizeMessageContentForDisplay(rawContent).trim()
         if (!content) return null
@@ -1731,6 +1810,8 @@ export async function processTranscriptWithAgentMode(
       { role: "system", content: currentSystemPrompt },
       ...conversationHistory
         .map((entry) => {
+          if (entry.skipModelReplay) return null
+
           const rawContent = typeof entry.content === "string" ? entry.content : ""
           const sanitizedContent = sanitizeMessageContentForDisplay(rawContent)
 
@@ -1749,10 +1830,6 @@ export async function processTranscriptWithAgentMode(
           // cause the model to parrot that placeholder back as garbled tool-call text and
           // answer our internal recovery nudges instead of the user's actual request.
           if (entry.role === "assistant" && !sanitizedContent.trim()) {
-            return null
-          }
-
-          if (entry.role === "assistant" && entry.skipModelReplay) {
             return null
           }
 
@@ -3056,6 +3133,17 @@ export async function processTranscriptWithAgentMode(
       } else {
         // Agent provided sufficient content, use it as the final content directly.
         finalContent = lastAssistantContent
+      }
+
+      if (!finalContent.trim() && !existingUserResponse?.trim().length && !forceFinalSummary) {
+        const completionSummary = toolCallsArray
+          .map((toolCall) => toolCall.name === MARK_WORK_COMPLETE_TOOL && typeof (toolCall.arguments as any)?.summary === "string"
+            ? (toolCall.arguments as any).summary.trim()
+            : "")
+          .find((summary) => summary.length > 0)
+        if (completionSummary && isDeliverableResponseContent(completionSummary)) {
+          finalContent = completionSummary
+        }
       }
 
       if (!existingUserResponse?.trim().length && !forceFinalSummary && !finalContent.trim().length) {

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -231,10 +231,10 @@ export function Component() {
                 </p>
               </div>
               <Control
-                label={<ControlLabel label="Thinking level" tooltip="Reasoning effort sent to Codex reasoning models. 'None' lets the provider answer instantly with no extra reasoning." />}
+                label={<ControlLabel label="Thinking level" tooltip="Reasoning effort sent to Codex reasoning models. Defaults to Low when unset. 'None' lets the provider answer with no extra reasoning." />}
               >
                 <Select
-                  value={config.openaiReasoningEffort || "medium"}
+                  value={config.openaiReasoningEffort || "low"}
                   onValueChange={(value) =>
                     saveConfig({
                       openaiReasoningEffort: value as Config["openaiReasoningEffort"],
@@ -247,8 +247,8 @@ export function Component() {
                   <SelectContent>
                     <SelectItem value="none">None</SelectItem>
                     <SelectItem value="minimal">Minimal</SelectItem>
-                    <SelectItem value="low">Low</SelectItem>
-                    <SelectItem value="medium">Medium (default)</SelectItem>
+                    <SelectItem value="low">Low (default)</SelectItem>
+                    <SelectItem value="medium">Medium</SelectItem>
                     <SelectItem value="high">High</SelectItem>
                     <SelectItem value="xhigh">Extra high</SelectItem>
                   </SelectContent>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1199,12 +1199,11 @@ export type Config = {
   /** @deprecated Use agentChatgptWebModel instead. */
   mcpToolsChatgptWebModel?: string
   /**
-   * Reasoning effort for OpenAI reasoning-capable models (GPT-5.x). Passed as
-   * `providerOptions.openai.reasoningEffort` on generateText calls. When unset
-   * the provider uses its own default — for GPT-5.4 the documented default is
-   * `none`, which causes the model to answer too quickly (issue #297). The
-   * provider layer applies "medium" automatically for GPT-5.x models unless
-   * this override is set.
+   * Reasoning effort for reasoning-capable OpenAI/Codex models. Passed as
+   * `providerOptions.openai.reasoningEffort` on OpenAI generateText calls and
+   * as `reasoning.effort` on ChatGPT Web Codex responses. When unset, the
+   * OpenAI provider applies "medium" for GPT-5.x models and the ChatGPT Web
+   * Codex provider applies "low" unless this override is set.
    */
   openaiReasoningEffort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
   /**

--- a/apps/desktop/tests/chatgpt-web-reasoning.test.mjs
+++ b/apps/desktop/tests/chatgpt-web-reasoning.test.mjs
@@ -8,16 +8,17 @@ const providerSource = fs.readFileSync(
   'utf8',
 )
 
-test('ChatGPT Codex provider sends reasoning effort in Responses API payload', () => {
+test('ChatGPT Codex provider sends low reasoning effort without automatic summaries', () => {
   assert.match(providerSource, /type CodexReasoningEffort = "minimal" \| "low" \| "medium" \| "high"/)
   assert.match(providerSource, /export function getCodexReasoningOptions\(model: string\)/)
   assert.match(providerSource, /if \(override === "none"\) return undefined/)
   assert.match(providerSource, /if \(effort === "xhigh"\) return "high"/)
+  assert.match(providerSource, /const effort = normalizeCodexReasoningEffort\(override\) \|\| "low"/)
+  assert.match(providerSource, /return \{ effort \}/)
   assert.match(providerSource, /const reasoning = getCodexReasoningOptions\(model\)/)
   assert.match(providerSource, /payload\.reasoning = reasoning/)
-  // summary: "auto" must be included alongside effort
-  assert.match(providerSource, /summary: "auto"/)
-  assert.match(providerSource, /effort,\s*summary: "auto"/)
+  assert.doesNotMatch(providerSource, /summary: "auto"/)
+  assert.doesNotMatch(providerSource, /effort,\s*summary/)
 })
 
 test('ChatGPT Codex provider handles reasoning summary streaming events', () => {


### PR DESCRIPTION
## Summary
- lower default ChatGPT/Codex reasoning effort to low and stop requesting automatic reasoning summaries by default
- reuse valid mark_work_complete summaries as final content when no separate final answer was produced
- compact older replay context and hide the optional completion tool for short answer-only continuation/status turns with prior evidence

## Autoresearch result
- baseline: 81.5s wall time
- best kept run: 19.0s wall time (-76.7%)
- correctness monitor stayed stable/improved vs baseline: e2e 0.186 -> 0.478, quality 3.8 -> 5.6

## Validation
- pnpm --filter @dotagents/desktop exec tsc --noEmit --pretty false

Only the two kept product files are included; autoresearch fixtures/results/logs are excluded.