### PR TITLE
Fix subagent continuation queue routing

### DIFF
--- a/apps/desktop/src/main/acp/internal-agent-utils.test.ts
+++ b/apps/desktop/src/main/acp/internal-agent-utils.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  countPersistedSeedMessages,
+  resolveQueuedSubSessionTarget,
+} from './internal-agent-utils';
+import type { ACPSubAgentMessage } from '../../shared/types';
+
+describe('countPersistedSeedMessages', () => {
+  it('matches persisted tool batches that include tool-name prefixes', () => {
+    const seedHistory: ACPSubAgentMessage[] = [
+      { role: 'user', content: 'Run checks', timestamp: 1 },
+      {
+        role: 'tool',
+        toolName: 'execute_command',
+        content: 'build passed',
+        timestamp: 2,
+      },
+      {
+        role: 'tool',
+        toolName: 'read_file',
+        content: 'config value',
+        timestamp: 3,
+      },
+      { role: 'assistant', content: 'Done', timestamp: 4 },
+    ];
+
+    const persistedMessages = [
+      { role: 'user', content: 'Run checks' },
+      { role: 'tool', content: '[execute_command] build passed\n\n[read_file] config value' },
+      { role: 'assistant', content: 'Done' },
+    ];
+
+    expect(countPersistedSeedMessages(seedHistory, persistedMessages)).toBe(4);
+  });
+
+  it('normalizes whitespace before deciding a seed message is missing', () => {
+    const seedHistory: ACPSubAgentMessage[] = [
+      { role: 'user', content: 'Line one\n\nLine two', timestamp: 1 },
+      { role: 'assistant', content: 'Ready', timestamp: 2 },
+    ];
+
+    const persistedMessages = [
+      { role: 'user', content: 'Line one Line two' },
+      { role: 'assistant', content: 'Ready' },
+    ];
+
+    expect(countPersistedSeedMessages(seedHistory, persistedMessages)).toBe(2);
+  });
+});
+
+describe('resolveQueuedSubSessionTarget', () => {
+  const subSessions = new Map([
+    ['subsession_done', { id: 'subsession_done', conversationId: 'conv-1', status: 'completed' as const }],
+    ['subsession_running', { id: 'subsession_running', conversationId: 'conv-1', status: 'running' as const }],
+    ['subsession_other_conv', { id: 'subsession_other_conv', conversationId: 'conv-2', status: 'completed' as const }],
+  ]);
+
+  it('uses the current sub-session when the queued message has no sub-session target', () => {
+    expect(resolveQueuedSubSessionTarget(
+      'subsession_current',
+      'conv-1',
+      undefined,
+      id => subSessions.get(id),
+    )).toEqual({ status: 'ready', subSessionId: 'subsession_current' });
+  });
+
+  it('routes FIFO work to a retained completed target sub-session', () => {
+    expect(resolveQueuedSubSessionTarget(
+      'subsession_current',
+      'conv-1',
+      'subsession_done',
+      id => subSessions.get(id),
+    )).toEqual({ status: 'ready', subSessionId: 'subsession_done' });
+  });
+
+  it('waits for active target sub-sessions to finish their own drain', () => {
+    expect(resolveQueuedSubSessionTarget(
+      'subsession_current',
+      'conv-1',
+      'subsession_running',
+      id => subSessions.get(id),
+    )).toEqual({ status: 'wait', subSessionId: 'subsession_running' });
+  });
+
+  it('fails stale or mismatched queue heads explicitly', () => {
+    expect(resolveQueuedSubSessionTarget(
+      'subsession_current',
+      'conv-1',
+      'subsession_missing',
+      id => subSessions.get(id),
+    )).toEqual({
+      status: 'failed',
+      error: 'Queued sub-session target no longer exists: subsession_missing',
+    });
+
+    expect(resolveQueuedSubSessionTarget(
+      'subsession_current',
+      'conv-1',
+      'subsession_other_conv',
+      id => subSessions.get(id),
+    )).toEqual({
+      status: 'failed',
+      error: 'Queued message target subsession_other_conv belongs to conversation conv-2, not conv-1',
+    });
+  });
+});

