### PR TITLE
feat(desktop): centralized TTS playback, decouple tile launch from snooze, suppress thought autoplay

### DIFF
--- a/apps/desktop/src/main/agent-session-tracker.ts
+++ b/apps/desktop/src/main/agent-session-tracker.ts
@@ -25,6 +25,7 @@ export interface AgentSession {
   lastActivity?: string
   errorMessage?: string
   isSnoozed?: boolean // When true, session runs in background without stealing focus
+  suppressPanelAutoShow?: boolean // When true, foreground/audible session still should not auto-open the floating panel
   isRepeatTask?: boolean // True for sessions created by repeat-task/loop execution
   /**
    * Profile snapshot captured at session creation time.

--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   showPanelWindow: vi.fn(),
   resizePanelForAgentMode: vi.fn(),
   isSessionSnoozed: vi.fn(),
+  getSession: vi.fn(),
   shouldStopSession: vi.fn(() => false),
   getSessionRunId: vi.fn(() => undefined),
   mainWindow: { isVisible: vi.fn(() => true), isFocused: vi.fn(() => false), webContents: { id: "main" } },
@@ -27,7 +28,7 @@ vi.mock("./state", () => ({
 }))
 
 vi.mock("./agent-session-tracker", () => ({
-  agentSessionTracker: { isSessionSnoozed: mocks.isSessionSnoozed },
+  agentSessionTracker: { isSessionSnoozed: mocks.isSessionSnoozed, getSession: mocks.getSession },
 }))
 
 vi.mock("./config", () => ({
@@ -46,6 +47,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     mocks.showPanelWindow.mockClear()
     mocks.resizePanelForAgentMode.mockClear()
     mocks.isSessionSnoozed.mockReset()
+    mocks.getSession.mockReset()
     mocks.shouldStopSession.mockClear()
     mocks.getSessionRunId.mockClear()
   })
@@ -77,6 +79,17 @@ describe("emitAgentProgress snoozed propagation", () => {
 
     expect(mocks.resizePanelForAgentMode).toHaveBeenCalledTimes(1)
     expect(mocks.showPanelWindow).toHaveBeenCalledWith({ markOpenedWithMain: false })
+  })
+
+  it("keeps unsnoozed sessions from auto-showing the panel when launch state suppresses it", async () => {
+    mocks.isSessionSnoozed.mockReturnValue(false)
+    mocks.getSession.mockReturnValue({ suppressPanelAutoShow: true })
+
+    await emitAgentProgress({ sessionId: "session-tile-visible", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
+
+    expect(mocks.sendSpy).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "session-tile-visible", isSnoozed: false }))
+    expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
+    expect(mocks.showPanelWindow).not.toHaveBeenCalled()
   })
 
   it("sends terminal delegation updates immediately instead of leaving them behind the throttle", async () => {

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -93,7 +93,15 @@ function sendToWindows(update: AgentProgressUpdate): void {
 
   if (!panel.isVisible() && update.sessionId) {
     const isSnoozed = agentSessionTracker.isSessionSnoozed(update.sessionId)
-    if (floatingPanelAutoShowEnabled && !isPanelAutoShowSuppressed() && !isSnoozed && !(hidePanelWhenMainFocused && isMainFocused)) {
+    const isSessionPanelAutoShowSuppressed =
+      agentSessionTracker.getSession(update.sessionId)?.suppressPanelAutoShow ?? false
+    if (
+      floatingPanelAutoShowEnabled &&
+      !isPanelAutoShowSuppressed() &&
+      !isSessionPanelAutoShowSuppressed &&
+      !isSnoozed &&
+      !(hidePanelWhenMainFocused && isMainFocused)
+    ) {
       resizePanelForAgentMode()
       showPanelWindow({ markOpenedWithMain: false })
     }
@@ -133,9 +141,9 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
   const displayUpdate = sanitizeAgentProgressUpdateForDisplay(update)
 
   // Backfill snoozed state from the session tracker when callers omit it.
-  // Tile follow-ups intentionally start snoozed so the panel stays quiet; if
-  // early progress updates lose that flag, the renderer can briefly switch the
-  // hidden panel into overlay/agent mode and trigger unintended focus/TTS side effects.
+  // True background sessions intentionally start snoozed; if early progress
+  // updates lose that flag, the renderer can briefly switch hidden surfaces into
+  // foreground/agent mode and trigger unintended focus/TTS side effects.
   if (displayUpdate.sessionId && typeof displayUpdate.isSnoozed === "undefined") {
     displayUpdate.isSnoozed = agentSessionTracker.isSessionSnoozed(displayUpdate.sessionId)
   }

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -18,6 +18,7 @@ import type { LoopConfig, SessionProfileSnapshot } from "../shared/types"
 import { formatRepeatTaskTitle } from "../shared/repeat-tasks"
 import type { RendererHandlers } from "./renderer-handlers"
 import { WINDOWS } from "./window"
+import { desktopTTSPlaybackCoordinator } from "./tts-playback-coordinator"
 import { getAgentsLayerPaths } from "./agents-files/modular-config"
 import {
   getTasksDir,
@@ -436,6 +437,8 @@ class LoopService {
       // assistant response. The session ran silently in the background; this
       // wakes it up only after the result is ready.
       if (loop.speakOnTrigger && sessionId) {
+        desktopTTSPlaybackCoordinator.clearSessionKeys(sessionId)
+
         // Clear stale TTS tracking keys for this session in all renderer
         // windows.  For continueInSession loops the sessionId is reused across
         // runs, so keys from the previous run would still be in the module-level

--- a/apps/desktop/src/main/message-queue-service.ts
+++ b/apps/desktop/src/main/message-queue-service.ts
@@ -93,11 +93,17 @@ class MessageQueueService {
   /**
    * Add a message to the queue for a conversation
    */
-  enqueue(conversationId: string, text: string, sessionId?: string): QueuedMessage {
+  enqueue(
+    conversationId: string,
+    text: string,
+    sessionId?: string,
+    launchState?: QueuedMessage["launchState"],
+  ): QueuedMessage {
     const message: QueuedMessage = {
       id: this.generateMessageId(),
       conversationId,
       sessionId,
+      ...(launchState ? { launchState } : {}),
       text,
       createdAt: Date.now(),
       status: "pending",

--- a/apps/desktop/src/main/renderer-handlers.ts
+++ b/apps/desktop/src/main/renderer-handlers.ts
@@ -1,5 +1,5 @@
 import { UpdateDownloadedEvent } from "electron-updater"
-import { AgentProgressUpdate, ElicitationRequest, SamplingRequest, QueuedMessage } from "../shared/types"
+import { AgentProgressUpdate, DesktopTTSPlaybackCommand, DesktopTTSPlaybackRequest, DesktopTTSPlaybackState, ElicitationRequest, SamplingRequest, QueuedMessage } from "../shared/types"
 import type { AgentSession } from "./agent-session-tracker"
 
 export type RendererHandlers = {
@@ -25,6 +25,12 @@ export type RendererHandlers = {
 
   // Stop all in-progress TTS playback in this renderer window
   stopAllTts: () => void
+
+  // Centralized TTS playback host/control messages. Requests and commands are
+  // routed to the main renderer host; state changes are broadcast to all windows.
+  ttsPlaybackRequest: (request: DesktopTTSPlaybackRequest) => void
+  ttsPlaybackCommand: (command: DesktopTTSPlaybackCommand) => void
+  ttsPlaybackStateChanged: (state: DesktopTTSPlaybackState) => void
 
   // Floating panel visibility changed (broadcast to all windows)
   panelVisibilityChanged: (data: { visible: boolean }) => void

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -636,8 +636,14 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     }
 
-    // Queue message for the target agent's conversation
-    const queuedMessage = messageQueueService.enqueue(session.conversationId, message, sessionId)
+    // Queue message for the target agent's conversation while preserving the
+    // target session's foreground/background state for the eventual continuation.
+    const startSnoozed = session.isSnoozed ?? false
+    const queuedMessage = messageQueueService.enqueue(session.conversationId, message, sessionId, {
+      startSnoozed,
+      suppressPanelAutoShow: startSnoozed,
+      focusPanelSession: !startSnoozed,
+    })
 
     return {
       content: [

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -54,6 +54,9 @@ import {
   Conversation,
   ConversationCompactionMetadata,
   ConversationHistoryItem,
+  DesktopTTSPlaybackCommand,
+  DesktopTTSPlaybackRequest,
+  DesktopTTSPlaybackState,
   AgentProgressUpdate,
   SessionProfileSnapshot,
   LoopConfig,
@@ -75,8 +78,9 @@ import {
   constrainPositionToScreen,
   PanelPosition,
 } from "./panel-position"
-import { state, agentProcessManager, suppressPanelAutoShow, isPanelAutoShowSuppressed, toolApprovalManager, agentSessionStateManager } from "./state"
+import { state, agentProcessManager, suppressPanelAutoShow, toolApprovalManager, agentSessionStateManager } from "./state"
 import { generateTTS } from "./tts-service"
+import { desktopTTSPlaybackCoordinator } from "./tts-playback-coordinator"
 
 
 import { startRemoteServer, stopRemoteServer, restartRemoteServer, printQRCodeToTerminal, getRemoteServerStatus, getRemoteServerPairingApiKey } from "./remote-server"
@@ -341,9 +345,11 @@ async function processWithAgentMode(
   text: string,
   conversationId?: string,
   existingSessionId?: string, // Optional: reuse existing session instead of creating new one
-  startSnoozed: boolean = false, // Whether to start session snoozed (default: false to show panel)
+  launchStateOrStartSnoozed: boolean | AgentLaunchState = false, // Defaults to foreground/panel-focused work.
   maxIterationsOverride?: number,
 ): Promise<string> {
+  const launchState = normalizeAgentLaunchState(launchStateOrStartSnoozed)
+  const { startSnoozed } = launchState
   const config = configStore.get()
   const maxIterationsFromOverride = typeof maxIterationsOverride === "number" && Number.isFinite(maxIterationsOverride)
     ? maxIterationsOverride
@@ -404,6 +410,10 @@ async function processWithAgentMode(
     // Start tracking this agent session (or reuse existing one)
     const sessionId = existingSessionId
       || agentSessionTracker.startSession(conversationId, conversationTitle, startSnoozed, profileSnapshot)
+    agentSessionTracker.updateSession(sessionId, {
+      isSnoozed: startSnoozed,
+      suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow,
+    })
     const runId = agentSessionStateManager.startSessionRun(sessionId, profileSnapshot)
 
     try {
@@ -449,8 +459,13 @@ async function processWithAgentMode(
 
   // Start tracking this agent session (or reuse existing one)
   let conversationTitle = text
-  // When creating a new session from keybind/UI, start unsnoozed so panel shows immediately
+  // When creating a new session from keybind/UI, start unsnoozed unless the
+  // caller explicitly requested true background/snoozed work.
   const sessionId = existingSessionId || agentSessionTracker.startSession(conversationId, conversationTitle, startSnoozed, profileSnapshot)
+  agentSessionTracker.updateSession(sessionId, {
+    isSnoozed: startSnoozed,
+    suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow,
+  })
   const runId = agentSessionStateManager.startSessionRun(sessionId, profileSnapshot)
 
   try {
@@ -586,9 +601,9 @@ async function processWithAgentMode(
       logLLM(`[tipc.ts processWithAgentMode] No conversationId provided, starting fresh conversation`)
     }
 
-    // Focus interactive sessions in the panel window.
-    // Background/snoozed sessions (e.g. scheduled loops) should not steal focus.
-    if (!startSnoozed) {
+    // Focus only callers that explicitly want panel session selection. A tile
+    // send can be foreground/audible without forcing the floating panel open.
+    if (launchState.shouldFocusPanelSession) {
       try {
         getWindowRendererHandlers("panel")?.focusAgentSession.send(sessionId)
       } catch (e) {
@@ -664,6 +679,59 @@ import { summarizationService } from "./summarization-service"
 import { updateTrayIcon } from "./tray"
 import { isAccessibilityGranted } from "./utils"
 import { writeText, writeTextWithFocusRestore } from "./keyboard"
+
+type AgentLaunchStateInput = {
+  /** Origin hint: the action came from an in-app/session tile. */
+  fromTile?: boolean
+  /** True background mode: keep the session quiet/hidden and disable TTS autoplay. */
+  startSnoozed?: boolean
+  /** Prevent floating-panel auto-show without implying background/snoozed work. */
+  suppressPanelAutoShow?: boolean
+  /** Select this session in the panel renderer when it starts. */
+  focusPanelSession?: boolean
+}
+
+type AgentLaunchState = {
+  startSnoozed: boolean
+  shouldSuppressPanelAutoShow: boolean
+  shouldFocusPanelSession: boolean
+}
+
+function resolveAgentLaunchState(input: AgentLaunchStateInput = {}): AgentLaunchState {
+  const startSnoozed = input.startSnoozed ?? false
+  const shouldSuppressPanelAutoShow =
+    startSnoozed || input.suppressPanelAutoShow === true || input.fromTile === true
+  const shouldFocusPanelSession =
+    input.focusPanelSession ?? (!startSnoozed && !shouldSuppressPanelAutoShow)
+
+  return {
+    startSnoozed,
+    shouldSuppressPanelAutoShow,
+    shouldFocusPanelSession,
+  }
+}
+
+function normalizeAgentLaunchState(
+  launchStateOrStartSnoozed: boolean | AgentLaunchState = false,
+): AgentLaunchState {
+  if (typeof launchStateOrStartSnoozed === "boolean") {
+    return resolveAgentLaunchState({
+      startSnoozed: launchStateOrStartSnoozed,
+      suppressPanelAutoShow: launchStateOrStartSnoozed,
+      focusPanelSession: !launchStateOrStartSnoozed,
+    })
+  }
+
+  return launchStateOrStartSnoozed
+}
+
+function serializeAgentLaunchState(launchState: AgentLaunchState) {
+  return {
+    startSnoozed: launchState.startSnoozed,
+    suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow,
+    focusPanelSession: launchState.shouldFocusPanelSession,
+  }
+}
 
 
 
@@ -937,13 +1005,22 @@ async function processQueuedMessages(conversationId: string): Promise<void> {
           messageQueueService.markAddedToHistory(conversationId, queuedMessage.id)
         }
 
-        // Determine if we should start snoozed based on panel visibility
-        // If the panel is currently visible, the user is actively watching - don't snooze
-        // If the panel is hidden, process in background to avoid unwanted pop-ups
+        // Preserve the launch semantics from the UI action that queued this
+        // message. Falling back to panel visibility is only for older/untyped
+        // enqueue sites that did not capture launch state.
         const panelWindow = WINDOWS.get("panel")
         const isPanelVisible = panelWindow?.isVisible() ?? false
-        const shouldStartSnoozed = !isPanelVisible
-        logLLM(`[processQueuedMessages] Panel visible: ${isPanelVisible}, startSnoozed: ${shouldStartSnoozed}`)
+        const queuedLaunchState = queuedMessage.launchState
+          ? resolveAgentLaunchState(queuedMessage.launchState)
+          : resolveAgentLaunchState({
+            startSnoozed: !isPanelVisible,
+            suppressPanelAutoShow: !isPanelVisible,
+            focusPanelSession: isPanelVisible,
+          })
+        if (queuedLaunchState.shouldSuppressPanelAutoShow) {
+          suppressPanelAutoShow(2000)
+        }
+        logLLM(`[processQueuedMessages] Panel visible: ${isPanelVisible}, launchState: ${JSON.stringify(serializeAgentLaunchState(queuedLaunchState))}`)
 
         // Prefer the exact session captured at enqueue time for strict same-session semantics.
         // If revive fails, fall back to conversation lookup for backward compatibility and continuity.
@@ -955,11 +1032,10 @@ async function processQueuedMessages(conversationId: string): Promise<void> {
         )
 
         for (const candidateSessionId of candidateSessionIds) {
-          // Only start snoozed if panel is not visible
-          const revived = agentSessionTracker.reviveSession(candidateSessionId, shouldStartSnoozed)
+          const revived = agentSessionTracker.reviveSession(candidateSessionId, queuedLaunchState.startSnoozed)
           if (revived) {
             existingSessionId = candidateSessionId
-            logLLM(`[processQueuedMessages] Revived session ${existingSessionId} for conversation ${conversationId}, snoozed: ${shouldStartSnoozed}`)
+            logLLM(`[processQueuedMessages] Revived session ${existingSessionId} for conversation ${conversationId}, snoozed: ${queuedLaunchState.startSnoozed}`)
             break
           }
 
@@ -968,10 +1044,7 @@ async function processQueuedMessages(conversationId: string): Promise<void> {
           }
         }
 
-        // Process with agent mode
-        // If panel is visible, user is watching - show the execution
-        // If panel is hidden, run in background without pop-ups
-        await processWithAgentMode(queuedMessage.text, conversationId, existingSessionId, shouldStartSnoozed)
+        await processWithAgentMode(queuedMessage.text, conversationId, existingSessionId, queuedLaunchState)
 
         // Only remove the message after successful processing
         messageQueueService.markProcessed(conversationId, queuedMessage.id)
@@ -1012,6 +1085,81 @@ function revealFileInFolder(filePath: string): OpenFileResult {
       path: filePath,
       error: error instanceof Error ? error.message : String(error),
     }
+  }
+}
+
+function broadcastTTSPlaybackState(state: DesktopTTSPlaybackState): number {
+  let windowsNotified = 0
+  logApp("[tipc][TTS] Broadcasting playback state", {
+    playbackId: state.playbackId,
+    status: state.status,
+    sessionId: state.sessionId,
+    source: state.source,
+    totalWindows: WINDOWS.size,
+    error: state.error,
+  })
+  for (const [id, win] of WINDOWS.entries()) {
+    try {
+      getRendererHandlers<RendererHandlers>(win.webContents).ttsPlaybackStateChanged?.send(state)
+      windowsNotified += 1
+    } catch (e) {
+      logApp(`[tipc] ttsPlaybackStateChanged send to ${id} failed:`, e)
+    }
+  }
+  return windowsNotified
+}
+
+function sendTTSPlaybackCommandToHost(command: DesktopTTSPlaybackCommand): boolean {
+  const main = WINDOWS.get("main")
+  logApp("[tipc][TTS] Routing playback command to main host", {
+    command,
+    mainAvailable: !!main,
+  })
+  if (!main) {
+    logApp("[tipc] Main window unavailable for TTS playback command", { command })
+    return false
+  }
+
+  try {
+    getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackCommand?.send(command)
+    return true
+  } catch (error) {
+    logApp("[tipc] Failed to route TTS playback command to main renderer:", error)
+    return false
+  }
+}
+
+function sendTTSPlaybackRequestToHost(request: DesktopTTSPlaybackRequest): boolean {
+  const main = WINDOWS.get("main")
+  logApp("[tipc][TTS] Routing playback request to main host", {
+    playbackId: request.playbackId,
+    sessionId: request.sessionId,
+    source: request.source,
+    autoPlay: request.autoPlay,
+    keyCount: request.ttsKeys?.length ?? 0,
+    audioByteLength: request.audio instanceof ArrayBuffer
+      ? request.audio.byteLength
+      : ArrayBuffer.isView(request.audio)
+        ? request.audio.byteLength
+        : Array.isArray(request.audio)
+          ? request.audio.length
+          : undefined,
+    mainAvailable: !!main,
+  })
+  if (!main) {
+    logApp("[tipc] Main window unavailable for TTS playback request", {
+      playbackId: request.playbackId,
+      sessionId: request.sessionId,
+    })
+    return false
+  }
+
+  try {
+    getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackRequest?.send(request)
+    return true
+  } catch (error) {
+    logApp("[tipc] Failed to route TTS playback request to main renderer:", error)
+    return false
   }
 }
 
@@ -1177,7 +1325,125 @@ export const router = {
     return { success: true, message: "Agent mode emergency stopped" }
   }),
 
+  claimTTSPlaybackKeys: t.procedure
+    .input<{ ttsKeys?: string[]; sessionId?: string; forced?: boolean }>()
+    .action(async ({ input }) => {
+      logApp("[tipc][TTS] claimTTSPlaybackKeys", {
+        sessionId: input.sessionId,
+        forced: input.forced ?? false,
+        keys: input.ttsKeys,
+      })
+      const claimed = desktopTTSPlaybackCoordinator.claimAutoPlayKeys(input.ttsKeys, {
+        sessionId: input.sessionId,
+        forced: input.forced ?? false,
+      })
+      logApp("[tipc][TTS] claimTTSPlaybackKeys result", {
+        claimed,
+        sessionId: input.sessionId,
+      })
+      return { claimed }
+    }),
+
+  releaseTTSPlaybackKeys: t.procedure
+    .input<{ ttsKeys?: string[] }>()
+    .action(async ({ input }) => {
+      logApp("[tipc][TTS] releaseTTSPlaybackKeys", { keys: input.ttsKeys })
+      desktopTTSPlaybackCoordinator.releaseAutoPlayKeys(input.ttsKeys)
+      return { success: true }
+    }),
+
+  getTTSPlaybackState: t.procedure.action(async () => {
+    return desktopTTSPlaybackCoordinator.getState()
+  }),
+
+  requestTTSPlayback: t.procedure
+    .input<DesktopTTSPlaybackRequest>()
+    .action(async ({ input }) => {
+      logApp("[tipc][TTS] requestTTSPlayback received", {
+        playbackId: input.playbackId,
+        sessionId: input.sessionId,
+        source: input.source,
+        autoPlay: input.autoPlay,
+        keyCount: input.ttsKeys?.length ?? 0,
+        mimeType: input.mimeType,
+        audioOutputDeviceId: input.audioOutputDeviceId,
+      })
+      const state = desktopTTSPlaybackCoordinator.setState({
+        playbackId: input.playbackId,
+        sourceWindowId: input.sourceWindowId,
+        source: input.source,
+        sessionId: input.sessionId,
+        ttsKey: input.ttsKeys?.[0],
+        textPreview: input.textPreview ?? input.text.slice(0, 120),
+        status: "loading",
+        currentTime: 0,
+        duration: 0,
+        audioOutputDeviceId: input.audioOutputDeviceId,
+        error: undefined,
+      })
+      broadcastTTSPlaybackState(state)
+
+      const routed = sendTTSPlaybackRequestToHost(input)
+      if (!routed) {
+        const failedState = desktopTTSPlaybackCoordinator.setState({
+          playbackId: input.playbackId,
+          status: "error",
+          error: "Main playback host is unavailable",
+        })
+        broadcastTTSPlaybackState(failedState)
+        logApp("[tipc][TTS] requestTTSPlayback failed to route", {
+          playbackId: input.playbackId,
+          sessionId: input.sessionId,
+        })
+        return { success: false, error: failedState.error }
+      }
+
+      logApp("[tipc][TTS] requestTTSPlayback routed", {
+        playbackId: input.playbackId,
+        sessionId: input.sessionId,
+      })
+      return { success: true }
+    }),
+
+  controlTTSPlayback: t.procedure
+    .input<DesktopTTSPlaybackCommand>()
+    .action(async ({ input }) => {
+      logApp("[tipc][TTS] controlTTSPlayback received", { command: input })
+      const routed = sendTTSPlaybackCommandToHost(input)
+
+      if (input.type === "stop" || !routed) {
+        const state = input.type === "stop"
+          ? desktopTTSPlaybackCoordinator.reset(input.reason)
+          : desktopTTSPlaybackCoordinator.setState({ status: "error", error: "Main playback host is unavailable" })
+        broadcastTTSPlaybackState(state)
+      }
+
+      logApp("[tipc][TTS] controlTTSPlayback routed", { command: input, routed })
+      return { success: routed }
+    }),
+
+  publishTTSPlaybackState: t.procedure
+    .input<DesktopTTSPlaybackState>()
+    .action(async ({ input }) => {
+      logApp("[tipc][TTS] publishTTSPlaybackState received", {
+        playbackId: input.playbackId,
+        status: input.status,
+        sessionId: input.sessionId,
+        source: input.source,
+        currentTime: input.currentTime,
+        duration: input.duration,
+        error: input.error,
+      })
+      const state = desktopTTSPlaybackCoordinator.setState(input)
+      const windowsNotified = broadcastTTSPlaybackState(state)
+      return { success: true, windowsNotified }
+    }),
+
   stopAllTts: t.procedure.action(async () => {
+    sendTTSPlaybackCommandToHost({ type: "stop", reason: "stopAllTts" })
+    const state = desktopTTSPlaybackCoordinator.reset("stopAllTts")
+    broadcastTTSPlaybackState(state)
+
     let windowsNotified = 0
     for (const [id, win] of WINDOWS.entries()) {
       try {
@@ -1216,6 +1482,7 @@ export const router = {
       // Session is being explicitly dismissed from UI; clear persisted
       // respond_to_user state for this session.
       clearSessionUserResponse(input.sessionId)
+      desktopTTSPlaybackCoordinator.clearSessionKeys(input.sessionId)
 
       // Also remove from the tracker's completed sessions list so it
       // doesn't re-appear in the sidebar on the next agentSessionsUpdated.
@@ -1236,7 +1503,9 @@ export const router = {
     // Clear completed sessions from the tracker
     agentSessionTracker.clearCompletedSessions((session) => {
       if (!session.conversationId) return true
-      return messageQueueService.getQueue(session.conversationId).length === 0
+      const shouldClear = messageQueueService.getQueue(session.conversationId).length === 0
+      if (shouldClear) desktopTTSPlaybackCoordinator.clearSessionKeys(session.id)
+      return shouldClear
     })
 
     // Send to all windows so both main and panel can update their state
@@ -2030,26 +2299,29 @@ export const router = {
       text: string
       conversationId?: string
       sessionId?: string
-      fromTile?: boolean // When true, session runs in background (snoozed) - panel won't show
+      fromTile?: boolean // Origin hint: suppress floating-panel auto-show, but do not imply snoozed/background work.
+      startSnoozed?: boolean // True background mode: keep hidden/quiet and disable TTS autoplay.
+      suppressPanelAutoShow?: boolean
+      focusPanelSession?: boolean
     }>()
     .action(async ({ input }) => {
       const config = configStore.get()
       const queueEnabled = config.mcpMessageQueueEnabled !== false
+      const launchState = resolveAgentLaunchState(input)
 
       logApp("[createMcpTextInput] Request received", {
         conversationId: input.conversationId ?? null,
         sessionId: input.sessionId ?? null,
         sessionKind: describeAgentSessionId(input.sessionId),
         fromTile: input.fromTile ?? false,
+        ...serializeAgentLaunchState(launchState),
         messageLength: input.text.length,
         queueEnabled,
       })
 
-      // Defensive guard: when the caller explicitly asks for a snoozed session
-      // (fromTile=true, e.g. SessionActionDialog inside the main window), also
-      // time-suppress panel auto-show so an early progress update cannot race
-      // the snoozed flag and briefly surface the floating panel.
-      if (input.fromTile === true) {
+      // Panel suppression is separate from snoozing. Tile-originated sessions
+      // can stay foreground/audible while still avoiding floating-panel popups.
+      if (launchState.shouldSuppressPanelAutoShow) {
         suppressPanelAutoShow(2000)
       }
 
@@ -2117,7 +2389,12 @@ export const router = {
             if (session && session.status === "active") {
               const queuedText = await conversationService.materializeInlineDataImagesInContent(conversationId, input.text)
               // Queue the message instead of starting a new session
-              const queuedMessage = messageQueueService.enqueue(conversationId, queuedText, activeSessionId)
+              const queuedMessage = messageQueueService.enqueue(
+                conversationId,
+                queuedText,
+                activeSessionId,
+                serializeAgentLaunchState(launchState),
+              )
               logApp("[createMcpTextInput] Queued message for active session", {
                 conversationId,
                 queuedMessageId: queuedMessage.id,
@@ -2159,8 +2436,7 @@ export const router = {
           ? requestedSessionId
           : agentSessionTracker.findSessionByConversationId(input.conversationId)
         if (foundSessionId) {
-          // Pass fromTile to reviveSession so it stays snoozed when continuing from a tile
-          const revived = agentSessionTracker.reviveSession(foundSessionId, input.fromTile ?? false)
+          const revived = agentSessionTracker.reviveSession(foundSessionId, launchState.startSnoozed)
           if (revived) {
             existingSessionId = foundSessionId
             logApp("[createMcpTextInput] Revived existing session", {
@@ -2188,8 +2464,7 @@ export const router = {
       // Fire-and-forget: Start agent processing without blocking
       // This allows multiple sessions to run concurrently
       // Pass existingSessionId to reuse the session if found
-      // When fromTile=true, start snoozed so the floating panel doesn't appear
-      processWithAgentMode(agentInputText, conversationId, existingSessionId, input.fromTile ?? false)
+      processWithAgentMode(agentInputText, conversationId, existingSessionId, launchState)
         .then((finalResponse) => {
           // Save to history after completion
           const history = getRecordingHistory()
@@ -2245,13 +2520,17 @@ export const router = {
       conversationId?: string
       sessionId?: string
       screenshot?: ScreenshotAttachmentInput
-      fromTile?: boolean // When true, session runs in background (snoozed) - panel won't show
+      fromTile?: boolean // Origin hint: suppress floating-panel auto-show, but do not imply snoozed/background work.
+      startSnoozed?: boolean // True background mode: keep hidden/quiet and disable TTS autoplay.
+      suppressPanelAutoShow?: boolean
+      focusPanelSession?: boolean
     }>()
     .action(async ({ input }) => {
-      // Defensive guard: see matching comment in createMcpTextInput. When a
-      // caller asks for a snoozed session, time-suppress panel auto-show to
-      // cover the window where progress updates may race the snoozed flag.
-      if (input.fromTile === true) {
+      const launchState = resolveAgentLaunchState(input)
+
+      // Panel suppression is separate from snoozing. Tile-originated recordings
+      // can stay foreground/audible while still hiding the waveform panel after capture.
+      if (launchState.shouldSuppressPanelAutoShow) {
         suppressPanelAutoShow(2000)
       }
 
@@ -2345,7 +2624,12 @@ export const router = {
             const queuedText = await conversationService.materializeInlineDataImagesInContent(input.conversationId, messageText)
 
             // Queue the transcript instead of processing immediately
-            const queuedMessage = messageQueueService.enqueue(input.conversationId, queuedText, activeSessionId)
+            const queuedMessage = messageQueueService.enqueue(
+              input.conversationId,
+              queuedText,
+              activeSessionId,
+              serializeAgentLaunchState(launchState),
+            )
             logApp(`[createMcpRecording] Queued voice transcript ${queuedMessage.id} for active session ${activeSessionId}`)
 
             return { conversationId: input.conversationId, queued: true, queuedMessageId: queuedMessage.id }
@@ -2387,8 +2671,7 @@ export const router = {
       // If sessionId is provided, try to revive that session.
       // Otherwise, if conversationId is provided, try to find and revive a session for that conversation.
       // This handles the case where user continues from history (only conversationId is set).
-      // When fromTile=true, sessions start snoozed so the floating panel doesn't appear.
-      const startSnoozed = input.fromTile ?? false
+      const startSnoozed = launchState.startSnoozed
       let sessionId: string
       if (input.sessionId) {
         // Try to revive the existing session by ID
@@ -2430,6 +2713,11 @@ export const router = {
         // No sessionId or conversationId provided, create a new session with profile snapshot
         sessionId = agentSessionTracker.startSession(tempConversationId, "Transcribing...", startSnoozed, profileSnapshot)
       }
+
+      agentSessionTracker.updateSession(sessionId, {
+        isSnoozed: startSnoozed,
+        suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow,
+      })
 
       try {
         // Emit initial "initializing" progress update
@@ -2569,9 +2857,9 @@ export const router = {
       )
 
         // Fire-and-forget: Start agent processing without blocking.
-        // Preserve the tile/background snooze state after transcription so
-        // voice follow-ups from a session tile do not re-focus the panel.
-        processWithAgentMode(agentInputText, conversationId, sessionId, startSnoozed)
+        // Preserve the explicit launch state after transcription so tile voice
+        // follow-ups remain audible without re-focusing the floating panel.
+        processWithAgentMode(agentInputText, conversationId, sessionId, launchState)
         .then((finalResponse) => {
           // Save to history after completion
           const history = getRecordingHistory()

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1100,7 +1100,12 @@ function broadcastTTSPlaybackState(state: DesktopTTSPlaybackState): number {
   })
   for (const [id, win] of WINDOWS.entries()) {
     try {
-      getRendererHandlers<RendererHandlers>(win.webContents).ttsPlaybackStateChanged?.send(state)
+      const handler = getRendererHandlers<RendererHandlers>(win.webContents).ttsPlaybackStateChanged
+      if (!handler) {
+        logApp(`[tipc] ttsPlaybackStateChanged handler missing for ${id}`)
+        continue
+      }
+      handler.send(state)
       windowsNotified += 1
     } catch (e) {
       logApp(`[tipc] ttsPlaybackStateChanged send to ${id} failed:`, e)
@@ -1121,7 +1126,12 @@ function sendTTSPlaybackCommandToHost(command: DesktopTTSPlaybackCommand): boole
   }
 
   try {
-    getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackCommand?.send(command)
+    const handler = getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackCommand
+    if (!handler) {
+      logApp("[tipc] Main renderer has no TTS playback command handler", { command })
+      return false
+    }
+    handler.send(command)
     return true
   } catch (error) {
     logApp("[tipc] Failed to route TTS playback command to main renderer:", error)
@@ -1155,7 +1165,15 @@ function sendTTSPlaybackRequestToHost(request: DesktopTTSPlaybackRequest): boole
   }
 
   try {
-    getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackRequest?.send(request)
+    const handler = getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackRequest
+    if (!handler) {
+      logApp("[tipc] Main renderer has no TTS playback request handler", {
+        playbackId: request.playbackId,
+        sessionId: request.sessionId,
+      })
+      return false
+    }
+    handler.send(request)
     return true
   } catch (error) {
     logApp("[tipc] Failed to route TTS playback request to main renderer:", error)

--- a/apps/desktop/src/main/tts-playback-coordinator.test.ts
+++ b/apps/desktop/src/main/tts-playback-coordinator.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { DesktopTTSPlaybackCoordinator } from "./tts-playback-coordinator"
+
+describe("DesktopTTSPlaybackCoordinator", () => {
+  it("claims response-event and content fallback keys as one auto-play unit", () => {
+    const coordinator = new DesktopTTSPlaybackCoordinator()
+    const keys = ["session-1:final:event:event-1", "session-1:final:content:hello"]
+
+    expect(coordinator.claimAutoPlayKeys(keys, { sessionId: "session-1" })).toBe(true)
+    expect(coordinator.claimAutoPlayKeys([keys[0]], { sessionId: "session-1" })).toBe(false)
+    expect(coordinator.claimAutoPlayKeys([keys[1]], { sessionId: "session-1" })).toBe(false)
+  })
+
+  it("releases failed generation claims so auto-play can retry", () => {
+    const coordinator = new DesktopTTSPlaybackCoordinator()
+    const keys = ["session-1:final:event:event-1"]
+
+    expect(coordinator.claimAutoPlayKeys(keys, { sessionId: "session-1" })).toBe(true)
+    coordinator.releaseAutoPlayKeys(keys)
+
+    expect(coordinator.claimAutoPlayKeys(keys, { sessionId: "session-1" })).toBe(true)
+  })
+
+  it("clears all keys scoped to a reused session", () => {
+    const coordinator = new DesktopTTSPlaybackCoordinator()
+
+    coordinator.claimAutoPlayKeys(["session-1:final:content:old"], { sessionId: "session-1" })
+    coordinator.claimAutoPlayKeys(["session-2:final:content:keep"], { sessionId: "session-2" })
+    coordinator.clearSessionKeys("session-1")
+
+    expect(coordinator.claimAutoPlayKeys(["session-1:final:content:old"], { sessionId: "session-1" })).toBe(true)
+    expect(coordinator.claimAutoPlayKeys(["session-2:final:content:keep"], { sessionId: "session-2" })).toBe(false)
+  })
+
+  it("accepts forced auto-play claims but still dedupes duplicate keys", () => {
+    const coordinator = new DesktopTTSPlaybackCoordinator()
+    const keys = ["session-forced:final:content:result"]
+
+    expect(coordinator.claimAutoPlayKeys(keys, { sessionId: "session-forced", forced: true })).toBe(true)
+    expect(coordinator.claimAutoPlayKeys(keys, { sessionId: "session-forced", forced: true })).toBe(false)
+  })
+
+  it("does not block manual replay because manual playback bypasses auto-play claims", () => {
+    const coordinator = new DesktopTTSPlaybackCoordinator()
+    const keys = ["session-1:final:content:already-spoken"]
+
+    expect(coordinator.claimAutoPlayKeys(keys, { sessionId: "session-1" })).toBe(true)
+
+    coordinator.setState({ playbackId: "manual-replay", status: "loading" })
+
+    expect(coordinator.getState().playbackId).toBe("manual-replay")
+    expect(coordinator.getState().status).toBe("loading")
+  })
+})

--- a/apps/desktop/src/main/tts-playback-coordinator.ts
+++ b/apps/desktop/src/main/tts-playback-coordinator.ts
@@ -1,0 +1,131 @@
+import type { DesktopTTSPlaybackState } from "../shared/types"
+import { logApp } from "./debug"
+
+type ClaimedTTSKey = {
+  sessionId?: string
+  forced: boolean
+  claimedAt: number
+}
+
+export const createIdleTTSPlaybackState = (): DesktopTTSPlaybackState => ({
+  playbackId: null,
+  status: "idle",
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  muted: false,
+  updatedAt: Date.now(),
+})
+
+export class DesktopTTSPlaybackCoordinator {
+  private state: DesktopTTSPlaybackState = createIdleTTSPlaybackState()
+  private claimedAutoPlayKeys = new Map<string, ClaimedTTSKey>()
+
+  claimAutoPlayKeys(
+    ttsKeys: string[] | undefined,
+    options: { sessionId?: string; forced?: boolean } = {},
+  ): boolean {
+    const uniqueKeys = this.normalizeKeys(ttsKeys)
+    if (uniqueKeys.length === 0) {
+      logApp("[TTSPlaybackCoordinator] claimAutoPlayKeys accepted with no keys", options)
+      return true
+    }
+
+    const existingKey = uniqueKeys.find((key) => this.claimedAutoPlayKeys.has(key))
+    if (existingKey) {
+      logApp("[TTSPlaybackCoordinator] claimAutoPlayKeys rejected", {
+        existingKey,
+        keys: uniqueKeys,
+        sessionId: options.sessionId,
+        forced: options.forced ?? false,
+        claimedKeyCount: this.claimedAutoPlayKeys.size,
+      })
+      return false
+    }
+
+    const claimedAt = Date.now()
+    for (const key of uniqueKeys) {
+      this.claimedAutoPlayKeys.set(key, {
+        sessionId: options.sessionId,
+        forced: options.forced ?? false,
+        claimedAt,
+      })
+    }
+
+    logApp("[TTSPlaybackCoordinator] claimAutoPlayKeys accepted", {
+      keys: uniqueKeys,
+      sessionId: options.sessionId,
+      forced: options.forced ?? false,
+      claimedKeyCount: this.claimedAutoPlayKeys.size,
+    })
+
+    return true
+  }
+
+  releaseAutoPlayKeys(ttsKeys: string[] | undefined): void {
+    const uniqueKeys = this.normalizeKeys(ttsKeys)
+    for (const key of this.normalizeKeys(ttsKeys)) {
+      this.claimedAutoPlayKeys.delete(key)
+    }
+    logApp("[TTSPlaybackCoordinator] releaseAutoPlayKeys", {
+      keys: uniqueKeys,
+      claimedKeyCount: this.claimedAutoPlayKeys.size,
+    })
+  }
+
+  clearSessionKeys(sessionId: string): void {
+    let clearedCount = 0
+    for (const [key, claim] of this.claimedAutoPlayKeys.entries()) {
+      if (claim.sessionId === sessionId || key.startsWith(`${sessionId}:`)) {
+        this.claimedAutoPlayKeys.delete(key)
+        clearedCount += 1
+      }
+    }
+    logApp("[TTSPlaybackCoordinator] clearSessionKeys", {
+      sessionId,
+      clearedCount,
+      claimedKeyCount: this.claimedAutoPlayKeys.size,
+    })
+  }
+
+  setState(statePatch: Partial<DesktopTTSPlaybackState>): DesktopTTSPlaybackState {
+    this.state = {
+      ...this.state,
+      ...statePatch,
+      updatedAt: statePatch.updatedAt ?? Date.now(),
+    }
+    logApp("[TTSPlaybackCoordinator] state updated", {
+      playbackId: this.state.playbackId,
+      status: this.state.status,
+      sessionId: this.state.sessionId,
+      source: this.state.source,
+      currentTime: this.state.currentTime,
+      duration: this.state.duration,
+      error: this.state.error,
+    })
+    return this.getState()
+  }
+
+  getState(): DesktopTTSPlaybackState {
+    return { ...this.state }
+  }
+
+  reset(reason?: string): DesktopTTSPlaybackState {
+    this.state = {
+      ...createIdleTTSPlaybackState(),
+      error: reason,
+    }
+    logApp("[TTSPlaybackCoordinator] reset", { reason })
+    return this.getState()
+  }
+
+  getClaimedKeyCount(): number {
+    return this.claimedAutoPlayKeys.size
+  }
+
+  private normalizeKeys(ttsKeys: string[] | undefined): string[] {
+    return Array.from(new Set((ttsKeys ?? []).filter((key) => typeof key === "string" && key.length > 0)))
+  }
+}
+
+export const desktopTTSPlaybackCoordinator = new DesktopTTSPlaybackCoordinator()

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -249,18 +249,6 @@ function broadcastPanelVisibility(visible: boolean) {
   }
 }
 
-// Stop TTS playing in the floating panel renderer only. Invoked from the
-// panel's `hide` handler so every hide path (ESC, hideFloatingPanelWindow,
-// main-window focus auto-hide, etc.) silences panel TTS without affecting
-// TTS playing in the main window.
-function stopPanelRendererTts() {
-  const panel = WINDOWS.get("panel")
-  if (!panel) return
-  try {
-    getRendererHandlers<RendererHandlers>(panel.webContents).stopAllTts?.send()
-  } catch {}
-}
-
 // One-shot flag for intentional main-window hide paths.
 // If main is hidden without this flag, we treat it as accidental and recover.
 let allowExpectedMainHide = false
@@ -1082,7 +1070,8 @@ export function createPanelWindow(): BrowserWindow | undefined {
       snapshot: getWindowFocusDebugSnapshot(),
     })
     getRendererHandlers<RendererHandlers>(win.webContents).stopRecording.send()
-    stopPanelRendererTts()
+    // Panel hide no longer owns or silences TTS. The main renderer playback
+    // host and global/emergency stop controls are the only TTS playback owners.
     broadcastPanelVisibility(false)
   })
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -190,7 +190,13 @@ async function loadAgentProgress(
 
   const Null = () => null
   const icon = (name: string) => (props: any) => ({ type: name, props })
-  const tipcMock = { tipcClient: new Proxy({ generateSpeech: vi.fn(), setPanelFocusable: vi.fn() }, { get: (target, key) => (target as any)[key] ?? vi.fn() }) }
+  const tipcMock = { tipcClient: new Proxy({
+    generateSpeech: vi.fn(),
+    setPanelFocusable: vi.fn(),
+    claimTTSPlaybackKeys: vi.fn().mockResolvedValue({ claimed: true }),
+    releaseTTSPlaybackKeys: vi.fn().mockResolvedValue({ success: true }),
+    controlTTSPlayback: vi.fn().mockResolvedValue({ success: true }),
+  }, { get: (target, key) => (target as any)[key] ?? vi.fn() }) }
   const queriesMock = {
     useConfigQuery: () => ({ data: { ttsEnabled: options?.ttsEnabled ?? false, ttsAutoPlay: options?.ttsAutoPlay ?? false, dualModelEnabled: false } }),
     useAvailableModelsQuery: () => ({ data: [{ id: "gpt-4.1-mini", name: "GPT 4.1 Mini" }], isLoading: false }),
@@ -357,6 +363,7 @@ async function loadAgentProgress(
     hasTTSPlayed: () => false,
     markTTSPlayed: vi.fn(),
     removeTTSKey: vi.fn(),
+    consumeSessionForcedAutoPlay: vi.fn(() => false),
     buildResponseEventTTSKey: vi.fn(() => null),
     buildContentTTSKey: vi.fn(() => null),
   }))
@@ -1099,7 +1106,10 @@ describe("agent progress response history", () => {
     let tree = runtime.render(AgentProgress, { progress, variant: "overlay" })
     runtime.commitEffects()
     await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
 
+    expect(tipcMock.tipcClient.claimTTSPlaybackKeys).toHaveBeenCalled()
     expect(tipcMock.tipcClient.generateSpeech).toHaveBeenCalledWith({ text: "Mid-conversation answer" })
   })
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.snoozed-tts.test.ts
@@ -6,7 +6,7 @@ const agentProgressSource = readFileSync(new URL("./agent-progress.tsx", import.
 describe("agent progress TTS guardrails", () => {
   it("disables overlay auto-play generation when the session is snoozed", () => {
     expect(agentProgressSource).toContain('function shouldAutoPlayTTSForVariant')
-    expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
+    expect(agentProgressSource).toContain('focus no\n  // longer decides whether a tile may request auto-play')
     expect(agentProgressSource).toContain('return !isSnoozed')
   })
 
@@ -25,21 +25,29 @@ describe("agent progress TTS guardrails", () => {
     expect(spinnerIndex).toBeGreaterThan(backgroundIconIndex)
   })
 
-  it("suppresses tile auto-play while the floating panel is visible so the same session is not spoken twice", () => {
-    expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
-    expect(agentProgressSource).toContain('shouldAutoPlayTTSForVariant(messageVariant, isSnoozed, isFocused, isFloatingPanelVisible)')
-    expect(agentProgressSource).toContain('const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)')
+  it("lets unfocused tiles request auto-play while central claims prevent duplicate speech", () => {
+    expect(agentProgressSource).toContain('focus no\n  // longer decides whether a tile may request auto-play')
+    expect(agentProgressSource).toContain('shouldAutoPlayTTSForVariant(messageVariant, isSnoozed)')
+    expect(agentProgressSource).toContain('tipcClient.claimTTSPlaybackKeys')
+    expect(agentProgressSource).toContain('tipcClient.requestTTSPlayback({')
   })
 
   it("keeps response-linked assistant messages replayable but only auto-plays the latest assistant message", () => {
-    expect(agentProgressSource).toContain('(isComplete || !!message.responseEvent)')
+    expect(agentProgressSource).toContain('const canUseTTSForAssistantMessage =')
+    expect(agentProgressSource).toContain('isThoughtEligibleForTTS')
+    expect(agentProgressSource).toContain('isAssistantThought: true')
+    expect(agentProgressSource).toContain('(!message.isAssistantThought || isThoughtEligibleForTTS)')
+    expect(agentProgressSource).toContain('!message.isThinking &&')
     expect(agentProgressSource).toContain('const shouldAutoPlayTTS = shouldShowTTSButton && isLast')
     expect(agentProgressSource).toContain('isLast &&')
+    expect(agentProgressSource).toContain('!ttsKeys.some((key) => hasTTSPlayed(key)) &&')
   })
 
   it("suppresses auto-play for historical sessions that mount with progress already complete", () => {
     expect(agentProgressSource).toContain('const observedLiveProgressRef = useRef(false)')
-    expect(agentProgressSource).toContain('if (!observedLiveProgressRef.current) {')
+    expect(agentProgressSource).toContain('parentObservedLiveProgress')
+    expect(agentProgressSource).toContain('const hasObservedLiveProgress = observedLiveProgressRef.current || parentObservedLiveProgress || !isComplete')
+    expect(agentProgressSource).toContain('if (!hasObservedLiveProgress) {')
     expect(agentProgressSource).toContain('consumeSessionForcedAutoPlay(sessionId)')
   })
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -301,9 +301,11 @@ describe("agent progress tile layout", () => {
     )
   })
 
-  it("does not auto-play TTS for tile expansion/collapse interactions", () => {
+  it("allows tile auto-play without requiring tile focus", () => {
     expect(agentProgressSource).toContain('function shouldAutoPlayTTSForVariant')
-    expect(agentProgressSource).toContain('if (variant === "tile") return isFocused && !isFloatingPanelVisible')
+    expect(agentProgressSource).toContain('focus no\n  // longer decides whether a tile may request auto-play')
+    expect(agentProgressSource).toContain('return !isSnoozed')
+    expect(agentProgressSource).toContain('tipcClient.claimTTSPlaybackKeys')
   })
 
   it("uses shared conversation-state normalization across agent progress surfaces", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -40,7 +40,6 @@ import { AgentSummaryView } from "./agent-summary-view"
 import { LoadingSpinner } from "./ui/loading-spinner"
 import { extractSubAgentToolDisplayContent } from "@shared/delegation-tool-display"
 import { buildContentTTSKey, buildResponseEventTTSKey, consumeSessionForcedAutoPlay, hasTTSPlayed, markTTSPlayed, removeTTSKey } from "@renderer/lib/tts-tracking"
-import { ttsManager } from "@renderer/lib/tts-manager"
 import { sanitizeMessageContentForDisplay, sanitizeMessageContentForSpeech } from "@dotagents/shared/message-display-utils"
 import { toast } from "sonner"
 import {
@@ -98,6 +97,7 @@ type DisplayItem =
       isComplete: boolean
       timestamp: number
       isThinking: boolean
+      isAssistantThought?: boolean
       toolCalls?: Array<{ name: string; arguments: any }>
       toolResults?: Array<{ success: boolean; content: string; error?: string }>
       responseEvent?: AgentUserResponseEvent
@@ -731,14 +731,13 @@ function normalizeAssistantResponseForDedupe(content: string | undefined): strin
 }
 
 function shouldAutoPlayTTSForVariant(
-  variant: "default" | "overlay" | "tile",
+  _variant: "default" | "overlay" | "tile",
   isSnoozed: boolean,
-  isFocused: boolean = false,
-  isFloatingPanelVisible: boolean = false,
 ): boolean {
-  // The floating panel owns TTS auto-play while it is visible. Tile surfaces
-  // in the main window defer so the same session isn't spoken twice.
-  if (variant === "tile") return isFocused && !isFloatingPanelVisible
+  // TTS playback ownership is centralized in the main renderer, so focus no
+  // longer decides whether a tile may request auto-play. The central
+  // coordinator prevents duplicate/overlapping speech. Snoozed/background
+  // sessions stay quiet until they are unsnoozed/revealed.
   return !isSnoozed
 }
 
@@ -774,6 +773,7 @@ type CompactMessageProps = {
     content: string
     isComplete?: boolean
     isThinking?: boolean
+    isAssistantThought?: boolean
     toolCalls?: Array<{ name: string; arguments: any }>
     toolResults?: Array<{ success: boolean; content: string; error?: string }>
     timestamp: number
@@ -786,14 +786,16 @@ type CompactMessageProps = {
   wasStopped?: boolean
   isExpanded: boolean
   onToggleExpand: () => void
-  /** Variant controls TTS auto-play; tile variants only auto-play when focused. */
+  /** Variant controls TTS presentation; focus does not gate centralized auto-play. */
   variant?: "default" | "overlay" | "tile"
-  /** Focused session tiles are the primary conversation surface and may auto-play TTS. */
+  /** Focused session tiles are the primary conversation surface for layout/scrolling. */
   isFocused?: boolean
   /** Session ID for tracking TTS playback across remounts */
   sessionId?: string
-  /** Snoozed/background sessions must never auto-play overlay TTS */
+  /** Snoozed/background sessions must not auto-play TTS */
   isSnoozed?: boolean
+  /** True when the parent session surface observed this run while it was live. */
+  parentObservedLiveProgress?: boolean
   /** Conversation ID for branching */
   conversationId?: string
   /** Absolute raw-history index to use when branching from this message */
@@ -805,7 +807,7 @@ type CompactMessageProps = {
 }
 
 // Compact message component for space efficiency
-const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default", isFocused = false, sessionId, isSnoozed = false, conversationId, branchMessageIndex, turnDurationMs, turnIsLive }) => {
+const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, isLast, isComplete, hasErrors, wasStopped = false, isExpanded, onToggleExpand, variant = "default", isFocused = false, sessionId, isSnoozed = false, parentObservedLiveProgress = false, conversationId, branchMessageIndex, turnDurationMs, turnIsLive }) => {
   const messageVariant = normalizeProgressVariant(variant)
   const [audioData, setAudioData] = useState<ArrayBuffer | null>(null)
   const [audioMimeType, setAudioMimeType] = useState<string | null>(null)
@@ -819,13 +821,12 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const inFlightTtsKeysRef = useRef<string[]>([])
   // Track the last ttsSource that was successfully auto-played to prevent replay on follow-up messages
   const lastAutoPlayedSourceRef = useRef<string | null>(null)
-  // Track whether the agent's progress was ever observed in a non-complete state during
-  // this component's lifetime. Live runs (including mid-turn respond_to_user emissions)
-  // always pass through `isComplete=false` first; reopened/historical sessions mount with
-  // `isComplete=true` from the start. Auto-play is gated on having observed an active run.
+  // Track whether this message instance, or its parent session surface, ever observed
+  // the agent in a non-complete state. Final assistant messages can be created only
+  // after completion, so parentObservedLiveProgress keeps live-session final replies
+  // eligible for autoplay while reopened history still stays quiet.
   const observedLiveProgressRef = useRef(false)
   const configQuery = useConfigQuery()
-  const isFloatingPanelVisible = useAgentStore((s) => s.isFloatingPanelVisible)
 
   // Cleanup copy timeout on unmount
   // NOTE: We intentionally do NOT remove TTS tracking keys on unmount.
@@ -904,8 +905,13 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
   const ttsGenerationIdRef = useRef(0)
 
   // TTS functionality
-  const generateAudio = async (): Promise<ArrayBuffer> => {
+  const generateAudio = async (): Promise<{ audio: ArrayBuffer; mimeType: string }> => {
     if (!configQuery.data?.ttsEnabled) {
+      logUI("[AgentProgress][TTS] generateAudio blocked because TTS disabled", {
+        playbackId,
+        sessionId,
+        textPreview: ttsSource.slice(0, 80),
+      })
       throw new Error("TTS is not enabled")
     }
 
@@ -916,8 +922,22 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
     setTtsError(null)
 
     try {
+      logUI("[AgentProgress][TTS] generateSpeech start", {
+        playbackId,
+        sessionId,
+        generationId,
+        textLength: generationSource.length,
+        textPreview: generationSource.slice(0, 80),
+      })
       const result = await tipcClient.generateSpeech({
         text: generationSource,
+      })
+      logUI("[AgentProgress][TTS] generateSpeech success", {
+        playbackId,
+        sessionId,
+        generationId,
+        mimeType: result.mimeType,
+        audioByteLength: result.audio?.byteLength,
       })
 
       // Ignore stale completions if the TTS source changed while this request was in-flight.
@@ -925,14 +945,27 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
         ttsGenerationIdRef.current !== generationId ||
         latestTtsSourceRef.current !== generationSource
       ) {
-        return result.audio
+        logUI("[AgentProgress][TTS] generateSpeech result is stale", {
+          playbackId,
+          sessionId,
+          generationId,
+          currentGenerationId: ttsGenerationIdRef.current,
+          latestTextPreview: latestTtsSourceRef.current.slice(0, 80),
+        })
+        return { audio: result.audio, mimeType: result.mimeType }
       }
 
       setAudioData(result.audio)
       setAudioMimeType(result.mimeType)
-      return result.audio
+      return { audio: result.audio, mimeType: result.mimeType }
     } catch (error) {
       console.error("[TTS UI] Failed to generate TTS audio:", error)
+      logUI("[AgentProgress][TTS] generateSpeech failed", {
+        playbackId,
+        sessionId,
+        generationId,
+        error: error instanceof Error ? error.message : String(error),
+      })
 
       // Set user-friendly error message
       let errorMessage = "Failed to generate audio"
@@ -979,104 +1012,221 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
     }
   }, [ttsSource])
 
-  // Detect whether this component has observed the parent agent in a non-complete
-  // state. Reopened/historical sessions mount with `isComplete=true` from the very
-  // first render, so the ref stays false and the auto-play effect treats those
-  // messages as historical. Live runs (including mid-turn respond_to_user updates
-  // before the agent overall completes) pass through `isComplete=false`, flipping
-  // the ref so subsequent final renders may auto-play.
+  // Detect whether this message component has observed the parent agent in a
+  // non-complete state. The parent session also passes a session-level signal
+  // for final messages that only mount after completion.
   useEffect(() => {
     if (!isComplete) {
       observedLiveProgressRef.current = true
     }
   }, [isComplete])
+  const hasObservedLiveProgress = observedLiveProgressRef.current || parentObservedLiveProgress || !isComplete
 
-  // Check if TTS button should be shown for this message (any completed assistant message with content)
+  const isThoughtEligibleForTTS = !!message.responseEvent
+
+  // Check if TTS button should be shown for this message. The overall session
+  // can remain incomplete briefly after the final assistant prose is visible
+  // (e.g. verification/title cleanup). Treat the latest non-thinking assistant
+  // text as TTS-eligible immediately so hiding/snoozing the panel after seeing
+  // the answer does not race ahead of autoplay. Provider thinking/thought blocks
+  // stay silent by default; they should only become speakable via an explicit
+  // user-facing response event or a future opt-in setting.
+  const canUseTTSForAssistantMessage =
+    isComplete ||
+    !!message.responseEvent ||
+    message.isComplete ||
+    (isLast && !message.isThinking && (!message.isAssistantThought || isThoughtEligibleForTTS))
   const shouldShowTTSButton =
     message.role === "assistant" &&
     configQuery.data?.ttsEnabled &&
     !!ttsSource &&
-    (isComplete || !!message.responseEvent)
+    !message.isThinking &&
+    (!message.isAssistantThought || isThoughtEligibleForTTS) &&
+    canUseTTSForAssistantMessage
   // Auto-play only the latest assistant message. Older response-linked messages
   // remain manually replayable but should not all auto-play after reload/remount.
   const shouldAutoPlayTTS = shouldShowTTSButton && isLast
+  const ttsKeys = useMemo(() => [
+    message.responseEvent ? buildResponseEventTTSKey(sessionId, message.responseEvent.id, "final") : null,
+    buildContentTTSKey(sessionId, ttsSource, "final"),
+  ].filter((key, index, arr): key is string => Boolean(key) && arr.indexOf(key) === index), [message.responseEvent, sessionId, ttsSource])
+  const playbackId = `agent-progress:${sessionId ?? "no-session"}:${message.responseEvent?.id ?? message.timestamp}`
   const shouldAutoPlayLoadedAudio =
     shouldAutoPlayTTS &&
-    shouldAutoPlayTTSForVariant(messageVariant, isSnoozed, isFocused, isFloatingPanelVisible) &&
+    shouldAutoPlayTTSForVariant(messageVariant, isSnoozed) &&
     (configQuery.data?.ttsAutoPlay ?? true) &&
+    !ttsKeys.some((key) => hasTTSPlayed(key)) &&
     lastAutoPlayedSourceRef.current === ttsSource
 
   // Auto-play TTS when assistant message completes (but NOT if agent was stopped by kill switch)
   //
   // TTS AUTO-PLAY STRATEGY:
-  // - Auto-play in the primary full conversation and overlay surfaces.
-  // - Never auto-play tile previews/expansion content.
+  // - Auto-play in the primary full conversation, overlay, and tile surfaces.
+  // - Tile focus is layout state only; it does not block auto-play requests.
   // - Snoozed sessions intentionally don't auto-play TTS
   //   (they run silently in background - user can unsnooze to see/hear them)
   // - Additionally, we track which sessions have already played TTS in a module-level set
   //   to prevent double playback when AgentProgress remounts (e.g., when switching between
   //   single-session and multi-session views in the panel)
   useEffect(() => {
-    const shouldAutoPlay = shouldAutoPlayTTSForVariant(messageVariant, isSnoozed, isFocused, isFloatingPanelVisible)
+    const shouldAutoPlay = shouldAutoPlayTTSForVariant(messageVariant, isSnoozed)
     const ttsAutoPlayEnabled = configQuery.data?.ttsAutoPlay ?? true
 
     if (!shouldAutoPlay || !shouldAutoPlayTTS || !ttsAutoPlayEnabled || audioData || isGeneratingAudio || ttsError || wasStopped) {
-      return
+      logUI("[AgentProgress][TTS] autoplay skipped by initial gate", {
+        playbackId,
+        sessionId,
+        shouldAutoPlay,
+        shouldAutoPlayTTS,
+        ttsAutoPlayEnabled,
+        hasAudioData: !!audioData,
+        isGeneratingAudio,
+        hasTtsError: !!ttsError,
+        wasStopped,
+        messageVariant,
+        isSnoozed,
+        isFocused,
+      })
+      return undefined
     }
 
     // Synthetic pending-resume tiles render saved conversation history before a
     // live session exists (e.g. after branching). The last assistant message is
     // historical, so auto-playing its TTS would replay an already-heard response.
     if (sessionId?.startsWith("pending-")) {
-      return
+      logUI("[AgentProgress][TTS] autoplay skipped for pending session", { playbackId, sessionId })
+      return undefined
     }
 
     // Reopening a previous session re-renders its last assistant message with
-    // `isComplete=true` from the first render. Treat as historical when the
-    // component never observed the parent agent in a non-complete state under
-    // its own lifetime. Manual TTS playback remains available via the play
-    // button. The speakOnTrigger path explicitly authorizes one auto-play via
-    // markSessionForcedAutoPlay, which we consume here so the historical guard
-    // does not suppress that flow.
-    if (!observedLiveProgressRef.current) {
-      const forced = sessionId ? consumeSessionForcedAutoPlay(sessionId) : false
+    // `isComplete=true` from the first render. Treat as historical when neither
+    // the message nor its parent session surface observed live progress. Manual
+    // TTS playback remains available via the play button. The speakOnTrigger path
+    // explicitly authorizes one auto-play via markSessionForcedAutoPlay, which we
+    // consume here so the historical guard does not suppress that flow.
+    let forced = false
+    if (!hasObservedLiveProgress) {
+      forced = sessionId ? consumeSessionForcedAutoPlay(sessionId) : false
       if (!forced) {
-        return
+        logUI("[AgentProgress][TTS] autoplay skipped for historical complete mount", {
+          playbackId,
+          sessionId,
+          observedLiveProgress: hasObservedLiveProgress,
+          parentObservedLiveProgress,
+        })
+        return undefined
       }
+      logUI("[AgentProgress][TTS] forced autoplay consumed", { playbackId, sessionId })
     }
 
     // Guard against replaying the same content on follow-up user messages.
     // When a user sends a follow-up, the message list re-evaluates and this effect
     // can re-fire even though the agent response hasn't changed. (fixes #72)
     if (ttsSource && lastAutoPlayedSourceRef.current === ttsSource) {
-      return
+      logUI("[AgentProgress][TTS] autoplay skipped because source already auto-played locally", {
+        playbackId,
+        sessionId,
+        textPreview: ttsSource.slice(0, 80),
+      })
+      return undefined
     }
-
-    const ttsKeys = [
-      message.responseEvent ? buildResponseEventTTSKey(sessionId, message.responseEvent.id, "final") : null,
-      buildContentTTSKey(sessionId, ttsSource, "final"),
-    ].filter((key, index, arr): key is string => Boolean(key) && arr.indexOf(key) === index)
 
     // If this response was already spoken from a mid-turn card or an earlier render, skip.
     if (ttsKeys.some((key) => hasTTSPlayed(key))) {
-      return
+      logUI("[AgentProgress][TTS] autoplay skipped because local TTS key already played", {
+        playbackId,
+        sessionId,
+        ttsKeys,
+      })
+      return undefined
     }
 
-    // Mark as playing before starting generation to prevent race conditions
-    if (ttsKeys.length > 0) {
-      ttsKeys.forEach((key) => markTTSPlayed(key))
-      inFlightTtsKeysRef.current = ttsKeys
-    }
+    logUI("[AgentProgress][TTS] claiming central autoplay keys", {
+      playbackId,
+      sessionId,
+      forced,
+      ttsKeys,
+      textPreview: ttsSource.slice(0, 80),
+    })
+    void tipcClient.claimTTSPlaybackKeys({ ttsKeys, sessionId, forced })
+      .then((claimResult: { claimed: boolean }) => {
+        logUI("[AgentProgress][TTS] central autoplay claim result", {
+          playbackId,
+          sessionId,
+          forced,
+          claimed: claimResult?.claimed,
+        })
+        if (!claimResult?.claimed) return undefined
 
-    // Track the source we're auto-playing to prevent replay on follow-up
-    lastAutoPlayedSourceRef.current = ttsSource
+        // Mark as playing before starting generation to prevent renderer-local rerender races.
+        if (ttsKeys.length > 0) {
+          ttsKeys.forEach((key) => markTTSPlayed(key))
+          inFlightTtsKeysRef.current = ttsKeys
+        }
 
-    generateAudio()
-      .then(() => {
-        // Generation succeeded, clear the in-flight ref (keys stay in the set permanently)
+        // Track the source we're auto-playing to prevent replay on follow-up.
+        lastAutoPlayedSourceRef.current = ttsSource
+
+        return generateAudio()
+      })
+      .then((generated) => {
+        if (!generated) return undefined
+        if (latestTtsSourceRef.current !== ttsSource) {
+          logUI("[AgentProgress][TTS] releasing generated autoplay because source became stale", {
+            playbackId,
+            sessionId,
+            ttsKeys,
+          })
+          void tipcClient.releaseTTSPlaybackKeys({ ttsKeys })
+          ttsKeys.forEach((key) => removeTTSKey(key))
+          inFlightTtsKeysRef.current = []
+          if (lastAutoPlayedSourceRef.current === ttsSource) {
+            lastAutoPlayedSourceRef.current = null
+          }
+          return undefined
+        }
+
+        // Generation succeeded, clear the in-flight ref (keys stay claimed centrally)
         inFlightTtsKeysRef.current = []
+        logUI("[AgentProgress][TTS] autoplay generation ready for playback request", {
+          playbackId,
+          sessionId,
+          mimeType: generated.mimeType,
+          audioByteLength: generated.audio.byteLength,
+        })
+
+        return tipcClient.requestTTSPlayback({
+          playbackId,
+          sourceWindowId: typeof window !== "undefined" ? window.location?.pathname || "renderer" : "renderer",
+          source: messageVariant,
+          sessionId,
+          ttsKeys,
+          text: ttsSource,
+          textPreview: ttsSource.slice(0, 120),
+          audio: generated.audio,
+          mimeType: generated.mimeType,
+          autoPlay: true,
+          audioOutputDeviceId: configQuery.data?.audioOutputDeviceId,
+        })
+          .then((result) => {
+            if (result?.success === false) {
+              throw new Error(result.error || "Failed to request autoplay playback")
+            }
+            logUI("[AgentProgress][TTS] autoplay requestPlayback success", {
+              playbackId,
+              sessionId,
+              source: messageVariant,
+            })
+            return undefined
+          })
       })
       .catch((error) => {
+        logUI("[AgentProgress][TTS] autoplay generation promise failed", {
+          playbackId,
+          sessionId,
+          ttsKeys,
+          error: error instanceof Error ? error.message : String(error),
+        })
         // If generation fails, remove from the set so user can retry
         // Only remove if these are still the in-flight keys (prevents race conditions
         // where a newer render re-added the keys and this old catch handler would delete them).
@@ -1085,6 +1235,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
           inFlightTtsKeysRef.current.length === ttsKeys.length &&
           inFlightTtsKeysRef.current.every((key) => ttsKeys.includes(key))
         ) {
+          void tipcClient.releaseTTSPlaybackKeys({ ttsKeys })
           ttsKeys.forEach((key) => removeTTSKey(key))
           inFlightTtsKeysRef.current = []
         }
@@ -1094,7 +1245,7 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
         }
         // Error is already handled in generateAudio function
       })
-  }, [shouldAutoPlayTTS, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isFocused, isSnoozed, isFloatingPanelVisible, ttsError, wasStopped, variant, sessionId, ttsSource, message.responseEvent])
+  }, [shouldAutoPlayTTS, configQuery.data?.ttsAutoPlay, audioData, isGeneratingAudio, isFocused, isSnoozed, ttsError, wasStopped, messageVariant, sessionId, ttsSource, message.responseEvent, ttsKeys, hasObservedLiveProgress, parentObservedLiveProgress])
 
   const getRoleStyle = () => {
     switch (message.role) {
@@ -1286,7 +1437,11 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
             <button
               onClick={(e) => {
                 e.stopPropagation()
-                ttsManager.stopAll("agent-progress-message-pause")
+                void tipcClient.controlTTSPlayback({
+                  type: "pause",
+                  playbackId,
+                  reason: "agent-progress-message-pause",
+                })
               }}
               className={cn(
                 "p-1 rounded hover:bg-muted/30 transition-colors",
@@ -1357,6 +1512,10 @@ const CompactMessageBase: React.FC<CompactMessageProps> = ({ message, ttsText, i
             error={ttsError}
             compact={true}
             autoPlay={shouldAutoPlayLoadedAudio}
+            playbackId={playbackId}
+            sessionId={sessionId}
+            ttsKeys={ttsKeys}
+            source={messageVariant}
             onPlayStateChange={setIsTTSPlaying}
             audioOutputDeviceId={configQuery.data?.audioOutputDeviceId}
             autoPlaySuppressionKey={
@@ -1382,6 +1541,7 @@ const CompactMessage = React.memo(CompactMessageBase, (prev, next) => (
   prev.variant === next.variant &&
   prev.sessionId === next.sessionId &&
   prev.isSnoozed === next.isSnoozed &&
+  prev.parentObservedLiveProgress === next.parentObservedLiveProgress &&
   prev.message.responseEvent?.id === next.message.responseEvent?.id &&
   prev.conversationId === next.conversationId &&
   prev.branchMessageIndex === next.branchMessageIndex &&
@@ -3663,6 +3823,19 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     steps?.some(step => step.title === "Agent stopped" ||
                                step.description?.includes("emergency kill switch"))
   const shouldAutoScrollContent = variant !== "tile" || !!isFocused || !!isExpanded || !isComplete
+  const observedSessionIdRef = useRef(progress.sessionId)
+  const observedSessionLiveProgressRef = useRef(false)
+
+  if (observedSessionIdRef.current !== progress.sessionId) {
+    observedSessionIdRef.current = progress.sessionId
+    observedSessionLiveProgressRef.current = false
+  }
+
+  useEffect(() => {
+    if (!isComplete) {
+      observedSessionLiveProgressRef.current = true
+    }
+  }, [isComplete, progress.sessionId])
 
   const messages = useMemo<Array<{
     role: "user" | "assistant" | "tool"
@@ -3670,6 +3843,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     isComplete: boolean
     timestamp: number
     isThinking: boolean
+    isAssistantThought?: boolean
     toolCalls?: Array<{ name: string; arguments: any }>
     toolResults?: Array<{ success: boolean; content: string; error?: string }>
     /** Absolute raw-history index to use when branching from this message */
@@ -3681,6 +3855,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       isComplete: boolean
       timestamp: number
       isThinking: boolean
+      isAssistantThought?: boolean
       toolCalls?: Array<{ name: string; arguments: any }>
       toolResults?: Array<{ success: boolean; content: string; error?: string }>
       branchMessageIndex?: number
@@ -3753,6 +3928,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             isComplete: false,
             timestamp: currentThinkingStep.timestamp,
             isThinking: false,
+            isAssistantThought: true,
           })
         } else if (!isStreaming) {
           const isVerificationStep = currentThinkingStep.title?.toLowerCase().includes("verifying")
@@ -3778,6 +3954,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               isComplete: step.status === "completed",
               timestamp: step.timestamp ?? fallbackBaseTimestamp + index,
               isThinking: false,
+                isAssistantThought: true,
             })
           } else if (step.status === "in_progress" && !isComplete) {
             const isVerificationStep = step.title?.toLowerCase().includes("verifying")
@@ -4873,6 +5050,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                             isFocused={isFocused}
                             sessionId={progress.sessionId}
                             isSnoozed={progress.isSnoozed}
+                            parentObservedLiveProgress={observedSessionLiveProgressRef.current}
                             conversationId={progress.conversationId}
                             branchMessageIndex={item.data.branchMessageIndex}
                             turnDurationMs={turnEntry?.durationMs}
@@ -5330,6 +5508,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                       isFocused={isFocused}
                       sessionId={progress.sessionId}
                       isSnoozed={progress.isSnoozed}
+                      parentObservedLiveProgress={observedSessionLiveProgressRef.current}
                       conversationId={progress.conversationId}
                       branchMessageIndex={item.data.branchMessageIndex}
                       turnDurationMs={turnEntry?.durationMs}

--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -16,7 +16,7 @@ import {
   useConfigQuery,
   useSaveConfigMutation,
 } from "@renderer/lib/query-client"
-import { ttsManager } from "@renderer/lib/tts-manager"
+import { useTTSPlaybackController } from "@renderer/lib/tts-playback-controller"
 import { applySelectedAgentToNextSession as applySelectedAgentForNextSession } from "@renderer/lib/apply-selected-agent"
 import { hasUnreadAgentResponse } from "@renderer/lib/sidebar-sessions"
 import { useAgentStore } from "@renderer/stores"
@@ -67,6 +67,7 @@ type SessionActionDialogState = {
 }
 
 export const Component = () => {
+  useTTSPlaybackController()
   const navigate = useNavigate()
   const location = useLocation()
   const [settingsExpanded, setSettingsExpanded] = useState(true)
@@ -262,8 +263,8 @@ export const Component = () => {
 
       const nextEnabled = !(configQuery.data?.ttsEnabled ?? true)
       if (!nextEnabled) {
-        ttsManager.stopAll("collapsed-sidebar-global-tts-disabled")
         try {
+          await tipcClient.controlTTSPlayback({ type: "stop", reason: "collapsed-sidebar-global-tts-disabled" })
           await tipcClient.stopAllTts()
         } catch (error) {
           console.error("Failed to stop TTS in all windows:", error)
@@ -280,8 +281,8 @@ export const Component = () => {
       if (isEmergencyStopping) return
 
       setIsEmergencyStopping(true)
-      ttsManager.stopAll("collapsed-sidebar-emergency-stop")
       try {
+        await tipcClient.controlTTSPlayback({ type: "stop", reason: "collapsed-sidebar-emergency-stop" })
         await tipcClient.stopAllTts()
       } catch (error) {
         console.error("Failed to stop TTS in all windows:", error)

--- a/apps/desktop/src/renderer/src/components/audio-player.autoplay.test.ts
+++ b/apps/desktop/src/renderer/src/components/audio-player.autoplay.test.ts
@@ -12,7 +12,8 @@ describe("audio player autoplay recovery", () => {
     expect(audioPlayerSource).toContain('window.addEventListener("keydown", retryPlayback, { once: true, capture: true })')
     expect(audioPlayerSource).toContain('setHasAutoPlayed(false)')
     expect(audioPlayerSource).toContain('setIsAutoplayBlocked(false)')
-    expect(audioPlayerSource).toContain('if (source !== "manual" && isAutoplayPolicyBlockedError(playError))')
+    expect(audioPlayerSource).toContain('if (requestSource !== "manual" && isAutoplayPolicyBlockedError(playError))')
+    expect(audioPlayerSource).toContain('tipcClient.requestTTSPlayback')
   })
 
   it("scopes cross-instance autoplay suppression by a caller-supplied key in addition to the normalized text", () => {

--- a/apps/desktop/src/renderer/src/components/audio-player.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/audio-player.layout.test.ts
@@ -21,7 +21,8 @@ describe("audio player layout", () => {
     expect(audioPlayerSource).toContain('"shrink-0 rounded p-1 transition-colors hover:bg-muted"')
     expect(audioPlayerSource).toContain("Autoplay blocked — press any key or click to listen")
     expect(audioPlayerSource).toContain("Press any key or click once to start playback")
-    expect(audioPlayerSource).toContain("<audio ref={audioRef} />")
+    expect(audioPlayerSource).toContain("tipcClient.requestTTSPlayback")
+    expect(audioPlayerSource).not.toContain("<audio ref={audioRef} />")
   })
 
   it("wraps full audio controls and protects secondary controls under zoom", () => {

--- a/apps/desktop/src/renderer/src/components/audio-player.tsx
+++ b/apps/desktop/src/renderer/src/components/audio-player.tsx
@@ -1,23 +1,32 @@
-import React, { useState, useRef, useEffect, useCallback } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { Button } from "@renderer/components/ui/button"
 import { Slider } from "@renderer/components/ui/slider"
 import { Play, Pause, Volume2, VolumeX, Loader2 } from "lucide-react"
 import { cn } from "@renderer/lib/utils"
-import { ttsManager } from "@renderer/lib/tts-manager"
+import { tipcClient } from "@renderer/lib/tipc-client"
+import { useAgentStore } from "@renderer/stores"
+import { logUI } from "@renderer/lib/debug"
 
 const AUTO_PLAY_ATTEMPT_SUPPRESSION_MS = 5_000
 const recentAutoPlayAttemptByKey = new Map<string, number>()
+
+type GeneratedAudioResult = ArrayBuffer | { audio: ArrayBuffer; mimeType?: string }
 
 interface AudioPlayerProps {
   audioData?: ArrayBuffer
   audioMimeType?: string
   text: string
-  onGenerateAudio?: () => Promise<ArrayBuffer>
+  onGenerateAudio?: () => Promise<GeneratedAudioResult>
   className?: string
   compact?: boolean
   isGenerating?: boolean
   error?: string | null
   autoPlay?: boolean
+  playbackId?: string
+  sessionId?: string
+  ttsKeys?: string[]
+  source?: "main" | "panel" | "tile" | "overlay" | "unknown" | string
+  onPlaybackRequestError?: (error: unknown) => void
   /** Called when play/pause state changes so parent can reflect it (e.g. header icon) */
   onPlayStateChange?: (playing: boolean) => void
   /** Audio output device ID (from navigator.mediaDevices.enumerateDevices) */
@@ -44,6 +53,20 @@ function isAutoplayPolicyBlockedError(error: unknown): boolean {
   )
 }
 
+function normalizeGeneratedAudio(result: GeneratedAudioResult, fallbackMimeType?: string) {
+  if (result instanceof ArrayBuffer) {
+    return { audio: result, mimeType: fallbackMimeType || "audio/wav" }
+  }
+  return { audio: result.audio, mimeType: result.mimeType || fallbackMimeType || "audio/wav" }
+}
+
+function deriveSourceFromLocation(): string {
+  if (typeof window === "undefined") return "unknown"
+  const path = window.location?.pathname ?? ""
+  if (path.includes("panel")) return "panel"
+  return "main"
+}
+
 export function AudioPlayer({
   audioData,
   audioMimeType,
@@ -54,188 +77,210 @@ export function AudioPlayer({
   isGenerating = false,
   error = null,
   autoPlay = false,
+  playbackId,
+  sessionId,
+  ttsKeys,
+  source,
+  onPlaybackRequestError,
   onPlayStateChange,
   audioOutputDeviceId,
   autoPlaySuppressionKey,
 }: AudioPlayerProps) {
-  const [isPlaying, setIsPlaying] = useState(false)
-  const [currentTime, setCurrentTime] = useState(0)
-  const [duration, setDuration] = useState(0)
-  const [volume, setVolume] = useState(1)
-  const [isMuted, setIsMuted] = useState(false)
+  const generatedPlaybackIdRef = useRef(`tts-${Date.now()}-${Math.random().toString(36).slice(2)}`)
+  const effectivePlaybackId = playbackId ?? generatedPlaybackIdRef.current
+  const playbackAttemptIdRef = useRef(0)
+  const autoPlayAttemptKeyRef = useRef<string | null>(null)
   const [hasAudio, setHasAudio] = useState(!!audioData)
   const [hasAutoPlayed, setHasAutoPlayed] = useState(false)
   const [wasStopped, setWasStopped] = useState(false)
   const [isAutoplayBlocked, setIsAutoplayBlocked] = useState(false)
-  const audioRef = useRef<HTMLAudioElement | null>(null)
-  const audioUrlRef = useRef<string | null>(null)
-  const playbackAttemptIdRef = useRef(0)
-  const autoPlayAttemptKeyRef = useRef<string | null>(null)
+  const [localVolume, setLocalVolume] = useState(1)
+  const [localMuted, setLocalMuted] = useState(false)
+  const ttsPlaybackState = useAgentStore((state) => state.ttsPlaybackState) ?? {
+    playbackId: null,
+    status: "idle" as const,
+    currentTime: 0,
+    duration: 0,
+    volume: 1,
+    muted: false,
+    updatedAt: 0,
+  }
+  const isActive = ttsPlaybackState?.playbackId === effectivePlaybackId
+  const isPlaying = isActive && ttsPlaybackState.status === "playing"
+  const currentTime = isActive ? ttsPlaybackState.currentTime : 0
+  const duration = isActive ? ttsPlaybackState.duration : 0
+  const volume = isActive ? ttsPlaybackState.volume : localVolume
+  const isMuted = isActive ? ttsPlaybackState.muted : localMuted
 
   useEffect(() => {
-    if (audioData) {
-      if (audioUrlRef.current) {
-        URL.revokeObjectURL(audioUrlRef.current)
-      }
-
-      const blob = new Blob([audioData], { type: audioMimeType || "audio/wav" })
-      audioUrlRef.current = URL.createObjectURL(blob)
-      setHasAudio(true)
-      setHasAutoPlayed(false)
-      autoPlayAttemptKeyRef.current = null
-      setWasStopped(false)
-      setIsAutoplayBlocked(false)
-
-      if (audioRef.current) {
-        audioRef.current.src = audioUrlRef.current
-        setIsPlaying(false)
-        setCurrentTime(0)
-      }
-    }
-
-    return () => {
-      if (audioUrlRef.current) {
-        URL.revokeObjectURL(audioUrlRef.current)
-      }
-    }
-  }, [audioData, audioMimeType])
+    setHasAudio(!!audioData)
+    setHasAutoPlayed(false)
+    autoPlayAttemptKeyRef.current = null
+    setWasStopped(false)
+    setIsAutoplayBlocked(false)
+    logUI("[AudioPlayer][TTS] audio props changed", {
+      playbackId: effectivePlaybackId,
+      sessionId,
+      source,
+      hasAudioData: !!audioData,
+      mimeType: audioMimeType,
+      textPreview: text.slice(0, 80),
+    })
+  }, [audioData, audioMimeType, text])
 
   useEffect(() => {
-    const audio = audioRef.current
-    if (!audio || !hasAudio) return undefined
-
-    const handleLoadedMetadata = () => {
-      setDuration(audio.duration)
-    }
-
-    const handleTimeUpdate = () => {
-      setCurrentTime(audio.currentTime)
-    }
-
-    const handleEnded = () => {
-      setIsPlaying(false)
-      setCurrentTime(0)
-      onPlayStateChange?.(false)
-    }
-
-    const handlePlay = () => {
-      setIsPlaying(true)
-      onPlayStateChange?.(true)
-    }
-
-    const handlePause = () => {
-      setIsPlaying(false)
-      onPlayStateChange?.(false)
-    }
-
-    const handleError = (event: Event) => {
-      console.error("[AudioPlayer] Audio error:", event)
-      setIsPlaying(false)
-    }
-
-    audio.addEventListener("loadedmetadata", handleLoadedMetadata)
-    audio.addEventListener("timeupdate", handleTimeUpdate)
-    audio.addEventListener("ended", handleEnded)
-    audio.addEventListener("play", handlePlay)
-    audio.addEventListener("pause", handlePause)
-    audio.addEventListener("error", handleError)
-
-    if (audio.src && !audio.paused) {
-      setIsPlaying(true)
-    } else {
-      setIsPlaying(false)
-    }
-
-    return () => {
-      audio.removeEventListener("loadedmetadata", handleLoadedMetadata)
-      audio.removeEventListener("timeupdate", handleTimeUpdate)
-      audio.removeEventListener("ended", handleEnded)
-      audio.removeEventListener("play", handlePlay)
-      audio.removeEventListener("pause", handlePause)
-      audio.removeEventListener("error", handleError)
-    }
-  }, [hasAudio, audioData])
+    onPlayStateChange?.(isPlaying)
+  }, [isPlaying, onPlayStateChange])
 
   useEffect(() => {
-    const audio = audioRef.current
-    if (!audio) return undefined
+    if (!isActive || ttsPlaybackState.status !== "error") return
+    logUI("[AudioPlayer][TTS] active playback entered error state", {
+      playbackId: effectivePlaybackId,
+      sessionId,
+      error: ttsPlaybackState.error,
+    })
+    setIsAutoplayBlocked(isAutoplayPolicyBlockedError(ttsPlaybackState.error))
+  }, [isActive, ttsPlaybackState.status, ttsPlaybackState.error])
 
-    const unregisterAudio = ttsManager.registerAudio(audio)
-
-    const unregisterCallback = ttsManager.registerStopCallback(() => {
-      if (audio) {
-        audio.pause()
-        audio.currentTime = 0
-        setIsPlaying(false)
-        setWasStopped(true)
-        onPlayStateChange?.(false)
-      }
-    }, audio)
-
-    return () => {
-      unregisterAudio()
-      unregisterCallback()
-    }
-  }, [onPlayStateChange])
-
-  // Apply selected audio output device via setSinkId
-  useEffect(() => {
-    const audio = audioRef.current
-    if (!audio) return
-    // setSinkId is available in Chromium/Electron
-    if (typeof (audio as any).setSinkId === "function") {
-      (audio as any).setSinkId(audioOutputDeviceId || "").catch((err: unknown) => {
-        console.warn("[AudioPlayer] Failed to set audio output device:", err)
-      })
-    }
-  }, [audioOutputDeviceId])
-
-  const playAudio = useCallback(async (source: "auto" | "manual" | "autoplay-retry") => {
-    if (!audioRef.current || !hasAudio) return false
-
+  const requestPlayback = useCallback(async (
+    audio: ArrayBuffer,
+    mimeType: string | undefined,
+    requestSource: "auto" | "manual" | "autoplay-retry",
+  ) => {
     const attemptId = ++playbackAttemptIdRef.current
+    const shouldAutoPlay = requestSource !== "manual"
 
     try {
-      await ttsManager.playExclusive(audioRef.current, {
-        source: `audio-player:${source}`,
-        autoPlay: source !== "manual",
-        textPreview: text.slice(0, 80),
+      logUI("[AudioPlayer][TTS] requestPlayback start", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        requestSource,
+        shouldAutoPlay,
+        source: source ?? deriveSourceFromLocation(),
+        keyCount: ttsKeys?.length ?? 0,
+        audioByteLength: audio.byteLength,
+        mimeType: mimeType || "audio/wav",
+        audioOutputDeviceId,
       })
+      const result = await tipcClient.requestTTSPlayback({
+        playbackId: effectivePlaybackId,
+        sourceWindowId: typeof window !== "undefined" ? window.location?.pathname || "renderer" : "renderer",
+        source: source ?? deriveSourceFromLocation(),
+        sessionId,
+        ttsKeys,
+        text,
+        textPreview: text.slice(0, 120),
+        audio,
+        mimeType: mimeType || "audio/wav",
+        autoPlay: shouldAutoPlay,
+        audioOutputDeviceId,
+      })
+
+      if (result?.success === false) {
+        logUI("[AudioPlayer][TTS] requestPlayback main rejected", {
+          playbackId: effectivePlaybackId,
+          sessionId,
+          result,
+        })
+        throw new Error(result.error || "Failed to request TTS playback")
+      }
+
+      if (!shouldAutoPlay) {
+        logUI("[AudioPlayer][TTS] sending manual play command after request", {
+          playbackId: effectivePlaybackId,
+          sessionId,
+        })
+        await tipcClient.controlTTSPlayback({ type: "play", playbackId: effectivePlaybackId, reason: "manual-replay" })
+      }
 
       if (playbackAttemptIdRef.current === attemptId) {
         setIsAutoplayBlocked(false)
+        setWasStopped(false)
       }
+      logUI("[AudioPlayer][TTS] requestPlayback success", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        requestSource,
+      })
       return true
     } catch (playError) {
-      if (playbackAttemptIdRef.current !== attemptId) {
-        return false
-      }
+      if (playbackAttemptIdRef.current !== attemptId) return false
 
-      if (source !== "manual" && isAutoplayPolicyBlockedError(playError)) {
+      if (requestSource !== "manual" && isAutoplayPolicyBlockedError(playError)) {
         console.warn("[AudioPlayer] Auto-play blocked until the next user gesture:", playError)
         setIsAutoplayBlocked(true)
-        setIsPlaying(false)
-        return false
+      } else {
+        console.error(requestSource === "manual" ? "[AudioPlayer] Playback failed:" : "[AudioPlayer] Auto-play failed:", playError)
       }
-
-      console.error(
-        source === "manual" ? "[AudioPlayer] Playback failed:" : "[AudioPlayer] Auto-play failed:",
-        playError,
-      )
-      setIsPlaying(false)
+      logUI("[AudioPlayer][TTS] requestPlayback failed", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        requestSource,
+        error: playError instanceof Error ? playError.message : String(playError),
+      })
+      onPlaybackRequestError?.(playError)
       return false
     }
-  }, [hasAudio, text])
+  }, [audioOutputDeviceId, effectivePlaybackId, onPlaybackRequestError, sessionId, source, text, ttsKeys])
+
+  const playAudio = useCallback(async (requestSource: "auto" | "manual" | "autoplay-retry") => {
+    logUI("[AudioPlayer][TTS] playAudio invoked", {
+      playbackId: effectivePlaybackId,
+      sessionId,
+      requestSource,
+      hasAudioData: !!audioData,
+      hasGenerator: !!onGenerateAudio,
+      isGenerating,
+      error,
+    })
+    if (audioData) return requestPlayback(audioData, audioMimeType, requestSource)
+    if (!onGenerateAudio || isGenerating || error) {
+      logUI("[AudioPlayer][TTS] playAudio skipped", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        reason: !onGenerateAudio ? "missing-generator" : isGenerating ? "already-generating" : "existing-error",
+      })
+      return false
+    }
+
+    try {
+      const generated = normalizeGeneratedAudio(await onGenerateAudio(), audioMimeType)
+      setHasAudio(true)
+      logUI("[AudioPlayer][TTS] generated audio for playback", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        audioByteLength: generated.audio.byteLength,
+        mimeType: generated.mimeType,
+      })
+      return requestPlayback(generated.audio, generated.mimeType, requestSource)
+    } catch (generationError) {
+      logUI("[AudioPlayer][TTS] audio generation failed before playback request", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        error: generationError instanceof Error ? generationError.message : String(generationError),
+      })
+      onPlaybackRequestError?.(generationError)
+      return false
+    }
+  }, [audioData, audioMimeType, error, isGenerating, onGenerateAudio, onPlaybackRequestError, requestPlayback])
 
   useEffect(() => {
-    if (autoPlay && hasAudio && audioRef.current && !isPlaying && !hasAutoPlayed && !wasStopped) {
+    if (autoPlay && hasAudio && !isPlaying && !hasAutoPlayed && !wasStopped) {
       const normalizedText = text.replace(/\s+/g, " ").trim().toLowerCase()
       const attemptKey = autoPlaySuppressionKey
         ? `${autoPlaySuppressionKey}::${normalizedText}`
         : normalizedText
       const now = Date.now()
       const lastAttemptAt = recentAutoPlayAttemptByKey.get(attemptKey) ?? 0
-      if (now - lastAttemptAt < AUTO_PLAY_ATTEMPT_SUPPRESSION_MS) return
+      if (now - lastAttemptAt < AUTO_PLAY_ATTEMPT_SUPPRESSION_MS) {
+        logUI("[AudioPlayer][TTS] autoplay suppressed by recent attempt", {
+          playbackId: effectivePlaybackId,
+          sessionId,
+          attemptKey,
+          msSinceLastAttempt: now - lastAttemptAt,
+        })
+        return
+      }
       recentAutoPlayAttemptByKey.set(attemptKey, now)
 
       for (const [key, attemptedAt] of recentAutoPlayAttemptByKey) {
@@ -244,9 +289,21 @@ export function AudioPlayer({
         }
       }
 
-      if (autoPlayAttemptKeyRef.current === attemptKey) return
+      if (autoPlayAttemptKeyRef.current === attemptKey) {
+        logUI("[AudioPlayer][TTS] autoplay skipped because this instance already tried key", {
+          playbackId: effectivePlaybackId,
+          sessionId,
+          attemptKey,
+        })
+        return
+      }
       autoPlayAttemptKeyRef.current = attemptKey
       setHasAutoPlayed(true)
+      logUI("[AudioPlayer][TTS] autoplay attempting", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+        attemptKey,
+      })
       void playAudio("auto")
     }
   }, [autoPlay, hasAudio, isPlaying, hasAutoPlayed, wasStopped, playAudio, autoPlaySuppressionKey, text])
@@ -261,6 +318,10 @@ export function AudioPlayer({
       window.removeEventListener("pointerdown", retryPlayback, { capture: true })
       window.removeEventListener("keydown", retryPlayback, { capture: true })
       setIsAutoplayBlocked(false)
+      logUI("[AudioPlayer][TTS] retrying autoplay after user gesture", {
+        playbackId: effectivePlaybackId,
+        sessionId,
+      })
       void playAudio("autoplay-retry")
     }
 
@@ -274,56 +335,47 @@ export function AudioPlayer({
   }, [hasAudio, isAutoplayBlocked, playAudio])
 
   const handlePlayPause = async () => {
-    if (!hasAudio && onGenerateAudio && !isGenerating && !error) {
-      try {
-        await onGenerateAudio()
-        return
-      } catch (error) {
-        return
-      }
+    logUI("[AudioPlayer][TTS] handlePlayPause", {
+      playbackId: effectivePlaybackId,
+      sessionId,
+      isPlaying,
+      isActive,
+      status: ttsPlaybackState.status,
+      hasAudio,
+    })
+    if (isPlaying) {
+      setWasStopped(true)
+      await tipcClient.controlTTSPlayback({ type: "pause", playbackId: effectivePlaybackId, reason: "audio-player-pause" })
+      return
     }
 
-    if (audioRef.current && hasAudio) {
-      try {
-        if (isPlaying) {
-          audioRef.current.pause()
-        } else {
-          setWasStopped(false)
-          await playAudio("manual")
-        }
-      } catch (playError) {
-        console.error("[AudioPlayer] Playback failed:", playError)
-        setIsPlaying(false)
-      }
+    if (isActive && ttsPlaybackState.status === "paused") {
+      setWasStopped(false)
+      await tipcClient.controlTTSPlayback({ type: "play", playbackId: effectivePlaybackId, reason: "audio-player-resume" })
+      return
     }
+
+    await playAudio("manual")
   }
 
   const handleSeek = (value: number[]) => {
-    if (audioRef.current) {
-      audioRef.current.currentTime = value[0]
-      setCurrentTime(value[0])
-    }
+    logUI("[AudioPlayer][TTS] seek", { playbackId: effectivePlaybackId, sessionId, currentTime: value[0] })
+    void tipcClient.controlTTSPlayback({ type: "seek", playbackId: effectivePlaybackId, currentTime: value[0], reason: "audio-player-seek" })
   }
 
   const handleVolumeChange = (value: number[]) => {
     const newVolume = value[0]
-    setVolume(newVolume)
-    if (audioRef.current) {
-      audioRef.current.volume = newVolume
-    }
-    setIsMuted(newVolume === 0)
+    logUI("[AudioPlayer][TTS] set volume", { playbackId: effectivePlaybackId, sessionId, volume: newVolume })
+    setLocalVolume(newVolume)
+    setLocalMuted(newVolume === 0)
+    void tipcClient.controlTTSPlayback({ type: "set-volume", playbackId: effectivePlaybackId, volume: newVolume, reason: "audio-player-volume" })
   }
 
   const toggleMute = () => {
-    if (audioRef.current) {
-      if (isMuted) {
-        audioRef.current.volume = volume
-        setIsMuted(false)
-      } else {
-        audioRef.current.volume = 0
-        setIsMuted(true)
-      }
-    }
+    const nextMuted = !isMuted
+    logUI("[AudioPlayer][TTS] set muted", { playbackId: effectivePlaybackId, sessionId, muted: nextMuted })
+    setLocalMuted(nextMuted)
+    void tipcClient.controlTTSPlayback({ type: "set-muted", playbackId: effectivePlaybackId, muted: nextMuted, reason: "audio-player-muted" })
   }
 
   const formatTime = (time: number) => {
@@ -371,7 +423,7 @@ export function AudioPlayer({
       ? compactStatusText
       : isAutoplayBlocked
         ? "Press any key or click once to start playback"
-        : "Preparing playback controls"
+        : "Preparing centralized playback controls"
     : isGenerating
       ? "Creating spoken playback"
       : error
@@ -380,12 +432,7 @@ export function AudioPlayer({
 
   if (compact) {
     return (
-      <div
-        className={cn(
-          "inline-flex items-center",
-          className
-        )}
-      >
+      <div className={cn("inline-flex items-center", className)} title={compactStatusDetail} aria-label={compactStatusLabel}>
         <button
           type="button"
           onClick={handlePlayPause}
@@ -407,7 +454,6 @@ export function AudioPlayer({
             <Volume2 className="h-3.5 w-3.5" />
           )}
         </button>
-        <audio ref={audioRef} />
       </div>
     )
   }
@@ -415,35 +461,14 @@ export function AudioPlayer({
   return (
     <div className={cn("min-w-0 max-w-full space-y-2 rounded-lg bg-muted/50 p-3", className)}>
       <div className="flex flex-wrap items-center gap-3">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handlePlayPause}
-          disabled={isGenerating}
-          className="h-10 w-10 shrink-0 p-0"
-          title={playPauseLabel}
-          aria-label={playPauseLabel}
-        >
-          {isGenerating ? (
-            <Loader2 className="h-5 w-5 animate-spin" />
-          ) : isPlaying ? (
-            <Pause className="h-5 w-5" />
-          ) : (
-            <Play className="h-5 w-5" />
-          )}
+        <Button variant="ghost" size="sm" onClick={handlePlayPause} disabled={isGenerating} className="h-10 w-10 shrink-0 p-0" title={playPauseLabel} aria-label={playPauseLabel}>
+          {isGenerating ? <Loader2 className="h-5 w-5 animate-spin" /> : isPlaying ? <Pause className="h-5 w-5" /> : <Play className="h-5 w-5" />}
         </Button>
 
         <div className="min-w-0 flex-1 space-y-1">
           {hasAudio && duration > 0 ? (
             <>
-              <Slider
-                value={[currentTime]}
-                max={duration}
-                step={0.1}
-                onValueChange={handleSeek}
-                className="w-full"
-                aria-label="Audio position"
-              />
+              <Slider value={[currentTime]} max={duration} step={0.1} onValueChange={handleSeek} className="w-full" aria-label="Audio position" />
               <div className="flex flex-wrap justify-between gap-2 text-xs text-muted-foreground">
                 <span className="shrink-0 font-mono tabular-nums">{formatTime(currentTime)}</span>
                 <span className="shrink-0 font-mono tabular-nums">{formatTime(duration)}</span>
@@ -463,32 +488,12 @@ export function AudioPlayer({
         </div>
 
         <div className="ml-auto flex min-w-0 max-w-full items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={toggleMute}
-            className="h-8 w-8 shrink-0 p-0"
-            title={isMuted ? "Unmute audio" : "Mute audio"}
-            aria-label={isMuted ? "Unmute audio" : "Mute audio"}
-          >
-            {isMuted ? (
-              <VolumeX className="h-4 w-4" />
-            ) : (
-              <Volume2 className="h-4 w-4" />
-            )}
+          <Button variant="ghost" size="sm" onClick={toggleMute} className="h-8 w-8 shrink-0 p-0" title={isMuted ? "Unmute audio" : "Mute audio"} aria-label={isMuted ? "Unmute audio" : "Mute audio"}>
+            {isMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
           </Button>
-          <Slider
-            value={[isMuted ? 0 : volume]}
-            max={1}
-            step={0.1}
-            onValueChange={handleVolumeChange}
-            className="min-w-[5rem] max-w-[8rem] flex-1"
-            aria-label="Audio volume"
-          />
+          <Slider value={[isMuted ? 0 : volume]} max={1} step={0.1} onValueChange={handleVolumeChange} className="min-w-[5rem] max-w-[8rem] flex-1" aria-label="Audio volume" />
         </div>
       </div>
-
-      <audio ref={audioRef} />
     </div>
   )
 }

--- a/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
@@ -22,9 +22,9 @@ interface SessionActionDialogProps {
   initialText?: string
   conversationId?: string
   sessionId?: string
-  // Retained for prop compatibility; the dialog always starts sessions snoozed
-  // because it runs inside the main window. Submit handlers force fromTile=true
-  // when calling createMcpTextInput/createMcpRecording regardless of this prop.
+  // Retained for prop compatibility; the dialog now uses fromTile-style launch
+  // semantics so it can suppress hover-panel auto-show without forcing the
+  // session into background/silent mode.
   fromTile?: boolean
   continueConversationTitle?: string | null
   agentName?: string | null
@@ -93,13 +93,14 @@ export function SessionActionDialog({
     try {
       // SessionActionDialog is rendered inside the main app window and its
       // description explicitly promises "without opening the hover panel".
-      // Force the session snoozed regardless of the fromTile prop so the
-      // floating panel never auto-shows from this dialog's submit path.
+      // Keep the session foreground/audible for TTS autoplay while still
+      // suppressing floating-panel auto-show via the tile-origin hint.
       const result = await tipcClient.createMcpTextInput({
         text,
         conversationId,
         sessionId,
         fromTile: true,
+        startSnoozed: false,
       })
 
       if (sessionId && !result?.queued) {
@@ -165,9 +166,8 @@ export function SessionActionDialog({
             ? await decodeBlobToPcm(blob)
             : undefined
 
-          // Match handleTextSubmit: always start voice sessions snoozed so the
-          // floating panel never auto-shows while the user is interacting with
-          // the in-app dialog. See comment in handleTextSubmit above.
+          // Match handleTextSubmit: keep the session foreground/audible for
+          // TTS autoplay while still suppressing hover-panel auto-show.
           await tipcClient.createMcpRecording({
             recording: await blob.arrayBuffer(),
             pcmRecording,
@@ -175,6 +175,7 @@ export function SessionActionDialog({
             conversationId,
             sessionId,
             fromTile: true,
+            startSnoozed: false,
           })
 
           await invalidateConversationQueries(conversationId)

--- a/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
+++ b/apps/desktop/src/renderer/src/components/tile-follow-up-input.tsx
@@ -107,16 +107,19 @@ export function TileFollowUpInput({
     mutationFn: async (message: string) => {
       if (!conversationId) {
         // Start a new conversation if none exists
-        // Mark as fromTile so the floating panel doesn't show - session continues in the tile
-        return await tipcClient.createMcpTextInput({ text: message, fromTile: true })
+        // Mark as fromTile to suppress the floating panel while keeping the
+        // interactive tile session foreground/audible for TTS autoplay.
+        return await tipcClient.createMcpTextInput({ text: message, fromTile: true, startSnoozed: false })
       } else {
         // Continue the existing conversation
-        // Mark as fromTile so the floating panel doesn't show - session continues in the tile
+        // Mark as fromTile to suppress the floating panel while keeping the
+        // interactive tile session foreground/audible for TTS autoplay.
         return await tipcClient.createMcpTextInput({
           text: message,
           conversationId,
           sessionId,
           fromTile: true,
+          startSnoozed: false,
         })
       }
     },

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.test.ts
@@ -295,6 +295,7 @@ function createAgentStoreState() {
     setSessionSnoozed: vi.fn(),
     setScrollToSessionId: vi.fn(),
     setFloatingPanelVisible: vi.fn(),
+    setTTSPlaybackState: vi.fn(),
     updateMessageQueue: vi.fn(),
     pinnedSessionIds: new Set<string>(),
     pinnedSessionIdsRevision: 0,
@@ -320,6 +321,7 @@ async function loadUseStoreSync(
   const tipcClient = {
     getAllMessageQueues: vi.fn().mockResolvedValue([]),
     getFloatingPanelVisibility: vi.fn().mockResolvedValue({ visible: false }),
+    getTTSPlaybackState: vi.fn().mockResolvedValue({ playbackId: null, status: 'idle', currentTime: 0, duration: 0, volume: 1, muted: false, updatedAt: 1 }),
     getConfig: vi.fn().mockImplementation(() => Promise.resolve(config)),
     saveConfig: vi.fn().mockResolvedValue(undefined),
   }
@@ -343,6 +345,7 @@ async function loadUseStoreSync(
       clearAgentSessionProgress: { listen },
       clearInactiveSessions: { listen },
       stopAllTts: { listen },
+      ttsPlaybackStateChanged: { listen },
       panelVisibilityChanged: { listen },
       focusAgentSession: { listen },
       setAgentSessionSnoozed: { listen },
@@ -373,8 +376,8 @@ async function loadUseStoreSync(
   }
   vi.doMock('@renderer/lib/tts-manager', () => ttsManagerMock)
   vi.doMock('../lib/tts-manager', () => ttsManagerMock)
-  vi.doMock('@renderer/lib/tts-tracking', () => ({ __esModule: true, clearSessionTTSTracking: vi.fn() }))
-  vi.doMock('../lib/tts-tracking', () => ({ __esModule: true, clearSessionTTSTracking: vi.fn() }))
+  vi.doMock('@renderer/lib/tts-tracking', () => ({ __esModule: true, clearSessionTTSTracking: vi.fn(), markSessionForcedAutoPlay: vi.fn() }))
+  vi.doMock('../lib/tts-tracking', () => ({ __esModule: true, clearSessionTTSTracking: vi.fn(), markSessionForcedAutoPlay: vi.fn() }))
   vi.doMock('@renderer/lib/debug', () => ({ __esModule: true, logUI: vi.fn() }))
   vi.doMock('../lib/debug', () => ({ __esModule: true, logUI: vi.fn() }))
   vi.doMock('@renderer/lib/config-save-error', () => ({ __esModule: true, reportConfigSaveError }))

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.test.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.test.ts
@@ -283,6 +283,45 @@ describe('useStoreSync pinned session persistence', () => {
 
     runtime.cleanupAllEffects()
   })
+
+  it('does not overwrite newer TTS playback state with stale hydration', async () => {
+    const runtime = createHookRuntime()
+    const storeState = createAgentStoreState()
+    const loaded = await loadUseStoreSync(runtime, storeState, { pinnedSessionIds: [] })
+    const deferredTTSState = createDeferred<typeof storeState.ttsPlaybackState>()
+    loaded.tipcClient.getTTSPlaybackState.mockReturnValue(deferredTTSState.promise)
+
+    runtime.render(loaded.useStoreSync)
+    runtime.commitEffects()
+
+    storeState.ttsPlaybackState = {
+      playbackId: 'newer-playback',
+      status: 'playing',
+      currentTime: 1,
+      duration: 3,
+      volume: 1,
+      muted: false,
+      updatedAt: 10,
+    }
+
+    deferredTTSState.resolve({
+      playbackId: 'older-playback',
+      status: 'paused',
+      currentTime: 0,
+      duration: 3,
+      volume: 1,
+      muted: false,
+      updatedAt: 2,
+    })
+    await flushPromises()
+
+    expect(storeState.setTTSPlaybackState).not.toHaveBeenCalledWith(
+      expect.objectContaining({ playbackId: 'older-playback' }),
+    )
+    expect(storeState.ttsPlaybackState.playbackId).toBe('newer-playback')
+
+    runtime.cleanupAllEffects()
+  })
 })
 
 function createAgentStoreState() {
@@ -295,7 +334,10 @@ function createAgentStoreState() {
     setSessionSnoozed: vi.fn(),
     setScrollToSessionId: vi.fn(),
     setFloatingPanelVisible: vi.fn(),
-    setTTSPlaybackState: vi.fn(),
+    ttsPlaybackState: { playbackId: null, status: 'idle', currentTime: 0, duration: 0, volume: 1, muted: false, updatedAt: 1 },
+    setTTSPlaybackState: vi.fn((ttsPlaybackState) => {
+      state.ttsPlaybackState = ttsPlaybackState
+    }),
     updateMessageQueue: vi.fn(),
     pinnedSessionIds: new Set<string>(),
     pinnedSessionIdsRevision: 0,

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { reportConfigSaveError } from '@renderer/lib/config-save-error'
 import { rendererHandlers, tipcClient } from '@renderer/lib/tipc-client'
 import { useAgentStore, useConversationStore } from '@renderer/stores'
-import { AgentProgressUpdate, QueuedMessage } from '@shared/types'
+import { AgentProgressUpdate, DesktopTTSPlaybackState, QueuedMessage } from '@shared/types'
 import { queryClient } from '@renderer/lib/queries'
 import { ttsManager } from '@renderer/lib/tts-manager'
 import { clearSessionTTSTracking, markSessionForcedAutoPlay } from '@renderer/lib/tts-tracking'
@@ -38,6 +38,7 @@ export function useStoreSync() {
   const archivedSessionIdsRevision = useAgentStore((s) => s.archivedSessionIdsRevision)
   const setArchivedSessionIds = useAgentStore((s) => s.setArchivedSessionIds)
   const setFloatingPanelVisible = useAgentStore((s) => s.setFloatingPanelVisible)
+  const setTTSPlaybackState = useAgentStore((s) => s.setTTSPlaybackState)
   const markConversationCompleted = useConversationStore((s) => s.markConversationCompleted)
 
   // Capture the initial store snapshot once per module load so remounts
@@ -102,6 +103,40 @@ export function useStoreSync() {
     )
     return unlisten
   }, [clearInactiveSessions])
+
+  useEffect(() => {
+    const unlisten = rendererHandlers.ttsPlaybackStateChanged.listen(
+      (state: DesktopTTSPlaybackState) => {
+        logUI("[StoreSync][TTS] ttsPlaybackStateChanged received", {
+          playbackId: state.playbackId,
+          status: state.status,
+          sessionId: state.sessionId,
+          source: state.source,
+          currentTime: state.currentTime,
+          duration: state.duration,
+          error: state.error,
+        })
+        setTTSPlaybackState(state)
+      },
+    )
+    return unlisten
+  }, [setTTSPlaybackState])
+
+  useEffect(() => {
+    tipcClient.getTTSPlaybackState?.().then((state: DesktopTTSPlaybackState) => {
+      if (state) {
+        logUI("[StoreSync][TTS] hydrated initial playback state", {
+          playbackId: state.playbackId,
+          status: state.status,
+          sessionId: state.sessionId,
+          source: state.source,
+        })
+        setTTSPlaybackState(state)
+      }
+    }).catch(() => {
+      // Best-effort hydration; the local idle default remains valid.
+    })
+  }, [setTTSPlaybackState])
 
   useEffect(() => {
     const unlisten = rendererHandlers.stopAllTts.listen(() => {

--- a/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
+++ b/apps/desktop/src/renderer/src/hooks/use-store-sync.ts
@@ -125,6 +125,16 @@ export function useStoreSync() {
   useEffect(() => {
     tipcClient.getTTSPlaybackState?.().then((state: DesktopTTSPlaybackState) => {
       if (state) {
+        const currentState = useAgentStore.getState().ttsPlaybackState
+        if (currentState.updatedAt > state.updatedAt) {
+          logUI("[StoreSync][TTS] skipped stale hydrated playback state", {
+            playbackId: state.playbackId,
+            status: state.status,
+            hydratedUpdatedAt: state.updatedAt,
+            currentUpdatedAt: currentState.updatedAt,
+          })
+          return
+        }
         logUI("[StoreSync][TTS] hydrated initial playback state", {
           playbackId: state.playbackId,
           status: state.status,

--- a/apps/desktop/src/renderer/src/lib/debug.ts
+++ b/apps/desktop/src/renderer/src/lib/debug.ts
@@ -10,6 +10,15 @@ interface DebugFlags {
 let cachedFlags: DebugFlags | null = null
 let flagsFetchPromise: Promise<DebugFlags> | null = null
 
+function getLocalDebugFlag(key: string): string | null {
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return null
+  try {
+    return localStorage.getItem(key)
+  } catch {
+    return null
+  }
+}
+
 export async function initDebugFlags(): Promise<void> {
   if (cachedFlags) return
 
@@ -23,8 +32,8 @@ export async function initDebugFlags(): Promise<void> {
       tools: false,
       keybinds: false,
       app: false,
-      ui: localStorage.getItem('DEBUG_UI') === 'true' || localStorage.getItem('DEBUG') === '*',
-      all: localStorage.getItem('DEBUG') === '*',
+      ui: getLocalDebugFlag('DEBUG_UI') === 'true' || getLocalDebugFlag('DEBUG') === '*',
+      all: getLocalDebugFlag('DEBUG') === '*',
     }
   }
 }
@@ -41,8 +50,8 @@ function getFlags(): DebugFlags {
     tools: false,
     keybinds: false,
     app: false,
-    ui: localStorage.getItem('DEBUG_UI') === 'true' || localStorage.getItem('DEBUG') === '*',
-    all: localStorage.getItem('DEBUG') === '*',
+    ui: getLocalDebugFlag('DEBUG_UI') === 'true' || getLocalDebugFlag('DEBUG') === '*',
+    all: getLocalDebugFlag('DEBUG') === '*',
   }
 }
 
@@ -69,21 +78,23 @@ function safeStringify(value: any): string {
   }
 }
 
+function formatDebugArg(arg: any): string {
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}\n${arg.stack}`
+  }
+  if (typeof arg === 'string') return arg
+  if (typeof arg === 'object' && arg !== null) {
+    return safeStringify(arg)
+  }
+  return String(arg)
+}
+
 export function logUI(...args: any[]) {
   if (!isDebugUI()) return
 
-  const clonedArgs = args.map(arg => {
-    if (typeof arg === 'object' && arg !== null) {
-      try {
-        return JSON.parse(JSON.stringify(arg))
-      } catch {
-        return arg
-      }
-    }
-    return arg
-  })
+  const formattedArgs = args.map(formatDebugArg)
 
-  console.log(`[${ts()}] [DEBUG][UI]`, ...clonedArgs)
+  console.log(`[${ts()}] [DEBUG][UI]`, ...formattedArgs)
 }
 
 export function logComponentLifecycle(componentName: string, event: string, data?: any) {

--- a/apps/desktop/src/renderer/src/lib/tts-playback-controller.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tts-playback-controller.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const controllerSource = readFileSync(new URL("./tts-playback-controller.ts", import.meta.url), "utf8")
+
+describe("tts playback controller", () => {
+  it("owns a single main-renderer audio element and listens for central playback IPC", () => {
+    expect(controllerSource).toContain("const audio = new Audio()")
+    expect(controllerSource).toContain("rendererHandlers.ttsPlaybackRequest.listen(handleRequest)")
+    expect(controllerSource).toContain("rendererHandlers.ttsPlaybackCommand.listen(handleCommand)")
+    expect(controllerSource).toContain("tipcClient.publishTTSPlaybackState(nextState)")
+  })
+
+  it("applies output devices, cleans object URLs, and publishes audio event state", () => {
+    expect(controllerSource).toContain("audio.setSinkId(audioOutputDeviceId || \"\")")
+    expect(controllerSource).toContain("URL.revokeObjectURL(objectUrlRef.current)")
+    expect(controllerSource).toContain('audio.addEventListener("timeupdate", onTimeUpdate)')
+    expect(controllerSource).toContain('audio.addEventListener("ended", onEnded)')
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/tts-playback-controller.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tts-playback-controller.test.ts
@@ -17,4 +17,8 @@ describe("tts playback controller", () => {
     expect(controllerSource).toContain('audio.addEventListener("timeupdate", onTimeUpdate)')
     expect(controllerSource).toContain('audio.addEventListener("ended", onEnded)')
   })
+
+  it("does not let late pause events overwrite an error state", () => {
+    expect(controllerSource).toContain('stateRef.current.status === "error"')
+  })
 })

--- a/apps/desktop/src/renderer/src/lib/tts-playback-controller.ts
+++ b/apps/desktop/src/renderer/src/lib/tts-playback-controller.ts
@@ -245,7 +245,12 @@ export function useTTSPlaybackController() {
       publishState({ status: "playing", error: undefined })
     }
     const onPause = () => {
-      if (!requestRef.current || stateRef.current.status === "ended" || stateRef.current.status === "idle") return
+      if (
+        !requestRef.current ||
+        stateRef.current.status === "ended" ||
+        stateRef.current.status === "idle" ||
+        stateRef.current.status === "error"
+      ) return
       logUI("[TTSPlaybackController] pause event", { playbackId: stateRef.current.playbackId })
       publishState({ status: "paused" })
     }

--- a/apps/desktop/src/renderer/src/lib/tts-playback-controller.ts
+++ b/apps/desktop/src/renderer/src/lib/tts-playback-controller.ts
@@ -1,0 +1,291 @@
+import { useEffect, useRef } from "react"
+import type { DesktopTTSPlaybackCommand, DesktopTTSPlaybackRequest, DesktopTTSPlaybackState } from "@shared/types"
+import { rendererHandlers, tipcClient } from "@renderer/lib/tipc-client"
+import { logUI } from "@renderer/lib/debug"
+
+type MutablePlaybackState = DesktopTTSPlaybackState
+
+function isAutoplayPolicyBlockedError(error: unknown): boolean {
+  const name = error instanceof DOMException ? error.name.toLowerCase() : ""
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error ?? "").toLowerCase()
+  return name === "notallowederror" || message.includes("autoplay") || message.includes("user gesture") || message.includes("not allowed")
+}
+
+function normalizeAudioData(audio: DesktopTTSPlaybackRequest["audio"]): BlobPart {
+  if (audio instanceof ArrayBuffer) return audio
+  if (ArrayBuffer.isView(audio)) {
+    const view = audio as Uint8Array
+    return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer
+  }
+  if (Array.isArray(audio)) return new Uint8Array(audio).buffer
+  const maybeBuffer = audio as unknown as { data?: number[] }
+  if (Array.isArray(maybeBuffer?.data)) return new Uint8Array(maybeBuffer.data).buffer
+  return audio as BlobPart
+}
+
+function canUseSinkId(audio: HTMLAudioElement): audio is HTMLAudioElement & { setSinkId: (sinkId: string) => Promise<void> } {
+  return typeof (audio as HTMLAudioElement & { setSinkId?: unknown }).setSinkId === "function"
+}
+
+export function useTTSPlaybackController() {
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const objectUrlRef = useRef<string | null>(null)
+  const requestRef = useRef<DesktopTTSPlaybackRequest | null>(null)
+  const stateRef = useRef<MutablePlaybackState>({
+    playbackId: null,
+    status: "idle",
+    currentTime: 0,
+    duration: 0,
+    volume: 1,
+    muted: false,
+    updatedAt: Date.now(),
+  })
+
+  useEffect(() => {
+    const audio = new Audio()
+    audio.preload = "auto"
+    audio.volume = stateRef.current.volume
+    audio.muted = stateRef.current.muted
+    audioRef.current = audio
+    logUI("[TTSPlaybackController] mounted main-renderer playback host")
+
+    const publishState = (patch: Partial<DesktopTTSPlaybackState>) => {
+      const nextState: DesktopTTSPlaybackState = {
+        ...stateRef.current,
+        ...patch,
+        updatedAt: Date.now(),
+      }
+      stateRef.current = nextState
+      if (patch.status || patch.error || patch.playbackId !== undefined) {
+        logUI("[TTSPlaybackController] publishState", {
+          playbackId: nextState.playbackId,
+          status: nextState.status,
+          sessionId: nextState.sessionId,
+          source: nextState.source,
+          currentTime: nextState.currentTime,
+          duration: nextState.duration,
+          error: nextState.error,
+        })
+      }
+      void tipcClient.publishTTSPlaybackState(nextState).catch((error: unknown) => {
+        console.warn("[TTSPlaybackController] Failed to publish playback state:", error)
+      })
+    }
+
+    const resetAudioSource = () => {
+      audio.pause()
+      audio.removeAttribute("src")
+      audio.load()
+      if (objectUrlRef.current) {
+        logUI("[TTSPlaybackController] revoking previous object URL", {
+          playbackId: stateRef.current.playbackId,
+        })
+        URL.revokeObjectURL(objectUrlRef.current)
+        objectUrlRef.current = null
+      }
+    }
+
+    const applyOutputDevice = async (audioOutputDeviceId?: string) => {
+      if (!canUseSinkId(audio)) {
+        logUI("[TTSPlaybackController] setSinkId unavailable", { audioOutputDeviceId })
+        return
+      }
+      try {
+        logUI("[TTSPlaybackController] applying output device", { audioOutputDeviceId })
+        await audio.setSinkId(audioOutputDeviceId || "")
+        logUI("[TTSPlaybackController] applied output device", { audioOutputDeviceId })
+      } catch (error) {
+        console.warn("[TTSPlaybackController] Failed to set audio output device:", error)
+        publishState({ status: "error", error: "Failed to set audio output device" })
+      }
+    }
+
+    const matchesActivePlayback = (playbackId?: string) => !playbackId || stateRef.current.playbackId === playbackId
+
+    const handleRequest = async (request: DesktopTTSPlaybackRequest) => {
+      logUI("[TTSPlaybackController] received playback request", {
+        playbackId: request.playbackId,
+        sessionId: request.sessionId,
+        source: request.source,
+        autoPlay: request.autoPlay,
+        keyCount: request.ttsKeys?.length ?? 0,
+        mimeType: request.mimeType,
+        audioOutputDeviceId: request.audioOutputDeviceId,
+      })
+      resetAudioSource()
+      requestRef.current = request
+
+      audio.volume = stateRef.current.volume
+      audio.muted = stateRef.current.muted
+      await applyOutputDevice(request.audioOutputDeviceId)
+
+      const blob = new Blob([normalizeAudioData(request.audio)], { type: request.mimeType || "audio/wav" })
+      const objectUrl = URL.createObjectURL(blob)
+      objectUrlRef.current = objectUrl
+      audio.src = objectUrl
+      audio.currentTime = 0
+      audio.load()
+      logUI("[TTSPlaybackController] audio source prepared", {
+        playbackId: request.playbackId,
+        blobSize: blob.size,
+        mimeType: blob.type,
+      })
+
+      publishState({
+        playbackId: request.playbackId,
+        sourceWindowId: request.sourceWindowId,
+        source: request.source,
+        sessionId: request.sessionId,
+        ttsKey: request.ttsKeys?.[0],
+        textPreview: request.textPreview ?? request.text.slice(0, 120),
+        status: "loading",
+        currentTime: 0,
+        duration: 0,
+        audioOutputDeviceId: request.audioOutputDeviceId,
+        error: undefined,
+      })
+
+      if (!request.autoPlay) {
+        logUI("[TTSPlaybackController] request prepared without autoplay", {
+          playbackId: request.playbackId,
+        })
+        publishState({ status: "paused" })
+        return
+      }
+
+      try {
+        logUI("[TTSPlaybackController] calling audio.play for request", {
+          playbackId: request.playbackId,
+          sessionId: request.sessionId,
+        })
+        await audio.play()
+        logUI("[TTSPlaybackController] audio.play resolved", {
+          playbackId: request.playbackId,
+        })
+      } catch (error) {
+        const autoplayBlocked = isAutoplayPolicyBlockedError(error)
+        logUI("[TTSPlaybackController] audio.play rejected", {
+          playbackId: request.playbackId,
+          autoplayBlocked,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        publishState({
+          status: "error",
+          error: autoplayBlocked
+            ? "Autoplay blocked. Click or press any key to start playback."
+            : error instanceof Error ? error.message : "Audio playback failed",
+        })
+      }
+    }
+
+    const handleCommand = async (command: DesktopTTSPlaybackCommand) => {
+      logUI("[TTSPlaybackController] received playback command", {
+        command,
+        activePlaybackId: stateRef.current.playbackId,
+        activeStatus: stateRef.current.status,
+      })
+      if (command.type !== "stop" && !matchesActivePlayback(command.playbackId)) {
+        logUI("[TTSPlaybackController] ignored command for inactive playback", {
+          command,
+          activePlaybackId: stateRef.current.playbackId,
+        })
+        return
+      }
+
+      try {
+        switch (command.type) {
+          case "play":
+            await audio.play()
+            break
+          case "pause":
+            audio.pause()
+            publishState({ status: "paused" })
+            break
+          case "stop":
+            requestRef.current = null
+            resetAudioSource()
+            publishState({ playbackId: null, status: "idle", currentTime: 0, duration: 0, error: command.reason })
+            break
+          case "seek":
+            audio.currentTime = command.currentTime
+            publishState({ currentTime: command.currentTime })
+            break
+          case "set-volume":
+            audio.volume = Math.max(0, Math.min(1, command.volume))
+            publishState({ volume: audio.volume, muted: audio.volume === 0 ? true : stateRef.current.muted })
+            break
+          case "set-muted":
+            audio.muted = command.muted
+            publishState({ muted: command.muted })
+            break
+          case "set-output-device":
+            await applyOutputDevice(command.audioOutputDeviceId)
+            publishState({ audioOutputDeviceId: command.audioOutputDeviceId })
+            break
+        }
+      } catch (error) {
+        logUI("[TTSPlaybackController] command failed", {
+          command,
+          error: error instanceof Error ? error.message : String(error),
+        })
+        publishState({ status: "error", error: error instanceof Error ? error.message : "Audio playback failed" })
+      }
+    }
+
+    const onLoadedMetadata = () => {
+      logUI("[TTSPlaybackController] loadedmetadata", {
+        playbackId: stateRef.current.playbackId,
+        duration: audio.duration,
+      })
+      publishState({ duration: Number.isFinite(audio.duration) ? audio.duration : 0 })
+    }
+    const onTimeUpdate = () => publishState({ currentTime: audio.currentTime, duration: Number.isFinite(audio.duration) ? audio.duration : stateRef.current.duration })
+    const onPlay = () => {
+      logUI("[TTSPlaybackController] play event", { playbackId: stateRef.current.playbackId })
+      publishState({ status: "playing", error: undefined })
+    }
+    const onPause = () => {
+      if (!requestRef.current || stateRef.current.status === "ended" || stateRef.current.status === "idle") return
+      logUI("[TTSPlaybackController] pause event", { playbackId: stateRef.current.playbackId })
+      publishState({ status: "paused" })
+    }
+    const onEnded = () => {
+      logUI("[TTSPlaybackController] ended event", { playbackId: stateRef.current.playbackId })
+      publishState({ status: "ended", currentTime: 0, duration: Number.isFinite(audio.duration) ? audio.duration : stateRef.current.duration })
+    }
+    const onError = () => {
+      logUI("[TTSPlaybackController] error event", {
+        playbackId: stateRef.current.playbackId,
+        mediaErrorCode: audio.error?.code,
+        mediaErrorMessage: audio.error?.message,
+      })
+      publishState({ status: "error", error: audio.error?.message || "Audio playback failed" })
+    }
+
+    audio.addEventListener("loadedmetadata", onLoadedMetadata)
+    audio.addEventListener("timeupdate", onTimeUpdate)
+    audio.addEventListener("play", onPlay)
+    audio.addEventListener("pause", onPause)
+    audio.addEventListener("ended", onEnded)
+    audio.addEventListener("error", onError)
+    const unlistenRequest = rendererHandlers.ttsPlaybackRequest.listen(handleRequest)
+    const unlistenCommand = rendererHandlers.ttsPlaybackCommand.listen(handleCommand)
+
+    return () => {
+      logUI("[TTSPlaybackController] unmounting playback host", {
+        playbackId: stateRef.current.playbackId,
+        status: stateRef.current.status,
+      })
+      unlistenRequest()
+      unlistenCommand()
+      audio.removeEventListener("loadedmetadata", onLoadedMetadata)
+      audio.removeEventListener("timeupdate", onTimeUpdate)
+      audio.removeEventListener("play", onPlay)
+      audio.removeEventListener("pause", onPause)
+      audio.removeEventListener("ended", onEnded)
+      audio.removeEventListener("error", onError)
+      resetAudioSource()
+      audioRef.current = null
+    }
+  }, [])
+}

--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -494,8 +494,8 @@ export function Component() {
       mcpScreenshotRef.current = undefined
       fromTileRef.current = false
 
-      // If recording was from a tile, hide the floating panel immediately
-      // The session will continue in the tile view
+      // If recording was from a tile, hide the floating panel immediately.
+      // The session continues in the tile view, but it is not forced snoozed.
       if (wasFromTile) {
         tipcClient.hidePanelWindow({})
       }
@@ -509,8 +509,10 @@ export function Component() {
         conversationId: conversationIdForMcp ?? undefined,
         sessionId: sessionIdForMcp,
         screenshot: screenshotForMcp,
-        // Pass fromTile so session starts snoozed when recording was from a tile
+        // Pass fromTile to suppress panel auto-show; keep interactive tile
+        // recordings unsnoozed so their replies can TTS autoplay.
         fromTile: wasFromTile,
+        startSnoozed: false,
       })
 
       // NOTE: Do NOT call continueConversation here!

--- a/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
+++ b/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
@@ -132,11 +132,11 @@ describe("sessions in-app actions", () => {
     expect(agentProgressSource).not.toContain('Conversation branched — find it in Saved Conversations')
   })
 
-  it("forces sessions started from SessionActionDialog to stay snoozed so the hover panel never auto-shows", () => {
+  it("keeps SessionActionDialog sessions audible while suppressing hover-panel auto-show", () => {
     // The dialog description literally promises "without opening the hover panel",
-    // so both text and voice submit paths must hardcode fromTile: true regardless
-    // of the prop value. Guards against the regression where sidebar + modal
-    // submits would surface the floating panel and drop the app from Cmd+Tab.
+    // but interactive submits should still be foreground/audible for TTS.
+    // So both text and voice submit paths should keep fromTile:true while
+    // explicitly sending startSnoozed:false.
     const textSubmitIndex = sessionActionDialogSource.indexOf("const handleTextSubmit")
     const voiceCreateIndex = sessionActionDialogSource.indexOf("tipcClient.createMcpRecording")
     expect(textSubmitIndex).toBeGreaterThan(-1)
@@ -145,22 +145,32 @@ describe("sessions in-app actions", () => {
     const textSubmitBlock = sessionActionDialogSource.slice(textSubmitIndex, textSubmitIndex + 800)
     expect(textSubmitBlock).toContain("tipcClient.createMcpTextInput")
     expect(textSubmitBlock).toContain("fromTile: true")
+    expect(textSubmitBlock).toContain("startSnoozed: false")
 
     const voiceSubmitBlock = sessionActionDialogSource.slice(voiceCreateIndex, voiceCreateIndex + 600)
     expect(voiceSubmitBlock).toContain("fromTile: true")
+    expect(voiceSubmitBlock).toContain("startSnoozed: false")
 
     // The fromTile prop must NOT be destructured into a local variable — the
-    // dialog always ignores it in favor of the hardcoded snoozed flag.
+    // dialog should always preserve the hardcoded panel-suppression hint.
     expect(sessionActionDialogSource).not.toContain("fromTile = false,")
     // Sanity: both submit paths must not pass a plain `fromTile` identifier,
     // which would bypass the hardcoded true.
     expect(textSubmitBlock).not.toContain("fromTile,\n      })")
   })
 
-  it("time-suppresses panel auto-show in createMcpTextInput/createMcpRecording when fromTile is true", () => {
-    // Defensive safety net: even with the session starting snoozed, an early
-    // progress update can race the flag on the main process. suppressPanelAutoShow
-    // closes that window so the floating panel cannot briefly flash.
+  it("decouples tile origin from background snooze state", () => {
+    expect(tileFollowUpSource).toContain("fromTile: true, startSnoozed: false")
+    expect(tipcSource).toContain("fromTile?: boolean // Origin hint")
+    expect(tipcSource).toContain("startSnoozed?: boolean // True background mode")
+    expect(tipcSource).toContain("startSnoozed || input.suppressPanelAutoShow === true || input.fromTile === true")
+    expect(tipcSource).toContain("suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow")
+    expect(tipcSource).toContain("processWithAgentMode(agentInputText, conversationId, existingSessionId, launchState)")
+  })
+
+  it("time-suppresses panel auto-show from explicit launch state without forcing snooze", () => {
+    // Defensive safety net: panel suppression is a separate launch-state axis.
+    // It can be true for tile-origin sessions even when startSnoozed is false.
     const textInputIndex = tipcSource.indexOf("createMcpTextInput: t.procedure")
     const recordingIndex = tipcSource.indexOf("createMcpRecording: t.procedure")
     expect(textInputIndex).toBeGreaterThan(-1)
@@ -169,9 +179,11 @@ describe("sessions in-app actions", () => {
     const textInputBlock = tipcSource.slice(textInputIndex, textInputIndex + 2000)
     const recordingBlock = tipcSource.slice(recordingIndex, recordingIndex + 2000)
 
-    expect(textInputBlock).toContain("if (input.fromTile === true) {")
+    expect(textInputBlock).toContain("const launchState = resolveAgentLaunchState(input)")
+    expect(textInputBlock).toContain("if (launchState.shouldSuppressPanelAutoShow) {")
     expect(textInputBlock).toContain("suppressPanelAutoShow(2000)")
-    expect(recordingBlock).toContain("if (input.fromTile === true) {")
+    expect(recordingBlock).toContain("const launchState = resolveAgentLaunchState(input)")
+    expect(recordingBlock).toContain("if (launchState.shouldSuppressPanelAutoShow) {")
     expect(recordingBlock).toContain("suppressPanelAutoShow(2000)")
   })
 

--- a/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
+++ b/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
@@ -187,6 +187,15 @@ describe("sessions in-app actions", () => {
     expect(recordingBlock).toContain("suppressPanelAutoShow(2000)")
   })
 
+  it("reports centralized TTS IPC delivery only when handlers are available", () => {
+    expect(tipcSource).toContain("const handler = getRendererHandlers<RendererHandlers>(win.webContents).ttsPlaybackStateChanged")
+    expect(tipcSource).toContain("handler.send(state)")
+    expect(tipcSource).toContain("windowsNotified += 1")
+    expect(tipcSource).toContain("const handler = getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackCommand")
+    expect(tipcSource).toContain("Main renderer has no TTS playback command handler")
+    expect(tipcSource).toContain("Main renderer has no TTS playback request handler")
+  })
+
   it("derives the active session tile's isFocused from the focusedSessionId store rather than hardcoding true", () => {
     expect(sessionsSource).toContain("const focusedSessionId = useAgentStore((state) => state.focusedSessionId)")
     expect(sessionsSource).toContain("const isFocused = focusedSessionId === sessionId")

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -16,7 +16,6 @@ import {
   useSaveConfigMutation,
 } from "@renderer/lib/query-client"
 import { getSelectableMainAcpAgents } from "./settings-general-main-agent-options"
-import { ttsManager } from "@renderer/lib/tts-manager"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { ExternalLink, FolderOpen, FolderUp, FileText, Search, X } from "lucide-react"
 import { toast } from "sonner"
@@ -1114,8 +1113,8 @@ export function Component() {
               defaultChecked={configQuery.data.ttsEnabled ?? false}
               onCheckedChange={async (value) => {
                 if (!value) {
-                  ttsManager.stopAll("settings-global-tts-disabled")
                   try {
+                    await tipcClient.controlTTSPlayback({ type: "stop", reason: "settings-global-tts-disabled" })
                     await tipcClient.stopAllTts()
                   } catch (error) {
                     console.error("Failed to stop TTS in all windows:", error)

--- a/apps/desktop/src/renderer/src/stores/agent-store.test.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { AgentProgressUpdate } from '@shared/types'
+
+vi.mock('@renderer/lib/debug', () => ({ logUI: vi.fn() }))
+
 import { useAgentStore } from './agent-store'
 
 const createBaseUpdate = (): AgentProgressUpdate => ({
@@ -41,6 +44,26 @@ describe('agent-store delegation merge', () => {
       pinnedSessionIdsRevision: 0,
       archivedSessionIds: new Set(),
       archivedSessionIdsRevision: 0,
+      ttsPlaybackState: { playbackId: null, status: 'idle', currentTime: 0, duration: 0, volume: 1, muted: false, updatedAt: 1 },
+    })
+  })
+
+  it('stores centralized TTS playback state updates', () => {
+    useAgentStore.getState().setTTSPlaybackState({
+      playbackId: 'playback-1',
+      status: 'playing',
+      currentTime: 1.5,
+      duration: 8,
+      volume: 0.75,
+      muted: false,
+      updatedAt: 2,
+    })
+
+    expect(useAgentStore.getState().ttsPlaybackState).toMatchObject({
+      playbackId: 'playback-1',
+      status: 'playing',
+      currentTime: 1.5,
+      duration: 8,
     })
   })
 

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { AgentProgressUpdate, QueuedMessage } from '@shared/types'
+import { AgentProgressUpdate, DesktopTTSPlaybackState, QueuedMessage } from '@shared/types'
 import { clearSessionTTSTracking } from '@renderer/lib/tts-tracking'
 import {
   sanitizeAgentProgressUpdateForDisplay,
@@ -123,6 +123,16 @@ export type SessionViewMode = 'grid' | 'list' | 'kanban'
 export type SessionFilter = 'all' | 'active' | 'completed' | 'error'
 export type SessionSortBy = 'recent' | 'oldest' | 'status'
 
+export const createIdleTTSPlaybackState = (): DesktopTTSPlaybackState => ({
+  playbackId: null,
+  status: 'idle',
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  muted: false,
+  updatedAt: Date.now(),
+})
+
 interface AgentState {
   agentProgressById: Map<string, AgentProgressUpdate>
   agentResponseReadAtBySessionId: Map<string, number>
@@ -145,9 +155,9 @@ interface AgentState {
   archivedSessionIdsRevision: number
 
   // Whether the floating panel window is currently visible. Used by the main
-  // window to suppress duplicate TTS auto-play when the panel is playing the
-  // same session's audio.
+  // window for UI visibility; TTS ownership is centralized in the main renderer.
   isFloatingPanelVisible: boolean
+  ttsPlaybackState: DesktopTTSPlaybackState
 
   updateSessionProgress: (update: AgentProgressUpdate) => void
   clearAllProgress: () => void
@@ -179,6 +189,7 @@ interface AgentState {
   isArchived: (sessionId: string) => boolean
 
   setFloatingPanelVisible: (visible: boolean) => void
+  setTTSPlaybackState: (state: DesktopTTSPlaybackState) => void
 }
 
 export const useAgentStore = create<AgentState>((set, get) => ({
@@ -200,6 +211,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   archivedSessionIdsRevision: 0,
 
   isFloatingPanelVisible: false,
+  ttsPlaybackState: createIdleTTSPlaybackState(),
 
   updateSessionProgress: (incomingUpdate: AgentProgressUpdate) => {
     const update = sanitizeAgentProgressUpdateForDisplay(incomingUpdate)
@@ -734,6 +746,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   setFloatingPanelVisible: (visible: boolean) => {
     set({ isFloatingPanelVisible: visible })
   },
+
+  setTTSPlaybackState: (ttsPlaybackState: DesktopTTSPlaybackState) => {
+    set({ ttsPlaybackState })
+  },
 }))
 
 const EMPTY_MESSAGE_QUEUE: QueuedMessage[] = []
@@ -771,4 +787,12 @@ export const useIsQueuePaused = (conversationId: string | undefined) => {
 
 export const useIsFloatingPanelVisible = () => {
   return useAgentStore((state) => state.isFloatingPanelVisible)
+}
+
+export const useTTSPlaybackState = () => {
+  return useAgentStore((state) => state.ttsPlaybackState)
+}
+
+export const useIsTTSPlaybackActive = (playbackId: string | null | undefined) => {
+  return useAgentStore((state) => !!playbackId && state.ttsPlaybackState.playbackId === playbackId)
 }

--- a/apps/desktop/src/renderer/src/stores/index.ts
+++ b/apps/desktop/src/renderer/src/stores/index.ts
@@ -1,5 +1,5 @@
 // Zustand stores for state management
-export { useAgentStore, useAgentSessionProgress, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused, useIsFloatingPanelVisible } from './agent-store'
+export { useAgentStore, useAgentSessionProgress, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused, useIsFloatingPanelVisible, useTTSPlaybackState, useIsTTSPlaybackActive } from './agent-store'
 export type { SessionViewMode, SessionFilter, SessionSortBy } from './agent-store'
 export { useConversationStore } from './conversation-store'
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1456,6 +1456,51 @@ export type Config = {
   loops?: LoopConfig[]  // Scheduled repeat tasks that run at intervals
 }
 
+// Centralized desktop TTS playback state shared between main and renderer.
+export type DesktopTTSPlaybackStatus = "idle" | "loading" | "playing" | "paused" | "ended" | "error"
+
+export type DesktopTTSPlaybackSource = "main" | "panel" | "tile" | "overlay" | "unknown" | string
+
+export interface DesktopTTSPlaybackState {
+  playbackId: string | null
+  sourceWindowId?: string
+  source?: DesktopTTSPlaybackSource
+  sessionId?: string
+  ttsKey?: string
+  textPreview?: string
+  status: DesktopTTSPlaybackStatus
+  currentTime: number
+  duration: number
+  volume: number
+  muted: boolean
+  audioOutputDeviceId?: string
+  error?: string
+  updatedAt: number
+}
+
+export interface DesktopTTSPlaybackRequest {
+  playbackId: string
+  sourceWindowId?: string
+  source: DesktopTTSPlaybackSource
+  sessionId?: string
+  ttsKeys?: string[]
+  text: string
+  textPreview?: string
+  audio: ArrayBuffer | Uint8Array | number[]
+  mimeType: string
+  autoPlay: boolean
+  audioOutputDeviceId?: string
+}
+
+export type DesktopTTSPlaybackCommand =
+  | { type: "play"; playbackId?: string; reason?: string }
+  | { type: "pause"; playbackId?: string; reason?: string }
+  | { type: "stop"; playbackId?: string; reason?: string }
+  | { type: "seek"; playbackId?: string; currentTime: number; reason?: string }
+  | { type: "set-volume"; playbackId?: string; volume: number; reason?: string }
+  | { type: "set-muted"; playbackId?: string; muted: boolean; reason?: string }
+  | { type: "set-output-device"; playbackId?: string; audioOutputDeviceId?: string; reason?: string }
+
 // Push Notification Token (from mobile clients)
 export interface PushNotificationToken {
   token: string

--- a/packages/core/src/debug.ts
+++ b/packages/core/src/debug.ts
@@ -143,6 +143,21 @@ function ts(): string {
   return d.toISOString()
 }
 
+function formatDebugArg(arg: unknown): string {
+  if (arg instanceof Error) {
+    return `${arg.name}: ${arg.message}\n${arg.stack}`
+  }
+  if (typeof arg === "string") return arg
+  if (typeof arg === "object" && arg !== null) {
+    try {
+      return JSON.stringify(arg, null, 2)
+    } catch {
+      return String(arg)
+    }
+  }
+  return String(arg)
+}
+
 export function logLLM(...args: unknown[]) {
   if (!isDebugLLM()) return
   // eslint-disable-next-line no-console
@@ -163,27 +178,16 @@ export function logKeybinds(...args: unknown[]) {
 
 export function logApp(...args: unknown[]) {
   if (!isDebugApp()) return
-  const formattedArgs = args.map(arg => {
-    if (arg instanceof Error) {
-      return `${arg.name}: ${arg.message}\n${arg.stack}`
-    }
-    if (typeof arg === "object" && arg !== null) {
-      try {
-        return JSON.stringify(arg, null, 2)
-      } catch {
-        return String(arg)
-      }
-    }
-    return arg
-  })
+  const formattedArgs = args.map(formatDebugArg)
   // eslint-disable-next-line no-console
   console.log(`[${ts()}] [DEBUG][APP]`, ...formattedArgs)
 }
 
 export function logUI(...args: unknown[]) {
   if (!isDebugUI()) return
+  const formattedArgs = args.map(formatDebugArg)
   // eslint-disable-next-line no-console
-  console.log(`[${ts()}] [DEBUG][UI]`, ...args)
+  console.log(`[${ts()}] [DEBUG][UI]`, ...formattedArgs)
 }
 
 export function logMCP(direction: "REQUEST" | "RESPONSE", serverName: string, data: unknown) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -70,6 +70,13 @@ export interface QueuedMessage {
   conversationId: string;
   /** Session that was active when this message was queued. */
   sessionId?: string;
+  /** Launch-state hints captured when the user queued the message. */
+  launchState?: {
+    fromTile?: boolean;
+    startSnoozed?: boolean;
+    suppressPanelAutoShow?: boolean;
+    focusPanelSession?: boolean;
+  };
   text: string;
   createdAt: number;
   status: 'pending' | 'processing' | 'cancelled' | 'failed';


### PR DESCRIPTION
## Summary

This PR introduces a centralized TTS playback authority for the DotAgents desktop app and fixes several edge cases around tile-originated autoplay and provider thinking blocks.

## Changes

### Centralized TTS coordination

- Added main-process TTS playback coordinator and renderer playback controller.
- Added main renderer playback host in AppLayout with store sync.
- Refactored AudioPlayer to request/control centralized playback instead of owning playback directly.

### Decoupled launch state

- Introduced AgentLaunchState to separate tile origin from snoozed/background state and panel suppression.
- Threaded explicit launch state through message queues, recordings, tile follow-ups, and dialog submits.
- Updated SessionActionDialog submits to suppress panel auto-show without forcing snoozed mode.

### Autoplay race fixes

- Fixed claim-cancel race where a winning surface released the claim before playback was requested.
- Final assistant messages that mount after completion now inherit parent live-run observation, so live replies can still autoplay.
- Visible final assistant text is TTS-eligible before session completion cleanup can race ahead.

### Thought suppression

- Provider thinking/thought assistant messages are flagged with isAssistantThought.
- Default TTS autoplay excludes those thoughts.
- User-facing final replies and responseEvent / respond_to_user messages remain TTS-eligible.
- Leaves room for a future explicit opt-in setting like Speak reasoning aloud.

## Validation

Ran locally:

- pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/agent-progress.snoozed-tts.test.ts src/renderer/src/components/agent-progress.tile-layout.test.ts src/renderer/src/components/agent-progress.response-history.test.ts src/renderer/src/pages/sessions.in-app-actions.test.ts src/renderer/src/components/session-action-dialog.voice.test.tsx src/main/emit-agent-progress.snoozed.test.ts
  - 6 files passed
  - 78 tests passed
- pnpm --filter @dotagents/desktop typecheck
  - passed

## Notes

- GitHub currently reports no required checks for this branch.
- Untracked local artifact directories (apps/desktop/runs/, autoresearch/) were intentionally excluded from the commit.
- Mobile parity for any analogous TTS UI can be handled in a follow-up.
