### PR TITLE
fix(sidebar): scope Cmd/Ctrl+N hotkeys to active sessions only

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
@@ -21,7 +21,7 @@ describe("active agents sidebar task section", () => {
   it("renders Tasks above regular sessions with separate pagination", () => {
     const tasksHeaderIndex = sidebarSource.indexOf("{hasTaskSessions && (")
     const sessionsHeaderIndex = sidebarSource.indexOf('<span className="select-none">Sessions</span>')
-    const sessionsListIndex = sidebarSource.indexOf("userSidebarSessions.map((entry, idx) =>")
+    const sessionsListIndex = sidebarSource.indexOf("userSidebarSessions.map((entry) =>")
 
     expect(tasksHeaderIndex).toBeGreaterThan(-1)
     expect(sessionsHeaderIndex).toBeGreaterThan(-1)
@@ -49,8 +49,8 @@ describe("active agents sidebar task section", () => {
     expect(sidebarSource).toContain("options: { forceSingleLine?: boolean } = {}")
     expect(sidebarSource).toContain("const forceSingleLine = options.forceSingleLine ?? false")
     expect(sidebarSource).toContain("!forceSingleLine &&")
-    expect(sidebarSource).toContain("visibleTaskSidebarSessions.map((entry, idx) =>")
-    expect(sidebarSource).toContain("renderSessionRow(entry, tasksOffset + idx, { forceSingleLine: true })")
+    expect(sidebarSource).toContain("visibleTaskSidebarSessions.map((entry) =>")
+    expect(sidebarSource).toContain("renderSessionRow(entry, { forceSingleLine: true })")
   })
 
   it("distinguishes task rows from regular sessions with section headings", () => {

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
@@ -50,8 +50,8 @@ describe("active agents sidebar task section", () => {
     expect(sidebarSource).toContain("reorderContainerGroupId?: string | null")
     expect(sidebarSource).toContain("const forceSingleLine = options.forceSingleLine ?? false")
     expect(sidebarSource).toContain("!forceSingleLine &&")
-    expect(sidebarSource).toContain("visibleTaskSidebarSessions.map((entry, idx) =>")
-    expect(sidebarSource).toContain("renderSessionRow(entry, tasksOffset + idx, { forceSingleLine: true })")
+    expect(sidebarSource).toContain("visibleTaskSidebarSessions.map((entry) =>")
+    expect(sidebarSource).toContain("renderSessionRow(entry, { forceSingleLine: true })")
   })
 
   it("supports dragging session groups to reorder them", () => {

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tasks-section.test.ts
@@ -96,6 +96,19 @@ describe("active agents sidebar task section", () => {
     expect(sidebarSource).toContain("const tasksListVisible = visibleTaskSidebarSessions.length > 0")
   })
 
+  it("keeps hotkey targets aligned with active parent rows and visible badges", () => {
+    expect(sidebarSource).toContain("const isSidebarHotkeyEligible = useCallback")
+    expect(sidebarSource).toContain("if (entry.isSubagent && (entry.nestingDepth ?? 0) > 0) return false")
+    expect(sidebarSource).toContain("const hasActiveChildProgress = sessionsWithActiveChildProgress.has(entry.session.id)")
+    expect(sidebarSource).toContain("return hasActiveChildProgress || (")
+    expect(sidebarSource).toContain("return entries.filter(isSidebarHotkeyEligible)")
+    expect(sidebarSource).toContain("const hotkeyIndexBySessionId = useMemo")
+    expect(sidebarSource).toContain("const hotkeyIndex = hotkeyIndexBySessionId.get(session.id)")
+    expect(sidebarSource).toContain("const canShowHotkeyBadge =")
+    expect(sidebarSource).toContain("!isNestedSubagent")
+    expect(sidebarSource).toContain("canShowHotkeyBadge && (sessionPreview || lastMessageMinutesAgo)")
+  })
+
   it("lets the session list size naturally instead of keeping a collapsed gap", () => {
     expect(sidebarSource).not.toContain("max-h-[45vh]")
     expect(sidebarSource).toContain("mt-1 space-y-0.5 overflow-visible")

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -600,20 +600,39 @@ export function ActiveAgentsSidebar({
   const hasTaskSessions = taskSidebarSessions.length > 0
   const tasksListVisible = visibleTaskSidebarSessions.length > 0
 
-  // Hotkeys (Cmd/Ctrl+1..9) target only entries that are currently rendered,
-  // in the same order as they appear: visible task rows → user sessions.
-  // Running task rows remain visible even when historical task rows are collapsed.
+  // Hotkeys (Cmd/Ctrl+1..9) only target *active* sessions/tasks, in the order
+  // they appear in the sidebar (visible task rows → user sessions). Saved
+  // conversations and completed/stopped sessions are skipped so the numbered
+  // shortcuts always cycle through running work.
   const visibleSidebarSessions = useMemo(
-    () => [
-      ...visibleTaskSidebarSessions,
-      ...(isExpanded ? userSidebarSessions : []),
-    ],
+    () => {
+      const entries = [
+        ...visibleTaskSidebarSessions,
+        ...(isExpanded ? userSidebarSessions : []),
+      ]
+      return entries.filter((entry) => {
+        if (entry.isSavedConversation) return false
+        const progress = agentProgressById.get(entry.session.id)
+        return entry.session.status === "active" && progress?.isComplete !== true
+      })
+    },
     [
       isExpanded,
       visibleTaskSidebarSessions,
       userSidebarSessions,
+      agentProgressById,
     ],
   )
+
+  // Per-session shortcut index (0-based) so each row can render its `⌘N`
+  // badge in sync with the hotkey handler above.
+  const hotkeyIndexBySessionId = useMemo(() => {
+    const map = new Map<string, number>()
+    visibleSidebarSessions.forEach((entry, idx) => {
+      map.set(entry.session.id, idx)
+    })
+    return map
+  }, [visibleSidebarSessions])
 
   const hasAnySessions = sidebarSessions.length > 0
 
@@ -1017,7 +1036,6 @@ export function ActiveAgentsSidebar({
                 isSubagent = false,
                 nestingDepth = 0,
               }: SidebarSessionEntry,
-              index: number,
               options: { forceSingleLine?: boolean } = {},
             ) => {
             const forceSingleLine = options.forceSingleLine ?? false
@@ -1166,6 +1184,7 @@ export function ActiveAgentsSidebar({
 
             // Active session row
             // Retained completed turns should stay visually active until the user dismisses them.
+            const hotkeyIndex = hotkeyIndexBySessionId.get(session.id)
             const repeatTaskLoop = findLoopForSession(session)
             const isInactiveRepeatTask =
               !!repeatTaskLoop &&
@@ -1295,13 +1314,13 @@ export function ActiveAgentsSidebar({
                         {lastMessageMinutesAgo}
                       </span>
                     )}
-                    {!isNestedSubagent && index < 9 && (sessionPreview || lastMessageMinutesAgo) && (
+                    {!isNestedSubagent && hotkeyIndex !== undefined && hotkeyIndex < 9 && (sessionPreview || lastMessageMinutesAgo) && (
                       <span
                         className="shrink-0 text-[10px] leading-4 tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0"
-                        title={`${IS_MAC ? "⌘" : "Ctrl+"}${index + 1} to focus this session`}
+                        title={`${IS_MAC ? "⌘" : "Ctrl+"}${hotkeyIndex + 1} to focus this session`}
                         aria-hidden="true"
                       >
-                        {SHORTCUT_MOD_SYMBOL}{IS_MAC ? "" : "+"}{index + 1}
+                        {SHORTCUT_MOD_SYMBOL}{IS_MAC ? "" : "+"}{hotkeyIndex + 1}
                       </span>
                     )}
                   </div>
@@ -1367,11 +1386,6 @@ export function ActiveAgentsSidebar({
             )
             }
 
-            // Hotkey ordering must mirror render ordering exactly; see
-            // visibleSidebarSessions above.
-            const tasksOffset = 0
-            const userOffset = visibleTaskSidebarSessions.length
-
             return (
               <>
                 {hasTaskSessions && (
@@ -1396,8 +1410,8 @@ export function ActiveAgentsSidebar({
                   </div>
                 )}
                 {tasksListVisible &&
-                  visibleTaskSidebarSessions.map((entry, idx) =>
-                    renderSessionRow(entry, tasksOffset + idx, { forceSingleLine: true }),
+                  visibleTaskSidebarSessions.map((entry) =>
+                    renderSessionRow(entry, { forceSingleLine: true }),
                   )}
                 {tasksSectionExpanded && hasMoreTaskSessions && (
                   <button
@@ -1447,8 +1461,8 @@ export function ActiveAgentsSidebar({
                     )}
                   </div>
                 )}
-                {isExpanded && userSidebarSessions.map((entry, idx) =>
-                  renderSessionRow(entry, userOffset + idx),
+                {isExpanded && userSidebarSessions.map((entry) =>
+                  renderSessionRow(entry),
                 )}
               </>
             )

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -819,20 +819,46 @@ export function ActiveAgentsSidebar({
   const hasTaskSessions = taskSidebarSessions.length > 0
   const tasksListVisible = visibleTaskSidebarSessions.length > 0
 
-  // Hotkeys (Cmd/Ctrl+1..9) target only entries that are currently rendered,
-  // in the same order as they appear: visible task rows → user sessions.
-  // Running task rows remain visible even when historical task rows are collapsed.
+  // Hotkeys (Cmd/Ctrl+1..9) only target *active* sessions/tasks, in the order
+  // they appear in the sidebar (visible task rows → user sessions). Saved
+  // conversations and completed/stopped sessions are skipped so the numbered
+  // shortcuts always cycle through running work.
+  const isSidebarHotkeyEligible = useCallback((entry: SidebarSessionEntry) => {
+    if (entry.isSavedConversation) return false
+    if (entry.isSubagent && (entry.nestingDepth ?? 0) > 0) return false
+    const progress = agentProgressById.get(entry.session.id)
+    const hasActiveChildProgress = sessionsWithActiveChildProgress.has(entry.session.id)
+    return hasActiveChildProgress || (
+      entry.session.status === "active" &&
+      progress?.isComplete !== true
+    )
+  }, [agentProgressById, sessionsWithActiveChildProgress])
+
   const visibleSidebarSessions = useMemo(
-    () => [
-      ...visibleTaskSidebarSessions,
-      ...(isExpanded ? visibleGroupedUserSidebarSessions : []),
-    ],
+    () => {
+      const entries = [
+        ...visibleTaskSidebarSessions,
+        ...(isExpanded ? visibleGroupedUserSidebarSessions : []),
+      ]
+      return entries.filter(isSidebarHotkeyEligible)
+    },
     [
       isExpanded,
       visibleTaskSidebarSessions,
       visibleGroupedUserSidebarSessions,
+      isSidebarHotkeyEligible,
     ],
   )
+
+  // Per-session shortcut index (0-based) so each row can render its `⌘N`
+  // badge in sync with the hotkey handler above.
+  const hotkeyIndexBySessionId = useMemo(() => {
+    const map = new Map<string, number>()
+    visibleSidebarSessions.forEach((entry, idx) => {
+      map.set(entry.session.id, idx)
+    })
+    return map
+  }, [visibleSidebarSessions])
 
   const hasUserSidebarContent = userSidebarSessions.length > 0 || sessionGroups.length > 0
   const hasAnySessions = sidebarSessions.length > 0 || sessionGroups.length > 0
@@ -1512,7 +1538,6 @@ export function ActiveAgentsSidebar({
                 isSubagent = false,
                 nestingDepth = 0,
               }: SidebarSessionEntry,
-              index: number,
               options: {
                 forceSingleLine?: boolean
                 reorderContainerGroupId?: string | null
@@ -1685,6 +1710,7 @@ export function ActiveAgentsSidebar({
 
             // Active session row
             // Retained completed turns should stay visually active until the user dismisses them.
+            const hotkeyIndex = hotkeyIndexBySessionId.get(session.id)
             const repeatTaskLoop = findLoopForSession(session)
             const isInactiveRepeatTask =
               !!repeatTaskLoop &&
@@ -1835,13 +1861,13 @@ export function ActiveAgentsSidebar({
                         {lastMessageMinutesAgo}
                       </span>
                     )}
-                    {!isNestedSubagent && index < 9 && (sessionPreview || lastMessageMinutesAgo) && (
+                    {!isNestedSubagent && hotkeyIndex !== undefined && hotkeyIndex < 9 && (sessionPreview || lastMessageMinutesAgo) && (
                       <span
                         className="shrink-0 text-[10px] leading-4 tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0"
-                        title={`${IS_MAC ? "⌘" : "Ctrl+"}${index + 1} to focus this session`}
+                        title={`${IS_MAC ? "⌘" : "Ctrl+"}${hotkeyIndex + 1} to focus this session`}
                         aria-hidden="true"
                       >
-                        {SHORTCUT_MOD_SYMBOL}{IS_MAC ? "" : "+"}{index + 1}
+                        {SHORTCUT_MOD_SYMBOL}{IS_MAC ? "" : "+"}{hotkeyIndex + 1}
                       </span>
                     )}
                   </div>
@@ -1908,17 +1934,6 @@ export function ActiveAgentsSidebar({
               </div>
             )
             }
-
-            // Hotkey ordering must mirror render ordering exactly; see
-            // visibleSidebarSessions above.
-            const tasksOffset = 0
-            const userOffset = visibleTaskSidebarSessions.length
-            const userHotkeyIndexByEntryKey = new Map(
-              visibleGroupedUserSidebarSessions.map((entry, idx) => [
-                entry.key,
-                userOffset + idx,
-              ]),
-            )
 
             const renderSessionGroupSection = (
               section: typeof userSidebarGroupSections[number],
@@ -2067,14 +2082,12 @@ export function ActiveAgentsSidebar({
                   {group.expanded && entries.map((entry) =>
                     renderSessionRow(
                       entry,
-                      userHotkeyIndexByEntryKey.get(entry.key) ?? userOffset,
                       { reorderContainerGroupId: group.id },
                     ),
                   )}
                 </div>
               )
             }
-
             return (
               <>
                 {hasTaskSessions && (
@@ -2099,8 +2112,8 @@ export function ActiveAgentsSidebar({
                   </div>
                 )}
                 {tasksListVisible &&
-                  visibleTaskSidebarSessions.map((entry, idx) =>
-                    renderSessionRow(entry, tasksOffset + idx, { forceSingleLine: true }),
+                  visibleTaskSidebarSessions.map((entry) =>
+                    renderSessionRow(entry, { forceSingleLine: true }),
                   )}
                 {tasksSectionExpanded && (hasMoreTaskSessions || (
                   visibleTaskConversationCount > SIDEBAR_TASKS_MIN_VISIBLE &&
@@ -2190,7 +2203,6 @@ export function ActiveAgentsSidebar({
                 {isExpanded && orderedUngroupedUserSidebarSessions.map((entry) =>
                   renderSessionRow(
                     entry,
-                    userHotkeyIndexByEntryKey.get(entry.key) ?? userOffset,
                     { reorderContainerGroupId: null },
                   ),
                 )}

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -1737,6 +1737,10 @@ export function ActiveAgentsSidebar({
             )
             const isNestedSubagent = isSubagent && normalizedNestingDepth > 0
             const isSelectedNestedSubagent = isNestedSubagent && isCurrentView
+            const canShowHotkeyBadge =
+              hotkeyIndex !== undefined &&
+              hotkeyIndex < 9 &&
+              !isNestedSubagent
             const subagentIndentClass = normalizedNestingDepth > 1 ? "ml-12" : "ml-8"
             const showSessionDetails =
               !forceSingleLine &&
@@ -1861,7 +1865,7 @@ export function ActiveAgentsSidebar({
                         {lastMessageMinutesAgo}
                       </span>
                     )}
-                    {!isNestedSubagent && hotkeyIndex !== undefined && hotkeyIndex < 9 && (sessionPreview || lastMessageMinutesAgo) && (
+                    {canShowHotkeyBadge && (sessionPreview || lastMessageMinutesAgo) && (
                       <span
                         className="shrink-0 text-[10px] leading-4 tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0"
                         title={`${IS_MAC ? "⌘" : "Ctrl+"}${hotkeyIndex + 1} to focus this session`}


### PR DESCRIPTION
## Summary
- Filter the sidebar's `Cmd/Ctrl+1..9` hotkey list to only include active running sessions (skip saved conversations and completed/stopped tasks).
- Render the per-row `⌘N` badge from the same active-only index so numbered labels stay in sync with the hotkey handler — inactive rows no longer show a number.
- Drop the now-unused positional `index` argument from `renderSessionRow` and update the related task-section tests.

## Why
Previously, when the Tasks or Sessions sections were expanded, inactive rows occupied hotkey slots, so `Cmd+1..9` could jump to a completed or saved row instead of a running one. Issue #448 asks for the shortcut to only cycle through active work.

## Test plan
- [x] `pnpm typecheck` (desktop, node + web) passes.
- [x] `pnpm vitest run src/renderer/src/components/active-agents-sidebar` — 21 tests pass.
- [ ] Manual: with mixed active + completed/saved tasks visible in the expanded sidebar, verify `Cmd+1..9` only navigates active rows and only those rows display a `⌘N` badge.

Closes #448

---
_Generated by [Claude Code](https://claude.ai/code/session_01TesJfUwAUWXoxuy1FXSfzc)_