### PR TITLE
Model replay: strip &lt;think&gt; blocks from outgoing content (#453)

### DIFF
--- a/apps/desktop/src/main/llm.respond-to-user-history.test.ts
+++ b/apps/desktop/src/main/llm.respond-to-user-history.test.ts
@@ -207,6 +207,33 @@ describe("processTranscriptWithAgentMode respond_to_user history", () => {
     expect(firstPrompt).not.toContain("prior reasoning")
   })
 
+  it("strips think blocks from prior assistant content in the model prompt (defense in depth)", async () => {
+    const { processTranscriptWithAgentMode } = await import("./llm")
+    mocks.makeLLMCallWithStreamingAndTools.mockResolvedValueOnce({ content: "Current answer", toolCalls: [] })
+
+    await processTranscriptWithAgentMode(
+      "Continue",
+      availableTools as any,
+      makeExecuteToolCall("session-think-in-content", 15),
+      1,
+      [{
+        role: "assistant",
+        content: "<think>leaked reasoning that should never reach the model</think>\n\nPrior answer",
+      }],
+      "conv-think-in-content",
+      "session-think-in-content",
+      undefined,
+      undefined,
+      15,
+    )
+
+    const firstPromptMessages = (mocks.makeLLMCallWithStreamingAndTools.mock.calls[0]?.[0] ?? []) as Array<{ content: string }>
+    const firstPrompt = firstPromptMessages.map((m) => m.content).join("\n")
+    expect(firstPrompt).toContain("Prior answer")
+    expect(firstPrompt).not.toContain("leaked reasoning")
+    expect(firstPrompt).not.toMatch(/<think/i)
+  })
+
   it("logs diagnostics for unrelated provider errors even when the global stop flag is active", async () => {
     const { processTranscriptWithAgentMode } = await import("./llm")
     const providerError = new Error("provider exploded")

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -58,7 +58,7 @@ import { filterEphemeralMessages, isInternalNudgeContent } from "./conversation-
 import {
   filterNamedItemsToAllowedTools,
 } from "./llm-tool-gating"
-import { sanitizeMessageContentForDisplay } from "@dotagents/shared"
+import { sanitizeMessageContentForDisplay, stripDisplayOnlyContent } from "@dotagents/shared"
 import {
   isDeliverableResponseContent,
   isGarbledToolCallText,
@@ -1488,7 +1488,7 @@ export async function processTranscriptWithAgentMode(
         if (entry.skipModelReplay) return null
 
         const rawContent = typeof entry.content === "string" ? entry.content : ""
-        const content = sanitizeMessageContentForDisplay(rawContent).trim()
+        const content = stripDisplayOnlyContent(sanitizeMessageContentForDisplay(rawContent)).trim()
         if (!content) return null
 
         if (entry.role === "tool") {
@@ -1961,7 +1961,7 @@ export async function processTranscriptWithAgentMode(
           if (entry.skipModelReplay) return null
 
           const rawContent = typeof entry.content === "string" ? entry.content : ""
-          const sanitizedContent = sanitizeMessageContentForDisplay(rawContent)
+          const sanitizedContent = stripDisplayOnlyContent(sanitizeMessageContentForDisplay(rawContent))
 
           if (entry.role === "tool") {
             const text = sanitizedContent.trim()
@@ -1982,9 +1982,10 @@ export async function processTranscriptWithAgentMode(
           }
 
           // Preserve user-provided image markdown for the provider adapter; it
-          // converts data/assets image URLs into multimodal message parts. The
-          // sanitized variant above is still used for tool replay and emptiness checks.
-          const content = rawContent
+          // converts data/assets image URLs into multimodal message parts. Reasoning
+          // <think> blocks (display-only) are still stripped, but image markdown is
+          // kept intact in the content forwarded to the provider.
+          const content = stripDisplayOnlyContent(rawContent)
           return {
             role: entry.role as "user" | "assistant",
             content,

--- a/apps/mobile/src/lib/openaiClient.sanitize.test.ts
+++ b/apps/mobile/src/lib/openaiClient.sanitize.test.ts
@@ -120,4 +120,29 @@ describe('sanitizeMessagesForRequest', () => {
     expect(sanitized[0].content).toBe('Final answer');
     expect(sanitized[0].displayContent).toBeUndefined();
   });
+
+  it('strips think blocks that ended up inside content (defense in depth)', () => {
+    const messages: ChatMessage[] = [{
+      role: 'assistant',
+      content: '<think>internal reasoning</think>\n\nUser-facing answer',
+    }];
+
+    const sanitized = sanitizeMessagesForRequest(messages);
+
+    expect(sanitized[0].content).toBe('User-facing answer');
+    const serialized = JSON.stringify(sanitized);
+    expect(serialized).not.toMatch(/<think/i);
+  });
+
+  it('strips an unclosed think block from content', () => {
+    const messages: ChatMessage[] = [{
+      role: 'assistant',
+      content: 'Answer body\n<think>still reasoning, never closed',
+    }];
+
+    const sanitized = sanitizeMessagesForRequest(messages);
+
+    expect(sanitized[0].content).toBe('Answer body');
+    expect(JSON.stringify(sanitized)).not.toMatch(/<think/i);
+  });
 });

--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -7,7 +7,7 @@ import type {
   AgentProgressStep,
   OnProgressCallback,
 } from '@dotagents/shared';
-import { normalizeApiBaseUrl } from '@dotagents/shared';
+import { normalizeApiBaseUrl, stripDisplayOnlyContent } from '@dotagents/shared';
 import { Platform } from 'react-native';
 import EventSource from 'react-native-sse';
 import {
@@ -55,6 +55,10 @@ export const sanitizeMessagesForRequest = (messages: ChatMessage[]): ChatMessage
     const requestMessage = { ...message };
     delete requestMessage.toolExecutions;
     delete requestMessage.displayContent;
+
+    if (typeof requestMessage.content === 'string' && requestMessage.content.length > 0) {
+      requestMessage.content = stripDisplayOnlyContent(requestMessage.content);
+    }
 
     if (message.toolExecutions?.length) {
       delete requestMessage.toolCalls;

--- a/packages/shared/src/message-display-utils.test.ts
+++ b/packages/shared/src/message-display-utils.test.ts
@@ -4,6 +4,7 @@ import {
   sanitizeMessageContentForDisplay,
   sanitizeMessageContentForSpeech,
   sanitizeAgentProgressUpdateForDisplay,
+  stripDisplayOnlyContent,
 } from './message-display-utils'
 import type { AgentProgressUpdate } from './agent-progress'
 
@@ -77,6 +78,33 @@ describe('normalizeMessagePreviewText', () => {
   it('falls back to thought text for open or thought-only tags', () => {
     expect(normalizeMessagePreviewText('<think>still reasoning')).toBe('still reasoning')
     expect(normalizeMessagePreviewText('<think>only thought</think>')).toBe('only thought')
+  })
+})
+
+describe('stripDisplayOnlyContent', () => {
+  it('returns plain content unchanged', () => {
+    expect(stripDisplayOnlyContent('Final answer')).toBe('Final answer')
+  })
+
+  it('returns empty/falsy content as-is', () => {
+    expect(stripDisplayOnlyContent('')).toBe('')
+  })
+
+  it('strips a closed think block, keeping prose', () => {
+    expect(stripDisplayOnlyContent('<think>reasoning</think>\n\nFinal answer')).toBe('Final answer')
+  })
+
+  it('strips multiple think blocks', () => {
+    const input = '<think>step 1</think>\nintro\n<think>step 2</think>\noutro'
+    expect(stripDisplayOnlyContent(input)).toBe('intro\noutro')
+  })
+
+  it('strips an unclosed think block at end of content', () => {
+    expect(stripDisplayOnlyContent('answer\n<think>still reasoning')).toBe('answer')
+  })
+
+  it('strips think tags with attributes', () => {
+    expect(stripDisplayOnlyContent('<think kind="summary">x</think>\nok')).toBe('ok')
   })
 })
 

--- a/packages/shared/src/message-display-utils.ts
+++ b/packages/shared/src/message-display-utils.ts
@@ -4,6 +4,8 @@ import type { AgentProgressUpdate } from "./agent-progress"
 const INLINE_DATA_IMAGE_REGEX = /!\[([^\]]*)\]\((data:image\/[^)]+)\)/gi
 const MARKDOWN_IMAGE_REGEX = /!\[([^\]]*)\]\(([^)]+)\)/gi
 const MARKDOWN_VIDEO_LINK_REGEX = /(^|[^!])\[([^\]]*)\]\((assets:\/\/conversation-video\/[^)]+|https?:\/\/[^)]+\.(?:mp4|m4v|webm|mov|ogv)(?:[?#][^)]*)?)\)/gi
+const THINK_BLOCK_REGEX = /<think\b[^>]*>[\s\S]*?<\/think>\s*/gi
+const OPEN_THINK_REGEX = /<think\b[^>]*>[\s\S]*$/i
 
 function hasInlineDataImage(content: string): boolean {
   return !!content && /data:image\//i.test(content)
@@ -18,6 +20,24 @@ export function sanitizeMessageContentForDisplay(content: string): string {
     const cleanedAlt = altText?.trim()
     return cleanedAlt ? `[Image: ${cleanedAlt}]` : "[Image]"
   })
+}
+
+/**
+ * Strip display-only reasoning markers from text destined for the model.
+ *
+ * Reasoning summaries are wrapped in `<think>...</think>` for the UI; they must
+ * never reach the provider as ordinary assistant prose. This is a defense-in-
+ * depth pass for the model-replay path: the canonical pipeline keeps reasoning
+ * out of `content` already, but if anything upstream merges reasoning into the
+ * persisted assistant content, this strips it before the request goes out.
+ */
+export function stripDisplayOnlyContent(content: string): string {
+  if (!content) return content
+  if (!/<think\b/i.test(content)) return content
+  return content
+    .replace(THINK_BLOCK_REGEX, "")
+    .replace(OPEN_THINK_REGEX, "")
+    .trim()
 }
 
 export function sanitizeMessageContentForSpeech(content: string): string {


### PR DESCRIPTION
Closes a partial mitigation for #453 (tool-result replay & reasoning trace leakage).

## Summary
This is a focused, defense-in-depth slice of the broader investigation in #453: it ensures that `<think>...</think>` reasoning markers cannot reach the provider via the model-replay path, even if something upstream accidentally merged display-only reasoning into persisted assistant content.

The canonical pipeline already keeps reasoning summaries in `displayContent` (UI-only) and out of `content`. But there is no centralized boundary that asserts the invariant before bytes go on the wire — the mobile sanitize stripped `displayContent` only, not stray `<think>` blocks inside `content`. This PR closes that gap on both desktop and mobile.

## Changes
- **`packages/shared/src/message-display-utils.ts`** — add `stripDisplayOnlyContent(content)` helper that strips closed and unclosed `<think>` blocks (case-insensitive, attribute-tolerant). No-op when no `<think` token is present, so the hot path stays cheap.
- **`apps/desktop/src/main/llm.ts`** — apply the helper in both `mapConversationToMessages` (history replay) and the live messages-build path used for the agent LLM call. Image markdown for multimodal user content is still preserved verbatim, only `<think>` blocks are stripped.
- **`apps/mobile/src/lib/openaiClient.ts`** — apply the helper inside `sanitizeMessagesForRequest`, immediately after `displayContent` is deleted.

## Tests
All new and existing tests pass:
- `packages/shared` `message-display-utils` — 23 tests, including 6 new tests for `stripDisplayOnlyContent` (closed, unclosed, multiple, attributed, plain, empty).
- `apps/mobile` `openaiClient.sanitize` — 8 tests, including 2 new defense-in-depth tests asserting `<think>` blocks inside `content` are stripped.
- `apps/desktop` `llm.respond-to-user-history` — 31 tests, including a new assertion that prior assistant content with leaked `<think>` reasoning never appears in the model prompt.
- `apps/desktop` `llm.continuation-guards` — 19 tests still pass.
- `apps/desktop` `typecheck:node` — clean.

## Out of scope
Issue #453 lists several broader directions (provider-native tool-result blocks with stable call IDs, structured truncation metadata, OpenAI Responses API reasoning-item continuity, a single `ModelReplayMessage` boundary, mobile/desktop/recovery contract parity). Those remain open; this PR only closes the most direct leak vector for `<think>` reasoning blocks.

https://claude.ai/code/session_01Shjqgq6sSmvdHBEJEvmuA9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Shjqgq6sSmvdHBEJEvmuA9)_