--- a/apps/desktop/src/main/acp/internal-agent-utils.ts
+++ b/apps/desktop/src/main/acp/internal-agent-utils.ts
@@ -1,0 +1,119 @@
+import type { ACPSubAgentMessage } from '../../shared/types';
+
+type PersistedSeedMessage = {
+  role: string;
+  content?: string;
+};
+
+type QueueTargetSubSession = {
+  id: string;
+  conversationId?: string;
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled';
+};
+
+export type QueuedSubSessionTargetResolution =
+  | { status: 'ready'; subSessionId: string }
+  | { status: 'wait'; subSessionId: string }
+  | { status: 'failed'; error: string };
+
+function normalizeSeedMessageContent(content?: string): string {
+  return (content ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function stripPersistedToolPrefix(content: string): string {
+  return content.replace(/^\[[^\]]+\]\s*(?:ERROR:\s*)?/, '');
+}
+
+function isMatchingSeedMessage(
+  seedMessage: ACPSubAgentMessage,
+  persistedMessage: PersistedSeedMessage,
+): boolean {
+  if (persistedMessage.role !== seedMessage.role) {
+    return false;
+  }
+
+  const seedContent = normalizeSeedMessageContent(seedMessage.content);
+  const persistedContent = normalizeSeedMessageContent(persistedMessage.content);
+  if (seedContent === persistedContent) {
+    return true;
+  }
+
+  if (seedMessage.role !== 'tool' || !seedContent || !persistedContent) {
+    return false;
+  }
+
+  const persistedToolContent = normalizeSeedMessageContent(stripPersistedToolPrefix(persistedMessage.content ?? ''));
+  if (persistedToolContent === seedContent || persistedToolContent.includes(seedContent)) {
+    return true;
+  }
+
+  return !!seedMessage.toolName && persistedContent.startsWith(`[${seedMessage.toolName}] `);
+}
+
+export function countPersistedSeedMessages(
+  seedHistory: ACPSubAgentMessage[],
+  persistedMessages: PersistedSeedMessage[],
+): number {
+  let seedIndex = 0;
+  for (const persistedMessage of persistedMessages) {
+    const seedMessage = seedHistory[seedIndex];
+    if (!seedMessage) {
+      break;
+    }
+
+    if (seedMessage.role === 'tool' && persistedMessage.role === 'tool') {
+      let matchedToolCount = 0;
+      while (
+        seedHistory[seedIndex]?.role === 'tool' &&
+        isMatchingSeedMessage(seedHistory[seedIndex], persistedMessage)
+      ) {
+        seedIndex += 1;
+        matchedToolCount += 1;
+      }
+      if (matchedToolCount > 0) {
+        continue;
+      }
+    }
+
+    if (isMatchingSeedMessage(seedMessage, persistedMessage)) {
+      seedIndex += 1;
+    }
+  }
+  return seedIndex;
+}
+
+export function resolveQueuedSubSessionTarget(
+  currentSubSessionId: string,
+  conversationId: string,
+  queuedSessionId: string | undefined,
+  getSubSession: (subSessionId: string) => QueueTargetSubSession | undefined,
+): QueuedSubSessionTargetResolution {
+  const targetSubSessionId = queuedSessionId?.startsWith('subsession_')
+    ? queuedSessionId
+    : currentSubSessionId;
+
+  if (targetSubSessionId === currentSubSessionId) {
+    return { status: 'ready', subSessionId: targetSubSessionId };
+  }
+
+  const targetSubSession = getSubSession(targetSubSessionId);
+  if (!targetSubSession) {
+    return {
+      status: 'failed',
+      error: `Queued sub-session target no longer exists: ${targetSubSessionId}`,
+    };
+  }
+
+  if (targetSubSession.conversationId !== conversationId) {
+    return {
+      status: 'failed',
+      error: `Queued message target ${targetSubSessionId} belongs to conversation ${targetSubSession.conversationId ?? 'unknown'}, not ${conversationId}`,
+    };
+  }
+
+  if (targetSubSession.status === 'running' || targetSubSession.status === 'pending') {
+    return { status: 'wait', subSessionId: targetSubSessionId };
+  }
+
+  return { status: 'ready', subSessionId: targetSubSessionId };
+}

--- a/apps/desktop/src/main/acp/internal-agent.ts
+++ b/apps/desktop/src/main/acp/internal-agent.ts
@@ -26,6 +26,7 @@ import { configStore } from '../config';
 import { conversationService } from '../conversation-service';
 import { messageQueueService } from '../message-queue-service';
 import { clearAcpToAppSessionMapping, setAcpToAppSessionMapping } from '../acp-session-state';
+import { countPersistedSeedMessages, resolveQueuedSubSessionTarget } from './internal-agent-utils';
 import { stringifySubAgentToolResultContent } from '@shared/delegation-tool-display'
 import type { AgentProgressUpdate, SessionProfileSnapshot, ACPDelegationProgress, ACPSubAgentMessage, ConversationMessage, AgentProfile } from '../../shared/types';
 import type { MCPToolCall, MCPToolResult } from '../mcp-service';
@@ -157,6 +158,16 @@ export function getChildSubSessions(parentSessionId: string): InternalSubSession
 }
 
 /**
+ * Get all retained sub-sessions for a parent, including completed children
+ * whose parent link was removed after the run ended but can still receive
+ * queued follow-up continuations.
+ */
+export function getAllSubSessionsForParent(parentSessionId: string): InternalSubSession[] {
+  return Array.from(activeSubSessions.values())
+    .filter(subSession => subSession.parentSessionId === parentSessionId);
+}
+
+/**
  * Get an internal sub-session by ID, including completed/cancelled sub-sessions
  * retained for UI history and follow-up continuations.
  */
@@ -190,13 +201,38 @@ function removeParentChildLink(parentSessionId: string, subSessionId: string): v
   }
 }
 
+async function appendMissingSeedMessages(
+  conversationId: string,
+  seedHistory: ACPSubAgentMessage[],
+  startIndex: number,
+): Promise<void> {
+  for (const message of seedHistory.slice(startIndex)) {
+    const updatedConversation = await conversationService.addMessageToConversation(
+      conversationId,
+      message.content,
+      message.role,
+    );
+    if (!updatedConversation) {
+      throw new Error(`Failed to persist ${message.role} seed message to conversation ${conversationId}`);
+    }
+  }
+}
+
 async function ensureDedicatedSubSessionConversation(
   subSession: InternalSubSession,
   seedHistory: ACPSubAgentMessage[],
 ): Promise<string | undefined> {
   const parentConversationId = agentSessionTracker.getConversationIdForSession(subSession.parentSessionId);
   if (subSession.conversationId && subSession.conversationId !== parentConversationId) {
-    return subSession.conversationId;
+    const conversation = await conversationService.loadConversation(subSession.conversationId);
+    if (conversation) {
+      const persistedMessages = conversation.rawMessages ?? conversation.messages ?? [];
+      const persistedSeedCount = countPersistedSeedMessages(seedHistory, persistedMessages);
+      await appendMissingSeedMessages(subSession.conversationId, seedHistory, persistedSeedCount);
+      return subSession.conversationId;
+    }
+
+    delete subSession.conversationId;
   }
 
   const firstMessage = seedHistory.find(msg => msg.role === 'user' || msg.role === 'assistant');
@@ -210,14 +246,8 @@ async function ensureDedicatedSubSessionConversation(
   );
   subSession.conversationId = conversation.id;
 
-  for (const message of seedHistory) {
-    if (message === firstMessage) continue;
-    await conversationService.addMessageToConversation(
-      conversation.id,
-      message.content,
-      message.role,
-    );
-  }
+  const firstMessageIndex = seedHistory.indexOf(firstMessage);
+  await appendMissingSeedMessages(conversation.id, seedHistory, firstMessageIndex + 1);
 
   return conversation.id;
 }
