### PR TITLE
Reduce sub-agent cancellation and status log noise

### DIFF
--- a/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
+++ b/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
@@ -68,7 +68,7 @@ export const acpRouterToolDefinitions = [
   },
   {
     name: 'check_agent_status',
-    description: 'Check the status of a running delegated agent task. If runId is omitted, checks the most recent delegated run (or filters by agentName if provided). Completed output is returned once; repeated checks return a compact already-delivered notice.',
+    description: 'Check the status of a delegated agent task. If runId is omitted, checks the most recent delegated run (or filters by agentName if provided). When the run is completed, the response includes the task and completed output on every poll.',
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
+++ b/apps/desktop/src/main/acp/acp-router-tool-definitions.ts
@@ -68,7 +68,7 @@ export const acpRouterToolDefinitions = [
   },
   {
     name: 'check_agent_status',
-    description: 'Check the status of a running delegated agent task. If runId is omitted, checks the most recent delegated run (or filters by agentName if provided).',
+    description: 'Check the status of a running delegated agent task. If runId is omitted, checks the most recent delegated run (or filters by agentName if provided). Completed output is returned once; repeated checks return a compact already-delivered notice.',
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -150,7 +150,7 @@ describe("handleDelegateToAgent", () => {
     )
   })
 
-  it("returns completed check_agent_status output only once", async () => {
+  it("returns a stable completed check_agent_status response on repeated polls", async () => {
     const { handleDelegateToAgent, handleCheckAgentStatus } = await import("./acp-router-tools")
 
     const delegation = await handleDelegateToAgent({
@@ -166,16 +166,15 @@ describe("handleDelegateToAgent", () => {
       success: true,
       status: "completed",
       task: "Say hello",
+      pollCount: 1,
       output: "Final user-facing answer",
     }))
     expect(secondStatus).toEqual(expect.objectContaining({
       success: true,
       status: "completed",
+      task: "Say hello",
       pollCount: 2,
-      outputOmitted: true,
-      outputLength: "Final user-facing answer".length,
+      output: "Final user-facing answer",
     }))
-    expect(secondStatus.output).toBeUndefined()
-    expect(secondStatus.task).toBeUndefined()
   })
 })

--- a/apps/desktop/src/main/acp/acp-router-tools.test.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.test.ts
@@ -142,6 +142,40 @@ describe("handleDelegateToAgent", () => {
       { appSessionId: "parent-session-1" },
       expect.stringMatching(/^dotagents:delegation:parent-session-1:/),
     )
-    expect(mockSetAcpToAppSessionMapping).toHaveBeenCalledWith("acp-session-1", "parent-session-1", 7)
+    expect(mockSetAcpToAppSessionMapping).toHaveBeenCalledWith(
+      "acp-session-1",
+      "parent-session-1",
+      7,
+      { registerAppSession: true },
+    )
+  })
+
+  it("returns completed check_agent_status output only once", async () => {
+    const { handleDelegateToAgent, handleCheckAgentStatus } = await import("./acp-router-tools")
+
+    const delegation = await handleDelegateToAgent({
+      agentName: "test-agent",
+      task: "Say hello",
+      waitForResult: true,
+    }, "parent-session-1") as any
+
+    const firstStatus = await handleCheckAgentStatus({ runId: delegation.runId }) as any
+    const secondStatus = await handleCheckAgentStatus({ runId: delegation.runId }) as any
+
+    expect(firstStatus).toEqual(expect.objectContaining({
+      success: true,
+      status: "completed",
+      task: "Say hello",
+      output: "Final user-facing answer",
+    }))
+    expect(secondStatus).toEqual(expect.objectContaining({
+      success: true,
+      status: "completed",
+      pollCount: 2,
+      outputOmitted: true,
+      outputLength: "Final user-facing answer".length,
+    }))
+    expect(secondStatus.output).toBeUndefined()
+    expect(secondStatus.task).toBeUndefined()
   })
 })

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -44,8 +44,6 @@ interface DelegatedRun extends ACPSubAgentState {
   lastEmitTime: number;
   /** Number of explicit check_agent_status calls served for this run */
   statusCheckCount: number;
-  /** Whether the completed output has already been returned by check_agent_status */
-  completedOutputDelivered: boolean;
 }
 
 /**
@@ -124,7 +122,6 @@ function createSubAgentState(args: CreateSubAgentStateArgs): DelegatedRun {
     conversation: [userMessage],
     lastEmitTime: 0,
     statusCheckCount: 0,
-    completedOutputDelivered: false,
   };
   delegatedRuns.set(runId, delegatedRun);
   return delegatedRun;
@@ -1343,17 +1340,13 @@ export async function handleCheckAgentStatus(args: { runId: string; historyLengt
       success: true,
       runId: subAgentState.runId,
       agentName: subAgentState.agentName,
+      task: subAgentState.task,
       workingDirectory: subAgentState.workingDirectory,
       status: subAgentState.status,
       startTime: subAgentState.startTime,
       duration: Date.now() - subAgentState.startTime,
+      pollCount: subAgentState.statusCheckCount,
     };
-
-    if (statusCheckCount === 0) {
-      response.task = subAgentState.task;
-    } else {
-      response.pollCount = subAgentState.statusCheckCount;
-    }
 
     if (subAgentState.progress) {
       response.progress = subAgentState.progress;
@@ -1363,14 +1356,7 @@ export async function handleCheckAgentStatus(args: { runId: string; historyLengt
       const outputText = subAgentState.result.output
         ?.map((msg) => msg.parts.map((p) => p.content).join('\n'))
         .join('\n\n') || '';
-      if (!subAgentState.completedOutputDelivered) {
-        response.output = outputText;
-        subAgentState.completedOutputDelivered = true;
-      } else {
-        response.outputOmitted = true;
-        response.message = 'Completed output was already returned by an earlier check_agent_status call.';
-        response.outputLength = outputText.length;
-      }
+      response.output = outputText;
       response.metadata = subAgentState.result.metadata;
     }
 

--- a/apps/desktop/src/main/acp/acp-router-tools.ts
+++ b/apps/desktop/src/main/acp/acp-router-tools.ts
@@ -42,6 +42,10 @@ interface DelegatedRun extends ACPSubAgentState {
   conversation: ACPSubAgentMessage[];
   /** Last time we emitted a progress update to the UI (for rate limiting) */
   lastEmitTime: number;
