### PR TITLE
fix(mcp-whatsapp): match phone numbers in allowlist against multi-device JIDs

### DIFF
--- a/packages/mcp-whatsapp/package.json
+++ b/packages/mcp-whatsapp/package.json
@@ -19,7 +19,8 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
@@ -31,7 +32,8 @@
     "@types/node": "^20.0.0",
     "@types/qrcode": "^1.5.6",
     "tsup": "^8.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^1.6.0"
   },
   "files": [
     "dist",

--- a/packages/mcp-whatsapp/src/index.ts
+++ b/packages/mcp-whatsapp/src/index.ts
@@ -30,6 +30,7 @@ import os from "os"
 import fs from "fs"
 import { WhatsAppSession } from "./session.js"
 import type { WhatsAppConfig, WhatsAppMessage } from "./types.js"
+import { normalizeWhatsAppId } from "./whatsapp-id.js"
 
 // Configuration from environment variables
 const config: WhatsAppConfig = {
@@ -54,15 +55,15 @@ const MAX_PENDING_MESSAGES = 100
  * WhatsApp can return different JID formats for the same chat:
  * - "@s.whatsapp.net" (phone number format)
  * - "@lid" (Linked ID format)
- * This function extracts just the numeric ID to ensure consistency.
+ * Plus a multi-device tag like ":23" before the suffix. This function returns
+ * just the bare numeric ID so the same chat always maps to the same key.
  */
 function normalizeChatId(chatId: string): string {
-  // Strip the @suffix and non-numeric characters to get a consistent key
-  return chatId.replace(/@.*$/, "").replace(/[^0-9]/g, "")
+  return normalizeWhatsAppId(chatId)
 }
 
 function normalizeWhatsAppOperatorIdentity(value: string | undefined): string {
-  return (value || "").replace(/@.*$/, "").replace(/[^0-9]/g, "")
+  return normalizeWhatsAppId(value)
 }
 
 type OperatorCommandMethod = "GET" | "POST"
@@ -1324,7 +1325,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         // Normalize chat ID and search both @s.whatsapp.net and @lid formats
         // Some DMs may be keyed/stored under @lid chat IDs
         let messages: WhatsAppMessage[] = []
-        const numericId = chat_id.replace(/[^0-9]/g, "")
+        const numericId = normalizeWhatsAppId(chat_id)
 
         if (chat_id.includes("@")) {
           // Already has a suffix, use as-is

--- a/packages/mcp-whatsapp/src/session.ts
+++ b/packages/mcp-whatsapp/src/session.ts
@@ -30,6 +30,7 @@ import type {
   SendMessageResult,
   WhatsAppChat,
 } from "./types.js"
+import { normalizeWhatsAppId } from "./whatsapp-id.js"
 
 // Simple pino logger for Baileys
 const logger = pino({
@@ -81,7 +82,7 @@ export class WhatsAppSession extends EventEmitter {
         const data = JSON.parse(fs.readFileSync(mappingsFile, "utf-8"))
         for (const [lid, phone] of Object.entries(data)) {
           if (typeof phone === "string") {
-            this.lidToPhoneMap.set(lid.replace(/[^0-9]/g, ""), phone.replace(/[^0-9]/g, ""))
+            this.lidToPhoneMap.set(normalizeWhatsAppId(lid), normalizeWhatsAppId(phone))
           }
         }
         console.error(`[WhatsApp] Loaded ${this.lidToPhoneMap.size} LID mappings from file`)
@@ -126,8 +127,8 @@ export class WhatsAppSession extends EventEmitter {
       if (creds && creds.lid && creds.me) {
         const me = creds.me as { id?: string; lid?: string }
         if (me.id && me.lid) {
-          const phoneNumber = me.id.replace(/@.*$/, "").replace(/[^0-9]/g, "").split(":")[0]
-          const lid = me.lid.replace(/@.*$/, "").replace(/[^0-9]/g, "")
+          const phoneNumber = normalizeWhatsAppId(me.id)
+          const lid = normalizeWhatsAppId(me.lid)
           if (lid && phoneNumber) {
             this.lidToPhoneMap.set(lid, phoneNumber)
             console.error(`[WhatsApp] Loaded own LID mapping from creds: ${lid} -> ${phoneNumber}`)
@@ -224,8 +225,8 @@ export class WhatsAppSession extends EventEmitter {
         for (const contact of contacts) {
           // contacts.update can include LID info
           if (contact.id && contact.lid) {
-            const phoneNumber = contact.id.replace(/@.*$/, "").replace(/[^0-9]/g, "")
-            const lid = contact.lid.replace(/@.*$/, "").replace(/[^0-9]/g, "")
+            const phoneNumber = normalizeWhatsAppId(contact.id)
+            const lid = normalizeWhatsAppId(contact.lid)
             if (lid && phoneNumber && !this.lidToPhoneMap.has(lid)) {
               this.lidToPhoneMap.set(lid, phoneNumber)
               newMappings++
@@ -382,12 +383,13 @@ export class WhatsAppSession extends EventEmitter {
 
       // Check allowlist if configured
       if (this.config.allowFrom && this.config.allowFrom.length > 0) {
-        // Get the sender identifier - could be phone number or LID
-        const senderNumber = message.from.replace(/[^0-9]/g, "")
-
-        // Also try to get the phone number from the chatId (which may have both formats)
-        // LIDs look like "98389177934034@lid", phone numbers like "61406142826@s.whatsapp.net"
-        const chatIdNumber = message.chatId?.replace(/@.*$/, "").replace(/[^0-9]/g, "") || ""
+        // Normalize sender and chat identifiers consistently with allowlist
+        // entries. This must strip JID suffixes (@s.whatsapp.net, @lid),
+        // multi-device tags (e.g. ":23"), and user-entered formatting like
+        // "+", spaces or dashes — otherwise a phone number on the allowlist
+        // never matches a JID like "61406142826:23@s.whatsapp.net".
+        const senderNumber = normalizeWhatsAppId(message.from)
+        const chatIdNumber = normalizeWhatsAppId(message.chatId)
 
         // Detect if this is a LID-based message by checking the chatId (not message.from)
         // message.from is already split at "@" so it won't contain "@lid"
@@ -403,7 +405,7 @@ export class WhatsAppSession extends EventEmitter {
           // If not found, try to get it from the message's verifiedBizName or pushName
           // which might contain the phone number
           if (!mappedPhoneNumber && msg.verifiedBizName) {
-            const bizPhone = msg.verifiedBizName.replace(/[^0-9]/g, "")
+            const bizPhone = normalizeWhatsAppId(msg.verifiedBizName)
             if (bizPhone.length >= 10) {
               mappedPhoneNumber = bizPhone
               this.lidToPhoneMap.set(senderNumber, bizPhone)
@@ -413,7 +415,7 @@ export class WhatsAppSession extends EventEmitter {
         }
 
         const isAllowed = this.config.allowFrom.some((allowed) => {
-          const normalizedAllowed = allowed.replace(/[^0-9]/g, "")
+          const normalizedAllowed = normalizeWhatsAppId(allowed)
           // Security: Require minimum length for allowlist entries to prevent weak matches
           if (normalizedAllowed.length < 7) {
             console.error(`[WhatsApp] Skipping allowlist entry "${allowed}" - too short (min 7 digits)`)
@@ -587,7 +589,7 @@ export class WhatsAppSession extends EventEmitter {
       let fallbackJid: string | null = null
 
       if (!jid.includes("@")) {
-        const numericId = jid.replace(/[^0-9]/g, "")
+        const numericId = normalizeWhatsAppId(jid)
 
         // Check if this ID is a known LID from our mapping (reverse lookup)
         const isKnownLid = Array.from(this.lidToPhoneMap.keys()).includes(numericId)
@@ -761,7 +763,7 @@ export class WhatsAppSession extends EventEmitter {
       let fallbackJid: string | null = null
 
       if (!jid.includes("@")) {
-        const numericId = jid.replace(/[^0-9]/g, "")
+        const numericId = normalizeWhatsAppId(jid)
 
         // Check if this ID is a known LID from our mapping
         const isKnownLid = Array.from(this.lidToPhoneMap.keys()).includes(numericId)
@@ -819,7 +821,7 @@ export class WhatsAppSession extends EventEmitter {
       let fallbackJid: string | null = null
 
       if (!jid.includes("@")) {
-        const numericId = jid.replace(/[^0-9]/g, "")
+        const numericId = normalizeWhatsAppId(jid)
 
         // Check if this ID is a known LID from our mapping
         const isKnownLid = Array.from(this.lidToPhoneMap.keys()).includes(numericId)

--- a/packages/mcp-whatsapp/src/whatsapp-id.test.ts
+++ b/packages/mcp-whatsapp/src/whatsapp-id.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest"
+import { normalizeWhatsAppId } from "./whatsapp-id.js"
+
+describe("normalizeWhatsAppId", () => {
+  it("returns an empty string for empty input", () => {
+    expect(normalizeWhatsAppId("")).toBe("")
+    expect(normalizeWhatsAppId(undefined)).toBe("")
+    expect(normalizeWhatsAppId(null)).toBe("")
+  })
+
+  it("strips the @s.whatsapp.net suffix", () => {
+    expect(normalizeWhatsAppId("61406142826@s.whatsapp.net")).toBe("61406142826")
+  })
+
+  it("strips the @lid suffix", () => {
+    expect(normalizeWhatsAppId("98389177934034@lid")).toBe("98389177934034")
+  })
+
+  it("strips the @g.us group suffix", () => {
+    // Group JIDs may contain a dash; the digits-only result is fine for
+    // equality comparison since both sides go through the same normalizer.
+    expect(normalizeWhatsAppId("123456789-987654321@g.us")).toBe("123456789987654321")
+  })
+
+  it("strips the multi-device :N tag before stripping formatting", () => {
+    // Without colon-stripping the device tag would be concatenated onto the
+    // phone number, which is exactly the regression that caused issue #461.
+    expect(normalizeWhatsAppId("61406142826:23@s.whatsapp.net")).toBe("61406142826")
+    expect(normalizeWhatsAppId("61406142826:23")).toBe("61406142826")
+  })
+
+  it("normalizes user-entered phone numbers with formatting", () => {
+    expect(normalizeWhatsAppId("+61 406 142 826")).toBe("61406142826")
+    expect(normalizeWhatsAppId("+1 (415) 555-1234")).toBe("14155551234")
+    expect(normalizeWhatsAppId("(415) 555 1234")).toBe("4155551234")
+    expect(normalizeWhatsAppId("+1-415-555-1234")).toBe("14155551234")
+  })
+
+  it("matches a formatted allowlist entry against an incoming JID", () => {
+    const allowlistEntry = "+61 406 142 826"
+    expect(normalizeWhatsAppId(allowlistEntry))
+      .toBe(normalizeWhatsAppId("61406142826@s.whatsapp.net"))
+    expect(normalizeWhatsAppId(allowlistEntry))
+      .toBe(normalizeWhatsAppId("61406142826:23@s.whatsapp.net"))
+    expect(normalizeWhatsAppId(allowlistEntry))
+      .toBe(normalizeWhatsAppId("61406142826:5"))
+  })
+
+  it("does not match different phone numbers", () => {
+    expect(normalizeWhatsAppId("+61 406 142 826"))
+      .not.toBe(normalizeWhatsAppId("+61 406 142 827"))
+  })
+})

--- a/packages/mcp-whatsapp/src/whatsapp-id.ts
+++ b/packages/mcp-whatsapp/src/whatsapp-id.ts
@@ -1,0 +1,26 @@
+/**
+ * Normalize a WhatsApp identifier (JID, phone number, or LID) into a plain
+ * digit-only string suitable for equality matching against an allowlist entry.
+ *
+ * Handles the formats WhatsApp/Baileys can produce, plus the formats users
+ * tend to type into the allowlist input:
+ *   - `61406142826@s.whatsapp.net`     (phone JID)
+ *   - `61406142826:23@s.whatsapp.net`  (multi-device JID with device suffix)
+ *   - `98389177934034@lid`             (privacy LID)
+ *   - `+61 406 142 826`                (user-entered phone with formatting)
+ *
+ * Order of operations matters here:
+ *   1. Strip the `@suffix` (any JID suffix, e.g. @s.whatsapp.net, @lid, @g.us).
+ *   2. Strip the `:device` suffix (the multi-device tag Baileys appends, e.g.
+ *      `61406142826:23`). If we ran the digit filter before this, the device
+ *      number would be concatenated onto the phone number and the entry would
+ *      no longer match the allowlist.
+ *   3. Strip every remaining non-digit character (formatting like `+`, spaces,
+ *      parentheses, dashes that users include when they type a phone number).
+ */
+export function normalizeWhatsAppId(value: string | undefined | null): string {
+  if (!value) return ""
+  const beforeAt = value.split("@")[0] ?? ""
+  const beforeColon = beforeAt.split(":")[0] ?? ""
+  return beforeColon.replace(/[^0-9]/g, "")
+}

--- a/packages/mcp-whatsapp/vitest.config.ts
+++ b/packages/mcp-whatsapp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

Fixes #461.

WhatsApp/Baileys produces sender JIDs of the form `61406142826:23@s.whatsapp.net` for multi-device accounts. The previous allowlist check stripped every non-digit before stripping the device tag, so the normalized sender became `6140614282623` and never matched the phone number on the allowlist — which is the symptom the issue describes.

This change centralizes identifier normalization into a single helper, `normalizeWhatsAppId`, and routes every site that compared raw IDs through it. The helper performs three steps in order:

1. Strip the `@suffix` (`@s.whatsapp.net`, `@lid`, `@g.us`, …).
2. Strip the multi-device `:N` tag (this is the new step that fixes the bug).
3. Strip remaining non-digit characters, so user-entered formats like `+61 406 142 826`, `+1 (415) 555-1234`, or `+1-415-555-1234` collapse to the same digits as the JID.

The same helper now backs:

- the inbound allowlist check in `session.ts`
- LID ↔ phone mapping (load from creds, contacts.update, persisted file, `verifiedBizName`)
- outbound JID resolution for `sendMessage` / typing indicators
- `normalizeChatId` / `normalizeWhatsAppOperatorIdentity` in `index.ts`
- the chat-history lookup keyed by raw `chat_id`

## Files

- `packages/mcp-whatsapp/src/whatsapp-id.ts` — new helper (pure function, no deps)
- `packages/mcp-whatsapp/src/whatsapp-id.test.ts` — unit tests covering the JID, multi-device, and user-formatting cases
- `packages/mcp-whatsapp/vitest.config.ts` + `package.json` — wire up `pnpm test` for this package (matches the existing `packages/shared` setup)
- `packages/mcp-whatsapp/src/session.ts`, `packages/mcp-whatsapp/src/index.ts` — use the helper everywhere

## Test plan

- [ ] `pnpm install` (picks up the new `vitest` devDependency in `packages/mcp-whatsapp`)
- [ ] `pnpm --filter @dotagents/mcp-whatsapp test` — all `normalizeWhatsAppId` cases pass, including `61406142826:23@s.whatsapp.net` ⇄ `+61 406 142 826`
- [ ] `pnpm --filter @dotagents/mcp-whatsapp typecheck`
- [ ] Manual: with a phone number on the allowlist, send from a multi-device WhatsApp account and confirm the message is allowed instead of blocked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtReHGq5ME1k7RcB9Sm8UQ)_