@@ -240,20 +270,39 @@ async function drainQueuedInternalSubSessionMessages(subSessionId: string): Prom
         return;
       }
 
-      if (queuedMessage.sessionId !== subSessionId) {
+      const targetResolution = resolveQueuedSubSessionTarget(
+        subSessionId,
+        conversationId,
+        queuedMessage.sessionId,
+        id => activeSubSessions.get(id),
+      );
+      if (targetResolution.status === 'failed') {
+        messageQueueService.markFailed(conversationId, queuedMessage.id, targetResolution.error);
         return;
+      }
+      if (targetResolution.status === 'wait') {
+        logSubSession(
+          `Queue head ${queuedMessage.id} for ${conversationId} belongs to active ${targetResolution.subSessionId}; waiting for that sub-session to drain it`,
+        );
+        return;
+      }
+
+      if (targetResolution.subSessionId !== subSessionId) {
+        logSubSession(
+          `Queue head ${queuedMessage.id} for ${conversationId} belongs to ${targetResolution.subSessionId}; routing FIFO drain from ${subSessionId}`,
+        );
       }
 
       if (!messageQueueService.markProcessing(conversationId, queuedMessage.id)) {
         continue;
       }
 
-      const result = await continueInternalSubSession(subSessionId, queuedMessage.text);
+      const result = await continueInternalSubSession(targetResolution.subSessionId, queuedMessage.text);
       if (!result.success) {
         messageQueueService.markFailed(
           conversationId,
           queuedMessage.id,
-          result.error || `Failed to continue internal sub-session ${subSessionId}`,
+          result.error || `Failed to continue internal sub-session ${targetResolution.subSessionId}`,
         );
         return;
       }
@@ -729,7 +778,11 @@ export async function runInternalSubSession(
       ?? (cfg.mcpUnlimitedIterations ? Infinity : (cfg.mcpMaxIterations ?? DEFAULT_SUB_SESSION_MAX_ITERATIONS));
 
     subSession.conversationId = conversationId;
-    await ensureDedicatedSubSessionConversation(subSession, subSession.conversationHistory);
+    try {
+      await ensureDedicatedSubSessionConversation(subSession, subSession.conversationHistory);
+    } catch (error) {
+      logSubSession(`Failed to create dedicated conversation for ${subSessionId}, continuing without persistence:`, error);
+    }
 
     const result = await processTranscriptWithAgentMode(
       fullPrompt,
@@ -881,6 +934,7 @@ export async function continueInternalSubSession(
   const parentSessionId = subSession.parentSessionId;
   const startedAt = Date.now();
   const previousConversationHistory = toAgentConversationHistory(subSession.conversationHistory);
+  const historyLengthBeforeContinuation = subSession.conversationHistory.length;
   const effectiveProfileSnapshot = subSession.profileSnapshot
     ?? agentSessionStateManager.getSessionProfileSnapshot(parentSessionId)
     ?? agentSessionTracker.getSessionProfileSnapshot(parentSessionId);
@@ -893,11 +947,6 @@ export async function continueInternalSubSession(
   subSession.delegationRunId = `${subSession.id}:turn:${startedAt}`;
   subSession.profileSnapshot = effectiveProfileSnapshot;
   subSession.parentRunId = agentSessionStateManager.getSessionRunId(parentSessionId);
-  subSession.conversationHistory.push({
-    role: 'user',
-    content: message,
-    timestamp: startedAt,
-  });
 
   addParentChildLink(parentSessionId, subSessionId);
   setAcpToAppSessionMapping(subSessionId, parentSessionId, subSession.parentRunId, { registerAppSession: true });
@@ -908,6 +957,12 @@ export async function continueInternalSubSession(
   } catch (error) {
     logSubSession(`Failed to create dedicated conversation for ${subSessionId}, continuing without persistence:`, error);
   }
+
+  subSession.conversationHistory.push({
+    role: 'user',
+    content: message,
+    timestamp: startedAt,
+  });
 
   emitSubSessionDelegationProgress(subSession, parentSessionId);
 
@@ -1013,6 +1068,16 @@ export async function continueInternalSubSession(
           timestamp: Date.now(),
         });
       }
+
+      try {
+        await ensureDedicatedSubSessionConversation(subSession, subSession.conversationHistory);
+      } catch (error) {
+        logSubSession(`Failed to persist continuation history for ${subSessionId}:`, error);
+      }
+    }
+
+    if (wasCancelled) {
+      subSession.conversationHistory.splice(historyLengthBeforeContinuation);
     }
 
     emitSubSessionDelegationProgress(subSession, parentSessionId);
@@ -1049,6 +1114,7 @@ export async function continueInternalSubSession(
       ? 'Sub-session was cancelled'
       : error instanceof Error ? error.message : String(error);
 
+    subSession.conversationHistory.splice(historyLengthBeforeContinuation);
     emitSubSessionDelegationProgress(subSession, parentSessionId);
 
     if (wasCancelled) {

--- a/apps/desktop/src/main/discord-service.ts
+++ b/apps/desktop/src/main/discord-service.ts
@@ -1,10 +1,9 @@
 import type { Client, Message } from "discord.js"
 import { configStore } from "./config"
-import { getResolvedRemoteServerApiKey } from "./remote-server"
+import { getResolvedRemoteServerApiKey } from "./remote-server-secret"
 import { emergencyStopAll } from "./emergency-stop"
 import { logApp } from "./debug"
 import { agentProfileService } from "./agent-profile-service"
-import { runAgent } from "./remote-server"
 import {
   getDiscordResolvedDefaultProfileId,
   getDiscordResolvedToken,
@@ -1316,6 +1315,7 @@ class DiscordService {
         }
 
         try {
+          const { runAgent } = await import("./remote-server")
           const result = await runAgent({
             prompt: enrichedPrompt,
             conversationId,

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -15,7 +15,7 @@ import type {
   ClientCapabilities,
 } from "@modelcontextprotocol/sdk/types.js"
 import { configStore, dataFolder, trySaveConfig } from "./config"
-import { getResolvedRemoteServerApiKey } from "./remote-server"
+import { getResolvedRemoteServerApiKey } from "./remote-server-secret"
 import {
   MCPConfig,
   MCPServerConfig,

--- a/apps/desktop/src/main/remote-server-secret.ts
+++ b/apps/desktop/src/main/remote-server-secret.ts
@@ -1,0 +1,63 @@
+import fs from "fs"
+import path from "path"
+import { configStore, globalAgentsFolder } from "./config"
+import type { Config } from "../shared/types"
+
+export const DOTAGENTS_SECRET_REF_PREFIX = "dotagents-secret://"
+export const DOTAGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"
+
+function getSecretReferenceCandidates(secretId: string): string[] {
+  const candidates = new Set<string>([secretId])
+  let current = secretId
+
+  for (let i = 0; i < 3; i += 1) {
+    try {
+      const decoded = decodeURIComponent(current)
+      if (decoded === current) break
+      candidates.add(decoded)
+      current = decoded
+    } catch {
+      break
+    }
+  }
+
+  return [...candidates]
+}
+
+export function readDotAgentsSecretReference(value: string): string | undefined {
+  if (!value.startsWith(DOTAGENTS_SECRET_REF_PREFIX)) {
+    return value
+  }
+
+  const secretId = value.slice(DOTAGENTS_SECRET_REF_PREFIX.length)
+  if (!secretId) return undefined
+
+  try {
+    const secretsPath = path.join(globalAgentsFolder, DOTAGENTS_SECRETS_LOCAL_JSON)
+    const parsed = JSON.parse(fs.readFileSync(secretsPath, "utf8")) as { secrets?: Record<string, unknown> }
+    const secrets = parsed && typeof parsed === "object" ? parsed.secrets : undefined
+    if (!secrets || typeof secrets !== "object") return undefined
+
+    for (const candidate of getSecretReferenceCandidates(secretId)) {
+      const secret = secrets[candidate]
+      if (typeof secret === "string" && secret.length > 0) {
+        return secret
+      }
+    }
+  } catch {
+    // Missing or invalid local secret storage should not expose the reference.
+  }
+
+  return undefined
+}
+
+export function getResolvedRemoteServerApiKey(cfg: Pick<Config, "remoteServerApiKey"> = configStore.get()): string {
+  const resolved = cfg.remoteServerApiKey
+    ? readDotAgentsSecretReference(cfg.remoteServerApiKey)
+    : undefined
+  return resolved?.trim() || ""
+}
+
+export function hasConfiguredRemoteServerApiKey(cfg: Pick<Config, "remoteServerApiKey"> = configStore.get()): boolean {
+  return (cfg.remoteServerApiKey ?? "").trim().length > 0
+}

--- a/apps/desktop/src/main/remote-server.routes.test.ts
+++ b/apps/desktop/src/main/remote-server.routes.test.ts
@@ -9,6 +9,12 @@ function getRemoteServerSource(): string {
   return readFileSync(remoteServerPath, "utf8")
 }
 
+function getRemoteServerSecretSource(): string {
+  const testDir = path.dirname(fileURLToPath(import.meta.url))
+  const remoteServerSecretPath = path.join(testDir, "remote-server-secret.ts")
+  return readFileSync(remoteServerSecretPath, "utf8")
+}
+
 function getDuplicateRoutes(source: string): Array<{ key: string; lines: number[] }> {
   const routeRegex = /fastify\.(get|post|patch|delete|put)\("([^"]+)"/g
   const linesByRoute = new Map<string, number[]>()
@@ -210,11 +216,13 @@ describe("remote-server route registration", () => {
 
   it("resolves remote server secret references only for authenticated pairing surfaces", () => {
     const source = getRemoteServerSource()
+    const secretSource = getRemoteServerSecretSource()
 
-    expect(source).toContain('const DOTAGENTS_SECRET_REF_PREFIX = "dotagents-secret://"')
-    expect(source).toContain('const DOTAGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"')
-    expect(source).toContain("function getResolvedRemoteServerApiKey")
-    expect(source).toContain("function hasConfiguredRemoteServerApiKey")
+    expect(source).toContain('from "./remote-server-secret"')
+    expect(secretSource).toContain('export const DOTAGENTS_SECRET_REF_PREFIX = "dotagents-secret://"')
+    expect(secretSource).toContain('export const DOTAGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"')
+    expect(secretSource).toContain("export function getResolvedRemoteServerApiKey")
+    expect(secretSource).toContain("export function hasConfiguredRemoteServerApiKey")
     expect(source).toContain("const hasConfiguredApiKey = hasConfiguredRemoteServerApiKey(cfg)")
     expect(source).toContain("!configuredApiKey && !hasConfiguredApiKey")
     expect(source).toContain("Remote server API key is configured but could not be resolved; preserving configured value")

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -9,8 +9,12 @@ import fs from "fs"
 import os from "os"
 import path from "path"
 import QRCode from "qrcode"
-import { configStore, globalAgentsFolder, recordingsFolder } from "./config"
+import { configStore, recordingsFolder } from "./config"
 import { getConversationIdValidationError } from "./conversation-id"
+import {
+  getResolvedRemoteServerApiKey,
+  hasConfiguredRemoteServerApiKey,
+} from "./remote-server-secret"
 import {
   DISCORD_SECRET_MASK,
   getDiscordLifecycleAction,
@@ -91,8 +95,6 @@ let server: FastifyInstance | null = null
 let lastError: string | undefined
 
 const REMOTE_SERVER_SECRET_MASK = "••••••••"
-const DOTAGENTS_SECRET_REF_PREFIX = "dotagents-secret://"
-const DOTAGENTS_SECRETS_LOCAL_JSON = "secrets.local.json"
 const OPERATOR_AUDIT_LOG_LIMIT = 200
 const OPERATOR_AUDIT_DEVICE_HEADER_KEYS = ["x-device-id", "x-dotagents-device-id"] as const
 const SENSITIVE_OPERATOR_SETTINGS_KEYS = new Set([
@@ -398,62 +400,6 @@ function redact(value?: string) {
 
 function generateRemoteServerApiKey(): string {
   return crypto.randomBytes(32).toString("hex")
-}
-
-function getSecretReferenceCandidates(secretId: string): string[] {
-  const candidates = new Set<string>([secretId])
-  let current = secretId
-
-  for (let i = 0; i < 3; i += 1) {
-    try {
-      const decoded = decodeURIComponent(current)
-      if (decoded === current) break
-      candidates.add(decoded)
-      current = decoded
-    } catch {
-      break
-    }
-  }
-
-  return [...candidates]
-}
-
-function readDotAgentsSecretReference(value: string): string | undefined {
-  if (!value.startsWith(DOTAGENTS_SECRET_REF_PREFIX)) {
-    return value
-  }
-
-  const secretId = value.slice(DOTAGENTS_SECRET_REF_PREFIX.length)
-  if (!secretId) return undefined
-
-  try {
-    const secretsPath = path.join(globalAgentsFolder, DOTAGENTS_SECRETS_LOCAL_JSON)
-    const parsed = JSON.parse(fs.readFileSync(secretsPath, "utf8")) as { secrets?: Record<string, unknown> }
-    const secrets = parsed && typeof parsed === "object" ? parsed.secrets : undefined
-    if (!secrets || typeof secrets !== "object") return undefined
-
-    for (const candidate of getSecretReferenceCandidates(secretId)) {
-      const secret = secrets[candidate]
-      if (typeof secret === "string" && secret.length > 0) {
-        return secret
-      }
-    }
-  } catch {
-    // Missing or invalid local secret storage should not expose the reference.
-  }
-
-  return undefined
-}
-
-export function getResolvedRemoteServerApiKey(cfg: Pick<Config, "remoteServerApiKey"> = configStore.get()): string {
-  const resolved = cfg.remoteServerApiKey
-    ? readDotAgentsSecretReference(cfg.remoteServerApiKey)
-    : undefined
-  return resolved?.trim() || ""
-}
-
-function hasConfiguredRemoteServerApiKey(cfg: Pick<Config, "remoteServerApiKey"> = configStore.get()): boolean {
-  return (cfg.remoteServerApiKey ?? "").trim().length > 0
 }
 
 function sanitizeOperatorAuditText(value: string | undefined, maxLength: number = 160): string | undefined {

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1348,22 +1348,38 @@ export const router = {
       // Cancel any pending tool approvals for this session so executeToolCall doesn't hang
       toolApprovalManager.cancelSessionApprovals(input.sessionId)
 
+      const conversationIdsToPause = new Set<string>()
       let requestedSubSessionConversationId: string | undefined
 
       // Cancel any internal sub-sessions spawned by this session
       try {
-        const { getChildSubSessions, cancelSubSession, getInternalSubSession } = await import("./acp/internal-agent")
+        const {
+          getChildSubSessions,
+          getAllSubSessionsForParent,
+          cancelSubSession,
+          getInternalSubSession,
+        } = await import("./acp/internal-agent")
         requestedSubSessionConversationId = requestedSessionKind === "subsession"
           ? getInternalSubSession(requestedSessionId)?.conversationId
           : undefined
+        if (requestedSubSessionConversationId) {
+          conversationIdsToPause.add(requestedSubSessionConversationId)
+        }
         const cancelledRequestedSubSession = requestedSessionKind === "subsession"
           ? cancelSubSession(requestedSessionId)
           : false
-        const childSessions = getChildSubSessions(input.sessionId)
+        const childSessionsById = new Map(
+          [...getChildSubSessions(input.sessionId), ...getAllSubSessionsForParent(input.sessionId)]
+            .map((child) => [child.id, child] as const),
+        )
+        const childSessions = Array.from(childSessionsById.values())
         const runningChildSessionIds = childSessions
           .filter((child) => child.status === "running")
           .map((child) => child.id)
         for (const child of childSessions) {
+          if (child.conversationId) {
+            conversationIdsToPause.add(child.conversationId)
+          }
           if (child.status === "running") {
             cancelSubSession(child.id)
             logLLM(`[stopAgentSession] Cancelled internal sub-session ${child.id}`)
@@ -1384,13 +1400,22 @@ export const router = {
       const session = agentSessionTracker.getSession(input.sessionId)
       const conversationIdToPause = session?.conversationId ?? requestedSubSessionConversationId ?? mappedTrackedSession?.conversationId
       if (conversationIdToPause) {
-        messageQueueService.pauseQueue(conversationIdToPause)
-        logLLM(`[stopAgentSession] Paused queue for conversation ${conversationIdToPause}`)
-        logApp("[stopAgentSession] Queue paused", {
+        conversationIdsToPause.add(conversationIdToPause)
+      }
+
+      if (conversationIdsToPause.size > 0) {
+        for (const conversationId of conversationIdsToPause) {
+          messageQueueService.pauseQueue(conversationId)
+          logLLM(`[stopAgentSession] Paused queue for conversation ${conversationId}`)
+        }
+        logApp("[stopAgentSession] Queues paused", {
           requestedSessionId,
-          pausedConversationId: conversationIdToPause,
+          pausedConversationIds: Array.from(conversationIdsToPause),
           pausedByTrackedSessionId: session?.id ?? mappedTrackedSession?.id ?? null,
-          queueLength: messageQueueService.getQueue(conversationIdToPause).length,
+          queueLengths: Array.from(conversationIdsToPause).map((conversationId) => ({
+            conversationId,
+            queueLength: messageQueueService.getQueue(conversationId).length,
+          })),
         })
       } else {
         logApp("[stopAgentSession] Queue pause skipped because requested session is not tracked", {

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.layout.test.ts
@@ -9,4 +9,11 @@ describe("active agents sidebar layout", () => {
     expect(sidebarSource).toContain('className="rounded-lg border border-border/60 bg-muted/20 p-2"')
     expect(sidebarSource).toContain('title="Start text session"')
   })
+
+  it("marks selected nested subagent rows with a visible selected state", () => {
+    expect(sidebarSource).toContain("const isSelectedNestedSubagent = isNestedSubagent && isCurrentView")
+    expect(sidebarSource).toContain('aria-current={isCurrentView ? "true" : undefined}')
+    expect(sidebarSource).toContain("bg-blue-500/15 text-foreground ring-1 ring-inset ring-blue-500/25")
+    expect(sidebarSource).toContain('isSelectedNestedSubagent ? "bg-blue-500" : statusRailColor')
+  })
 })

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -28,6 +28,7 @@ import {
   getSidebarSessionGroupKey,
   getLatestAgentResponseTimestamp,
   getSidebarProgressTitle,
+  hasSidebarSessionGroupKey,
   getSessionIdsWithActiveChildProgress,
   getSubagentTitleBySessionIdMap,
   getSubagentParentSessionIdMap,
@@ -696,7 +697,7 @@ export function ActiveAgentsSidebar({
         const conversationId = entry.session.conversationId
         return (
           (!!conversationId && pinnedSessionIds.has(conversationId)) ||
-          alwaysVisibleSessionKeys.has(getSidebarSessionGroupKey(entry.session))
+          hasSidebarSessionGroupKey(entry.session, alwaysVisibleSessionKeys)
         )
       }),
     [allUserSidebarSessions, alwaysVisibleSessionKeys, pinnedSessionIds, sessionGroups],
@@ -731,7 +732,7 @@ export function ActiveAgentsSidebar({
       if (!entry.isSavedConversation) return false
       const conversationId = entry.session.conversationId
       if (conversationId && pinnedSessionIds.has(conversationId)) return false
-      return !alwaysVisibleSessionKeys.has(getSidebarSessionGroupKey(entry.session))
+      return !hasSidebarSessionGroupKey(entry.session, alwaysVisibleSessionKeys)
     }).length,
     [alwaysVisibleSessionKeys, pinnedSessionIds, userSidebarSessions],
   )
@@ -1709,6 +1710,7 @@ export function ActiveAgentsSidebar({
               Math.min(nestingDepth, 2),
             )
             const isNestedSubagent = isSubagent && normalizedNestingDepth > 0
+            const isSelectedNestedSubagent = isNestedSubagent && isCurrentView
             const subagentIndentClass = normalizedNestingDepth > 1 ? "ml-12" : "ml-8"
             const showSessionDetails =
               !forceSingleLine &&
@@ -1728,6 +1730,7 @@ export function ActiveAgentsSidebar({
                   ? (event) => handleSessionRowDrop(event, reorderContainerGroupId, sessionGroupKey)
                   : undefined}
                 onClick={() => handleActiveSessionSelect(session.id)}
+                aria-current={isCurrentView ? "true" : undefined}
                 className={cn(
                   "group relative flex cursor-pointer items-start rounded text-xs transition-all",
                   isNestedSubagent
@@ -1736,8 +1739,8 @@ export function ActiveAgentsSidebar({
                   isNestedSubagent
                     ? isLifecycleNeedsInput
                       ? "text-amber-700 hover:bg-amber-500/5 dark:text-amber-300"
-                      : isCurrentView
-                        ? "bg-muted/25 text-foreground"
+                      : isSelectedNestedSubagent
+                        ? "bg-blue-500/15 text-foreground ring-1 ring-inset ring-blue-500/25 shadow-[inset_2px_0_0_rgb(59_130_246)]"
                         : "text-muted-foreground hover:bg-muted/20"
                     : isLifecycleNeedsInput
                       ? "bg-amber-500/10"
@@ -1754,7 +1757,10 @@ export function ActiveAgentsSidebar({
                 {isNestedSubagent && (
                   <span
                     aria-hidden="true"
-                    className="pointer-events-none absolute -left-6 top-0 h-1/2 w-6 rounded-bl border-b border-l border-border/70"
+                    className={cn(
+                      "pointer-events-none absolute -left-6 top-0 h-1/2 w-6 rounded-bl border-b border-l",
+                      isSelectedNestedSubagent ? "border-blue-500/60" : "border-border/70",
+                    )}
                   />
                 )}
                 {!isNestedSubagent && isActivePinned ? (
@@ -1785,7 +1791,10 @@ export function ActiveAgentsSidebar({
                     {isNestedSubagent && (
                       <CornerDownRight
                         aria-hidden="true"
-                        className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/60"
+                        className={cn(
+                          "mt-0.5 h-3 w-3 shrink-0",
+                          isSelectedNestedSubagent ? "text-blue-500" : "text-muted-foreground/60",
+                        )}
                       />
                     )}
                     {isNestedSubagent && (
@@ -1793,7 +1802,7 @@ export function ActiveAgentsSidebar({
                         aria-hidden="true"
                         className={cn(
                           "mt-[5px] h-1.5 w-1.5 shrink-0 rounded-full",
-                          statusRailColor,
+                          isSelectedNestedSubagent ? "bg-blue-500" : statusRailColor,
                           shouldPulseStatus && "animate-pulse",
                         )}
                       />

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
@@ -5,6 +5,7 @@ import {
   dedupeTaskEntriesByTitle,
   filterPastSessionsAgainstActiveSessions,
   getSidebarSessionGroupKey,
+  getSidebarSessionGroupKeys,
   getSidebarActivityPresentation,
   getSidebarProgressTitle,
   getSubagentParentSessionIdMap,
@@ -13,6 +14,7 @@ import {
   getSessionIdsWithActiveChildProgress,
   getLatestAgentResponseTimestamp,
   hasUnreadAgentResponse,
+  hasSidebarSessionGroupKey,
   isProgressLiveForSidebar,
   isSidebarSessionCurrentlyViewed,
   moveSidebarSessionToGroupPosition,
@@ -62,6 +64,10 @@ describe("sidebar session groups", () => {
     expect(getSidebarSessionGroupKey(activeSession("session-1", "conversation-1"))).toBe(
       "conversation:conversation-1",
     )
+    expect(getSidebarSessionGroupKeys(activeSession("session-1", "conversation-1"))).toEqual([
+      "conversation:conversation-1",
+      "session:session-1",
+    ])
     expect(getSidebarSessionGroupKey(activeSession("session-2"))).toBe(
       "session:session-2",
     )
@@ -181,6 +187,20 @@ describe("sidebar session groups", () => {
     ])
   })
 
+  it("orders entries using older session keys after a conversation id is assigned", () => {
+    const entries = [
+      { session: activeSession("session-1", "conversation-1") },
+      { session: activeSession("session-2") },
+    ]
+
+    expect(orderSidebarSessionEntriesByKeys(entries, [
+      "session:session-1",
+    ]).map((entry) => entry.session.id)).toEqual([
+      "session-1",
+      "session-2",
+    ])
+  })
+
   it("normalizes persisted ungrouped session key order", () => {
     expect(normalizeSidebarSessionKeyOrder([
       " session:one ",
@@ -212,6 +232,32 @@ describe("sidebar session groups", () => {
     ])
     expect(result.ungroupedEntries.map((entry) => entry.session.id)).toEqual([
       "session-3",
+    ])
+  })
+
+  it("keeps folders populated when persisted keys predate conversation ids", () => {
+    const entries = [
+      { session: activeSession("session-1", "conversation-1") },
+      { session: activeSession("session-2", "conversation-2") },
+    ]
+
+    const groupedSessionKeys = new Set(["session:session-1"])
+    expect(hasSidebarSessionGroupKey(entries[0].session, groupedSessionKeys)).toBe(true)
+
+    const result = groupSidebarSessionEntries(entries, [
+      {
+        id: "group-a",
+        name: "A",
+        expanded: true,
+        sessionKeys: ["session:session-1"],
+      },
+    ])
+
+    expect(result.groupedSections[0]?.entries.map((entry) => entry.session.id)).toEqual([
+      "session-1",
+    ])
+    expect(result.ungroupedEntries.map((entry) => entry.session.id)).toEqual([
+      "session-2",
     ])
   })
 
@@ -1135,6 +1181,37 @@ describe("paginateSidebarEntries", () => {
       "personal",
     ])
     expect(paginated.hasMoreEntries).toBe(true)
+    expect(grouped.groupedSections[0]?.entries.map((entry) => entry.session.id)).toEqual([
+      "personal",
+    ])
+  })
+
+  it("keeps grouped saved entries visible when the group stores the older session key", () => {
+    const groupedSessionKeys = new Set(["session:personal"])
+    const paginated = paginateSidebarEntries(
+      [
+        { session: { id: "active", conversationId: "active-c" }, isSavedConversation: false },
+        { session: { id: "personal", conversationId: "personal-c" }, isSavedConversation: true },
+        { session: { id: "hidden", conversationId: "hidden-c" }, isSavedConversation: true },
+      ],
+      new Set(),
+      0,
+      groupedSessionKeys,
+    )
+
+    const grouped = groupSidebarSessionEntries(paginated.visibleEntries, [
+      {
+        id: "personal",
+        name: "Personal",
+        expanded: true,
+        sessionKeys: ["session:personal"],
+      },
+    ])
+
+    expect(paginated.visibleEntries.map((entry) => entry.session.id)).toEqual([
+      "active",
+      "personal",
+    ])
     expect(grouped.groupedSections[0]?.entries.map((entry) => entry.session.id)).toEqual([
       "personal",
     ])

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.ts
@@ -96,8 +96,22 @@ export interface SidebarActivityPresentation {
 type RepeatTaskTitleHints = ReadonlySet<string>
 
 export function getSidebarSessionGroupKey(session: SessionLike): string {
+  return getSidebarSessionGroupKeys(session)[0]
+}
+
+export function getSidebarSessionGroupKeys(session: SessionLike): string[] {
   const conversationId = session.conversationId?.trim()
-  return conversationId ? `conversation:${conversationId}` : `session:${session.id}`
+  const keys = conversationId
+    ? [`conversation:${conversationId}`, `session:${session.id}`]
+    : [`session:${session.id}`]
+  return Array.from(new Set(keys))
+}
+
+export function hasSidebarSessionGroupKey(
+  session: SessionLike,
+  sessionKeys: ReadonlySet<string>,
+): boolean {
+  return getSidebarSessionGroupKeys(session).some((key) => sessionKeys.has(key))
 }
 
 export function normalizeSidebarSessionKeyOrder(input: unknown): string[] {
@@ -259,28 +273,34 @@ export function groupSidebarSessionEntries<T extends { session: SessionLike }>(
 ): { groupedSections: SidebarSessionGroupSection<T>[]; ungroupedEntries: T[] } {
   const entryBySessionKey = new Map<string, T>()
   for (const entry of entries) {
-    const sessionKey = getSidebarSessionGroupKey(entry.session)
-    if (!entryBySessionKey.has(sessionKey)) {
-      entryBySessionKey.set(sessionKey, entry)
+    for (const sessionKey of getSidebarSessionGroupKeys(entry.session)) {
+      if (!entryBySessionKey.has(sessionKey)) {
+        entryBySessionKey.set(sessionKey, entry)
+      }
     }
   }
 
   const groupedSessionKeys = new Set<string>()
+  const groupedSessionIds = new Set<string>()
   const groupedSections = groups.map((group) => {
     const seenInGroup = new Set<string>()
     const groupedEntries = group.sessionKeys.flatMap((sessionKey) => {
       if (seenInGroup.has(sessionKey) || groupedSessionKeys.has(sessionKey)) return []
       seenInGroup.add(sessionKey)
       const entry = entryBySessionKey.get(sessionKey)
+      if (entry && groupedSessionIds.has(entry.session.id)) return []
       if (!entry) return []
-      groupedSessionKeys.add(sessionKey)
+      groupedSessionIds.add(entry.session.id)
+      for (const key of getSidebarSessionGroupKeys(entry.session)) {
+        groupedSessionKeys.add(key)
+      }
       return [entry]
     })
     return { group, entries: groupedEntries }
   })
 
   const ungroupedEntries = entries.filter(
-    (entry) => !groupedSessionKeys.has(getSidebarSessionGroupKey(entry.session)),
+    (entry) => !hasSidebarSessionGroupKey(entry.session, groupedSessionKeys),
   )
 
   return { groupedSections, ungroupedEntries }
@@ -294,24 +314,29 @@ export function orderSidebarSessionEntriesByKeys<T extends { session: SessionLik
 
   const entryBySessionKey = new Map<string, T>()
   for (const entry of entries) {
-    const sessionKey = getSidebarSessionGroupKey(entry.session)
-    if (!entryBySessionKey.has(sessionKey)) {
-      entryBySessionKey.set(sessionKey, entry)
+    for (const sessionKey of getSidebarSessionGroupKeys(entry.session)) {
+      if (!entryBySessionKey.has(sessionKey)) {
+        entryBySessionKey.set(sessionKey, entry)
+      }
     }
   }
 
   const orderedEntries: T[] = []
   const seenSessionKeys = new Set<string>()
+  const seenSessionIds = new Set<string>()
   for (const sessionKey of orderedSessionKeys) {
     const entry = entryBySessionKey.get(sessionKey)
-    if (!entry || seenSessionKeys.has(sessionKey)) continue
+    if (!entry || seenSessionKeys.has(sessionKey) || seenSessionIds.has(entry.session.id)) continue
     orderedEntries.push(entry)
-    seenSessionKeys.add(sessionKey)
+    seenSessionIds.add(entry.session.id)
+    for (const key of getSidebarSessionGroupKeys(entry.session)) {
+      seenSessionKeys.add(key)
+    }
   }
 
   return [
     ...orderedEntries,
-    ...entries.filter((entry) => !seenSessionKeys.has(getSidebarSessionGroupKey(entry.session))),
+    ...entries.filter((entry) => !hasSidebarSessionGroupKey(entry.session, seenSessionKeys)),
   ]
 }
 
@@ -497,13 +522,12 @@ export function paginateSidebarEntries<
   const pageableEntries: T[] = []
   for (const entry of entries) {
     const conversationId = entry.session.conversationId
-    const sessionKey = getSidebarSessionGroupKey(entry.session)
     const isPinnedSavedConversation =
       entry.isSavedConversation &&
       !!conversationId &&
       pinnedSessionIds.has(conversationId)
     const isGroupedSavedConversation =
-      entry.isSavedConversation && alwaysVisibleSessionKeys.has(sessionKey)
+      entry.isSavedConversation && hasSidebarSessionGroupKey(entry.session, alwaysVisibleSessionKeys)
 
     if (!entry.isSavedConversation || isPinnedSavedConversation || isGroupedSavedConversation) {
       alwaysVisibleEntries.push(entry)

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -2113,7 +2113,7 @@ export default function ChatScreen({ route, navigation }: any) {
     // If message queue is enabled and we're already responding, queue the message
     if (messageQueueEnabled && responding) {
       console.log('[ChatScreen] Agent busy, queuing message:', getMessageLogMeta(text));
-      messageQueue.enqueue(currentConversationId, text);
+      messageQueue.enqueue(currentConversationId, text, currentConversationId);
       setInput('');
       if (options?.fromComposer) {
         setPendingImages([]);
@@ -2957,7 +2957,7 @@ export default function ChatScreen({ route, navigation }: any) {
     const composedMessage = buildMessageWithPendingImages(input, pendingImages);
     if (!composedMessage.trim()) return;
 
-    messageQueue.enqueue(currentConversationId, composedMessage);
+    messageQueue.enqueue(currentConversationId, composedMessage, currentConversationId);
     setInput('');
     setPendingImages([]);
     setDebugInfo('Message queued. Use Send Next when you are ready.');

--- a/apps/mobile/src/store/message-queue.ts
+++ b/apps/mobile/src/store/message-queue.ts
@@ -19,7 +19,7 @@ export interface MessageQueueStore {
   queues: Map<string, QueuedMessage[]>;
   
   /** Add a message to the queue for a conversation */
-  enqueue: (conversationId: string, text: string) => QueuedMessage;
+  enqueue: (conversationId: string, text: string, sessionId?: string) => QueuedMessage;
   
   /** Get all queued messages for a conversation */
   getQueue: (conversationId: string) => QueuedMessage[];
@@ -66,10 +66,11 @@ export function useMessageQueue(): MessageQueueStore {
     });
   }, []);
 
-  const enqueue = useCallback((conversationId: string, text: string): QueuedMessage => {
+  const enqueue = useCallback((conversationId: string, text: string, sessionId = conversationId): QueuedMessage => {
     const message: QueuedMessage = {
       id: generateMessageId(),
       conversationId,
+      sessionId,
       text,
       createdAt: Date.now(),
       status: 'pending',
@@ -309,4 +310,3 @@ export function useMessageQueueContext(): MessageQueueStore {
   if (!ctx) throw new Error('MessageQueueContext missing');
   return ctx;
 }
-


### PR DESCRIPTION
## Summary

- Route subagent continuation queue messages through explicit continuation handling instead of leaking into main chat flows.
- Resolve remote server API key references before passing callback auth into Discord and MCP child processes.
- Keep queued mobile messages tied to the intended agent/session state.
- Address review feedback by making seed-history dedupe tolerant of persisted tool-message formatting and by failing/routing stale FIFO sub-session queue heads explicitly.
- Make the active nested subagent selection visible in the sidebar with a blue selected row treatment and `aria-current`.
- Restore persisted sidebar folders whose saved session keys predate assigned conversation IDs.

## Validation

- `pnpm --filter @dotagents/desktop typecheck`
- `pnpm --filter @dotagents/desktop exec vitest run src/main/acp/internal-agent-utils.test.ts src/main/remote-server.routes.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/active-agents-sidebar.layout.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/lib/sidebar-sessions.test.ts src/renderer/src/components/active-agents-sidebar.layout.test.ts`

Note: `pnpm --filter @dotagents/mobile typecheck` was not available because the mobile package has no `typecheck` script.