### PR TITLE
Encourage agents to deliver media inline in chat (#458)

### DIFF
--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -124,7 +124,7 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 - To send images, use respond_to_user.images with either URL/data URL entries or local file paths
 - MEDIA DELIVERY: When your final output includes generated, downloaded, or fetched media assets (images, videos, screenshots, thumbnails), prefer delivering them inline through respond_to_user.images / respond_to_user.videos rather than only returning a local filepath
 - Treat local paths as a secondary reference for follow-up, not the primary delivery mechanism — include them alongside the inline asset when useful, but do not rely on a bare path when inline display is supported
-- Only fall back to path-only responses when inline display/attachment is genuinely unavailable (no respond_to_user, unsupported media type, or the user explicitly asked for a path)`)
+- Only fall back to path-only responses when inline display/attachment is genuinely unavailable (unsupported media type, or the user explicitly asked for a path)`)
   } else {
     sections.push(`RESPONDING TO USER:
 - No direct user-response tool is available in this run. Put the final user-facing answer in normal assistant text.`)

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -121,7 +121,10 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 - On voice interfaces this will be spoken aloud; on messaging channels (mobile, WhatsApp) it will be sent as a message
 - Write respond_to_user content naturally and conversationally
 - Markdown is allowed when useful (for example links or image captions)
-- To send images, use respond_to_user.images with either URL/data URL entries or local file paths`)
+- To send images, use respond_to_user.images with either URL/data URL entries or local file paths
+- MEDIA DELIVERY: When your final output includes generated, downloaded, or fetched media assets (images, videos, screenshots, thumbnails), prefer delivering them inline through respond_to_user.images / respond_to_user.videos rather than only returning a local filepath
+- Treat local paths as a secondary reference for follow-up, not the primary delivery mechanism — include them alongside the inline asset when useful, but do not rely on a bare path when inline display is supported
+- Only fall back to path-only responses when inline display/attachment is genuinely unavailable (no respond_to_user, unsupported media type, or the user explicitly asked for a path)`)
   } else {
     sections.push(`RESPONDING TO USER:
 - No direct user-response tool is available in this run. Put the final user-facing answer in normal assistant text.`)


### PR DESCRIPTION
## Summary
Closes #458.

Updates the agent-mode system prompt so agents prefer sending generated, downloaded, or fetched media (images, videos, screenshots, thumbnails) through the existing `respond_to_user.images` / `respond_to_user.videos` channels instead of replying with only a local filepath — which is unhelpful in chat contexts where the asset can be displayed inline.

## Changes
- `apps/desktop/src/main/system-prompts.ts` — extended the `RESPONDING TO USER` section (within `getAgentModeAdditions`, only when `respond_to_user` is available) with three additional bullets:
  - Prefer inline delivery via `respond_to_user.images` / `respond_to_user.videos` for media outputs.
  - Treat local paths as a secondary reference, not the primary delivery mechanism.
  - Fall back to path-only responses only when inline display/attachment is unavailable or the user explicitly asked for a path.

The change is purely additive to an existing prompt section and is gated on `hasRespondToUser`, so runs without that tool fall back to the existing path-only guidance.

## Test plan
- [ ] `pnpm --filter @dotagents/desktop test -- system-prompts` (existing suite — only positive `toContain` assertions in this section, so the additive text should not regress)
- [ ] Manual: trigger an agent run that produces an image (e.g. screenshot tool) and confirm it returns the image inline via `respond_to_user.images` rather than just a path
- [ ] Manual: confirm agents still include the local path as secondary reference where useful

---
_Generated by [Claude Code](https://claude.ai/code/session_019qzM8HWVDhdqjGVwA9ksUf)_