### PR TITLE
Persist full execute_command transcripts per session (#445 phase 1)

### DIFF
--- a/apps/desktop/src/main/command-log-service.test.ts
+++ b/apps/desktop/src/main/command-log-service.test.ts
@@ -1,0 +1,110 @@
+import os from "node:os"
+import path from "node:path"
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  appendCommandLogEntry,
+  readCommandLog,
+  getCommandLogPath,
+  setCommandLogDirForTesting,
+  type CommandLogEntry,
+} from "./command-log-service"
+
+let tempDir: string
+
+function makeEntry(overrides: Partial<CommandLogEntry> = {}): CommandLogEntry {
+  return {
+    sessionId: "session-1",
+    command: "echo hi",
+    cwd: "/tmp",
+    startedAt: new Date(0).toISOString(),
+    durationMs: 12,
+    exitCode: 0,
+    timedOut: false,
+    stdout: "hi\n",
+    stderr: "",
+    ...overrides,
+  }
+}
+
+describe("command-log-service", () => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "dotagents-cmdlog-"))
+    setCommandLogDirForTesting(tempDir)
+  })
+
+  afterEach(async () => {
+    setCommandLogDirForTesting(null)
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it("writes one JSON line per entry and round-trips through readCommandLog", async () => {
+    const path1 = await appendCommandLogEntry(makeEntry())
+    const path2 = await appendCommandLogEntry(makeEntry({
+      command: "ls",
+      stdout: "a\nb\n",
+      durationMs: 34,
+    }))
+
+    expect(path1).toBeTruthy()
+    expect(path2).toBe(path1)
+
+    const raw = await readFile(path1!, "utf8")
+    const lines = raw.split("\n").filter(Boolean)
+    expect(lines).toHaveLength(2)
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow()
+    }
+
+    const entries = await readCommandLog("session-1")
+    expect(entries.map((e) => e.command)).toEqual(["echo hi", "ls"])
+    expect(entries[1].durationMs).toBe(34)
+  })
+
+  it("isolates logs per session and sanitizes session IDs that contain path separators", async () => {
+    await appendCommandLogEntry(makeEntry({ sessionId: "session-a", command: "a" }))
+    await appendCommandLogEntry(makeEntry({ sessionId: "session-b", command: "b" }))
+    await appendCommandLogEntry(makeEntry({ sessionId: "../escape/attempt", command: "c" }))
+
+    const sessionA = await readCommandLog("session-a")
+    const sessionB = await readCommandLog("session-b")
+    const escape = await readCommandLog("../escape/attempt")
+
+    expect(sessionA.map((e) => e.command)).toEqual(["a"])
+    expect(sessionB.map((e) => e.command)).toEqual(["b"])
+    expect(escape.map((e) => e.command)).toEqual(["c"])
+
+    const escapePath = await getCommandLogPath("../escape/attempt")
+    expect(escapePath).toBeTruthy()
+    // Sanitization must keep the file inside the configured logs dir, no
+    // matter what characters appear in the session ID.
+    const resolved = path.resolve(escapePath!)
+    expect(resolved.startsWith(path.resolve(tempDir) + path.sep)).toBe(true)
+    expect(path.dirname(resolved)).toBe(path.resolve(tempDir))
+  })
+
+  it("returns null and skips writing when no sessionId is present", async () => {
+    const result = await appendCommandLogEntry(makeEntry({ sessionId: "" }))
+    expect(result).toBeNull()
+  })
+
+  it("readCommandLog skips malformed lines instead of throwing", async () => {
+    await appendCommandLogEntry(makeEntry({ command: "valid" }))
+
+    const filePath = (await getCommandLogPath("session-1"))!
+    await mkdir(path.dirname(filePath), { recursive: true })
+    // Append a junk line followed by another valid entry.
+    await writeFile(
+      filePath,
+      (await readFile(filePath, "utf8")) +
+        "this is not json\n" +
+        JSON.stringify(makeEntry({ command: "after-junk" })) +
+        "\n",
+      "utf8",
+    )
+
+    const entries = await readCommandLog("session-1")
+    expect(entries.map((e) => e.command)).toEqual(["valid", "after-junk"])
+  })
+})