+  /** Number of explicit check_agent_status calls served for this run */
+  statusCheckCount: number;
+  /** Whether the completed output has already been returned by check_agent_status */
+  completedOutputDelivered: boolean;
 }
 
 /**
@@ -119,6 +123,8 @@ function createSubAgentState(args: CreateSubAgentStateArgs): DelegatedRun {
     isAsync: args.isAsync,
     conversation: [userMessage],
     lastEmitTime: 0,
+    statusCheckCount: 0,
+    completedOutputDelivered: false,
   };
   delegatedRuns.set(runId, delegatedRun);
   return delegatedRun;
@@ -150,13 +156,23 @@ function createCompletedResult(
 ): DelegationResult {
   subAgentState.status = 'completed';
   const resolvedOutput = getPreferredDelegationOutput(output, conversation);
+  const endTime = Date.now();
+  subAgentState.result = {
+    runId: subAgentState.runId,
+    agentName: subAgentState.agentName,
+    status: 'completed',
+    startTime: subAgentState.startTime,
+    endTime,
+    metadata: { duration: endTime - subAgentState.startTime },
+    output: [{ role: 'assistant', parts: [{ content: resolvedOutput }] }],
+  };
   return {
     success: true,
     runId: subAgentState.runId,
     agentName: subAgentState.agentName,
     status: 'completed',
     output: resolvedOutput,
-    duration: Date.now() - subAgentState.startTime,
+    duration: endTime - subAgentState.startTime,
     conversation,
   };
 }
@@ -170,13 +186,23 @@ function createFailedResult(
   conversation?: ACPSubAgentMessage[]
 ): DelegationResult {
   subAgentState.status = 'failed';
+  const endTime = Date.now();
+  subAgentState.result = {
+    runId: subAgentState.runId,
+    agentName: subAgentState.agentName,
+    status: 'failed',
+    startTime: subAgentState.startTime,
+    endTime,
+    metadata: { duration: endTime - subAgentState.startTime },
+    error,
+  };
   return {
     success: false,
     runId: subAgentState.runId,
     agentName: subAgentState.agentName,
     status: 'failed',
     error,
-    duration: Date.now() - subAgentState.startTime,
+    duration: endTime - subAgentState.startTime,
     conversation,
   };
 }
@@ -1310,16 +1336,24 @@ export async function handleCheckAgentStatus(args: { runId: string; historyLengt
       };
     }
 
+    const statusCheckCount = subAgentState.statusCheckCount ?? 0;
+    subAgentState.statusCheckCount = statusCheckCount + 1;
+
     const response: Record<string, unknown> = {
       success: true,
       runId: subAgentState.runId,
       agentName: subAgentState.agentName,
-      task: subAgentState.task,
       workingDirectory: subAgentState.workingDirectory,
       status: subAgentState.status,
       startTime: subAgentState.startTime,
       duration: Date.now() - subAgentState.startTime,
     };
+
+    if (statusCheckCount === 0) {
+      response.task = subAgentState.task;
+    } else {
+      response.pollCount = subAgentState.statusCheckCount;
+    }
 
     if (subAgentState.progress) {
       response.progress = subAgentState.progress;
@@ -1329,7 +1363,14 @@ export async function handleCheckAgentStatus(args: { runId: string; historyLengt
       const outputText = subAgentState.result.output
         ?.map((msg) => msg.parts.map((p) => p.content).join('\n'))
         .join('\n\n') || '';
-      response.output = outputText;
+      if (!subAgentState.completedOutputDelivered) {
+        response.output = outputText;
+        subAgentState.completedOutputDelivered = true;
+      } else {
+        response.outputOmitted = true;
+        response.message = 'Completed output was already returned by an earlier check_agent_status call.';
+        response.outputLength = outputText.length;
+      }
       response.metadata = subAgentState.result.metadata;
     }
 

--- a/apps/desktop/src/main/acp/internal-agent.ts
+++ b/apps/desktop/src/main/acp/internal-agent.ts
@@ -32,6 +32,15 @@ const logSubSession = (...args: unknown[]) => {
   console.log(`[${new Date().toISOString()}] [InternalSubSession]`, ...args);
 };
 
+function isExpectedCancellationError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes('session stopped by kill switch') ||
+    normalized.includes('aborted by emergency stop')
+  );
+}
+
 // ============================================================================
 // Configuration & Limits
 // ============================================================================
@@ -675,14 +684,23 @@ export async function runInternalSubSession(
     };
 
   } catch (error) {
-    subSession.status = 'failed';
+    const currentSubSession = activeSubSessions.get(subSessionId);
+    const wasCancelled = currentSubSession?.status === 'cancelled' || isExpectedCancellationError(error);
+
+    subSession.status = wasCancelled ? 'cancelled' : 'failed';
     subSession.endTime = Date.now();
-    subSession.error = error instanceof Error ? error.message : String(error);
+    subSession.error = wasCancelled
+      ? 'Sub-session was cancelled'
+      : error instanceof Error ? error.message : String(error);
 
     // Emit final delegation progress showing failure
     emitSubSessionDelegationProgress(subSession, parentSessionId);
 
-    logSubSession(`Sub-session ${subSessionId} failed:`, error);
+    if (wasCancelled) {
+      logSubSession(`Sub-session ${subSessionId} was cancelled`);
+    } else {
+      logSubSession(`Sub-session ${subSessionId} failed:`, error);
+    }
 
     return {
       success: false,

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -4,16 +4,19 @@ import { INTERNAL_COMPLETION_NUDGE_TEXT } from "../shared/runtime-tool-names"
 let currentConfig: any
 
 const mocks = vi.hoisted(() => ({
+  state: { shouldStopAgent: false, isAgentModeActive: false, agentIterationCount: 0 },
   makeLLMCallWithFetch: vi.fn(),
   makeLLMCallWithStreamingAndTools: vi.fn(),
   verifyCompletionWithFetch: vi.fn(),
+  diagnosticsLogError: vi.fn(),
   emitAgentProgress: vi.fn(() => Promise.resolve()),
   addMessageToConversation: vi.fn(async (...args: any[]) => ({ id: args[0] })),
   maybeAutoGenerateConversationTitle: vi.fn(async () => undefined),
   createSession: vi.fn(),
   startSessionRun: vi.fn(() => 1),
   getSessionProfileSnapshot: vi.fn(() => undefined),
-  shouldStopSession: vi.fn(() => false),
+  isSessionRegistered: vi.fn((_: string) => false),
+  shouldStopSession: vi.fn((_: string) => false),
   updateIterationCount: vi.fn(),
   cleanupSession: vi.fn(),
   isSessionSnoozed: vi.fn(() => false),
@@ -38,9 +41,9 @@ vi.mock("./llm-fetch", () => ({
   makeTextCompletionWithFetch: vi.fn(),
 }))
 vi.mock("./system-prompts", () => ({ constructSystemPrompt: vi.fn(() => "system prompt") }))
-vi.mock("./state", () => ({ state: {}, agentSessionStateManager: mocks }))
+vi.mock("./state", () => ({ state: mocks.state, agentSessionStateManager: mocks }))
 vi.mock("./debug", () => ({ isDebugLLM: () => false, isDebugTools: () => false, logLLM: vi.fn(), logTools: vi.fn(), logApp: vi.fn() }))
-vi.mock("./diagnostics", () => ({ diagnosticsService: { logError: vi.fn(), logWarning: vi.fn(), logInfo: vi.fn() } }))
+vi.mock("./diagnostics", () => ({ diagnosticsService: { logError: mocks.diagnosticsLogError, logWarning: vi.fn(), logInfo: vi.fn() } }))
 vi.mock("./context-budget", () => ({
   shrinkMessagesForLLM: vi.fn(async ({ messages }: any) => ({ messages, estTokensAfter: 0, maxTokens: 0, appliedStrategies: [] })),
   estimateTokensFromMessages: vi.fn(() => 0),
@@ -93,6 +96,13 @@ async function clearResponses(...sessionIds: string[]) {
 describe("processTranscriptWithAgentMode respond_to_user history", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.state.shouldStopAgent = false
+    mocks.state.isAgentModeActive = false
+    mocks.state.agentIterationCount = 0
+    mocks.isSessionRegistered.mockReturnValue(false)
+    mocks.shouldStopSession.mockReturnValue(false)
+    mocks.getSession.mockImplementation((id: string): { id: string; conversationTitle: string } | undefined => ({ id, conversationTitle: "Test conversation" }))
+    mocks.getAcpSessionTitleOverride.mockImplementation((_: string): string | undefined => undefined)
     mocks.makeLLMCallWithFetch.mockReset()
     mocks.makeLLMCallWithStreamingAndTools.mockReset()
     mocks.verifyCompletionWithFetch.mockReset()
@@ -131,7 +141,82 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
       "session-reasoning-stub",
       "session-reasoning-only-empty-retry",
       "session-latest-completion-summary",
+      "session-provider-error-after-stop",
+      "session-abort-after-stop",
     )
+  })
+
+  it("logs diagnostics for unrelated provider errors even when a session stop flag is active", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+    const providerError = new Error("503 Service Unavailable")
+    const sessionId = "session-provider-error-after-stop"
+
+    mocks.isSessionRegistered.mockImplementation((id: string) => Boolean(id === sessionId))
+    mocks.shouldStopSession.mockImplementation(() => mocks.makeLLMCallWithStreamingAndTools.mock.calls.length > 0)
+    mocks.makeLLMCallWithStreamingAndTools.mockRejectedValueOnce(providerError)
+
+    await processTranscriptWithAgentMode(
+      "Finish this",
+      availableTools as any,
+      makeExecuteToolCall(sessionId, 11),
+      3,
+      [],
+      "conv-provider-error-after-stop",
+      sessionId,
+      undefined,
+      undefined,
+      11,
+    )
+
+    expect(mocks.diagnosticsLogError).toHaveBeenCalledWith("llm", "Agent LLM call failed", providerError)
+  })
+
+  it("logs diagnostics for unrelated provider errors even when the global stop flag is active", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+    const providerError = new Error("provider exploded")
+    mocks.state.shouldStopAgent = true
+    mocks.makeLLMCallWithStreamingAndTools.mockRejectedValueOnce(providerError)
+
+    await expect(processTranscriptWithAgentMode(
+      "Finish this",
+      availableTools as any,
+      makeExecuteToolCall("session-global-provider-error", 12),
+      3,
+      [],
+      "conv-global-provider-error",
+      "session-global-provider-error",
+      undefined,
+      undefined,
+      12,
+    )).rejects.toThrow("provider exploded")
+
+    expect(mocks.diagnosticsLogError).toHaveBeenCalledWith("llm", "Agent LLM call failed", providerError)
+  })
+
+  it("suppresses diagnostics for abort errors when a session stop flag is active", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+    const abortError = new Error("The operation was aborted")
+    abortError.name = "AbortError"
+    const sessionId = "session-abort-after-stop"
+
+    mocks.isSessionRegistered.mockImplementation((id: string) => Boolean(id === sessionId))
+    mocks.shouldStopSession.mockImplementation(() => mocks.makeLLMCallWithStreamingAndTools.mock.calls.length > 0)
+    mocks.makeLLMCallWithStreamingAndTools.mockRejectedValueOnce(abortError)
+
+    await processTranscriptWithAgentMode(
+      "Finish this",
+      availableTools as any,
+      makeExecuteToolCall(sessionId, 13),
+      3,
+      [],
+      "conv-abort-after-stop",
+      sessionId,
+      undefined,
+      undefined,
+      13,
+    )
+
+    expect(mocks.diagnosticsLogError).not.toHaveBeenCalledWith("llm", "Agent LLM call failed", abortError)
   })
 
   it("preserves earlier numbered respond_to_user content in the next turn prompt", async () => {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -140,6 +140,33 @@ function resolveProgressConversationState(update: Pick<AgentProgressUpdate, "con
   return update.isComplete ? "complete" : "running"
 }
 
+function getExpectedStopReason(error: unknown, sessionId?: string): string | null {
+  const message = error instanceof Error ? error.message : String(error)
+  const normalized = message.toLowerCase()
+
+  if (
+    sessionId &&
+    agentSessionStateManager.isSessionRegistered(sessionId) &&
+    agentSessionStateManager.shouldStopSession(sessionId)
+  ) {
+    return "Session stopped by kill switch"
+  }
+
+  if (state.shouldStopAgent) {
+    return "Aborted by emergency stop"
+  }
+
+  if (normalized.includes("session stopped by kill switch")) {
+    return "Session stopped by kill switch"
+  }
+
+  if (normalized.includes("aborted by emergency stop")) {
+    return "Aborted by emergency stop"
+  }
+
+  return null
+}
+
 function getVerificationOutcomeDescription(state: AgentConversationState): string {
   switch (state) {
     case "complete":
@@ -3471,10 +3498,15 @@ async function makeLLMCall(
     }
     return result
   } catch (error) {
-    if (isDebugLLM()) {
+    const expectedStopReason = getExpectedStopReason(error, sessionId)
+    if (isDebugLLM() && expectedStopReason) {
+      logLLM("LLM call stopped", { sessionId, reason: expectedStopReason })
+    } else if (isDebugLLM()) {
       logLLM("LLM CALL ERROR:", error)
     }
-    diagnosticsService.logError("llm", "Agent LLM call failed", error)
+    if (!expectedStopReason) {
+      diagnosticsService.logError("llm", "Agent LLM call failed", error)
+    }
     throw error
   }
 }

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -144,6 +144,26 @@ function getExpectedStopReason(error: unknown, sessionId?: string): string | nul
   const message = error instanceof Error ? error.message : String(error)
   const normalized = message.toLowerCase()
 
+  if (normalized.includes("session stopped by kill switch")) {
+    return "Session stopped by kill switch"
+  }
+
+  if (normalized.includes("aborted by emergency stop")) {
+    return "Aborted by emergency stop"
+  }
+
+  const normalizedName = error instanceof Error ? error.name.toLowerCase() : ""
+  const isKnownStopError =
+    normalizedName === "aborterror" ||
+    normalizedName.includes("abort") ||
+    normalizedName.includes("cancel") ||
+    normalized.includes("abort") ||
+    normalized.includes("cancel")
+
+  if (!isKnownStopError) {
+    return null
+  }
+
   if (
     sessionId &&
     agentSessionStateManager.isSessionRegistered(sessionId) &&
@@ -153,14 +173,6 @@ function getExpectedStopReason(error: unknown, sessionId?: string): string | nul
   }
 
   if (state.shouldStopAgent) {
-    return "Aborted by emergency stop"
-  }
-
-  if (normalized.includes("session stopped by kill switch")) {
-    return "Session stopped by kill switch"
-  }
-
-  if (normalized.includes("aborted by emergency stop")) {
     return "Aborted by emergency stop"
   }
 

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -147,6 +147,42 @@ export interface MCPToolResult {
   isError?: boolean
 }
 
+function summarizeRuntimeToolResultForDebug(toolName: string, result: MCPToolResult): unknown {
+  if (toolName !== "check_agent_status") {
+    return result
+  }
+
+  const text = result.content[0]?.text
+  if (!text) {
+    return { isError: result.isError, contentItems: result.content.length }
+  }
+
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    const output = typeof parsed.output === "string" ? parsed.output : undefined
+    return {
+      isError: result.isError,
+      success: parsed.success,
+      runId: parsed.runId,
+      agentName: parsed.agentName,
+      status: parsed.status,
+      duration: parsed.duration,
+      pollCount: parsed.pollCount,
+      hasOutput: output !== undefined,
+      outputLength: output?.length ?? parsed.outputLength,
+      outputOmitted: parsed.outputOmitted,
+      metadata: parsed.metadata,
+    }
+  } catch {
+    return {
+      isError: result.isError,
+      contentItems: result.content.length,
+      textLength: text.length,
+      preview: text.slice(0, 300),
+    }
+  }
+}
+
 export interface LLMToolCallResponse {
   content?: string
   toolCalls?: MCPToolCall[]
@@ -2711,7 +2747,7 @@ export class MCPService {
         const result = await executeRuntimeTool(toolCall.name, toolCall.arguments || {}, sessionId)
         if (result) {
           if (isDebugTools()) {
-            logTools("Runtime tool result", { name: toolCall.name, result })
+            logTools("Runtime tool result", { name: toolCall.name, result: summarizeRuntimeToolResultForDebug(toolCall.name, result) })
           }
           return endSpanAndReturn(result)
         }


### PR DESCRIPTION
## Summary
- Treat expected kill-switch/emergency-stop cancellation as a normal stopped LLM call instead of logging scary LLM error / diagnostics errors.
- Mark internal sub-sessions cancelled when their agent loop exits from expected cancellation.
- Compact repeated check_agent_status calls by returning completed output once, then returning an already-delivered notice with output length.
- Summarize check_agent_status debug logs so completed sub-agent outputs are not repeatedly dumped into logs.

## Validation
- pnpm --filter @dotagents/desktop test -- --run acp-router-tools.test.ts
- pnpm --filter @dotagents/desktop typecheck

## Notes
- Leaves unrelated untracked local autoresearch/ directory out of the commit.
