### PR TITLE
Avatar dropdown agent edit/create, repeat-task play, slim voice waveform

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -6,12 +6,14 @@ import {
   ChevronDown,
   ChevronRight,
   Pin,
+  Play,
   X,
   Clock,
   CornerDownRight,
   Mic,
   Plus,
 } from "lucide-react"
+import { toast } from "sonner"
 import { cn } from "@renderer/lib/utils"
 import { useAgentStore } from "@renderer/stores"
 import { logUI, logStateChange, logExpand } from "@renderer/lib/debug"
@@ -484,12 +486,22 @@ export function ActiveAgentsSidebar({
     archivedSessionIds,
   ])
 
+  const loopByTitleHint = useMemo(() => {
+    const map = new Map<string, LoopConfig>()
+    for (const loop of repeatTasksQuery.data ?? []) {
+      for (const hint of getRepeatTaskTitleHints(loop)) {
+        if (!map.has(hint)) map.set(hint, loop)
+      }
+    }
+    return map
+  }, [repeatTasksQuery.data])
+
   const {
     userSidebarSessions: allUserSidebarSessions,
     pinnedTaskSidebarSessions,
     unpinnedTaskSidebarSessions,
   } = useMemo(() => {
-    const repeatTaskTitleHints = new Set(
+    const repeatTaskTitleHints = new Set<string>(
       (repeatTasksQuery.data ?? []).flatMap(getRepeatTaskTitleHints),
     )
     const { userEntries, taskEntries } = partitionTaskAndUserEntries(
@@ -687,6 +699,35 @@ export function ActiveAgentsSidebar({
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [visibleSidebarSessions, handleSavedConversationOpen, handleActiveSessionSelect])
+
+  const findLoopForSession = useCallback(
+    (session: SidebarSessionRecord): LoopConfig | undefined => {
+      const title = session.conversationTitle?.trim()
+      if (!title) return undefined
+      const direct = loopByTitleHint.get(title)
+      if (direct) return direct
+      const stripped = title.startsWith("Repeat: ") ? title.slice("Repeat: ".length).trim() : null
+      return stripped ? loopByTitleHint.get(stripped) : undefined
+    },
+    [loopByTitleHint],
+  )
+
+  const handleRunRepeatTask = useCallback(
+    async (loop: LoopConfig, e: React.MouseEvent) => {
+      e.stopPropagation()
+      try {
+        const result = await tipcClient.triggerLoop?.({ loopId: loop.id })
+        if (result && !result.success) {
+          toast.error(`Could not trigger "${loop.name}" right now`)
+          return
+        }
+        toast.success(`Running "${loop.name}"...`)
+      } catch {
+        toast.error("Failed to trigger task")
+      }
+    },
+    [],
+  )
 
   const handleStopSession = async (sessionId: string, e: React.MouseEvent) => {
     e.stopPropagation() // Prevent session focus when clicking stop
@@ -1105,6 +1146,10 @@ export function ActiveAgentsSidebar({
 
             // Active session row
             // Retained completed turns should stay visually active until the user dismisses them.
+            const repeatTaskLoop = findLoopForSession(session)
+            const isInactiveRepeatTask =
+              !!repeatTaskLoop &&
+              (session.status !== "active" || sessionProgress?.isComplete === true)
             const statusRailColor = sidebarStatusPresentation.railClassName
             const shouldPulseStatus = sidebarStatusPresentation.shouldPulse
             const isLifecycleNeedsInput = sidebarStatusPresentation.lifecycleState === "needs_input"
@@ -1261,6 +1306,18 @@ export function ActiveAgentsSidebar({
                     </div>
                   )}
                 </div>
+                {isInactiveRepeatTask && repeatTaskLoop && (
+                  <button
+                    onClick={(e) => handleRunRepeatTask(repeatTaskLoop, e)}
+                    onMouseDown={(event) => event.stopPropagation()}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    className="absolute right-7 top-1/2 z-20 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded transition-all hover:bg-emerald-500/20 hover:text-emerald-600 dark:hover:text-emerald-400"
+                    title={`Run "${repeatTaskLoop.name}" now`}
+                    aria-label={`Run ${repeatTaskLoop.name} now`}
+                  >
+                    <Play className="h-3 w-3" />
+                  </button>
+                )}
                 <div
                   className={cn(
                     "bg-background/90 absolute right-1 top-1/2 z-20 flex -translate-y-1/2 items-center gap-0 rounded-sm pl-1 opacity-0 transition-opacity",

--- a/apps/desktop/src/renderer/src/components/agent-selector.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-selector.tsx
@@ -5,8 +5,9 @@
 
 import React from "react"
 import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "react-router-dom"
 import { tipcClient } from "@renderer/lib/tipc-client"
-import { Bot, Check } from "lucide-react"
+import { Bot, Check, Edit2, Plus } from "lucide-react"
 import { cn } from "@renderer/lib/utils"
 import type { AgentProfile } from "../../../shared/types"
 import {
@@ -98,6 +99,7 @@ interface AgentSelectorProps {
 }
 
 export function AgentSelector({ selectedAgentId, onSelectAgent }: AgentSelectorProps) {
+  const navigate = useNavigate()
   const { data: agents = [] } = useQuery<AgentProfile[]>({
     queryKey: ["agentProfilesSelector"],
     queryFn: () => tipcClient.getAgentProfiles(),
@@ -167,8 +169,11 @@ export function AgentSelector({ selectedAgentId, onSelectAgent }: AgentSelectorP
         {enabledAgents.map((agent) => (
           <DropdownMenuItem
             key={agent.id}
-            onClick={() => onSelectAgent(agent.id)}
-            className="min-w-0 items-center gap-2"
+            onSelect={(event) => {
+              event.preventDefault()
+              onSelectAgent(agent.id)
+            }}
+            className="min-w-0 items-center gap-2 pr-1"
           >
             <div className="h-5 w-5 shrink-0 rounded overflow-hidden flex items-center justify-center">
               {agent.avatarDataUrl ? (
@@ -179,8 +184,34 @@ export function AgentSelector({ selectedAgentId, onSelectAgent }: AgentSelectorP
             </div>
             <span className="min-w-0 flex-1 truncate text-sm font-medium">{agent.displayName || agent.name}</span>
             <Check className={cn("h-3.5 w-3.5 shrink-0", selectedAgentId === agent.id ? "opacity-100" : "opacity-0")} />
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                navigate(`/settings/agents?edit=${encodeURIComponent(agent.id)}`)
+              }}
+              onPointerDown={(event) => event.stopPropagation()}
+              className="ml-1 flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              title={`Edit ${agent.displayName || agent.name}`}
+              aria-label={`Edit ${agent.displayName || agent.name}`}
+            >
+              <Edit2 className="h-3.5 w-3.5" />
+            </button>
           </DropdownMenuItem>
         ))}
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          onSelect={() => navigate("/settings/agents?create=1")}
+          className="min-w-0 items-center gap-2"
+        >
+          <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground">
+            <Plus className="h-4 w-4" />
+          </div>
+          <span className="min-w-0 flex-1 truncate text-sm font-medium">New agent…</span>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
@@ -31,7 +31,7 @@ interface SessionActionDialogProps {
   onSubmitted?: () => void
 }
 
-const VISUALIZER_BAR_COUNT = 56
+const VISUALIZER_BAR_COUNT = 52
 const INITIAL_VISUALIZER_DATA = Array<number>(VISUALIZER_BAR_COUNT).fill(0.01)
 
 function getErrorMessage(error: unknown, fallback: string) {
@@ -326,12 +326,12 @@ export function SessionActionDialog({
                   <span>{statusMessage ?? (recording ? "Listening…" : "Preparing microphone…")}</span>
                 </div>
 
-                <div className="flex h-24 w-full items-end justify-center gap-1 rounded-lg bg-background/80 px-3 py-4">
+                <div className="flex h-20 w-full items-center justify-center gap-0.5 overflow-hidden rounded-lg bg-background/80 px-4 py-3">
                   {voiceBars.map((value, index) => (
                     <div
                       key={index}
-                      className="w-1.5 shrink-0 rounded-full bg-red-500/90 transition-all dark:bg-white"
-                      style={{ height: `${Math.max(12, Math.min(100, value * 100))}%` }}
+                      className="h-full w-0.5 shrink-0 rounded-lg bg-red-500/90 transition-all dark:bg-white"
+                      style={{ height: `${Math.max(16, Math.min(100, value * 100))}%` }}
                     />
                   ))}
                 </div>

--- a/apps/desktop/src/renderer/src/pages/settings-agents.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.tsx
@@ -237,14 +237,24 @@ export function SettingsAgents() {
     setCommandVerification(null)
   }, [editing?.presetKey, editing?.connectionType, editing?.connectionCommand, editing?.connectionArgs, editing?.connectionCwd])
 
-  // Handle URL-driven navigation: ?edit=<agentId> opens edit, ?view=list returns to list
+  // Handle URL-driven navigation: ?edit=<agentId> opens edit, ?create=1 opens
+  // the create form, ?view=list returns to list
   useEffect(() => {
     const editId = searchParams.get("edit")
     const viewMode = searchParams.get("view")
+    const createFlag = searchParams.get("create")
 
     if (viewMode === "list") {
       setEditing(null)
       setIsCreating(false)
+      setSearchParams({}, { replace: true })
+      return
+    }
+
+    if (createFlag && !isCreating) {
+      setIsCreating(true)
+      setEditing(emptyAgent())
+      setCommandVerification(null)
       setSearchParams({}, { replace: true })
       return
     }


### PR DESCRIPTION
## Summary
Bundles three sidebar/voice UX fixes into one change.

- **#434 Agents dropdown edit/create**: AgentSelector now shows an inline edit icon per enabled agent and a `New agent…` entry. Both route to `/settings/agents` (`?edit=<id>` or `?create=1`). SettingsAgents opens the create form when the new param is present.
- **#435 Play button for inactive repeat tasks**: ActiveAgentsSidebar maps repeat tasks to their derived title hints, then renders a Play button on inactive task rows that fires `tipcClient.triggerLoop({ loopId })` — the same path used by the Repeat Tasks menu Play action.
- **#436 Voice waveform sizing**: SessionActionDialog now uses the same bar width (2px), gap (2px), bar count (52), and rounded styling as the floating panel popup so both voice flows feel consistent.

Closes #434, #435, #436.

## Test plan
- [ ] Open the avatar dropdown in the active-agents sidebar; click the pencil next to an agent → lands in the agent's edit form
- [ ] From the same dropdown, click `New agent…` → lands in the create form
- [ ] Trigger a repeat task; once it completes, hover the row in the sidebar Tasks section and click Play → toast shows `Running "<task>"…` and the loop runs again
- [ ] Click the sidebar mic button → Start with Voice modal waveform now matches the Ctrl-popup waveform sizing
- [ ] `pnpm --filter @dotagents/desktop run typecheck:web`
- [ ] `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts src/renderer/src/pages/settings-agents.install-handoff.test.tsx`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJues9seToQRfEZN4KWHCn)_