### PR TITLE
[codex] Load display history from raw conversations

### DIFF
--- a/apps/desktop/src/main/conversation-service.lazy-load.test.ts
+++ b/apps/desktop/src/main/conversation-service.lazy-load.test.ts
@@ -85,6 +85,63 @@ describe("conversation lazy loading", () => {
     expect(loaded).not.toHaveProperty("rawMessages")
   })
 
+  it("loads display windows from preserved raw history after compaction", async () => {
+    const service = await setupConversationServiceTest()
+    const rawMessages = Array.from({ length: 25 }, (_, index) => ({
+      id: `r${index}`,
+      role: index % 2 === 0 ? "user" as const : "assistant" as const,
+      content: `Raw ${index}`,
+      timestamp: 1_700_000_000_000 + index,
+    }))
+
+    await service.saveConversation({
+      id: "conv_lazy_raw_window",
+      title: "Lazy raw window",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: [
+        {
+          id: "summary-1",
+          role: "assistant",
+          content: "Summary",
+          timestamp: 1,
+          isSummary: true,
+          summarizedMessageCount: 15,
+        },
+        ...rawMessages.slice(15),
+      ],
+      rawMessages,
+      compaction: {
+        rawHistoryPreserved: true,
+        storedRawMessageCount: rawMessages.length,
+        representedMessageCount: rawMessages.length,
+        summary: "Summary",
+        firstKeptMessageIndex: 15,
+        summarizedRange: { startIndex: 0, endIndex: 14 },
+        summarizedMessageCount: 15,
+      },
+    }, true)
+
+    const loadedWindow = await service.loadConversationForDisplay("conv_lazy_raw_window", { messageLimit: 5 })
+    const loadedFull = await service.loadConversationForDisplay("conv_lazy_raw_window")
+
+    expect(loadedWindow?.messages.map((message) => message.content)).toEqual([
+      "Raw 20",
+      "Raw 21",
+      "Raw 22",
+      "Raw 23",
+      "Raw 24",
+    ])
+    expect(loadedWindow?.messageOffset).toBe(20)
+    expect(loadedWindow?.totalMessageCount).toBe(25)
+    expect(loadedWindow?.branchMessageIndexOffset).toBe(20)
+    expect(loadedWindow).not.toHaveProperty("rawMessages")
+
+    expect(loadedFull?.messages[0]?.content).toBe("Raw 0")
+    expect(loadedFull?.messages).toHaveLength(25)
+    expect(loadedFull).not.toHaveProperty("rawMessages")
+  })
+
   it("persists display-only message content separately from canonical content", async () => {
     const service = await setupConversationServiceTest()
     await service.saveConversation({

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -928,6 +928,36 @@ export class ConversationService {
     }
   }
 
+  private buildDisplayLoadedConversation(
+    conversation: Conversation,
+    messageLimit?: number,
+  ): LoadedConversation {
+    const hasStoredRawMessages = Array.isArray(conversation.rawMessages) && conversation.rawMessages.length > 0
+    if (!hasStoredRawMessages) {
+      return this.applyConversationMessageLimit(conversation, messageLimit)
+    }
+
+    const displayMessages = this.getStoredRawMessages(conversation)
+    const normalizedLimit = typeof messageLimit === "number" && Number.isFinite(messageLimit)
+      ? Math.max(0, Math.floor(messageLimit ?? 0))
+      : 0
+    const totalMessageCount = displayMessages.length
+    const messageOffset = normalizedLimit > 0
+      ? Math.max(0, totalMessageCount - normalizedLimit)
+      : 0
+    const { rawMessages: _rawMessages, ...conversationWithoutRawMessages } = conversation
+
+    return {
+      ...conversationWithoutRawMessages,
+      messages: normalizedLimit > 0
+        ? displayMessages.slice(messageOffset)
+        : displayMessages,
+      messageOffset,
+      totalMessageCount,
+      branchMessageIndexOffset: messageOffset,
+    }
+  }
+
   private getStoredRawMessages(conversation: Conversation): ConversationMessage[] {
     if (Array.isArray(conversation.rawMessages) && conversation.rawMessages.length > 0) {
       return conversation.rawMessages
@@ -1147,6 +1177,18 @@ export class ConversationService {
       const conversation = await this.loadConversationFromDisk(conversationId)
       return conversation
         ? this.applyConversationMessageLimit(conversation, options?.messageLimit)
+        : null
+    })
+  }
+
+  async loadConversationForDisplay(
+    conversationId: string,
+    options?: { messageLimit?: number },
+  ): Promise<LoadedConversation | null> {
+    return this.enqueueConversationMutation(conversationId, async () => {
+      const conversation = await this.loadConversationFromDisk(conversationId)
+      return conversation
+        ? this.buildDisplayLoadedConversation(conversation, options?.messageLimit)
         : null
     })
   }

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3526,7 +3526,7 @@ export const router = {
   loadConversation: t.procedure
     .input<{ conversationId: string; messageLimit?: number }>()
     .action(async ({ input }) => {
-      return conversationService.loadConversation(input.conversationId, {
+      return conversationService.loadConversationForDisplay(input.conversationId, {
         messageLimit: input.messageLimit,
       })
     }),


### PR DESCRIPTION
## Summary

- Route renderer conversation display loads through a display-specific service method.
- Use preserved `rawMessages` for display windows when a conversation has been compacted, while keeping `rawMessages` out of the renderer payload.
- Add a regression test covering lazy display loads from compacted conversations with preserved raw history.

## Root Cause

Compacted saved conversations kept the true first messages in `rawMessages`, but the main window loaded the compacted `messages` array for display. Once compacted, the UI could not page back before the summary because those earlier messages were not part of the renderer-facing payload.

## Validation

- `pnpm --filter @dotagents/desktop exec vitest run src/main/conversation-service.lazy-load.test.ts`
- `pnpm --filter @dotagents/desktop typecheck`
- CDP validation in a fresh Electron debug instance confirmed the first raw user message renders for the affected 42-message and 56-message conversations.