--- a/apps/desktop/src/main/command-log-service.ts
+++ b/apps/desktop/src/main/command-log-service.ts
@@ -1,0 +1,127 @@
+/**
+ * Per-session execute_command transcript logger.
+ *
+ * Phase 1 of the per-session shell work tracked in issue #445: keep the current
+ * stateless execution model for `execute_command`, but persist the full
+ * stdout/stderr and metadata for every invocation to a per-session log file
+ * outside the assistant context. The assistant-facing tool result remains
+ * truncated; users can open the on-disk log for the unfiltered transcript.
+ *
+ * Logs live under `<dataFolder>/shell-logs/<sessionId>.log`. Each entry is one
+ * JSON object per line (newline-delimited JSON) so the file can be tailed,
+ * grepped, and parsed without a full reader.
+ */
+
+import { promises as fs } from "fs"
+import path from "path"
+
+let cachedLogsDir: string | null = null
+
+async function resolveLogsDir(): Promise<string | null> {
+  if (cachedLogsDir) return cachedLogsDir
+
+  // Avoid importing electron in non-electron contexts (e.g. plain Node tests
+  // that exercise this module directly). The override below covers tests that
+  // need a deterministic location.
+  try {
+    const { dataFolder } = await import("./config")
+    cachedLogsDir = path.join(dataFolder, "shell-logs")
+    return cachedLogsDir
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Override the on-disk location used for command logs. Intended for tests; the
+ * desktop app derives the path from `dataFolder` automatically.
+ */
+export function setCommandLogDirForTesting(dir: string | null): void {
+  cachedLogsDir = dir
+}
+
+function sanitizeSessionId(sessionId: string): string {
+  // Strip path separators and other characters that could escape the logs dir.
+  // The transformation is deterministic so the same session always maps to the
+  // same file.
+  return sessionId.replace(/[^A-Za-z0-9._-]/g, "_")
+}
+
+export interface CommandLogEntry {
+  sessionId: string
+  command: string
+  cwd: string
+  startedAt: string
+  durationMs: number
+  exitCode: number | null
+  timedOut: boolean
+  stdout: string
+  stderr: string
+  skillName?: string
+  error?: string
+}
+
+/**
+ * Append a single command transcript entry to the session's log file.
+ *
+ * Failures are swallowed: logging is a best-effort UX feature and must never
+ * break command execution. The function returns the path that was written when
+ * the entry was persisted, or `null` when logging was skipped or failed.
+ */
+export async function appendCommandLogEntry(entry: CommandLogEntry): Promise<string | null> {
+  if (!entry.sessionId) return null
+
+  const logsDir = await resolveLogsDir()
+  if (!logsDir) return null
+
+  const fileName = `${sanitizeSessionId(entry.sessionId)}.log`
+  const filePath = path.join(logsDir, fileName)
+
+  try {
+    await fs.mkdir(logsDir, { recursive: true })
+    const line = JSON.stringify(entry) + "\n"
+    await fs.appendFile(filePath, line, "utf8")
+    return filePath
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the full transcript for a session as parsed entries. Lines that fail to
+ * parse are skipped rather than aborting the read so a partially-written tail
+ * does not hide valid history.
+ */
+export async function readCommandLog(sessionId: string): Promise<CommandLogEntry[]> {
+  const logsDir = await resolveLogsDir()
+  if (!logsDir) return []
+
+  const filePath = path.join(logsDir, `${sanitizeSessionId(sessionId)}.log`)
+  let raw: string
+  try {
+    raw = await fs.readFile(filePath, "utf8")
+  } catch {
+    return []
+  }
+
+  const entries: CommandLogEntry[] = []
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue
+    try {
+      entries.push(JSON.parse(line) as CommandLogEntry)
+    } catch {
+      // Skip malformed lines rather than failing the whole read.
+    }
+  }
+  return entries
+}
+
+/**
+ * Resolve the on-disk path for a session log without reading it. Useful for
+ * the UI affordance described in the issue ("download/copy raw transcript").
+ */
+export async function getCommandLogPath(sessionId: string): Promise<string | null> {
+  const logsDir = await resolveLogsDir()
+  if (!logsDir) return null
+  return path.join(logsDir, `${sanitizeSessionId(sessionId)}.log`)
+}

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -1191,6 +1191,11 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
+    const { appendCommandLogEntry } = await import("./command-log-service")
+    const startedAt = new Date()
+    const startedAtIso = startedAt.toISOString()
+    const startedAtMs = startedAt.getTime()
+
     try {
       const execOptions: { cwd?: string; timeout?: number; maxBuffer?: number; shell?: string } = {
         maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
@@ -1226,6 +1231,21 @@ const toolHandlers: Record<string, ToolHandler> = {
         outputTruncated = true
       }
 
+      const logPath = context.sessionId
+        ? await appendCommandLogEntry({
+            sessionId: context.sessionId,
+            command: effectiveCommand,
+            cwd: effectiveCwd,
+            startedAt: startedAtIso,
+            durationMs: Date.now() - startedAtMs,
+            exitCode: 0,
+            timedOut: false,
+            stdout: stdout || "",
+            stderr: stderr || "",
+            skillName,
+          })
+        : null
+
       return {
         content: [
           {
@@ -1241,6 +1261,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               stdout: truncatedStdout,
               stderr: stderr || "",
               ...(outputTruncated ? { outputTruncated: true, hint: "Output was truncated. Use head -n/tail -n/sed -n 'X,Yp' to read specific sections." } : {}),
+              ...(logPath ? { fullTranscriptLogPath: logPath } : {}),
             }, null, 2),
           },
         ],
@@ -1271,6 +1292,24 @@ const toolHandlers: Record<string, ToolHandler> = {
         ? '\n\nHINT: This command likely failed due to shell escaping issues with special characters or long strings. Try writing the content to a file first (e.g., with write_file or echo > file), then reference the file in your command.'
         : '';
 
+      // SIGTERM with a configured timeout means the runner killed the process.
+      const timedOut = error.signal === "SIGTERM" && timeout > 0
+      const logPath = context.sessionId
+        ? await appendCommandLogEntry({
+            sessionId: context.sessionId,
+            command: effectiveCommand,
+            cwd: effectiveCwd,
+            startedAt: startedAtIso,
+            durationMs: Date.now() - startedAtMs,
+            exitCode: typeof exitCode === "number" ? exitCode : null,
+            timedOut,
+            stdout: error.stdout || "",
+            stderr,
+            skillName,
+            error: errorMessage,
+          })
+        : null
+
       return {
         content: [
           {
@@ -1287,6 +1326,7 @@ const toolHandlers: Record<string, ToolHandler> = {
               exitCode,
               stdout,
               stderr,
+              ...(logPath ? { fullTranscriptLogPath: logPath } : {}),
             }, null, 2),
           },
         ],


### PR DESCRIPTION
## Summary
First slice of issue #445. Adds per-session, full-fidelity logging for every `execute_command` invocation while keeping the existing stateless execution model and the bounded assistant-facing tool result.

- New `command-log-service.ts` writes one entry per command to `<dataFolder>/shell-logs/<sessionId>.log` as newline-delimited JSON. Each entry captures the resolved command, cwd, ISO start time, duration, exit code, timeout flag, full stdout/stderr, optional skill name, and (on failure) the raw error message.
- `runtime-tools.execute_command` now logs both the success and failure paths, including SIGTERM-on-timeout, and returns `fullTranscriptLogPath` in the tool result so the UI can link to the on-disk transcript.
- Session IDs are sanitized so untrusted IDs cannot escape the logs directory; logging failures are swallowed so they never break command execution.
- Tests cover round-trip read/write, per-session isolation, path-traversal sanitization, missing-session no-op, and tolerant parsing of malformed lines.

This intentionally stops short of the persistent PTY / live streaming work in the issue's later phases — that's a much larger surface (UI, lifecycle, cross-platform PTY) and is best landed separately on top of this log foundation.

Closes the Phase 1 acceptance criteria from #445:
- [x] Each session has a unique log context for `execute_command` activity.
- [x] Complete stdout/stderr is preserved even when assistant-facing output is truncated.
- [x] Each entry has command, cwd, start time, duration, exit code, stdout, stderr.
- [x] Assistant-facing responses remain bounded.
- [x] Logs are stored locally under the existing data folder.

Follow-ups (separate PRs):
- UI affordance (terminal panel / "View command log" link) using the new `fullTranscriptLogPath`.
- Live streaming output (Phase 2).
- Persistent shell/PTY (Phase 3).

## Test plan
- [x] `pnpm exec vitest run src/main/command-log-service.test.ts` — 4 passing.
- [x] `pnpm exec vitest run src/main/runtime-tools.execute-command.test.ts` — 4 passing (no regressions).
- [ ] Manual: run a command in a real session and confirm the transcript file appears under `<dataFolder>/shell-logs/`.

https://claude.ai/code/session_01QzdPa2uFEy8WsJof2JqpCc

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzdPa2uFEy8WsJof2JqpCc)_