### PR TITLE
Align Langfuse trace IDs with per-run agent lifecycle

### DIFF
--- a/apps/desktop/src/main/langfuse-service.test.ts
+++ b/apps/desktop/src/main/langfuse-service.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import fs from "fs"
+import os from "os"
+import path from "path"
+
+/**
+ * Per-run Langfuse trace identity tests (issue #441).
+ *
+ * Verifies that:
+ * 1. `makeLangfuseTraceId` is stable per (sessionId, runId) and changes per run.
+ * 2. Two consecutive runs of the same DotAgents agent session produce two
+ *    distinct local trace files, not one reused trace bucket.
+ * 3. `forceCloseTraceOperations` emits matching `span.end`/`generation.end`
+ *    events with ERROR level for any operation still open at finalize time.
+ * 4. `setActiveRunTrace`/`getActiveRunTrace` round-trip per session and clear
+ *    only when the caller's trace ID still owns the slot (race-safe).
+ * 5. Local trace logging works even when remote Langfuse upload is disabled.
+ */
+
+let currentConfig: {
+  langfuseEnabled?: boolean
+  langfuseSecretKey?: string
+  langfusePublicKey?: string
+  langfuseBaseUrl?: string
+  localTraceLoggingEnabled?: boolean
+  localTraceLogPath?: string
+} = {}
+let tempDir: string
+
+vi.mock("./config", () => ({
+  configStore: { get: () => currentConfig },
+  get dataFolder() { return tempDir },
+}))
+vi.mock("./debug", () => ({
+  isDebugLLM: () => false,
+  logLLM: vi.fn(),
+}))
+// Avoid loading the optional langfuse package in tests; force not-installed.
+vi.mock("./langfuse-loader", () => ({
+  Langfuse: null,
+  isInstalled: false,
+  // Types are erased at runtime; placeholders are unused.
+  LangfuseInstance: null,
+  LangfuseTraceClient: null,
+  LangfuseSpanClient: null,
+  LangfuseGenerationClient: null,
+}))
+
+describe("langfuse-service per-run trace identity (#441)", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-langfuse-"))
+    currentConfig = { localTraceLoggingEnabled: true }
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    } catch {
+      // best-effort cleanup
+    }
+  })
+
+  it("derives stable per-run trace IDs that differ across runs", async () => {
+    const { makeLangfuseTraceId } = await import("./langfuse-service")
+    const t1 = makeLangfuseTraceId({ agentSessionId: "session_abc", runId: 1 })
+    const t1Again = makeLangfuseTraceId({ agentSessionId: "session_abc", runId: 1 })
+    const t2 = makeLangfuseTraceId({ agentSessionId: "session_abc", runId: 2 })
+
+    expect(t1).toBe(t1Again)
+    expect(t1).not.toBe(t2)
+    expect(t1).toContain("session_abc")
+    expect(t1).toContain("run_1")
+    expect(t2).toContain("run_2")
+  })
+
+  it("writes separate local trace files for two runs of the same agent session", async () => {
+    const { makeLangfuseTraceId, createAgentTrace, endAgentTrace } = await import(
+      "./langfuse-service"
+    )
+    const { flushLocalTraceLogger } = await import("./local-trace-logger")
+
+    const agentSessionId = "session_xyz"
+    const conversationId = "conv_123"
+
+    const traceA = makeLangfuseTraceId({ agentSessionId, runId: 1 })
+    createAgentTrace(traceA, { name: "Run A", sessionId: conversationId })
+    endAgentTrace(traceA, { output: "done A" })
+
+    const traceB = makeLangfuseTraceId({ agentSessionId, runId: 2 })
+    createAgentTrace(traceB, { name: "Run B", sessionId: conversationId })
+    endAgentTrace(traceB, { output: "done B" })
+
+    await flushLocalTraceLogger()
+
+    const fileA = path.join(tempDir, "traces", `${traceA}.jsonl`)
+    const fileB = path.join(tempDir, "traces", `${traceB}.jsonl`)
+
+    expect(fs.existsSync(fileA)).toBe(true)
+    expect(fs.existsSync(fileB)).toBe(true)
+
+    const linesA = fs.readFileSync(fileA, "utf8").trim().split("\n").map(JSON.parse)
+    const linesB = fs.readFileSync(fileB, "utf8").trim().split("\n").map(JSON.parse)
+
+    // Each per-run file should contain exactly one trace.start and one trace.end —
+    // no reused-bucket pollution.
+    expect(linesA.filter((l) => l.type === "trace.start")).toHaveLength(1)
+    expect(linesA.filter((l) => l.type === "trace.end")).toHaveLength(1)
+    expect(linesB.filter((l) => l.type === "trace.start")).toHaveLength(1)
+    expect(linesB.filter((l) => l.type === "trace.end")).toHaveLength(1)
+
+    // The Langfuse session ID (conversation) should be carried in metadata so
+    // remote Langfuse can group the two runs under one Sessions view entry.
+    expect(linesA[0].metadata.sessionId).toBe(conversationId)
+    expect(linesB[0].metadata.sessionId).toBe(conversationId)
+  })
+
+  it("force-closes still-open spans and generations with ERROR level", async () => {
+    const {
+      createAgentTrace,
+      endAgentTrace,
+      createToolSpan,
+      createLLMGeneration,
+      forceCloseTraceOperations,
+    } = await import("./langfuse-service")
+    const { flushLocalTraceLogger } = await import("./local-trace-logger")
+
+    const traceId = "trace_run_force_close"
+
+    createAgentTrace(traceId, { name: "Agent" })
+    createToolSpan(traceId, "span_1", { name: "Tool: search" })
+    createLLMGeneration(traceId, "gen_1", {
+      name: "LLM Call",
+      model: "test-model",
+      input: "hi",
+    })
+
+    const closed = forceCloseTraceOperations(traceId, {
+      level: "ERROR",
+      statusMessage: "Run aborted",
+    })
+    expect(closed.closedSpans).toBe(1)
+    expect(closed.closedGenerations).toBe(1)
+
+    endAgentTrace(traceId, { output: undefined, metadata: { wasAborted: true } })
+    await flushLocalTraceLogger()
+
+    const filePath = path.join(tempDir, "traces", `${traceId}.jsonl`)
+    const lines = fs.readFileSync(filePath, "utf8").trim().split("\n").map(JSON.parse)
+
+    const spanEnds = lines.filter((l) => l.type === "span.end")
+    const genEnds = lines.filter((l) => l.type === "generation.end")
+    const traceEnds = lines.filter((l) => l.type === "trace.end")
+
+    expect(spanEnds).toHaveLength(1)
+    expect(genEnds).toHaveLength(1)
+    expect(traceEnds).toHaveLength(1)
+    expect(spanEnds[0].level).toBe("ERROR")
+    expect(spanEnds[0].statusMessage).toBe("Run aborted")
+    expect(genEnds[0].level).toBe("ERROR")
+    expect(traceEnds[0].metadata.wasAborted).toBe(true)
+  })
+
+  it("force-close after explicit end is a no-op for already-closed observations", async () => {
+    const {
+      createAgentTrace,
+      endAgentTrace,
+      createToolSpan,
+      endToolSpan,
+      forceCloseTraceOperations,
+    } = await import("./langfuse-service")
+    const { flushLocalTraceLogger } = await import("./local-trace-logger")
+
+    const traceId = "trace_run_clean"
+    createAgentTrace(traceId, { name: "Agent" })
+    createToolSpan(traceId, "span_ok", { name: "Tool: ok" })
+    endToolSpan("span_ok", { output: "result" })
+
+    const closed = forceCloseTraceOperations(traceId)
+    expect(closed.closedSpans).toBe(0)
+    expect(closed.closedGenerations).toBe(0)
+
+    endAgentTrace(traceId, { output: "done" })
+    await flushLocalTraceLogger()
+
+    const filePath = path.join(tempDir, "traces", `${traceId}.jsonl`)
+    const lines = fs.readFileSync(filePath, "utf8").trim().split("\n").map(JSON.parse)
+
+    // span.start + span.end + trace.start + trace.end = 4 events, no extras
+    expect(lines.filter((l) => l.type === "span.end")).toHaveLength(1)
+  })
+
+  it("active run trace round-trips per session and clears race-safely", async () => {
+    const { setActiveRunTrace, getActiveRunTrace, clearActiveRunTrace } = await import(
+      "./langfuse-service"
+    )
+
+    setActiveRunTrace("session_a", "trace_run_1")
+    expect(getActiveRunTrace("session_a")).toBe("trace_run_1")
+
+    // A newer run claims the slot.
+    setActiveRunTrace("session_a", "trace_run_2")
+    expect(getActiveRunTrace("session_a")).toBe("trace_run_2")
+
+    // Late finalizer for run 1 must not wipe the active run 2 entry.
+    clearActiveRunTrace("session_a", "trace_run_1")
+    expect(getActiveRunTrace("session_a")).toBe("trace_run_2")
+
+    // Run 2 finalizes properly.
+    clearActiveRunTrace("session_a", "trace_run_2")
+    expect(getActiveRunTrace("session_a")).toBeUndefined()
+  })
+
+  it("shouldRecordObservations is true when local tracing is on even if remote langfuse is off", async () => {
+    const { shouldRecordObservations, isLangfuseEnabled } = await import(
+      "./langfuse-service"
+    )
+    currentConfig = { localTraceLoggingEnabled: true, langfuseEnabled: false }
+    expect(isLangfuseEnabled()).toBe(false)
+    expect(shouldRecordObservations()).toBe(true)
+  })
+
+  it("shouldRecordObservations is false when both remote and local tracing are off", async () => {
+    const { shouldRecordObservations } = await import("./langfuse-service")
+    currentConfig = { localTraceLoggingEnabled: false, langfuseEnabled: false }
+    expect(shouldRecordObservations()).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/langfuse-service.ts
+++ b/apps/desktop/src/main/langfuse-service.ts
@@ -4,10 +4,15 @@
  *
  * Key features:
  * - LLM call tracing with token counts and costs
- * - Agent session traces
+ * - Agent session traces (one trace per agent run, grouped by conversation in Langfuse sessions)
  * - MCP tool call instrumentation
  * - Optional/configurable (won't block functionality if not configured)
  * - Langfuse is an OPTIONAL dependency - this module handles its absence gracefully
+ *
+ * Trace identity model (issue #441):
+ * - Langfuse `sessionId` = DotAgents conversation ID (groups multi-turn conversations)
+ * - Langfuse `traceId`   = unique per agent run (derived from agent session ID + runId)
+ * - Observations         = LLM generations, MCP tool spans, etc., attached to the per-run trace
  */
 
 import { configStore } from "./config"
@@ -22,16 +27,25 @@ import {
 } from "./langfuse-loader"
 import {
   appendLocalTraceEvent,
+  isLocalTraceLoggingEnabled,
   resetLocalTraceLogger,
 } from "./local-trace-logger"
 
 // Singleton Langfuse instance
 let langfuseInstance: LangfuseInstance | null = null
 
-// Active traces and spans for linking
+// Active traces and observations for linking and force-close.
 const activeTraces = new Map<string, LangfuseTraceClient>()
 const activeSpans = new Map<string, LangfuseSpanClient>()
 const activeGenerations = new Map<string, LangfuseGenerationClient>()
+
+// Reverse index: which spans/generations belong to which trace (for force-close on abort).
+const traceSpanIds = new Map<string, Set<string>>()
+const traceGenerationIds = new Map<string, Set<string>>()
+
+// Active per-run trace ID per agent session, so deeper subsystems (mcp-service)
+// can resolve the right trace without changing every call signature.
+const sessionRunTraceIds = new Map<string, string>()
 
 /**
  * Check if Langfuse package is installed and available
@@ -51,6 +65,54 @@ export function isLangfuseEnabled(): boolean {
   if (!isInstalled) return false
   const config = configStore.get()
   return !!(config.langfuseEnabled && config.langfuseSecretKey && config.langfusePublicKey)
+}
+
+/**
+ * Should we record any tracing observations? True if either remote Langfuse is
+ * enabled or local trace logging is opted in. Local tracing must work even when
+ * remote upload is disabled (issue #441).
+ */
+export function shouldRecordObservations(): boolean {
+  return isLangfuseEnabled() || isLocalTraceLoggingEnabled()
+}
+
+/**
+ * Build a per-run Langfuse trace ID from the long-lived agent session ID and
+ * the run number. Stable for a given (session, run) pair so debug tooling can
+ * cross-reference local trace files with remote traces.
+ */
+export function makeLangfuseTraceId(opts: {
+  agentSessionId: string
+  runId: number
+}): string {
+  return `${opts.agentSessionId}__run_${opts.runId}`
+}
+
+/**
+ * Register the active per-run trace ID for an agent session. Used by mcp-service
+ * to attach tool spans to the right per-run trace without threading the trace ID
+ * through every call signature.
+ */
+export function setActiveRunTrace(sessionId: string, traceId: string): void {
+  sessionRunTraceIds.set(sessionId, traceId)
+}
+
+/**
+ * Look up the active per-run trace ID for an agent session, if any.
+ */
+export function getActiveRunTrace(sessionId: string): string | undefined {
+  return sessionRunTraceIds.get(sessionId)
+}
+
+/**
+ * Clear the active per-run trace ID for a session, but only if it still matches
+ * the trace ID the caller owns. Avoids races where a newer run has already set
+ * its own trace.
+ */
+export function clearActiveRunTrace(sessionId: string, traceId: string): void {
+  if (sessionRunTraceIds.get(sessionId) === traceId) {
+    sessionRunTraceIds.delete(sessionId)
+  }
 }
 
 /**
@@ -97,25 +159,35 @@ export function reinitializeLangfuse(): void {
     langfuseInstance.shutdownAsync().catch(console.error)
     langfuseInstance = null
   }
-  // Clear all active traces/spans
+  // Force-close any still-open per-trace observations before clearing state
+  // so local trace files don't end up with unbalanced events.
+  for (const traceId of Array.from(activeTraces.keys())) {
+    forceCloseTraceOperations(traceId, {
+      level: "ERROR",
+      statusMessage: "Langfuse reinitialized before run completed",
+    })
+  }
   activeTraces.clear()
   activeSpans.clear()
   activeGenerations.clear()
+  traceSpanIds.clear()
+  traceGenerationIds.clear()
+  sessionRunTraceIds.clear()
   // Local trace logger caches the resolved path; reset so config changes apply.
   resetLocalTraceLogger()
 }
 
 /**
- * Create a new trace for an agent session
+ * Create a new per-run Langfuse trace.
  *
  * Langfuse concepts:
  * - sessionId: Groups multiple traces together (e.g., a conversation thread)
- * - trace id: Individual trace within a session (e.g., one agent interaction)
+ * - trace id: A single agent run (one request/operation, in Langfuse data-model terms)
  * - userId: The user who initiated the trace
  * - tags: Categorization labels for filtering in the Langfuse dashboard
  * - release: Application version for tracking across releases
  *
- * @param traceId - Unique ID for this trace (our internal sessionId)
+ * @param traceId - Unique ID for this trace (per agent run, see makeLangfuseTraceId)
  * @param options - Trace configuration options
  */
 export function createAgentTrace(
@@ -177,17 +249,18 @@ export function createAgentTrace(
 }
 
 /**
- * Get an existing trace by session ID
+ * Get an existing trace by trace ID.
  */
-export function getAgentTrace(sessionId: string): LangfuseTraceClient | null {
-  return activeTraces.get(sessionId) || null
+export function getAgentTrace(traceId: string): LangfuseTraceClient | null {
+  return activeTraces.get(traceId) || null
 }
 
 /**
- * End a trace with output
+ * End a trace with output. Also drops the per-trace observation index so the
+ * trace can no longer be force-closed retroactively.
  */
 export function endAgentTrace(
-  sessionId: string,
+  traceId: string,
   options: {
     output?: string
     metadata?: Record<string, unknown>
@@ -195,27 +268,29 @@ export function endAgentTrace(
 ): void {
   appendLocalTraceEvent({
     type: "trace.end",
-    traceId: sessionId,
+    traceId,
     output: options.output,
     metadata: options.metadata,
   })
 
-  const trace = activeTraces.get(sessionId)
-  if (!trace) return
-
-  try {
-    trace.update({
-      output: options.output,
-      metadata: options.metadata,
-    })
-    activeTraces.delete(sessionId)
-  } catch (error) {
-    console.error("[Langfuse] Failed to end trace:", error)
+  const trace = activeTraces.get(traceId)
+  if (trace) {
+    try {
+      trace.update({
+        output: options.output,
+        metadata: options.metadata,
+      })
+    } catch (error) {
+      console.error("[Langfuse] Failed to end trace:", error)
+    }
   }
+  activeTraces.delete(traceId)
+  traceSpanIds.delete(traceId)
+  traceGenerationIds.delete(traceId)
 }
 
 /**
- * Create a span for a tool call
+ * Create a span for a tool call.
  */
 export function createToolSpan(
   traceId: string,
@@ -235,6 +310,14 @@ export function createToolSpan(
     metadata: options.metadata,
   })
 
+  // Index the span against its trace so abort/finalize can force-close it.
+  let spanSet = traceSpanIds.get(traceId)
+  if (!spanSet) {
+    spanSet = new Set()
+    traceSpanIds.set(traceId, spanSet)
+  }
+  spanSet.add(spanId)
+
   const trace = activeTraces.get(traceId)
   if (!trace) return null
 
@@ -253,7 +336,7 @@ export function createToolSpan(
 }
 
 /**
- * End a tool span with output
+ * End a tool span with output.
  */
 export function endToolSpan(
   spanId: string,
@@ -274,23 +357,29 @@ export function endToolSpan(
   })
 
   const span = activeSpans.get(spanId)
-  if (!span) return
-
-  try {
-    span.end({
-      output: options.output,
-      metadata: options.metadata,
-      level: options.level,
-      statusMessage: options.statusMessage,
-    })
-    activeSpans.delete(spanId)
-  } catch (error) {
-    console.error("[Langfuse] Failed to end span:", error)
+  if (span) {
+    try {
+      span.end({
+        output: options.output,
+        metadata: options.metadata,
+        level: options.level,
+        statusMessage: options.statusMessage,
+      })
+    } catch (error) {
+      console.error("[Langfuse] Failed to end span:", error)
+    }
+  }
+  activeSpans.delete(spanId)
+  // Drop reverse index entry too.
+  for (const [traceId, set] of traceSpanIds) {
+    if (set.delete(spanId) && set.size === 0) {
+      traceSpanIds.delete(traceId)
+    }
   }
 }
 
 /**
- * Create a generation for an LLM call
+ * Create a generation for an LLM call.
  */
 export function createLLMGeneration(
   traceId: string | null,
@@ -313,6 +402,15 @@ export function createLLMGeneration(
     input: options.input,
     metadata: options.metadata,
   })
+
+  if (traceId) {
+    let genSet = traceGenerationIds.get(traceId)
+    if (!genSet) {
+      genSet = new Set()
+      traceGenerationIds.set(traceId, genSet)
+    }
+    genSet.add(generationId)
+  }
 
   const langfuse = getLangfuse()
   if (!langfuse) return null
@@ -347,7 +445,7 @@ export function createLLMGeneration(
 }
 
 /**
- * End an LLM generation with output and usage metrics
+ * End an LLM generation with output and usage metrics.
  */
 export function endLLMGeneration(
   generationId: string,
@@ -374,20 +472,71 @@ export function endLLMGeneration(
   })
 
   const generation = activeGenerations.get(generationId)
-  if (!generation) return
-
-  try {
-    generation.end({
-      output: options.output,
-      usage: options.usage,
-      metadata: options.metadata,
-      level: options.level,
-      statusMessage: options.statusMessage,
-    })
-    activeGenerations.delete(generationId)
-  } catch (error) {
-    console.error("[Langfuse] Failed to end generation:", error)
+  if (generation) {
+    try {
+      generation.end({
+        output: options.output,
+        usage: options.usage,
+        metadata: options.metadata,
+        level: options.level,
+        statusMessage: options.statusMessage,
+      })
+    } catch (error) {
+      console.error("[Langfuse] Failed to end generation:", error)
+    }
   }
+  activeGenerations.delete(generationId)
+  for (const [traceId, set] of traceGenerationIds) {
+    if (set.delete(generationId) && set.size === 0) {
+      traceGenerationIds.delete(traceId)
+    }
+  }
+}
+
+/**
+ * Force-close any spans/generations still open under the given trace, emitting
+ * matching `span.end` / `generation.end` events with the supplied error metadata.
+ *
+ * Intended for run finalization (abort/stop/reinitialize/shutdown) so local
+ * trace files don't end up with unbalanced lifecycle events.
+ */
+export function forceCloseTraceOperations(
+  traceId: string,
+  options: {
+    level?: "DEBUG" | "DEFAULT" | "WARNING" | "ERROR"
+    statusMessage?: string
+  } = {},
+): { closedSpans: number; closedGenerations: number } {
+  const level = options.level ?? "ERROR"
+  const status = options.statusMessage ?? "Run ended before observation completed"
+
+  const spans = traceSpanIds.get(traceId)
+  const generations = traceGenerationIds.get(traceId)
+
+  let closedSpans = 0
+  let closedGenerations = 0
+
+  if (spans) {
+    for (const spanId of Array.from(spans)) {
+      endToolSpan(spanId, {
+        level,
+        statusMessage: status,
+      })
+      closedSpans++
+    }
+  }
+
+  if (generations) {
+    for (const generationId of Array.from(generations)) {
+      endLLMGeneration(generationId, {
+        level,
+        statusMessage: status,
+      })
+      closedGenerations++
+    }
+  }
+
+  return { closedSpans, closedGenerations }
 }
 
 /**
@@ -401,5 +550,19 @@ export async function flushLangfuse(): Promise<void> {
     await langfuse.flushAsync()
   } catch (error) {
     console.error("[Langfuse] Failed to flush:", error)
+  }
+}
+
+/**
+ * Shutdown Langfuse, awaiting any in-flight events. Use at app shutdown.
+ */
+export async function shutdownLangfuse(): Promise<void> {
+  if (!langfuseInstance) return
+  try {
+    await langfuseInstance.shutdownAsync()
+  } catch (error) {
+    console.error("[Langfuse] Failed to shutdown:", error)
+  } finally {
+    langfuseInstance = null
   }
 }

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -93,6 +93,8 @@ vi.mock('./ai-sdk-provider', () => ({
 // Mock the langfuse-service module
 vi.mock('./langfuse-service', () => ({
   isLangfuseEnabled: vi.fn(() => false),
+  shouldRecordObservations: vi.fn(() => false),
+  getActiveRunTrace: vi.fn(() => undefined),
   createLLMGeneration: vi.fn(() => null),
   endLLMGeneration: vi.fn(),
 }))

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -37,7 +37,8 @@ import { isMissingApiKeyErrorMessage } from "@dotagents/shared"
 import {
   createLLMGeneration,
   endLLMGeneration,
-  isLangfuseEnabled,
+  getActiveRunTrace,
+  shouldRecordObservations,
 } from "./langfuse-service"
 import { recordActualTokenUsage } from "./context-budget"
 import { getCurrentChatGptWebModelName, isChatGptWebProvider, makeChatGptWebCompletion, makeChatGptWebResponse } from "./chatgpt-web-provider"
@@ -875,9 +876,10 @@ export async function makeLLMCallWithFetch(
 
         if (isChatGptWebProvider(effectiveProviderId)) {
           const modelName = getCurrentChatGptWebModelName("mcp")
-          const generationId = isLangfuseEnabled() ? randomUUID() : null
+          const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+          const generationId = shouldRecordObservations() ? randomUUID() : null
           if (generationId) {
-            createLLMGeneration(sessionId || null, generationId, {
+            createLLMGeneration(traceId, generationId, {
               name: "LLM Call",
               model: modelName,
               modelParameters: {
@@ -981,10 +983,12 @@ export async function makeLLMCallWithFetch(
           })
         }
 
-        // Create Langfuse generation if enabled
-        const generationId = isLangfuseEnabled() ? randomUUID() : null
+        // Create per-run trace generation when remote Langfuse OR local trace
+        // logging is enabled (issue #441: local tracing must work standalone).
+        const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+        const generationId = shouldRecordObservations() ? randomUUID() : null
         if (generationId) {
-          createLLMGeneration(sessionId || null, generationId, {
+          createLLMGeneration(traceId, generationId, {
             name: "LLM Call",
             model: modelName,
             modelParameters: {
@@ -1176,9 +1180,10 @@ export async function makeLLMCallWithStreamingAndTools(
         : undefined
 
       if (isChatGptWebProvider(effectiveProviderId)) {
-        const generationId = isLangfuseEnabled() ? randomUUID() : null
+        const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+        const generationId = shouldRecordObservations() ? randomUUID() : null
         if (generationId) {
-          createLLMGeneration(sessionId || null, generationId, {
+          createLLMGeneration(traceId, generationId, {
             name: "Streaming LLM Call",
             model: modelName,
             modelParameters: {
@@ -1263,9 +1268,10 @@ export async function makeLLMCallWithStreamingAndTools(
         })
       }
 
-      const generationId = isLangfuseEnabled() ? randomUUID() : null
+      const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+      const generationId = shouldRecordObservations() ? randomUUID() : null
       if (generationId) {
-        createLLMGeneration(sessionId || null, generationId, {
+        createLLMGeneration(traceId, generationId, {
           name: "Streaming LLM Call",
           model: modelName,
           modelParameters: {
@@ -1401,14 +1407,16 @@ export async function makeTextCompletionWithFetch(
     async () => {
       const abortController = createSessionAbortController(sessionId)
 
-      // Create Langfuse generation if enabled
-      const generationId = isLangfuseEnabled() ? randomUUID() : null
+      // Create per-run trace generation when remote Langfuse OR local trace
+      // logging is enabled (issue #441).
+      const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+      const generationId = shouldRecordObservations() ? randomUUID() : null
       const modelName = isChatGptWebProvider(effectiveProviderId)
         ? getCurrentChatGptWebModelName("transcript")
         : getCurrentModelName(effectiveProviderId, "transcript")
 
       if (generationId) {
-        createLLMGeneration(sessionId || null, generationId, {
+        createLLMGeneration(traceId, generationId, {
           name: "Text Completion",
           model: modelName,
           modelParameters: { provider: effectiveProviderId },
@@ -1521,8 +1529,10 @@ export async function verifyCompletionWithFetch(
           ? getCurrentChatGptWebModelName("mcp")
           : getCurrentModelName(effectiveProviderId)
 
-        // Create Langfuse generation if enabled
-        const generationId = isLangfuseEnabled() ? randomUUID() : null
+        // Create per-run trace generation when remote Langfuse OR local trace
+        // logging is enabled (issue #441).
+        const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+        const generationId = shouldRecordObservations() ? randomUUID() : null
         const promptCaching = isChatGptWebProvider(effectiveProviderId)
           ? undefined
           : getPromptCachingConfig(effectiveProviderId)
@@ -1535,7 +1545,7 @@ export async function verifyCompletionWithFetch(
         )
         const { system, messages: convertedMessages } = convertMessages(messages)
         if (generationId) {
-          createLLMGeneration(sessionId || null, generationId, {
+          createLLMGeneration(traceId, generationId, {
             name: "Verification Call",
             model: modelName,
             modelParameters: {

--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -53,7 +53,7 @@ vi.mock("./emit-agent-progress", () => ({ emitAgentProgress: mocks.emitAgentProg
 vi.mock("./agent-session-tracker", () => ({ agentSessionTracker: mocks }))
 vi.mock("./conversation-service", () => ({ conversationService: { addMessageToConversation: mocks.addMessageToConversation, maybeAutoGenerateConversationTitle: mocks.maybeAutoGenerateConversationTitle } }))
 vi.mock("./acp-session-state", () => ({ getAcpSessionTitleOverride: mocks.getAcpSessionTitleOverride }))
-vi.mock("./langfuse-service", () => ({ isLangfuseEnabled: vi.fn(() => false), createAgentTrace: vi.fn(), endAgentTrace: vi.fn(), flushLangfuse: vi.fn(async () => undefined) }))
+vi.mock("./langfuse-service", () => ({ isLangfuseEnabled: vi.fn(() => false), shouldRecordObservations: vi.fn(() => false), makeLangfuseTraceId: vi.fn((opts: { agentSessionId: string; runId: number }) => `${opts.agentSessionId}__run_${opts.runId}`), setActiveRunTrace: vi.fn(), clearActiveRunTrace: vi.fn(), forceCloseTraceOperations: vi.fn(() => ({ closedSpans: 0, closedGenerations: 0 })), createAgentTrace: vi.fn(), endAgentTrace: vi.fn(), flushLangfuse: vi.fn(async () => undefined) }))
 vi.mock("./summarization-service", () => ({ isSummarizationEnabled: vi.fn(() => false), shouldSummarizeStep: vi.fn(() => false), summarizeAgentStep: vi.fn(), summarizationService: { getSummaries: vi.fn(() => []), getLatestSummary: vi.fn(() => undefined), addSummary: vi.fn() } }))
 vi.mock("./knowledge-notes-service", () => ({ knowledgeNotesService: { createNoteFromSummary: vi.fn(), saveNote: vi.fn() } }))
 vi.mock("./agent-run-utils", () => ({ appendAgentStopNote: vi.fn(), resolveAgentIterationLimits: vi.fn((maxIterations: number) => ({ loopMaxIterations: maxIterations, guardrailBudget: maxIterations })) }))

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -24,6 +24,11 @@ import {
   endAgentTrace,
   isLangfuseEnabled,
   flushLangfuse,
+  shouldRecordObservations,
+  makeLangfuseTraceId,
+  setActiveRunTrace,
+  clearActiveRunTrace,
+  forceCloseTraceOperations,
 } from "./langfuse-service"
 import {
   isSummarizationEnabled,
@@ -691,14 +696,27 @@ export async function processTranscriptWithAgentMode(
   // Track step summaries for dual-model mode
   const stepSummaries: import("../shared/types").AgentStepSummary[] = []
 
-  // Create Langfuse trace for this agent session if enabled
-  // - traceId: unique ID for this trace (our agent session ID)
-  // - sessionId: groups traces together in Langfuse (our conversation ID)
-  if (isLangfuseEnabled()) {
-    createAgentTrace(currentSessionId, {
+  // Create Langfuse trace for this agent run (issue #441):
+  // - Langfuse traceId: unique per agent run, derived from (agentSessionId, runId).
+  // - Langfuse sessionId: the DotAgents conversation ID, which groups all runs in
+  //   the same multi-turn conversation.
+  // We register the per-run trace ID against the agent session so subsystems
+  // (mcp-service, llm-fetch) can attach observations without changing every
+  // call signature. Local trace logging still records lifecycle events even
+  // when remote Langfuse upload is disabled.
+  const langfuseTraceId = makeLangfuseTraceId({
+    agentSessionId: currentSessionId,
+    runId: effectiveRunId,
+  })
+  setActiveRunTrace(currentSessionId, langfuseTraceId)
+  if (shouldRecordObservations()) {
+    createAgentTrace(langfuseTraceId, {
       name: "Agent Session",
-      sessionId: currentConversationId,  // Groups all agent sessions in this conversation
+      sessionId: currentConversationId,  // Groups all agent runs in this conversation
       metadata: {
+        conversationId: currentConversationId,
+        agentSessionId: currentSessionId,
+        runId: effectiveRunId,
         maxIterations,
         hasHistory: !!previousConversationHistory?.length,
         profileId: effectiveProfileSnapshot?.profileId,
@@ -3514,10 +3532,18 @@ export async function processTranscriptWithAgentMode(
       totalIterations: iteration,
     }
   } finally {
-    // End Langfuse trace for this agent session if enabled
-    // This is in a finally block to ensure traces are closed even on unexpected exceptions
-    if (isLangfuseEnabled()) {
-      endAgentTrace(currentSessionId, {
+    // End Langfuse trace for this agent run.
+    // Force-close any straggling spans/generations first so local trace files
+    // never end up with unbalanced lifecycle events on abort/exception paths
+    // (issue #441 acceptance criteria).
+    if (shouldRecordObservations()) {
+      forceCloseTraceOperations(langfuseTraceId, {
+        level: "ERROR",
+        statusMessage: wasAborted
+          ? "Run aborted before observation completed"
+          : "Run ended before observation completed",
+      })
+      endAgentTrace(langfuseTraceId, {
         output: finalContent,
         metadata: {
           totalIterations: iteration,
@@ -3531,9 +3557,14 @@ export async function processTranscriptWithAgentMode(
           }),
         },
       })
-      // Flush to ensure trace is sent
-      flushLangfuse().catch(() => {})
+      // Await flush so the run's events make it out before the agent loop
+      // returns and the caller proceeds (Langfuse docs recommend explicit
+      // flush at lifecycle boundaries).
+      if (isLangfuseEnabled()) {
+        await flushLangfuse().catch(() => {})
+      }
     }
+    clearActiveRunTrace(currentSessionId, langfuseTraceId)
 
     // Clean up context budget tracking for this session
     clearActualTokenUsage(currentSessionId)

--- a/apps/desktop/src/main/mcp-service.option-b.test.ts
+++ b/apps/desktop/src/main/mcp-service.option-b.test.ts
@@ -22,7 +22,7 @@ vi.mock("./oauth-client", () => ({ OAuthClient: class {} }))
 vi.mock("./oauth-storage", () => ({ oauthStorage: {} }))
 vi.mock("./mcp-elicitation", () => ({ requestElicitation: vi.fn(), handleElicitationComplete: vi.fn(), cancelAllElicitations: vi.fn() }))
 vi.mock("./mcp-sampling", () => ({ requestSampling: vi.fn(), cancelAllSamplingRequests: vi.fn() }))
-vi.mock("./langfuse-service", () => ({ isLangfuseEnabled: vi.fn(() => false), createToolSpan: vi.fn(), endToolSpan: vi.fn(), getAgentTrace: vi.fn(() => null) }))
+vi.mock("./langfuse-service", () => ({ isLangfuseEnabled: vi.fn(() => false), shouldRecordObservations: vi.fn(() => false), getActiveRunTrace: vi.fn(() => undefined), createToolSpan: vi.fn(), endToolSpan: vi.fn(), getAgentTrace: vi.fn(() => null) }))
 vi.mock("./agent-profile-service", () => ({ agentProfileService: { getCurrentProfile: () => ({ id: "profile_1", toolConfig: { enabledRuntimeTools: currentProfileEnabledRuntimeTools } }), saveCurrentMcpStateToProfile: mockSaveCurrentMcpStateToProfile } }))
 vi.mock("./runtime-tools", () => ({ runtimeTools, isRuntimeTool: (n: string) => runtimeTools.some((tool) => tool.name === n), executeRuntimeTool: mockExecuteRuntimeTool }))
 

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -45,7 +45,8 @@ import { randomUUID } from "crypto"
 import {
   createToolSpan,
   endToolSpan,
-  isLangfuseEnabled,
+  getActiveRunTrace,
+  shouldRecordObservations,
   getAgentTrace,
 } from "./langfuse-service"
 
@@ -2664,10 +2665,15 @@ export class MCPService {
     sessionId?: string,
     profileMcpConfig?: ProfileMcpServerConfig
   ): Promise<MCPToolResult> {
-    // Create Langfuse span for tool call if enabled and we have a trace
-    const spanId = isLangfuseEnabled() && sessionId ? randomUUID() : null
-    if (spanId && sessionId) {
-      createToolSpan(sessionId, spanId, {
+    // Attach the tool span to the active per-run Langfuse trace for this
+    // session (issue #441). The agent run registers its trace ID via
+    // setActiveRunTrace; if no run is active, fall back to no trace so the
+    // span is recorded as orphan rather than misattributed to the long-lived
+    // session ID.
+    const traceId = sessionId ? getActiveRunTrace(sessionId) ?? null : null
+    const spanId = shouldRecordObservations() && traceId ? randomUUID() : null
+    if (spanId && traceId) {
+      createToolSpan(traceId, spanId, {
         name: `Tool: ${toolCall.name}`,
         input: toolCall.arguments as Record<string, unknown>,
         metadata: { toolName: toolCall.name },


### PR DESCRIPTION
Closes #441.

## Summary

Stop reusing the long-lived DotAgents agent session ID as the Langfuse trace ID. Each agent run now gets its own per-run Langfuse trace derived from `(agentSessionId, runId)`, grouped under the conversation ID via Langfuse's `sessionId` field. LLM generations and MCP tool spans attach to that per-run trace, so each local trace file contains exactly one logical trace lifecycle and remote Langfuse observations no longer cross between runs that overlap, continue, or restart on the same session.

```txt
Langfuse sessionId = DotAgents conversationId   (groups runs of the same chat)
Langfuse traceId   = unique per agent run       (derived from agentSessionId + runId)
Observations       = LLM generations / MCP tool spans, attached to the per-run trace
```

## Changes

- `apps/desktop/src/main/langfuse-service.ts`
  - `makeLangfuseTraceId({ agentSessionId, runId })` — stable per-run trace ID
  - `setActiveRunTrace` / `getActiveRunTrace` / `clearActiveRunTrace` — register the active run trace per session so subsystems can attach observations without changing every call signature; `clearActiveRunTrace` only clears when the caller's trace ID still owns the slot, so a late finalizer for run N never wipes run N+1
  - Per-trace span/generation indexes plus `forceCloseTraceOperations(traceId, options)` to emit matching `span.end`/`generation.end` events with `ERROR` level when a run aborts/stops/reinitializes
  - `shouldRecordObservations()` — local trace logging now works as a standalone debugging feature even when remote Langfuse upload is disabled
  - `shutdownLangfuse()` — explicit awaitable shutdown for app teardown
  - `reinitializeLangfuse()` now force-closes outstanding traces before resetting state so files don't end up unbalanced

- `apps/desktop/src/main/llm.ts`
  - Build `langfuseTraceId` once after `effectiveRunId` is known and register it for the agent session
  - Use it for `createAgentTrace` / `endAgentTrace` and persist the conversation/session/run identifiers as Langfuse trace metadata
  - In `finally`: `forceCloseTraceOperations(...)` for any straggling spans/generations, then `endAgentTrace(...)`, then `await flushLangfuse()`, then `clearActiveRunTrace`
  - Trace creation now also fires when local trace logging is on (no longer gated on `isLangfuseEnabled()`)

- `apps/desktop/src/main/llm-fetch.ts`
  - All `createLLMGeneration(sessionId || null, ...)` callsites now resolve the active per-run trace via `getActiveRunTrace(sessionId)` and gate on `shouldRecordObservations()`

- `apps/desktop/src/main/mcp-service.ts`
  - `executeToolCall` resolves the active per-run trace via `getActiveRunTrace(sessionId)` instead of treating `sessionId` as the trace ID; spans only fire when there is an active trace and `shouldRecordObservations()` is true

- Tests
  - New `apps/desktop/src/main/langfuse-service.test.ts` covers: stable per-run trace IDs, two consecutive runs producing separate local trace files (no reused-bucket pollution), `forceCloseTraceOperations` emitting `ERROR` span/generation ends, race-safe `clearActiveRunTrace`, and local-tracing-without-remote-langfuse
  - Updated existing mock-based tests (`llm-fetch.test.ts`, `mcp-service.option-b.test.ts`, `llm.respond-to-user-history.test.ts`) for the new `langfuse-service` exports

## Acceptance criteria mapping

- [x] One agent invocation/run produces one Langfuse trace ID
- [x] Continuing the same conversation creates a new trace under the same Langfuse `sessionId`
- [x] `currentConversationId` remains the Langfuse `sessionId`
- [x] `currentSessionId` is no longer used as the Langfuse trace ID
- [x] `effectiveRunId` participates in the trace identity and trace metadata
- [x] LLM generations attach to the per-run trace
- [x] MCP tool spans attach to the per-run trace
- [x] Local trace files no longer contain multiple logical `trace.start` / `trace.end` pairs for separate runs
- [x] Active spans/generations are force-closed with error metadata on abort/stop/reinitialize
- [x] Local trace logging operates independently of remote Langfuse enablement
- [x] Flush is awaited at run finalization; awaitable `shutdownLangfuse()` exposed for shutdown paths
- [x] Tests for repeated runs producing different trace IDs / files
- [x] Tests for force-close emitting matching `span.end` with `ERROR`

## Test plan

- [x] `pnpm --filter @dotagents/desktop typecheck:node`
- [x] `pnpm --filter @dotagents/desktop typecheck:web`
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/langfuse-service.test.ts src/main/local-trace-logger.test.ts src/main/llm-fetch.test.ts src/main/mcp-service.option-b.test.ts src/main/llm.respond-to-user-history.test.ts src/main/llm.continuation-guards.test.ts src/main/llm-verification-replay.test.ts` (110 tests passed, 1 skipped live test)
- [ ] Manual: enable local trace logging, run an agent twice on the same session; verify two distinct `<sessionId>__run_N.jsonl` files each containing exactly one `trace.start`/`trace.end` pair
- [ ] Manual: hit the kill switch mid-tool-call; verify the corresponding `span.end` is emitted with `level=ERROR`

---
_Generated by [Claude Code](https://claude.ai/code/session_0172mWXdB6ffDHTwjRSWHRSK)_