### PR TITLE
Add session file view tab

### DIFF
--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -6,6 +6,7 @@ import { isPanelAutoShowSuppressed, agentSessionStateManager } from "./state"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { configStore } from "./config"
 import { sanitizeAgentProgressUpdateForDisplay } from "@dotagents/shared"
+import { recordSessionFileActivity } from "./session-file-browser"
 
 // Throttle interval for non-critical progress updates (ms).
 // Updates within this window are collapsed — only the latest is sent.
@@ -138,6 +139,7 @@ function isCriticalUpdate(update: AgentProgressUpdate, state?: {
 }
 
 export async function emitAgentProgress(update: AgentProgressUpdate): Promise<void> {
+  recordSessionFileActivity(update)
   const displayUpdate = sanitizeAgentProgressUpdateForDisplay(update)
 
   // Backfill snoozed state from the session tracker when callers omit it.

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -139,7 +139,6 @@ function isCriticalUpdate(update: AgentProgressUpdate, state?: {
 }
 
 export async function emitAgentProgress(update: AgentProgressUpdate): Promise<void> {
-  recordSessionFileActivity(update)
   const displayUpdate = sanitizeAgentProgressUpdateForDisplay(update)
 
   // Backfill snoozed state from the session tracker when callers omit it.
@@ -206,6 +205,11 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
       state.runId = incomingRunId
     }
   }
+
+  // Record file-activity roots only after the stopped-session and stale-run
+  // guards above have cleared, so updates that will be discarded cannot
+  // contribute workspace roots to a restarted or reused session.
+  recordSessionFileActivity(update)
 
   // Critical updates bypass the throttle entirely
   if (isCriticalUpdate(displayUpdate, state, { isFirstUpdateForSession })) {

--- a/apps/desktop/src/main/session-file-browser.test.ts
+++ b/apps/desktop/src/main/session-file-browser.test.ts
@@ -6,7 +6,6 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   createTrackedSessionFileEntry,
   deleteTrackedSessionFileEntry,
-  getTrackedSessionFileActivity,
   getTrackedSessionFileRoots,
   listTrackedSessionFiles,
   moveTrackedSessionFileEntry,
@@ -121,42 +120,6 @@ describe("session-file-browser", () => {
     expect(listing.entries).toHaveLength(listing.limit)
     expect(listing.totalEntries).toBe(506)
     expect(listing.truncated).toBe(true)
-  })
-
-  it("tracks exact files that structured tools read and edit", () => {
-    const repoRoot = createTempWorkspace()
-    tempDirs.push(repoRoot)
-    fs.writeFileSync(path.join(repoRoot, "package.json"), "{}", "utf8")
-    const readPath = path.join(repoRoot, "README.md")
-    const editPath = path.join(repoRoot, "src", "index.ts")
-    fs.writeFileSync(readPath, "# Hello", "utf8")
-    fs.mkdirSync(path.dirname(editPath), { recursive: true })
-    fs.writeFileSync(editPath, "export {}\n", "utf8")
-
-    recordSessionFileActivity({
-      sessionId: "session-activity",
-      currentIteration: 1,
-      maxIterations: 1,
-      steps: [],
-      isComplete: false,
-      conversationHistory: [{
-        role: "assistant",
-        content: "",
-        timestamp: Date.now(),
-        toolCalls: [
-          { name: "read_file", arguments: { path: readPath } },
-          { name: "write_file", arguments: { path: editPath, content: "export const value = 1\n" } },
-        ],
-      }],
-    })
-
-    expect(getTrackedSessionFileActivity("session-activity").map((entry) => ({
-      kind: entry.kind,
-      relativePath: entry.relativePath,
-    }))).toEqual([
-      { kind: "edited", relativePath: "src/index.ts" },
-      { kind: "read", relativePath: "README.md" },
-    ])
   })
 
   it("falls back to markerless home subdirectories when the home marker is blocked", () => {

--- a/apps/desktop/src/main/session-file-browser.test.ts
+++ b/apps/desktop/src/main/session-file-browser.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   createTrackedSessionFileEntry,
   deleteTrackedSessionFileEntry,
+  getTrackedSessionFileActivity,
   getTrackedSessionFileRoots,
   listTrackedSessionFiles,
   moveTrackedSessionFileEntry,
@@ -120,6 +121,72 @@ describe("session-file-browser", () => {
     expect(listing.entries).toHaveLength(listing.limit)
     expect(listing.totalEntries).toBe(506)
     expect(listing.truncated).toBe(true)
+  })
+
+  it("tracks exact files that structured tools read and edit", () => {
+    const repoRoot = createTempWorkspace()
+    tempDirs.push(repoRoot)
+    fs.writeFileSync(path.join(repoRoot, "package.json"), "{}", "utf8")
+    const readPath = path.join(repoRoot, "README.md")
+    const editPath = path.join(repoRoot, "src", "index.ts")
+    fs.writeFileSync(readPath, "# Hello", "utf8")
+    fs.mkdirSync(path.dirname(editPath), { recursive: true })
+    fs.writeFileSync(editPath, "export {}\n", "utf8")
+
+    recordSessionFileActivity({
+      sessionId: "session-activity",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [],
+      isComplete: false,
+      conversationHistory: [{
+        role: "assistant",
+        content: "",
+        timestamp: Date.now(),
+        toolCalls: [
+          { name: "read_file", arguments: { path: readPath } },
+          { name: "write_file", arguments: { path: editPath, content: "export const value = 1\n" } },
+        ],
+      }],
+    })
+
+    expect(getTrackedSessionFileActivity("session-activity").map((entry) => ({
+      kind: entry.kind,
+      relativePath: entry.relativePath,
+    }))).toEqual([
+      { kind: "edited", relativePath: "src/index.ts" },
+      { kind: "read", relativePath: "README.md" },
+    ])
+  })
+
+  it("falls back to markerless home subdirectories when the home marker is blocked", () => {
+    const homeMarker = path.join(os.homedir(), ".agents")
+    if (!fs.existsSync(homeMarker)) return
+
+    const outputDir = fs.mkdtempSync(path.join(os.homedir(), ".dotagents-session-file-browser-test-"))
+    tempDirs.push(outputDir)
+    const outputPath = path.join(outputDir, "render.mp4")
+    fs.writeFileSync(outputPath, "video", "utf8")
+
+    recordSessionFileActivity({
+      sessionId: "session-home-output",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [],
+      isComplete: false,
+      conversationHistory: [{
+        role: "assistant",
+        content: "",
+        timestamp: Date.now(),
+        toolCalls: [
+          { name: "write_file", arguments: { path: outputPath, content: "video" } },
+        ],
+      }],
+    })
+
+    expect(getTrackedSessionFileRoots("session-home-output")).toEqual([
+      { path: fs.realpathSync(outputDir), label: path.basename(outputDir) },
+    ])
   })
 
   it("supports create, move, delete, and preview within tracked roots", () => {

--- a/apps/desktop/src/main/session-file-browser.test.ts
+++ b/apps/desktop/src/main/session-file-browser.test.ts
@@ -51,8 +51,9 @@ describe("session-file-browser", () => {
       }],
     })
 
+    const realRepoRoot = fs.realpathSync(repoRoot)
     expect(getTrackedSessionFileRoots("session-1")).toEqual([
-      { path: repoRoot, label: path.basename(repoRoot) },
+      { path: realRepoRoot, label: path.basename(realRepoRoot) },
     ])
   })
 
@@ -80,8 +81,45 @@ describe("session-file-browser", () => {
       isComplete: false,
     })
 
-    const entries = listTrackedSessionFiles({ sessionId: "session-2", rootPath: repoRoot, directoryPath: repoRoot })
+    const listing = listTrackedSessionFiles({ sessionId: "session-2", rootPath: repoRoot, directoryPath: repoRoot })
+    const entries = listing.entries
+    expect(listing.truncated).toBe(false)
     expect(entries.map((entry) => entry.name)).toEqual(["src", "README.md", "package.json"])
+  })
+
+  it("caps large directory listings to keep File View responsive", () => {
+    const repoRoot = createTempWorkspace()
+    tempDirs.push(repoRoot)
+    fs.writeFileSync(path.join(repoRoot, "package.json"), "{}", "utf8")
+
+    for (let index = 0; index < 505; index += 1) {
+      fs.writeFileSync(path.join(repoRoot, `file-${String(index).padStart(3, "0")}.txt`), "ok", "utf8")
+    }
+
+    recordSessionFileActivity({
+      sessionId: "session-large-listing",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [{
+        id: "tool-1",
+        type: "tool_result",
+        title: "Tool result",
+        status: "completed",
+        timestamp: Date.now(),
+        toolResult: { success: true, content: JSON.stringify({ cwd: repoRoot }) },
+      }],
+      isComplete: false,
+    })
+
+    const listing = listTrackedSessionFiles({
+      sessionId: "session-large-listing",
+      rootPath: repoRoot,
+      directoryPath: repoRoot,
+    })
+
+    expect(listing.entries).toHaveLength(listing.limit)
+    expect(listing.totalEntries).toBe(506)
+    expect(listing.truncated).toBe(true)
   })
 
   it("supports create, move, delete, and preview within tracked roots", () => {

--- a/apps/desktop/src/main/session-file-browser.test.ts
+++ b/apps/desktop/src/main/session-file-browser.test.ts
@@ -1,0 +1,167 @@
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  createTrackedSessionFileEntry,
+  deleteTrackedSessionFileEntry,
+  getTrackedSessionFileRoots,
+  listTrackedSessionFiles,
+  moveTrackedSessionFileEntry,
+  readTrackedSessionFilePreview,
+  recordSessionFileActivity,
+  resetTrackedSessionFileActivityForTests,
+} from "./session-file-browser"
+
+function createTempWorkspace(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-session-files-"))
+}
+
+describe("session-file-browser", () => {
+  const tempDirs: string[] = []
+
+  afterEach(() => {
+    resetTrackedSessionFileActivityForTests()
+    while (tempDirs.length > 0) {
+      fs.rmSync(tempDirs.pop()!, { recursive: true, force: true })
+    }
+  })
+
+  it("derives workspace roots from execute_command cwd metadata", () => {
+    const repoRoot = createTempWorkspace()
+    tempDirs.push(repoRoot)
+    fs.writeFileSync(path.join(repoRoot, "pnpm-lock.yaml"), "lockfile", "utf8")
+    fs.mkdirSync(path.join(repoRoot, "apps", "desktop"), { recursive: true })
+
+    recordSessionFileActivity({
+      sessionId: "session-1",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [],
+      isComplete: false,
+      conversationHistory: [{
+        role: "tool",
+        content: "",
+        timestamp: Date.now(),
+        toolResults: [{
+          success: true,
+          content: JSON.stringify({ cwd: path.join(repoRoot, "apps", "desktop"), stdout: "ok" }),
+        }],
+      }],
+    })
+
+    expect(getTrackedSessionFileRoots("session-1")).toEqual([
+      { path: repoRoot, label: path.basename(repoRoot) },
+    ])
+  })
+
+  it("lists visible files while filtering noisy directories", () => {
+    const repoRoot = createTempWorkspace()
+    tempDirs.push(repoRoot)
+    fs.writeFileSync(path.join(repoRoot, "package.json"), "{}", "utf8")
+    fs.mkdirSync(path.join(repoRoot, "src"), { recursive: true })
+    fs.mkdirSync(path.join(repoRoot, "node_modules"), { recursive: true })
+    fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true })
+    fs.writeFileSync(path.join(repoRoot, "README.md"), "# Hello", "utf8")
+
+    recordSessionFileActivity({
+      sessionId: "session-2",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [{
+        id: "tool-1",
+        type: "tool_result",
+        title: "Tool result",
+        status: "completed",
+        timestamp: Date.now(),
+        toolResult: { success: true, content: JSON.stringify({ cwd: repoRoot }) },
+      }],
+      isComplete: false,
+    })
+
+    const entries = listTrackedSessionFiles({ sessionId: "session-2", rootPath: repoRoot, directoryPath: repoRoot })
+    expect(entries.map((entry) => entry.name)).toEqual(["src", "README.md", "package.json"])
+  })
+
+  it("supports create, move, delete, and preview within tracked roots", () => {
+    const repoRoot = createTempWorkspace()
+    tempDirs.push(repoRoot)
+    fs.writeFileSync(path.join(repoRoot, "package.json"), "{}", "utf8")
+
+    recordSessionFileActivity({
+      sessionId: "session-3",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [{
+        id: "tool-1",
+        type: "tool_result",
+        title: "Tool result",
+        status: "completed",
+        timestamp: Date.now(),
+        toolResult: { success: true, content: JSON.stringify({ cwd: repoRoot }) },
+      }],
+      isComplete: false,
+    })
+
+    const created = createTrackedSessionFileEntry({
+      sessionId: "session-3",
+      rootPath: repoRoot,
+      targetPath: path.join(repoRoot, "notes", "todo.md"),
+      kind: "file",
+      content: "# Todo\n",
+    })
+    expect(created.relativePath).toBe("notes/todo.md")
+
+    const moved = moveTrackedSessionFileEntry({
+      sessionId: "session-3",
+      rootPath: repoRoot,
+      sourcePath: created.path,
+      targetPath: path.join(repoRoot, "notes", "done.md"),
+    })
+    expect(moved.relativePath).toBe("notes/done.md")
+
+    const preview = readTrackedSessionFilePreview({
+      sessionId: "session-3",
+      rootPath: repoRoot,
+      filePath: moved.path,
+    })
+    expect(preview.kind).toBe("markdown")
+    expect(preview.content).toContain("# Todo")
+
+    deleteTrackedSessionFileEntry({
+      sessionId: "session-3",
+      rootPath: repoRoot,
+      targetPath: moved.path,
+    })
+    expect(fs.existsSync(moved.path)).toBe(false)
+  })
+
+  it("rejects paths that escape the tracked workspace", () => {
+    const repoRoot = createTempWorkspace()
+    const outsideRoot = createTempWorkspace()
+    tempDirs.push(repoRoot, outsideRoot)
+    fs.writeFileSync(path.join(repoRoot, "package.json"), "{}", "utf8")
+
+    recordSessionFileActivity({
+      sessionId: "session-4",
+      currentIteration: 1,
+      maxIterations: 1,
+      steps: [{
+        id: "tool-1",
+        type: "tool_result",
+        title: "Tool result",
+        status: "completed",
+        timestamp: Date.now(),
+        toolResult: { success: true, content: JSON.stringify({ cwd: repoRoot }) },
+      }],
+      isComplete: false,
+    })
+
+    expect(() => listTrackedSessionFiles({
+      sessionId: "session-4",
+      rootPath: repoRoot,
+      directoryPath: outsideRoot,
+    })).toThrow("outside the selected workspace")
+  })
+})

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -177,15 +177,18 @@ function resolveWorkspaceRoot(candidatePath: string): string | null {
   }
 
   let current = path.resolve(candidateDir)
-  let highestMarkerRoot: string | null = null
+  let markerRoot: string | null = null
   while (true) {
-    if (hasWorkspaceMarker(current)) highestMarkerRoot = current
+    if (hasWorkspaceMarker(current)) {
+      markerRoot = current
+      break
+    }
     const parent = path.dirname(current)
     if (parent === current) break
     current = parent
   }
 
-  const rootPath = realpathIfPossible(highestMarkerRoot ?? candidateDir)
+  const rootPath = realpathIfPossible(markerRoot ?? candidateDir)
   return BLOCKED_ROOT_PATHS.has(rootPath) ? null : rootPath
 }
 
@@ -287,13 +290,24 @@ function resolvePathWithinRoot(rootPath: string, requestedPath?: string): string
   const resolvedPath = path.isAbsolute(trimmed)
     ? path.resolve(trimmed)
     : path.resolve(normalizedRoot, trimmed)
-  const resolvedParent = realpathIfPossible(path.dirname(resolvedPath))
-  const normalizedResolved = fs.existsSync(resolvedPath) ? realpathIfPossible(resolvedPath) : path.resolve(resolvedPath)
+
+  // Anchor on the realpath of the nearest existing ancestor so symlinks inside
+  // the workspace cannot be used to escape it via a parent-only containment check.
+  let normalizedResolved: string
+  if (fs.existsSync(resolvedPath)) {
+    normalizedResolved = realpathIfPossible(resolvedPath)
+  } else {
+    const existingAncestor = nearestExistingAncestor(resolvedPath)
+    if (!existingAncestor) {
+      throw new Error("That path is outside the selected workspace")
+    }
+    const resolvedAncestor = realpathIfPossible(existingAncestor)
+    const tail = path.relative(existingAncestor, resolvedPath)
+    normalizedResolved = tail ? path.join(resolvedAncestor, tail) : resolvedAncestor
+  }
 
   const withinRoot = normalizedResolved === normalizedRoot
     || normalizedResolved.startsWith(`${normalizedRoot}${path.sep}`)
-    || resolvedParent === normalizedRoot
-    || resolvedParent.startsWith(`${normalizedRoot}${path.sep}`)
   if (!withinRoot) {
     throw new Error("That path is outside the selected workspace")
   }
@@ -406,9 +420,21 @@ export function readTrackedSessionFilePreview(input: {
   }
 
   const extension = path.extname(filePath).toLowerCase()
-  const fileBuffer = fs.readFileSync(filePath)
   const maxTextBytes = 200_000
+  const maxImageBytes = 5 * 1024 * 1024
+
+  const binaryFallback = (): SessionFilePreview => ({
+    path: filePath,
+    relativePath,
+    name: path.basename(filePath),
+    kind: "binary",
+    size: stats.size,
+    modifiedAt: stats.mtimeMs,
+  })
+
   if (IMAGE_MIME_BY_EXTENSION.has(extension)) {
+    if (stats.size > maxImageBytes) return binaryFallback()
+    const fileBuffer = fs.readFileSync(filePath)
     return {
       path: filePath,
       relativePath,
@@ -420,8 +446,20 @@ export function readTrackedSessionFilePreview(input: {
     }
   }
 
-  if (isTextPreviewable(filePath, fileBuffer)) {
-    const previewBuffer = fileBuffer.subarray(0, Math.min(fileBuffer.length, maxTextBytes))
+  // Read only up to maxTextBytes so large logs or generated artifacts cannot
+  // pin the Electron main process while we decide whether to preview them.
+  const bytesToRead = Math.min(stats.size, maxTextBytes)
+  const sampleBuffer = Buffer.alloc(bytesToRead)
+  if (bytesToRead > 0) {
+    const fd = fs.openSync(filePath, "r")
+    try {
+      fs.readSync(fd, sampleBuffer, 0, bytesToRead, 0)
+    } finally {
+      fs.closeSync(fd)
+    }
+  }
+
+  if (isTextPreviewable(filePath, sampleBuffer)) {
     return {
       path: filePath,
       relativePath,
@@ -429,19 +467,12 @@ export function readTrackedSessionFilePreview(input: {
       kind: MARKDOWN_EXTENSIONS.has(extension) ? "markdown" : "text",
       size: stats.size,
       modifiedAt: stats.mtimeMs,
-      content: previewBuffer.toString("utf8"),
-      ...(fileBuffer.length > maxTextBytes ? { truncated: true } : {}),
+      content: sampleBuffer.toString("utf8"),
+      ...(stats.size > maxTextBytes ? { truncated: true } : {}),
     }
   }
 
-  return {
-    path: filePath,
-    relativePath,
-    name: path.basename(filePath),
-    kind: "binary",
-    size: stats.size,
-    modifiedAt: stats.mtimeMs,
-  }
+  return binaryFallback()
 }
 
 export function createTrackedSessionFileEntry(input: {

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -380,10 +380,10 @@ export function listTrackedSessionFiles(input: {
   if (!stats.isDirectory()) throw new Error("Only directories can be listed")
 
   return fs.readdirSync(directoryPath, { withFileTypes: true })
-    .filter((entry) => !entry.name.startsWith(".") && !NOISY_ENTRY_NAMES.has(entry.name))
+    .filter((entry) => !entry.name.startsWith(".") && !NOISY_ENTRY_NAMES.has(entry.name) && !entry.isSymbolicLink())
     .map((entry) => {
       const entryPath = path.join(directoryPath, entry.name)
-      const entryStats = ensureNonSymlink(entryPath)
+      const entryStats = fs.lstatSync(entryPath)
       return {
         path: entryPath,
         relativePath: path.relative(rootPath, entryPath) || ".",

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -1,0 +1,515 @@
+import fs from "fs"
+import path from "path"
+
+import type { AgentProgressUpdate, ConversationMessage } from "../shared/types"
+
+export type SessionFileRoot = {
+  path: string
+  label: string
+}
+
+export type SessionFileEntry = {
+  path: string
+  relativePath: string
+  name: string
+  kind: "file" | "directory"
+  size?: number
+  modifiedAt: number
+}
+
+export type SessionFilePreview = {
+  path: string
+  relativePath: string
+  name: string
+  kind: "directory" | "text" | "markdown" | "image" | "binary"
+  size: number
+  modifiedAt: number
+  content?: string
+  dataUrl?: string
+  truncated?: boolean
+}
+
+const ROOT_MARKERS = [
+  ".git",
+  ".agents",
+  "pnpm-lock.yaml",
+  "package.json",
+  "package-lock.json",
+  "yarn.lock",
+  "bun.lock",
+  "bun.lockb",
+  "Cargo.toml",
+  "pyproject.toml",
+  "go.mod",
+]
+const NOISY_ENTRY_NAMES = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  ".next",
+  "out",
+  "target",
+  "__pycache__",
+])
+const BLOCKED_ROOT_PATHS = new Set([
+  path.resolve(path.sep),
+  path.resolve(path.sep, "bin"),
+  path.resolve(path.sep, "boot"),
+  path.resolve(path.sep, "dev"),
+  path.resolve(path.sep, "etc"),
+  path.resolve(path.sep, "lib"),
+  path.resolve(path.sep, "lib64"),
+  path.resolve(path.sep, "proc"),
+  path.resolve(path.sep, "sbin"),
+  path.resolve(path.sep, "sys"),
+  path.resolve(path.sep, "usr"),
+  path.resolve(path.sep, "var"),
+])
+const MARKDOWN_EXTENSIONS = new Set([".markdown", ".md", ".mdx"])
+const TEXT_EXTENSIONS = new Set([
+  ".c",
+  ".cc",
+  ".conf",
+  ".cpp",
+  ".css",
+  ".csv",
+  ".env",
+  ".go",
+  ".graphql",
+  ".h",
+  ".html",
+  ".ini",
+  ".java",
+  ".js",
+  ".json",
+  ".jsx",
+  ".log",
+  ".mjs",
+  ".py",
+  ".rb",
+  ".rs",
+  ".scss",
+  ".sh",
+  ".sql",
+  ".svg",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".xml",
+  ".yaml",
+  ".yml",
+  ".zsh",
+])
+const IMAGE_MIME_BY_EXTENSION = new Map<string, string>([
+  [".gif", "image/gif"],
+  [".jpeg", "image/jpeg"],
+  [".jpg", "image/jpeg"],
+  [".png", "image/png"],
+  [".webp", "image/webp"],
+])
+const DIRECTORY_HINT_KEYS = new Set([
+  "cwd",
+  "directory",
+  "directorypath",
+  "dir",
+  "rootpath",
+  "workspace",
+  "workspacedir",
+  "workspacefolder",
+  "workspace_folder",
+  "workspaceroot",
+  "workingdirectory",
+])
+const FILE_HINT_KEYS = new Set([
+  "file",
+  "filepath",
+  "outputpath",
+  "path",
+  "sourcepath",
+  "targetpath",
+])
+
+const trackedSessionFileRoots = new Map<string, Set<string>>()
+
+function realpathIfPossible(value: string): string {
+  try {
+    return fs.realpathSync(value)
+  } catch {
+    return path.resolve(value)
+  }
+}
+
+function isAbsolutePathLike(value: string): boolean {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed.startsWith("data:")) return false
+  if (path.isAbsolute(trimmed)) return true
+  return /^[A-Za-z]:[\\/]/.test(trimmed)
+}
+
+function nearestExistingAncestor(candidatePath: string): string | null {
+  let current = path.resolve(candidatePath)
+  while (true) {
+    if (fs.existsSync(current)) return current
+    const parent = path.dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+}
+
+function hasWorkspaceMarker(dirPath: string): boolean {
+  return ROOT_MARKERS.some((marker) => fs.existsSync(path.join(dirPath, marker)))
+}
+
+function resolveWorkspaceRoot(candidatePath: string): string | null {
+  const existingAncestor = nearestExistingAncestor(candidatePath)
+  if (!existingAncestor) return null
+
+  let candidateDir = existingAncestor
+  try {
+    const stats = fs.lstatSync(existingAncestor)
+    if (stats.isSymbolicLink()) return null
+    if (stats.isFile()) candidateDir = path.dirname(existingAncestor)
+  } catch {
+    return null
+  }
+
+  let current = path.resolve(candidateDir)
+  let highestMarkerRoot: string | null = null
+  while (true) {
+    if (hasWorkspaceMarker(current)) highestMarkerRoot = current
+    const parent = path.dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+
+  const rootPath = realpathIfPossible(highestMarkerRoot ?? candidateDir)
+  return BLOCKED_ROOT_PATHS.has(rootPath) ? null : rootPath
+}
+
+function normalizeCandidatePath(rawValue: string, keyHint?: string): string | null {
+  if (!isAbsolutePathLike(rawValue)) return null
+  const normalized = path.normalize(rawValue.trim())
+  const normalizedKey = (keyHint ?? "").toLowerCase().replace(/[^a-z]/g, "")
+
+  try {
+    const stats = fs.lstatSync(normalized)
+    if (stats.isSymbolicLink()) return null
+    if (stats.isDirectory()) return normalized
+    if (stats.isFile()) return path.dirname(normalized)
+  } catch {
+    // Ignore missing paths and fall through to key-based heuristics.
+  }
+
+  if (DIRECTORY_HINT_KEYS.has(normalizedKey)) return normalized
+  if (FILE_HINT_KEYS.has(normalizedKey) || path.extname(normalized)) return path.dirname(normalized)
+  return normalized
+}
+
+function extractCandidatePathsFromValue(value: unknown, keyHint?: string): string[] {
+  if (!value) return []
+  if (typeof value === "string") {
+    const candidate = normalizeCandidatePath(value, keyHint)
+    return candidate ? [candidate] : []
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractCandidatePathsFromValue(entry, keyHint))
+  }
+  if (typeof value === "object") {
+    return Object.entries(value).flatMap(([key, nestedValue]) => extractCandidatePathsFromValue(nestedValue, key))
+  }
+  return []
+}
+
+function parseJsonObject(rawValue?: string): unknown {
+  const trimmed = rawValue?.trim()
+  if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) return null
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+}
+
+function extractCandidatePathsFromToolResultContent(content?: string): string[] {
+  const parsed = parseJsonObject(content)
+  return parsed ? extractCandidatePathsFromValue(parsed) : []
+}
+
+function collectProgressCandidatePaths(update: Pick<AgentProgressUpdate, "steps" | "conversationHistory">): string[] {
+  const results: string[] = []
+  for (const step of update.steps ?? []) {
+    results.push(...extractCandidatePathsFromValue(step.toolCall?.arguments))
+    results.push(...extractCandidatePathsFromToolResultContent(step.toolResult?.content))
+    results.push(...extractCandidatePathsFromToolResultContent(step.toolResult?.error))
+  }
+  for (const message of update.conversationHistory ?? []) {
+    for (const toolCall of message.toolCalls ?? []) {
+      results.push(...extractCandidatePathsFromValue(toolCall.arguments))
+    }
+    for (const toolResult of message.toolResults ?? []) {
+      results.push(...extractCandidatePathsFromToolResultContent(toolResult.content))
+      results.push(...extractCandidatePathsFromToolResultContent(toolResult.error))
+    }
+  }
+  return results
+}
+
+function mergeTrackedPaths(sessionId: string, candidatePaths: Iterable<string>): void {
+  const resolvedRoots = Array.from(candidatePaths)
+    .map(resolveWorkspaceRoot)
+    .filter((value): value is string => Boolean(value))
+  if (resolvedRoots.length === 0) return
+
+  const existing = trackedSessionFileRoots.get(sessionId) ?? new Set<string>()
+  for (const rootPath of resolvedRoots) {
+    existing.add(rootPath)
+  }
+  trackedSessionFileRoots.set(sessionId, existing)
+}
+
+function ensureTrackedRoot(sessionId: string, requestedRootPath: string): string {
+  const normalizedRequestedRoot = realpathIfPossible(requestedRootPath)
+  const allowedRoots = getTrackedSessionFileRoots(sessionId).map((root) => realpathIfPossible(root.path))
+  if (!allowedRoots.includes(normalizedRequestedRoot)) {
+    throw new Error("That workspace is not available for this session")
+  }
+  return normalizedRequestedRoot
+}
+
+function resolvePathWithinRoot(rootPath: string, requestedPath?: string): string {
+  const normalizedRoot = realpathIfPossible(rootPath)
+  if (!requestedPath || !requestedPath.trim()) return normalizedRoot
+
+  const trimmed = requestedPath.trim()
+  const resolvedPath = path.isAbsolute(trimmed)
+    ? path.resolve(trimmed)
+    : path.resolve(normalizedRoot, trimmed)
+  const resolvedParent = realpathIfPossible(path.dirname(resolvedPath))
+  const normalizedResolved = fs.existsSync(resolvedPath) ? realpathIfPossible(resolvedPath) : path.resolve(resolvedPath)
+
+  const withinRoot = normalizedResolved === normalizedRoot
+    || normalizedResolved.startsWith(`${normalizedRoot}${path.sep}`)
+    || resolvedParent === normalizedRoot
+    || resolvedParent.startsWith(`${normalizedRoot}${path.sep}`)
+  if (!withinRoot) {
+    throw new Error("That path is outside the selected workspace")
+  }
+
+  return normalizedResolved
+}
+
+function ensureNonSymlink(targetPath: string): fs.Stats {
+  const stats = fs.lstatSync(targetPath)
+  if (stats.isSymbolicLink()) {
+    throw new Error("Symlinks are not supported in File View")
+  }
+  return stats
+}
+
+function isTextPreviewable(filePath: string, sample?: Buffer): boolean {
+  const extension = path.extname(filePath).toLowerCase()
+  if (MARKDOWN_EXTENSIONS.has(extension) || TEXT_EXTENSIONS.has(extension)) return true
+  if (!sample) return false
+  return !sample.subarray(0, Math.min(sample.length, 1024)).includes(0)
+}
+
+export function recordSessionFileActivity(update: AgentProgressUpdate): void {
+  if (!update.sessionId) return
+  mergeTrackedPaths(update.sessionId, collectProgressCandidatePaths(update))
+}
+
+export function recordSessionConversationFileActivity(sessionId: string, messages: ConversationMessage[]): void {
+  mergeTrackedPaths(sessionId, collectProgressCandidatePaths({ steps: [], conversationHistory: messages }))
+}
+
+export function clearSessionFileActivity(sessionId: string): void {
+  trackedSessionFileRoots.delete(sessionId)
+}
+
+export function getTrackedSessionFileRoots(sessionId: string): SessionFileRoot[] {
+  const uniqueRoots = Array.from(trackedSessionFileRoots.get(sessionId) ?? [])
+    .map((rootPath) => realpathIfPossible(rootPath))
+    .sort((a, b) => a.length - b.length || a.localeCompare(b))
+    .filter((rootPath, index, allRoots) => {
+      return !allRoots.some((candidate, candidateIndex) => {
+        if (candidateIndex === index) return false
+        return rootPath.startsWith(`${candidate}${path.sep}`)
+      })
+    })
+
+  return uniqueRoots.map((rootPath) => ({
+    path: rootPath,
+    label: path.basename(rootPath) || rootPath,
+  }))
+}
+
+export function resolveTrackedSessionPath(input: {
+  sessionId: string
+  rootPath: string
+  targetPath?: string
+}): string {
+  const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
+  return resolvePathWithinRoot(rootPath, input.targetPath)
+}
+
+export function listTrackedSessionFiles(input: {
+  sessionId: string
+  rootPath: string
+  directoryPath?: string
+}): SessionFileEntry[] {
+  const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
+  const directoryPath = resolvePathWithinRoot(rootPath, input.directoryPath)
+  const stats = ensureNonSymlink(directoryPath)
+  if (!stats.isDirectory()) throw new Error("Only directories can be listed")
+
+  return fs.readdirSync(directoryPath, { withFileTypes: true })
+    .filter((entry) => !entry.name.startsWith(".") && !NOISY_ENTRY_NAMES.has(entry.name))
+    .map((entry) => {
+      const entryPath = path.join(directoryPath, entry.name)
+      const entryStats = ensureNonSymlink(entryPath)
+      return {
+        path: entryPath,
+        relativePath: path.relative(rootPath, entryPath) || ".",
+        name: entry.name,
+        kind: entryStats.isDirectory() ? "directory" : "file",
+        ...(entryStats.isDirectory() ? {} : { size: entryStats.size }),
+        modifiedAt: entryStats.mtimeMs,
+      } satisfies SessionFileEntry
+    })
+    .sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+}
+
+export function readTrackedSessionFilePreview(input: {
+  sessionId: string
+  rootPath: string
+  filePath: string
+}): SessionFilePreview {
+  const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
+  const filePath = resolvePathWithinRoot(rootPath, input.filePath)
+  const stats = ensureNonSymlink(filePath)
+  const relativePath = path.relative(rootPath, filePath) || path.basename(filePath)
+  if (stats.isDirectory()) {
+    return {
+      path: filePath,
+      relativePath,
+      name: path.basename(filePath) || rootPath,
+      kind: "directory",
+      size: 0,
+      modifiedAt: stats.mtimeMs,
+    }
+  }
+
+  const extension = path.extname(filePath).toLowerCase()
+  const fileBuffer = fs.readFileSync(filePath)
+  const maxTextBytes = 200_000
+  if (IMAGE_MIME_BY_EXTENSION.has(extension)) {
+    return {
+      path: filePath,
+      relativePath,
+      name: path.basename(filePath),
+      kind: "image",
+      size: stats.size,
+      modifiedAt: stats.mtimeMs,
+      dataUrl: `data:${IMAGE_MIME_BY_EXTENSION.get(extension)};base64,${fileBuffer.toString("base64")}`,
+    }
+  }
+
+  if (isTextPreviewable(filePath, fileBuffer)) {
+    const previewBuffer = fileBuffer.subarray(0, Math.min(fileBuffer.length, maxTextBytes))
+    return {
+      path: filePath,
+      relativePath,
+      name: path.basename(filePath),
+      kind: MARKDOWN_EXTENSIONS.has(extension) ? "markdown" : "text",
+      size: stats.size,
+      modifiedAt: stats.mtimeMs,
+      content: previewBuffer.toString("utf8"),
+      ...(fileBuffer.length > maxTextBytes ? { truncated: true } : {}),
+    }
+  }
+
+  return {
+    path: filePath,
+    relativePath,
+    name: path.basename(filePath),
+    kind: "binary",
+    size: stats.size,
+    modifiedAt: stats.mtimeMs,
+  }
+}
+
+export function createTrackedSessionFileEntry(input: {
+  sessionId: string
+  rootPath: string
+  targetPath: string
+  kind: "file" | "directory"
+  content?: string
+}): { path: string; relativePath: string } {
+  const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
+  const targetPath = resolvePathWithinRoot(rootPath, input.targetPath)
+  if (targetPath === rootPath) throw new Error("Cannot create over the workspace root")
+  if (fs.existsSync(targetPath)) throw new Error("That path already exists")
+
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+  if (input.kind === "directory") {
+    fs.mkdirSync(targetPath, { recursive: true })
+  } else {
+    fs.writeFileSync(targetPath, input.content ?? "", "utf8")
+  }
+
+  return {
+    path: targetPath,
+    relativePath: path.relative(rootPath, targetPath) || ".",
+  }
+}
+
+export function moveTrackedSessionFileEntry(input: {
+  sessionId: string
+  rootPath: string
+  sourcePath: string
+  targetPath: string
+}): { path: string; relativePath: string } {
+  const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
+  const sourcePath = resolvePathWithinRoot(rootPath, input.sourcePath)
+  const targetPath = resolvePathWithinRoot(rootPath, input.targetPath)
+  if (sourcePath === rootPath || targetPath === rootPath) {
+    throw new Error("Cannot rename or move the workspace root")
+  }
+  if (!fs.existsSync(sourcePath)) throw new Error("That path no longer exists")
+  if (fs.existsSync(targetPath) && realpathIfPossible(targetPath) !== realpathIfPossible(sourcePath)) {
+    throw new Error("The destination already exists")
+  }
+
+  ensureNonSymlink(sourcePath)
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+  fs.renameSync(sourcePath, targetPath)
+
+  return {
+    path: targetPath,
+    relativePath: path.relative(rootPath, targetPath) || ".",
+  }
+}
+
+export function deleteTrackedSessionFileEntry(input: {
+  sessionId: string
+  rootPath: string
+  targetPath: string
+}): void {
+  const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
+  const targetPath = resolvePathWithinRoot(rootPath, input.targetPath)
+  if (targetPath === rootPath) throw new Error("Cannot delete the workspace root")
+  if (!fs.existsSync(targetPath)) throw new Error("That path no longer exists")
+
+  ensureNonSymlink(targetPath)
+  fs.rmSync(targetPath, { recursive: true, force: false })
+}
+
+export function resetTrackedSessionFileActivityForTests(): void {
+  trackedSessionFileRoots.clear()
+}

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -25,17 +25,6 @@ export type SessionFileListing = {
   truncated: boolean
 }
 
-export type SessionFileActivityKind = "read" | "edited"
-
-export type SessionFileActivity = {
-  path: string
-  rootPath: string
-  relativePath: string
-  kind: SessionFileActivityKind
-  source: string
-  lastSeenAt: number
-}
-
 export type SessionFilePreview = {
   path: string
   relativePath: string
@@ -152,47 +141,7 @@ const FILE_HINT_KEYS = new Set([
   "sourcepath",
   "targetpath",
 ])
-const READ_TOOL_NAME_HINTS = [
-  "cat",
-  "fetch",
-  "find",
-  "get",
-  "grep",
-  "head",
-  "list",
-  "ls",
-  "nl",
-  "open",
-  "read",
-  "rg",
-  "search",
-  "sed",
-  "stat",
-  "tail",
-  "view",
-  "wc",
-]
-const EDIT_TOOL_NAME_HINTS = [
-  "apply_patch",
-  "append",
-  "create",
-  "delete",
-  "edit",
-  "mkdir",
-  "move",
-  "patch",
-  "rename",
-  "rm",
-  "save",
-  "touch",
-  "update",
-  "write",
-]
-const READ_COMMANDS = new Set(["cat", "file", "find", "grep", "head", "ls", "nl", "rg", "sed", "stat", "tail", "wc"])
-const EDIT_COMMANDS = new Set(["apply_patch", "cp", "mkdir", "mv", "rm", "rmdir", "tee", "touch"])
-
 const trackedSessionFileRoots = new Map<string, Set<string>>()
-const trackedSessionFileActivity = new Map<string, Map<string, SessionFileActivity>>()
 
 function realpathIfPossible(value: string): string {
   try {
@@ -289,108 +238,6 @@ function extractCandidatePathsFromValue(value: unknown, keyHint?: string): strin
   return []
 }
 
-function normalizeTouchedCandidatePath(rawValue: string, keyHint?: string): string | null {
-  if (!isAbsolutePathLike(rawValue)) return null
-  const expanded = rawValue.trim().startsWith("~")
-    ? path.join(os.homedir(), rawValue.trim().slice(1))
-    : rawValue.trim()
-  const normalized = path.normalize(expanded)
-  const normalizedKey = (keyHint ?? "").toLowerCase().replace(/[^a-z]/g, "")
-
-  try {
-    const stats = fs.lstatSync(normalized)
-    if (stats.isSymbolicLink()) return null
-    return normalized
-  } catch {
-    // Missing edited output paths are still useful when their parent exists.
-  }
-
-  if (DIRECTORY_HINT_KEYS.has(normalizedKey)) return normalized
-  if (FILE_HINT_KEYS.has(normalizedKey) || path.extname(normalized)) return normalized
-  return null
-}
-
-function extractTouchedCandidatePathsFromValue(value: unknown, keyHint?: string): string[] {
-  if (!value) return []
-  if (typeof value === "string") {
-    const candidate = normalizeTouchedCandidatePath(value, keyHint)
-    return candidate ? [candidate] : []
-  }
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => extractTouchedCandidatePathsFromValue(entry, keyHint))
-  }
-  if (typeof value === "object") {
-    return Object.entries(value).flatMap(([key, nestedValue]) => extractTouchedCandidatePathsFromValue(nestedValue, key))
-  }
-  return []
-}
-
-function extractCommandPathCandidates(command: string): string[] {
-  const pathTokens = [
-    ...(command.match(/(?:~|\.{0,2}\/|\/)[^\s"'`|;&)]+/g) ?? []),
-    ...command.split(/\s+/).filter((token) => {
-      if (!token || token.startsWith("-")) return false
-      const cleaned = token.replace(/^["']|["',:;)]+$/g, "")
-      return cleaned.includes(path.sep) || Boolean(path.extname(cleaned))
-    }),
-  ]
-  return pathTokens
-    .map((token) => token.replace(/^["']|["',:;)]+$/g, ""))
-    .map((token) => token.startsWith("~") ? path.join(os.homedir(), token.slice(1)) : token)
-    .map((token) => path.isAbsolute(token) ? token : path.resolve(process.cwd(), token))
-}
-
-function getToolActivityKind(toolName?: string, args?: unknown): SessionFileActivityKind | null {
-  const normalizedName = (toolName ?? "").toLowerCase()
-  const command = typeof (args as { command?: unknown } | undefined)?.command === "string"
-    ? String((args as { command: string }).command)
-    : ""
-  const commandName = command.trim().split(/\s+/)[0]?.split("/").pop()?.toLowerCase() ?? ""
-
-  if (normalizedName === "execute_command" || normalizedName.endsWith(":execute_command")) {
-    if (EDIT_COMMANDS.has(commandName) || />\s*(?:~|\.{0,2}\/|\/)/.test(command)) return "edited"
-    if (READ_COMMANDS.has(commandName)) return "read"
-    return null
-  }
-
-  if (EDIT_TOOL_NAME_HINTS.some((hint) => normalizedName.includes(hint))) return "edited"
-  if (READ_TOOL_NAME_HINTS.some((hint) => normalizedName.includes(hint))) return "read"
-  return null
-}
-
-function resolveActivityPath(candidatePath: string): string | null {
-  const expanded = candidatePath.startsWith("~")
-    ? path.join(os.homedir(), candidatePath.slice(1))
-    : candidatePath
-  const resolvedPath = path.resolve(expanded)
-  if (fs.existsSync(resolvedPath)) return realpathIfPossible(resolvedPath)
-
-  const existingAncestor = nearestExistingAncestor(resolvedPath)
-  if (!existingAncestor) return null
-  const resolvedAncestor = realpathIfPossible(existingAncestor)
-  const tail = path.relative(existingAncestor, resolvedPath)
-  return tail ? path.join(resolvedAncestor, tail) : resolvedAncestor
-}
-
-function collectToolFileActivity(toolName: string | undefined, args: unknown): Array<{ kind: SessionFileActivityKind; path: string; source: string }> {
-  const kind = getToolActivityKind(toolName, args)
-  if (!kind) return []
-
-  const normalizedName = (toolName ?? "tool").toLowerCase()
-  const command = typeof (args as { command?: unknown } | undefined)?.command === "string"
-    ? String((args as { command: string }).command)
-    : ""
-  const candidatePaths = command
-    ? extractCommandPathCandidates(command)
-    : extractTouchedCandidatePathsFromValue(args)
-
-  return candidatePaths.map((candidatePath) => ({
-    kind,
-    path: candidatePath,
-    source: normalizedName,
-  }))
-}
-
 function parseJsonObject(rawValue?: string): unknown {
   const trimmed = rawValue?.trim()
   if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) return null
@@ -425,19 +272,6 @@ function collectProgressCandidatePaths(update: Pick<AgentProgressUpdate, "steps"
   return results
 }
 
-function collectProgressFileActivity(update: Pick<AgentProgressUpdate, "steps" | "conversationHistory">): Array<{ kind: SessionFileActivityKind; path: string; source: string }> {
-  const results: Array<{ kind: SessionFileActivityKind; path: string; source: string }> = []
-  for (const step of update.steps ?? []) {
-    results.push(...collectToolFileActivity(step.toolCall?.name, step.toolCall?.arguments))
-  }
-  for (const message of update.conversationHistory ?? []) {
-    for (const toolCall of message.toolCalls ?? []) {
-      results.push(...collectToolFileActivity(toolCall.name, toolCall.arguments))
-    }
-  }
-  return results
-}
-
 function mergeTrackedPaths(sessionId: string, candidatePaths: Iterable<string>): void {
   const resolvedRoots = Array.from(candidatePaths)
     .map(resolveWorkspaceRoot)
@@ -449,33 +283,6 @@ function mergeTrackedPaths(sessionId: string, candidatePaths: Iterable<string>):
     existing.add(rootPath)
   }
   trackedSessionFileRoots.set(sessionId, existing)
-}
-
-function mergeTrackedFileActivity(sessionId: string, activity: Iterable<{ kind: SessionFileActivityKind; path: string; source: string }>): void {
-  const existing = trackedSessionFileActivity.get(sessionId) ?? new Map<string, SessionFileActivity>()
-  const rootSet = trackedSessionFileRoots.get(sessionId) ?? new Set<string>()
-
-  for (const entry of activity) {
-    const targetPath = resolveActivityPath(entry.path)
-    if (!targetPath) continue
-    const rootPath = resolveWorkspaceRoot(targetPath)
-    if (!rootPath) continue
-    if (!(targetPath === rootPath || targetPath.startsWith(`${rootPath}${path.sep}`))) continue
-
-    rootSet.add(rootPath)
-    const key = `${entry.kind}:${targetPath}`
-    existing.set(key, {
-      path: targetPath,
-      rootPath,
-      relativePath: path.relative(rootPath, targetPath) || ".",
-      kind: entry.kind,
-      source: entry.source,
-      lastSeenAt: Date.now(),
-    })
-  }
-
-  if (rootSet.size > 0) trackedSessionFileRoots.set(sessionId, rootSet)
-  if (existing.size > 0) trackedSessionFileActivity.set(sessionId, existing)
 }
 
 function ensureTrackedRoot(sessionId: string, requestedRootPath: string): string {
@@ -538,17 +345,14 @@ function isTextPreviewable(filePath: string, sample?: Buffer): boolean {
 export function recordSessionFileActivity(update: AgentProgressUpdate): void {
   if (!update.sessionId) return
   mergeTrackedPaths(update.sessionId, collectProgressCandidatePaths(update))
-  mergeTrackedFileActivity(update.sessionId, collectProgressFileActivity(update))
 }
 
 export function recordSessionConversationFileActivity(sessionId: string, messages: ConversationMessage[]): void {
   mergeTrackedPaths(sessionId, collectProgressCandidatePaths({ steps: [], conversationHistory: messages }))
-  mergeTrackedFileActivity(sessionId, collectProgressFileActivity({ steps: [], conversationHistory: messages }))
 }
 
 export function clearSessionFileActivity(sessionId: string): void {
   trackedSessionFileRoots.delete(sessionId)
-  trackedSessionFileActivity.delete(sessionId)
 }
 
 export function getTrackedSessionFileRoots(sessionId: string): SessionFileRoot[] {
@@ -566,14 +370,6 @@ export function getTrackedSessionFileRoots(sessionId: string): SessionFileRoot[]
     path: rootPath,
     label: path.basename(rootPath) || rootPath,
   }))
-}
-
-export function getTrackedSessionFileActivity(sessionId: string): SessionFileActivity[] {
-  return Array.from(trackedSessionFileActivity.get(sessionId)?.values() ?? [])
-    .sort((a, b) => {
-      if (a.kind !== b.kind) return a.kind === "edited" ? -1 : 1
-      return b.lastSeenAt - a.lastSeenAt || a.relativePath.localeCompare(b.relativePath)
-    })
 }
 
 export function resolveTrackedSessionPath(input: {
@@ -644,7 +440,6 @@ export function readTrackedSessionFilePreview(input: {
       modifiedAt: stats.mtimeMs,
     }
   }
-  mergeTrackedFileActivity(input.sessionId, [{ kind: "read", path: filePath, source: "file_view" }])
 
   const extension = path.extname(filePath).toLowerCase()
   const maxTextBytes = 200_000
@@ -720,7 +515,6 @@ export function createTrackedSessionFileEntry(input: {
   } else {
     fs.writeFileSync(targetPath, input.content ?? "", "utf8")
   }
-  mergeTrackedFileActivity(input.sessionId, [{ kind: "edited", path: targetPath, source: "file_view" }])
 
   return {
     path: targetPath,
@@ -748,7 +542,6 @@ export function moveTrackedSessionFileEntry(input: {
   ensureNonSymlink(sourcePath)
   fs.mkdirSync(path.dirname(targetPath), { recursive: true })
   fs.renameSync(sourcePath, targetPath)
-  mergeTrackedFileActivity(input.sessionId, [{ kind: "edited", path: targetPath, source: "file_view" }])
 
   return {
     path: targetPath,
@@ -768,10 +561,8 @@ export function deleteTrackedSessionFileEntry(input: {
 
   ensureNonSymlink(targetPath)
   fs.rmSync(targetPath, { recursive: true, force: false })
-  mergeTrackedFileActivity(input.sessionId, [{ kind: "edited", path: targetPath, source: "file_view" }])
 }
 
 export function resetTrackedSessionFileActivityForTests(): void {
   trackedSessionFileRoots.clear()
-  trackedSessionFileActivity.clear()
 }

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -18,6 +18,13 @@ export type SessionFileEntry = {
   modifiedAt: number
 }
 
+export type SessionFileListing = {
+  entries: SessionFileEntry[]
+  totalEntries: number
+  limit: number
+  truncated: boolean
+}
+
 export type SessionFilePreview = {
   path: string
   relativePath: string
@@ -112,6 +119,7 @@ const IMAGE_MIME_BY_EXTENSION = new Map<string, string>([
   [".png", "image/png"],
   [".webp", "image/webp"],
 ])
+const MAX_DIRECTORY_ENTRIES = 500
 const DIRECTORY_HINT_KEYS = new Set([
   "cwd",
   "directory",
@@ -375,14 +383,21 @@ export function listTrackedSessionFiles(input: {
   sessionId: string
   rootPath: string
   directoryPath?: string
-}): SessionFileEntry[] {
+}): SessionFileListing {
   const rootPath = ensureTrackedRoot(input.sessionId, input.rootPath)
   const directoryPath = resolvePathWithinRoot(rootPath, input.directoryPath)
   const stats = ensureNonSymlink(directoryPath)
   if (!stats.isDirectory()) throw new Error("Only directories can be listed")
 
-  return fs.readdirSync(directoryPath, { withFileTypes: true })
+  const visibleEntries = fs.readdirSync(directoryPath, { withFileTypes: true })
     .filter((entry) => !entry.name.startsWith(".") && !NOISY_ENTRY_NAMES.has(entry.name) && !entry.isSymbolicLink())
+    .sort((a, b) => {
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1
+      if (a.name === b.name) return 0
+      return a.name < b.name ? -1 : 1
+    })
+
+  const entries = visibleEntries.slice(0, MAX_DIRECTORY_ENTRIES)
     .map((entry) => {
       const entryPath = path.join(directoryPath, entry.name)
       const entryStats = fs.lstatSync(entryPath)
@@ -395,10 +410,13 @@ export function listTrackedSessionFiles(input: {
         modifiedAt: entryStats.mtimeMs,
       } satisfies SessionFileEntry
     })
-    .sort((a, b) => {
-      if (a.kind !== b.kind) return a.kind === "directory" ? -1 : 1
-      return a.name.localeCompare(b.name)
-    })
+
+  return {
+    entries,
+    totalEntries: visibleEntries.length,
+    limit: MAX_DIRECTORY_ENTRIES,
+    truncated: visibleEntries.length > MAX_DIRECTORY_ENTRIES,
+  }
 }
 
 export function readTrackedSessionFilePreview(input: {

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -1,4 +1,5 @@
 import fs from "fs"
+import os from "os"
 import path from "path"
 
 import type { AgentProgressUpdate, ConversationMessage } from "../shared/types"
@@ -66,6 +67,7 @@ const BLOCKED_ROOT_PATHS = new Set([
   path.resolve(path.sep, "sys"),
   path.resolve(path.sep, "usr"),
   path.resolve(path.sep, "var"),
+  path.resolve(os.homedir()),
 ])
 const MARKDOWN_EXTENSIONS = new Set([".markdown", ".md", ".mdx"])
 const TEXT_EXTENSIONS = new Set([

--- a/apps/desktop/src/main/session-file-browser.ts
+++ b/apps/desktop/src/main/session-file-browser.ts
@@ -25,6 +25,17 @@ export type SessionFileListing = {
   truncated: boolean
 }
 
+export type SessionFileActivityKind = "read" | "edited"
+
+export type SessionFileActivity = {
+  path: string
+  rootPath: string
+  relativePath: string
+  kind: SessionFileActivityKind
+  source: string
+  lastSeenAt: number
+}
+
 export type SessionFilePreview = {
   path: string
   relativePath: string
@@ -141,8 +152,47 @@ const FILE_HINT_KEYS = new Set([
   "sourcepath",
   "targetpath",
 ])
+const READ_TOOL_NAME_HINTS = [
+  "cat",
+  "fetch",
+  "find",
+  "get",
+  "grep",
+  "head",
+  "list",
+  "ls",
+  "nl",
+  "open",
+  "read",
+  "rg",
+  "search",
+  "sed",
+  "stat",
+  "tail",
+  "view",
+  "wc",
+]
+const EDIT_TOOL_NAME_HINTS = [
+  "apply_patch",
+  "append",
+  "create",
+  "delete",
+  "edit",
+  "mkdir",
+  "move",
+  "patch",
+  "rename",
+  "rm",
+  "save",
+  "touch",
+  "update",
+  "write",
+]
+const READ_COMMANDS = new Set(["cat", "file", "find", "grep", "head", "ls", "nl", "rg", "sed", "stat", "tail", "wc"])
+const EDIT_COMMANDS = new Set(["apply_patch", "cp", "mkdir", "mv", "rm", "rmdir", "tee", "touch"])
 
 const trackedSessionFileRoots = new Map<string, Set<string>>()
+const trackedSessionFileActivity = new Map<string, Map<string, SessionFileActivity>>()
 
 function realpathIfPossible(value: string): string {
   try {
@@ -190,15 +240,18 @@ function resolveWorkspaceRoot(candidatePath: string): string | null {
   let markerRoot: string | null = null
   while (true) {
     if (hasWorkspaceMarker(current)) {
-      markerRoot = current
-      break
+      const resolvedMarkerRoot = realpathIfPossible(current)
+      if (!BLOCKED_ROOT_PATHS.has(resolvedMarkerRoot)) {
+        markerRoot = resolvedMarkerRoot
+        break
+      }
     }
     const parent = path.dirname(current)
     if (parent === current) break
     current = parent
   }
 
-  const rootPath = realpathIfPossible(markerRoot ?? candidateDir)
+  const rootPath = markerRoot ?? realpathIfPossible(candidateDir)
   return BLOCKED_ROOT_PATHS.has(rootPath) ? null : rootPath
 }
 
@@ -236,6 +289,108 @@ function extractCandidatePathsFromValue(value: unknown, keyHint?: string): strin
   return []
 }
 
+function normalizeTouchedCandidatePath(rawValue: string, keyHint?: string): string | null {
+  if (!isAbsolutePathLike(rawValue)) return null
+  const expanded = rawValue.trim().startsWith("~")
+    ? path.join(os.homedir(), rawValue.trim().slice(1))
+    : rawValue.trim()
+  const normalized = path.normalize(expanded)
+  const normalizedKey = (keyHint ?? "").toLowerCase().replace(/[^a-z]/g, "")
+
+  try {
+    const stats = fs.lstatSync(normalized)
+    if (stats.isSymbolicLink()) return null
+    return normalized
+  } catch {
+    // Missing edited output paths are still useful when their parent exists.
+  }
+
+  if (DIRECTORY_HINT_KEYS.has(normalizedKey)) return normalized
+  if (FILE_HINT_KEYS.has(normalizedKey) || path.extname(normalized)) return normalized
+  return null
+}
+
+function extractTouchedCandidatePathsFromValue(value: unknown, keyHint?: string): string[] {
+  if (!value) return []
+  if (typeof value === "string") {
+    const candidate = normalizeTouchedCandidatePath(value, keyHint)
+    return candidate ? [candidate] : []
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractTouchedCandidatePathsFromValue(entry, keyHint))
+  }
+  if (typeof value === "object") {
+    return Object.entries(value).flatMap(([key, nestedValue]) => extractTouchedCandidatePathsFromValue(nestedValue, key))
+  }
+  return []
+}
+
+function extractCommandPathCandidates(command: string): string[] {
+  const pathTokens = [
+    ...(command.match(/(?:~|\.{0,2}\/|\/)[^\s"'`|;&)]+/g) ?? []),
+    ...command.split(/\s+/).filter((token) => {
+      if (!token || token.startsWith("-")) return false
+      const cleaned = token.replace(/^["']|["',:;)]+$/g, "")
+      return cleaned.includes(path.sep) || Boolean(path.extname(cleaned))
+    }),
+  ]
+  return pathTokens
+    .map((token) => token.replace(/^["']|["',:;)]+$/g, ""))
+    .map((token) => token.startsWith("~") ? path.join(os.homedir(), token.slice(1)) : token)
+    .map((token) => path.isAbsolute(token) ? token : path.resolve(process.cwd(), token))
+}
+
+function getToolActivityKind(toolName?: string, args?: unknown): SessionFileActivityKind | null {
+  const normalizedName = (toolName ?? "").toLowerCase()
+  const command = typeof (args as { command?: unknown } | undefined)?.command === "string"
+    ? String((args as { command: string }).command)
+    : ""
+  const commandName = command.trim().split(/\s+/)[0]?.split("/").pop()?.toLowerCase() ?? ""
+
+  if (normalizedName === "execute_command" || normalizedName.endsWith(":execute_command")) {
+    if (EDIT_COMMANDS.has(commandName) || />\s*(?:~|\.{0,2}\/|\/)/.test(command)) return "edited"
+    if (READ_COMMANDS.has(commandName)) return "read"
+    return null
+  }
+
+  if (EDIT_TOOL_NAME_HINTS.some((hint) => normalizedName.includes(hint))) return "edited"
+  if (READ_TOOL_NAME_HINTS.some((hint) => normalizedName.includes(hint))) return "read"
+  return null
+}
+
+function resolveActivityPath(candidatePath: string): string | null {
+  const expanded = candidatePath.startsWith("~")
+    ? path.join(os.homedir(), candidatePath.slice(1))
+    : candidatePath
+  const resolvedPath = path.resolve(expanded)
+  if (fs.existsSync(resolvedPath)) return realpathIfPossible(resolvedPath)
+
+  const existingAncestor = nearestExistingAncestor(resolvedPath)
+  if (!existingAncestor) return null
+  const resolvedAncestor = realpathIfPossible(existingAncestor)
+  const tail = path.relative(existingAncestor, resolvedPath)
+  return tail ? path.join(resolvedAncestor, tail) : resolvedAncestor
+}
+
+function collectToolFileActivity(toolName: string | undefined, args: unknown): Array<{ kind: SessionFileActivityKind; path: string; source: string }> {
+  const kind = getToolActivityKind(toolName, args)
+  if (!kind) return []
+
+  const normalizedName = (toolName ?? "tool").toLowerCase()
+  const command = typeof (args as { command?: unknown } | undefined)?.command === "string"
+    ? String((args as { command: string }).command)
+    : ""
+  const candidatePaths = command
+    ? extractCommandPathCandidates(command)
+    : extractTouchedCandidatePathsFromValue(args)
+
+  return candidatePaths.map((candidatePath) => ({
+    kind,
+    path: candidatePath,
+    source: normalizedName,
+  }))
+}
+
 function parseJsonObject(rawValue?: string): unknown {
   const trimmed = rawValue?.trim()
   if (!trimmed || (!trimmed.startsWith("{") && !trimmed.startsWith("["))) return null
@@ -270,6 +425,19 @@ function collectProgressCandidatePaths(update: Pick<AgentProgressUpdate, "steps"
   return results
 }
 
+function collectProgressFileActivity(update: Pick<AgentProgressUpdate, "steps" | "conversationHistory">): Array<{ kind: SessionFileActivityKind; path: string; source: string }> {
+  const results: Array<{ kind: SessionFileActivityKind; path: string; source: string }> = []
+  for (const step of update.steps ?? []) {
+    results.push(...collectToolFileActivity(step.toolCall?.name, step.toolCall?.arguments))
+  }
+  for (const message of update.conversationHistory ?? []) {
+    for (const toolCall of message.toolCalls ?? []) {
+      results.push(...collectToolFileActivity(toolCall.name, toolCall.arguments))
+    }
+  }
+  return results
+}
+
 function mergeTrackedPaths(sessionId: string, candidatePaths: Iterable<string>): void {
   const resolvedRoots = Array.from(candidatePaths)
     .map(resolveWorkspaceRoot)
@@ -281,6 +449,33 @@ function mergeTrackedPaths(sessionId: string, candidatePaths: Iterable<string>):
     existing.add(rootPath)
   }
   trackedSessionFileRoots.set(sessionId, existing)
+}
+
+function mergeTrackedFileActivity(sessionId: string, activity: Iterable<{ kind: SessionFileActivityKind; path: string; source: string }>): void {
+  const existing = trackedSessionFileActivity.get(sessionId) ?? new Map<string, SessionFileActivity>()
+  const rootSet = trackedSessionFileRoots.get(sessionId) ?? new Set<string>()
+
+  for (const entry of activity) {
+    const targetPath = resolveActivityPath(entry.path)
+    if (!targetPath) continue
+    const rootPath = resolveWorkspaceRoot(targetPath)
+    if (!rootPath) continue
+    if (!(targetPath === rootPath || targetPath.startsWith(`${rootPath}${path.sep}`))) continue
+
+    rootSet.add(rootPath)
+    const key = `${entry.kind}:${targetPath}`
+    existing.set(key, {
+      path: targetPath,
+      rootPath,
+      relativePath: path.relative(rootPath, targetPath) || ".",
+      kind: entry.kind,
+      source: entry.source,
+      lastSeenAt: Date.now(),
+    })
+  }
+
+  if (rootSet.size > 0) trackedSessionFileRoots.set(sessionId, rootSet)
+  if (existing.size > 0) trackedSessionFileActivity.set(sessionId, existing)
 }
 
 function ensureTrackedRoot(sessionId: string, requestedRootPath: string): string {
@@ -343,14 +538,17 @@ function isTextPreviewable(filePath: string, sample?: Buffer): boolean {
 export function recordSessionFileActivity(update: AgentProgressUpdate): void {
   if (!update.sessionId) return
   mergeTrackedPaths(update.sessionId, collectProgressCandidatePaths(update))
+  mergeTrackedFileActivity(update.sessionId, collectProgressFileActivity(update))
 }
 
 export function recordSessionConversationFileActivity(sessionId: string, messages: ConversationMessage[]): void {
   mergeTrackedPaths(sessionId, collectProgressCandidatePaths({ steps: [], conversationHistory: messages }))
+  mergeTrackedFileActivity(sessionId, collectProgressFileActivity({ steps: [], conversationHistory: messages }))
 }
 
 export function clearSessionFileActivity(sessionId: string): void {
   trackedSessionFileRoots.delete(sessionId)
+  trackedSessionFileActivity.delete(sessionId)
 }
 
 export function getTrackedSessionFileRoots(sessionId: string): SessionFileRoot[] {
@@ -368,6 +566,14 @@ export function getTrackedSessionFileRoots(sessionId: string): SessionFileRoot[]
     path: rootPath,
     label: path.basename(rootPath) || rootPath,
   }))
+}
+
+export function getTrackedSessionFileActivity(sessionId: string): SessionFileActivity[] {
+  return Array.from(trackedSessionFileActivity.get(sessionId)?.values() ?? [])
+    .sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === "edited" ? -1 : 1
+      return b.lastSeenAt - a.lastSeenAt || a.relativePath.localeCompare(b.relativePath)
+    })
 }
 
 export function resolveTrackedSessionPath(input: {
@@ -438,6 +644,7 @@ export function readTrackedSessionFilePreview(input: {
       modifiedAt: stats.mtimeMs,
     }
   }
+  mergeTrackedFileActivity(input.sessionId, [{ kind: "read", path: filePath, source: "file_view" }])
 
   const extension = path.extname(filePath).toLowerCase()
   const maxTextBytes = 200_000
@@ -513,6 +720,7 @@ export function createTrackedSessionFileEntry(input: {
   } else {
     fs.writeFileSync(targetPath, input.content ?? "", "utf8")
   }
+  mergeTrackedFileActivity(input.sessionId, [{ kind: "edited", path: targetPath, source: "file_view" }])
 
   return {
     path: targetPath,
@@ -540,6 +748,7 @@ export function moveTrackedSessionFileEntry(input: {
   ensureNonSymlink(sourcePath)
   fs.mkdirSync(path.dirname(targetPath), { recursive: true })
   fs.renameSync(sourcePath, targetPath)
+  mergeTrackedFileActivity(input.sessionId, [{ kind: "edited", path: targetPath, source: "file_view" }])
 
   return {
     path: targetPath,
@@ -559,8 +768,10 @@ export function deleteTrackedSessionFileEntry(input: {
 
   ensureNonSymlink(targetPath)
   fs.rmSync(targetPath, { recursive: true, force: false })
+  mergeTrackedFileActivity(input.sessionId, [{ kind: "edited", path: targetPath, source: "file_view" }])
 }
 
 export function resetTrackedSessionFileActivityForTests(): void {
   trackedSessionFileRoots.clear()
+  trackedSessionFileActivity.clear()
 }

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -103,7 +103,6 @@ import {
   clearSessionFileActivity,
   createTrackedSessionFileEntry,
   deleteTrackedSessionFileEntry,
-  getTrackedSessionFileActivity,
   getTrackedSessionFileRoots,
   listTrackedSessionFiles,
   moveTrackedSessionFileEntry,
@@ -4012,12 +4011,6 @@ export const router = {
     .input<{ sessionId: string }>()
     .action(async ({ input }) => {
       return getTrackedSessionFileRoots(input.sessionId)
-    }),
-
-  getTrackedSessionFileActivity: t.procedure
-    .input<{ sessionId: string }>()
-    .action(async ({ input }) => {
-      return getTrackedSessionFileActivity(input.sessionId)
     }),
 
   listTrackedSessionFiles: t.procedure

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -103,6 +103,7 @@ import {
   clearSessionFileActivity,
   createTrackedSessionFileEntry,
   deleteTrackedSessionFileEntry,
+  getTrackedSessionFileActivity,
   getTrackedSessionFileRoots,
   listTrackedSessionFiles,
   moveTrackedSessionFileEntry,
@@ -4011,6 +4012,12 @@ export const router = {
     .input<{ sessionId: string }>()
     .action(async ({ input }) => {
       return getTrackedSessionFileRoots(input.sessionId)
+    }),
+
+  getTrackedSessionFileActivity: t.procedure
+    .input<{ sessionId: string }>()
+    .action(async ({ input }) => {
+      return getTrackedSessionFileActivity(input.sessionId)
     }),
 
   listTrackedSessionFiles: t.procedure

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -99,6 +99,17 @@ import { loopService } from "./loop-service"
 import { clearSessionUserResponse } from "./session-user-response-store"
 import { isMissingApiKeyErrorMessage } from "@dotagents/shared"
 import { hasRepeatTaskTitlePrefix } from "../shared/repeat-tasks"
+import {
+  clearSessionFileActivity,
+  createTrackedSessionFileEntry,
+  deleteTrackedSessionFileEntry,
+  getTrackedSessionFileRoots,
+  listTrackedSessionFiles,
+  moveTrackedSessionFileEntry,
+  readTrackedSessionFilePreview,
+  recordSessionConversationFileActivity,
+  resolveTrackedSessionPath,
+} from "./session-file-browser"
 
 function describeAgentSessionId(sessionId?: string | null): "missing" | "pending" | "subsession" | "session" | "unknown" {
   if (!sessionId) return "missing"
@@ -1505,6 +1516,7 @@ export const router = {
       // Also remove from the tracker's completed sessions list so it
       // doesn't re-appear in the sidebar on the next agentSessionsUpdated.
       agentSessionTracker.removeCompletedSession(input.sessionId)
+      clearSessionFileActivity(input.sessionId)
 
       // Send to all windows (panel and main) so both can update their state
       for (const [id, win] of WINDOWS.entries()) {
@@ -1518,13 +1530,25 @@ export const router = {
     }),
 
   clearInactiveSessions: t.procedure.action(async () => {
+    const clearedSessionIds: string[] = []
+
     // Clear completed sessions from the tracker
     agentSessionTracker.clearCompletedSessions((session) => {
-      if (!session.conversationId) return true
+      if (!session.conversationId) {
+        clearedSessionIds.push(session.id)
+        return true
+      }
       const shouldClear = messageQueueService.getQueue(session.conversationId).length === 0
-      if (shouldClear) desktopTTSPlaybackCoordinator.clearSessionKeys(session.id)
+      if (shouldClear) {
+        desktopTTSPlaybackCoordinator.clearSessionKeys(session.id)
+        clearedSessionIds.push(session.id)
+      }
       return shouldClear
     })
+
+    for (const sessionId of clearedSessionIds) {
+      clearSessionFileActivity(sessionId)
+    }
 
     // Send to all windows so both main and panel can update their state
     for (const [id, win] of WINDOWS.entries()) {
@@ -3947,11 +3971,80 @@ export const router = {
   }),
 
   loadConversation: t.procedure
-    .input<{ conversationId: string; messageLimit?: number }>()
+    .input<{ conversationId: string; messageLimit?: number; sessionId?: string }>()
     .action(async ({ input }) => {
-      return conversationService.loadConversationForDisplay(input.conversationId, {
+      const conversation = await conversationService.loadConversationForDisplay(input.conversationId, {
         messageLimit: input.messageLimit,
       })
+
+      if (input.sessionId && conversation) {
+        const storedConversation = await conversationService.loadConversation(input.conversationId)
+        const storedMessages = storedConversation?.rawMessages ?? storedConversation?.messages ?? conversation.messages
+        recordSessionConversationFileActivity(input.sessionId, storedMessages)
+      }
+
+      return conversation
+    }),
+
+  getTrackedSessionFileRoots: t.procedure
+    .input<{ sessionId: string }>()
+    .action(async ({ input }) => {
+      return getTrackedSessionFileRoots(input.sessionId)
+    }),
+
+  listTrackedSessionFiles: t.procedure
+    .input<{ sessionId: string; rootPath: string; directoryPath?: string }>()
+    .action(async ({ input }) => {
+      return listTrackedSessionFiles(input)
+    }),
+
+  readTrackedSessionFilePreview: t.procedure
+    .input<{ sessionId: string; rootPath: string; filePath: string }>()
+    .action(async ({ input }) => {
+      return readTrackedSessionFilePreview(input)
+    }),
+
+  createTrackedSessionFileEntry: t.procedure
+    .input<{ sessionId: string; rootPath: string; targetPath: string; kind: "file" | "directory"; content?: string }>()
+    .action(async ({ input }) => {
+      return createTrackedSessionFileEntry(input)
+    }),
+
+  moveTrackedSessionFileEntry: t.procedure
+    .input<{ sessionId: string; rootPath: string; sourcePath: string; targetPath: string }>()
+    .action(async ({ input }) => {
+      return moveTrackedSessionFileEntry(input)
+    }),
+
+  deleteTrackedSessionFileEntry: t.procedure
+    .input<{ sessionId: string; rootPath: string; targetPath: string }>()
+    .action(async ({ input }) => {
+      deleteTrackedSessionFileEntry(input)
+      return { success: true }
+    }),
+
+  openTrackedSessionPath: t.procedure
+    .input<{ sessionId: string; rootPath: string; targetPath?: string }>()
+    .action(async ({ input }) => {
+      const targetPath = resolveTrackedSessionPath(input)
+      const error = await shell.openPath(targetPath)
+      return { success: !error, error: error || undefined, path: targetPath }
+    }),
+
+  revealTrackedSessionPath: t.procedure
+    .input<{ sessionId: string; rootPath: string; targetPath?: string }>()
+    .action(async ({ input }) => {
+      const targetPath = resolveTrackedSessionPath(input)
+      try {
+        shell.showItemInFolder(targetPath)
+        return { success: true, path: targetPath }
+      } catch (error) {
+        return {
+          success: false,
+          path: targetPath,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
     }),
 
   saveConversation: t.procedure

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3990,6 +3990,23 @@ export const router = {
       return conversation
     }),
 
+  hydrateConversationFileActivity: t.procedure
+    .input<{ conversationId: string; sessionId: string }>()
+    .action(async ({ input }) => {
+      const conversation = await conversationService.loadConversationForDisplay(input.conversationId)
+      if (!conversation) return []
+
+      recordSessionConversationFileActivity(input.sessionId, conversation.messages)
+      return getTrackedSessionFileRoots(input.sessionId)
+    }),
+
+  clearTrackedSessionFileActivity: t.procedure
+    .input<{ sessionId: string }>()
+    .action(async ({ input }) => {
+      clearSessionFileActivity(input.sessionId)
+      return { success: true }
+    }),
+
   getTrackedSessionFileRoots: t.procedure
     .input<{ sessionId: string }>()
     .action(async ({ input }) => {

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3977,7 +3977,10 @@ export const router = {
         messageLimit: input.messageLimit,
       })
 
-      if (input.sessionId && conversation) {
+      // Skip synthetic `pending-*` IDs: they are never added to
+      // `agentSessionTracker`, so `clearSessionFileActivity` would never fire
+      // for them and `trackedSessionFileRoots` would grow unbounded.
+      if (input.sessionId && !input.sessionId.startsWith("pending-") && conversation) {
         // `loadConversationForDisplay` already returns the stored raw messages
         // (via `buildDisplayLoadedConversation`/`getStoredRawMessages`), so we
         // can hydrate file-activity from those without a second disk read.

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3978,9 +3978,10 @@ export const router = {
       })
 
       if (input.sessionId && conversation) {
-        const storedConversation = await conversationService.loadConversation(input.conversationId)
-        const storedMessages = storedConversation?.rawMessages ?? storedConversation?.messages ?? conversation.messages
-        recordSessionConversationFileActivity(input.sessionId, storedMessages)
+        // `loadConversationForDisplay` already returns the stored raw messages
+        // (via `buildDisplayLoadedConversation`/`getStoredRawMessages`), so we
+        // can hydrate file-activity from those without a second disk read.
+        recordSessionConversationFileActivity(input.sessionId, conversation.messages)
       }
 
       return conversation

--- a/apps/desktop/src/renderer/src/components/agent-progress.interaction.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.interaction.test.ts
@@ -15,4 +15,10 @@ describe("agent progress interactions", () => {
     expect(agentProgressSource).toContain("onClick={shouldToggleFromContentClick ? handleToggleExpand : undefined}")
     expect(agentProgressSource).toContain("e.stopPropagation()")
   })
+
+  it("resets an unavailable summary tab back to chat", () => {
+    expect(agentProgressSource).toContain('if (activeTab === "summary" && !hasSummaryTab)')
+    expect(agentProgressSource).toContain('setActiveTab("chat")')
+    expect(agentProgressSource).toContain("[activeTab, hasSummaryTab]")
+  })
 })

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -256,6 +256,7 @@ async function loadAgentProgress(
     OctagonX: icon("OctagonX"),
     MessageSquare: icon("MessageSquare"),
     Brain: icon("Brain"),
+    FolderOpen: icon("FolderOpen"),
     Volume2: icon("Volume2"),
     Wrench: icon("Wrench"),
     Play: icon("Play"),
@@ -359,6 +360,7 @@ async function loadAgentProgress(
   vi.doMock("./tool-execution-stats", () => ({ ToolExecutionStats: Null }))
   vi.doMock("./acp-session-badge", () => ({ ACPSessionBadge: Null }))
   vi.doMock("./agent-summary-view", () => ({ AgentSummaryView: Null }))
+  vi.doMock("./session-file-view", () => ({ SessionFileView: ({ sessionId }: { sessionId?: string }) => `SessionFileView:${sessionId ?? "none"}` }))
   vi.doMock("@renderer/lib/tts-tracking", () => ({
     hasTTSPlayed: () => false,
     markTTSPlayed: vi.fn(),
@@ -1074,6 +1076,33 @@ describe("agent progress response history", () => {
 
     loadButton.props.onClick({ preventDefault: vi.fn(), stopPropagation: vi.fn() })
     expect(onLoadEarlierConversationHistory).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows a Files tab and swaps to the file view for session workspaces", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const progress = {
+      sessionId: "session-files-tab",
+      conversationId: "conversation-files-tab",
+      currentIteration: 1,
+      maxIterations: 2,
+      steps: [],
+      isComplete: false,
+      finalContent: "",
+      conversationHistory: [],
+    }
+
+    let tree = runtime.render(AgentProgress, { progress, variant: "tile" })
+    const filesButton = findAll(
+      tree,
+      (value) => value?.type === "button" && getTextContent(value).includes("Files"),
+    )[0]
+
+    expect(filesButton).toBeTruthy()
+    filesButton.props.onClick({ preventDefault: vi.fn(), stopPropagation: vi.fn() })
+
+    tree = runtime.render(AgentProgress, { progress, variant: "tile" })
+    expect(getTextContent(tree)).toContain("SessionFileView:session-files-tab")
   })
 
   it("smartly auto-speaks response-linked assistant messages and keeps replay available before completion", async () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -5177,7 +5177,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             {/* File View Tab */}
             {activeTab === "files" && (
               <div className="relative flex-1 min-h-0 overflow-hidden" onClick={(e) => e.stopPropagation()}>
-                <SessionFileView sessionId={progress.sessionId} className="h-full" />
+                <SessionFileView sessionId={progress.sessionId} conversationId={progress.conversationId} className="h-full" />
               </div>
             )}
 
@@ -5659,7 +5659,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       {/* File View Tab */}
       {activeTab === "files" && (
         <div className="relative flex-1 min-h-0 overflow-hidden" onClick={(e) => e.stopPropagation()}>
-          <SessionFileView sessionId={progress.sessionId} className="h-full" />
+          <SessionFileView sessionId={progress.sessionId} conversationId={progress.conversationId} className="h-full" />
         </div>
       )}
 

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -3795,6 +3795,12 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   const hasSummaryTab = (progress.stepSummaries?.length ?? 0) > 0
   const isQueueEnabled = configQuery.data?.mcpMessageQueueEnabled ?? true
 
+  useEffect(() => {
+    if (activeTab === "summary" && !hasSummaryTab) {
+      setActiveTab("chat")
+    }
+  }, [activeTab, hasSummaryTab])
+
   // Detect if agent was stopped by kill switch
   const wasStopped = finalContent?.includes("emergency kill switch") ||
                     steps?.some(step => step.title === "Agent stopped" ||

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { cn } from "@renderer/lib/utils"
 import type { AgentProgressUpdate, ACPDelegationProgress, ACPSubAgentMessage, Config, ModelPreset } from "../../../shared/types"
 import { INTERNAL_COMPLETION_NUDGE_TEXT, RESPOND_TO_USER_TOOL, MARK_WORK_COMPLETE_TOOL } from "../../../shared/runtime-tool-names"
-import { ChevronDown, ChevronUp, ChevronRight, X, AlertTriangle, Shield, Check, XCircle, Loader2, Clock, Copy, CheckCheck, GripHorizontal, Activity, Moon, Maximize2, Bot, OctagonX, MessageSquare, Brain, Volume2, Wrench, Play, Pause, Pin, GitBranch } from "lucide-react"
+import { ChevronDown, ChevronUp, ChevronRight, X, AlertTriangle, Shield, Check, XCircle, Loader2, Clock, Copy, CheckCheck, GripHorizontal, Activity, Moon, Maximize2, Bot, OctagonX, MessageSquare, Brain, Volume2, Wrench, Play, Pause, Pin, GitBranch, FolderOpen } from "lucide-react"
 import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
 import { Button } from "./ui/button"
 import { Badge } from "./ui/badge"
@@ -36,6 +36,7 @@ import {
 import { ToolExecutionStats } from "./tool-execution-stats"
 import { ACPSessionBadge } from "./acp-session-badge"
 import { AgentSummaryView } from "./agent-summary-view"
+import { SessionFileView } from "./session-file-view"
 import { LoadingSpinner } from "./ui/loading-spinner"
 import { extractSubAgentToolDisplayContent } from "@shared/delegation-tool-display"
 import { buildContentTTSKey, buildResponseEventTTSKey, consumeSessionForcedAutoPlay, hasTTSPlayed, markTTSPlayed, removeTTSKey } from "@renderer/lib/tts-tracking"
@@ -3547,8 +3548,8 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   // Expansion state management - preserve across re-renders
   const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({})
 
-  // Tab state for Chat/Summary view toggle (only relevant when dual-model is enabled)
-  const [activeTab, setActiveTab] = useState<"chat" | "summary">("chat")
+  // Tab state for Chat/Summary/File View toggle.
+  const [activeTab, setActiveTab] = useState<"chat" | "summary" | "files">("chat")
   const [selectedDelegationRunId, setSelectedDelegationRunId] = useState<string | null>(null)
   const [isDelegationSummaryCollapsed, setIsDelegationSummaryCollapsed] = useState(false)
 
@@ -3791,6 +3792,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     profileName,
     acpSessionInfo,
   } = progress
+  const hasSummaryTab = (progress.stepSummaries?.length ?? 0) > 0
   const isQueueEnabled = configQuery.data?.mcpMessageQueueEnabled ?? true
 
   // Detect if agent was stopped by kill switch
@@ -4920,22 +4922,35 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         {/* Collapsible content */}
         {!isCollapsed && (
           <>
-            {/* Tab toggle for Chat/Summary view - only show when summaries exist */}
-            {(progress.stepSummaries?.length ?? 0) > 0 && (
-              <div className="flex flex-wrap items-center gap-1 border-b border-border/30 bg-muted/5 px-2.5 py-1.5" onClick={(e) => e.stopPropagation()}>
-                <button
-                  type="button"
-                  onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("chat"); }}
-                  className={cn(
-                    "inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
-                    activeTab === "chat"
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                  )}
-                >
-                  <MessageSquare className="h-3 w-3" />
-                  <span className="truncate">Chat</span>
-                </button>
+            {/* Tab toggle for Chat/Summary/File View */}
+            <div className="flex flex-wrap items-center gap-1 border-b border-border/30 bg-muted/5 px-2.5 py-1.5" onClick={(e) => e.stopPropagation()}>
+              <button
+                type="button"
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("chat"); }}
+                className={cn(
+                  "inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                  activeTab === "chat"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                <MessageSquare className="h-3 w-3" />
+                <span className="truncate">Chat</span>
+              </button>
+              <button
+                type="button"
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("files"); }}
+                className={cn(
+                  "inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+                  activeTab === "files"
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                <FolderOpen className="h-3 w-3" />
+                <span className="truncate">Files</span>
+              </button>
+              {hasSummaryTab && (
                 <button
                   type="button"
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("summary"); }}
@@ -4952,11 +4967,11 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     {progress.stepSummaries?.length ?? 0}
                   </Badge>
                 </button>
-              </div>
-            )}
+              )}
+            </div>
 
             {/* Message Stream (Chat Tab) */}
-            <div className={cn("relative flex-1 min-h-0 flex flex-col", activeTab !== "chat" && (progress.stepSummaries?.length ?? 0) > 0 && "hidden")} onClick={(e) => e.stopPropagation()}>
+            <div className={cn("relative flex-1 min-h-0 flex flex-col", activeTab !== "chat" && "hidden")} onClick={(e) => e.stopPropagation()}>
               <DelegationSummaryStrip
                 entries={delegationSummaryEntries}
                 maxItems={delegationSummaryMaxItems}
@@ -5150,12 +5165,19 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
             )}
 
             {/* Summary View Tab */}
-            {activeTab === "summary" && (progress.stepSummaries?.length ?? 0) > 0 && (
+            {activeTab === "summary" && hasSummaryTab && (
               <div className="relative flex-1 min-h-0 overflow-y-auto p-3" onClick={(e) => e.stopPropagation()}>
                 <AgentSummaryView
                   progress={progress}
                   conversationId={progress.conversationId}
                 />
+              </div>
+            )}
+
+            {/* File View Tab */}
+            {activeTab === "files" && (
+              <div className="relative flex-1 min-h-0 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+                <SessionFileView sessionId={progress.sessionId} className="h-full" />
               </div>
             )}
 
@@ -5373,22 +5395,35 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         </div>
       </div>
 
-      {/* Tab toggle for Chat/Summary view - only show when summaries exist */}
-      {(progress.stepSummaries?.length ?? 0) > 0 && (
-        <div className="flex flex-wrap items-center gap-1 border-b border-border/30 bg-muted/5 px-2.5 py-1.5" onClick={(e) => e.stopPropagation()}>
-          <button
-            type="button"
-            onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("chat"); }}
-            className={cn(
-              "inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
-              activeTab === "chat"
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground"
-            )}
-          >
-            <MessageSquare className="h-3 w-3" />
-            <span className="truncate">Chat</span>
-          </button>
+      {/* Tab toggle for Chat/Summary/File View */}
+      <div className="flex flex-wrap items-center gap-1 border-b border-border/30 bg-muted/5 px-2.5 py-1.5" onClick={(e) => e.stopPropagation()}>
+        <button
+          type="button"
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("chat"); }}
+          className={cn(
+            "inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+            activeTab === "chat"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground"
+          )}
+        >
+          <MessageSquare className="h-3 w-3" />
+          <span className="truncate">Chat</span>
+        </button>
+        <button
+          type="button"
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("files"); }}
+          className={cn(
+            "inline-flex min-w-0 max-w-full items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors",
+            activeTab === "files"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground"
+          )}
+        >
+          <FolderOpen className="h-3 w-3" />
+          <span className="truncate">Files</span>
+        </button>
+        {hasSummaryTab && (
           <button
             type="button"
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); setActiveTab("summary"); }}
@@ -5405,11 +5440,11 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               {progress.stepSummaries?.length ?? 0}
             </Badge>
           </button>
-        </div>
-      )}
+        )}
+      </div>
 
       {/* Message Stream - Left-aligned content (Chat Tab) */}
-      <div className={cn("relative flex min-h-0 flex-1 flex-col", activeTab !== "chat" && (progress.stepSummaries?.length ?? 0) > 0 && "hidden")}>
+      <div className={cn("relative flex min-h-0 flex-1 flex-col", activeTab !== "chat" && "hidden")}>
         <DelegationSummaryStrip
           entries={delegationSummaryEntries}
           maxItems={delegationSummaryMaxItems}
@@ -5612,12 +5647,19 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       />
 
       {/* Summary View Tab */}
-      {activeTab === "summary" && (progress.stepSummaries?.length ?? 0) > 0 && (
+      {activeTab === "summary" && hasSummaryTab && (
         <div className="relative flex-1 min-h-0 overflow-y-auto p-3" onClick={(e) => e.stopPropagation()}>
           <AgentSummaryView
             progress={progress}
             conversationId={progress.conversationId}
           />
+        </div>
+      )}
+
+      {/* File View Tab */}
+      {activeTab === "files" && (
+        <div className="relative flex-1 min-h-0 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+          <SessionFileView sessionId={progress.sessionId} className="h-full" />
         </div>
       )}
 

--- a/apps/desktop/src/renderer/src/components/session-file-view.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/session-file-view.layout.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const sessionFileViewSource = readFileSync(
+  new URL("./session-file-view.tsx", import.meta.url),
+  "utf8",
+)
+
+describe("session file view layout", () => {
+  it("bounds the file tree and preview panes so both can scroll inside the tab", () => {
+    expect(sessionFileViewSource).toContain(
+      'className="flex max-h-[14rem] min-h-0 flex-col border-b border-border/40 md:max-h-none md:w-[18rem] md:border-b-0 md:border-r"',
+    )
+    expect(sessionFileViewSource).toContain(
+      'className="min-h-0 flex-1 overflow-y-auto px-2 py-2"',
+    )
+    expect(sessionFileViewSource).toContain(
+      'className="min-h-0 flex-1 overflow-y-auto p-3"',
+    )
+  })
+
+  it("keeps collapsed file tree rows and toolbar actions to one line", () => {
+    expect(sessionFileViewSource).toContain(
+      'className="flex flex-nowrap items-center gap-2 overflow-x-auto border-b border-border/40 px-3 py-2"',
+    )
+    expect(sessionFileViewSource).toContain(
+      "shrink-0 gap-1.5 whitespace-nowrap",
+    )
+    expect(sessionFileViewSource).toContain(
+      "whitespace-nowrap rounded px-1 py-1 text-left text-sm",
+    )
+    expect(sessionFileViewSource).toContain("title={entry.name}")
+  })
+
+  it("renders markdown and text previews with overflow-safe chrome", () => {
+    expect(sessionFileViewSource).toContain(
+      'className="max-w-full overflow-x-hidden rounded-md border bg-background p-3 text-sm [overflow-wrap:anywhere]"',
+    )
+    expect(sessionFileViewSource).toContain(
+      'className="max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-md border bg-background p-3 text-xs leading-5 text-foreground [overflow-wrap:anywhere]"',
+    )
+  })
+
+  it("hydrates and clears temporary roots for saved conversation file views", () => {
+    expect(sessionFileViewSource).toContain(
+      'sessionId.startsWith("pending-") && conversationId',
+    )
+    expect(sessionFileViewSource).toContain(
+      "tipcClient.hydrateConversationFileActivity",
+    )
+    expect(sessionFileViewSource).toContain("clearTrackedSessionFileActivity")
+  })
+})

--- a/apps/desktop/src/renderer/src/components/session-file-view.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/session-file-view.layout.test.ts
@@ -50,4 +50,11 @@ describe("session file view layout", () => {
     )
     expect(sessionFileViewSource).toContain("clearTrackedSessionFileActivity")
   })
+
+  it("shows exact read and edited file activity in a compact list", () => {
+    expect(sessionFileViewSource).toContain("getTrackedSessionFileActivity")
+    expect(sessionFileViewSource).toContain("Touched files")
+    expect(sessionFileViewSource).toContain('renderActivityGroup("edited", "Edited")')
+    expect(sessionFileViewSource).toContain('renderActivityGroup("read", "Read")')
+  })
 })

--- a/apps/desktop/src/renderer/src/components/session-file-view.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/session-file-view.layout.test.ts
@@ -51,10 +51,4 @@ describe("session file view layout", () => {
     expect(sessionFileViewSource).toContain("clearTrackedSessionFileActivity")
   })
 
-  it("shows exact read and edited file activity in a compact list", () => {
-    expect(sessionFileViewSource).toContain("getTrackedSessionFileActivity")
-    expect(sessionFileViewSource).toContain("Touched files")
-    expect(sessionFileViewSource).toContain('renderActivityGroup("edited", "Edited")')
-    expect(sessionFileViewSource).toContain('renderActivityGroup("read", "Read")')
-  })
 })

--- a/apps/desktop/src/renderer/src/components/session-file-view.tsx
+++ b/apps/desktop/src/renderer/src/components/session-file-view.tsx
@@ -33,6 +33,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 
 type SessionFileRoot = { path: string; label: string }
 type SessionFileEntry = { path: string; relativePath: string; name: string; kind: "file" | "directory"; size?: number; modifiedAt: number }
+type SessionFileListing = { entries: SessionFileEntry[]; totalEntries: number; limit: number; truncated: boolean }
 type SessionFilePreview = {
   path: string
   relativePath: string
@@ -89,14 +90,14 @@ function formatBytes(size?: number) {
   return `${(size / (1024 * 1024)).toFixed(1)} MB`
 }
 
-export function SessionFileView({ sessionId, className }: { sessionId?: string | null; className?: string }) {
+export function SessionFileView({ sessionId, conversationId, className }: { sessionId?: string | null; conversationId?: string | null; className?: string }) {
   const [roots, setRoots] = useState<SessionFileRoot[]>([])
   const [isLoadingRoots, setIsLoadingRoots] = useState(false)
   const [rootsError, setRootsError] = useState<string | null>(null)
   const [selectedRootPath, setSelectedRootPath] = useState<string>("")
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>({})
-  const [entriesByDirectory, setEntriesByDirectory] = useState<Record<string, SessionFileEntry[]>>({})
+  const [listingsByDirectory, setListingsByDirectory] = useState<Record<string, SessionFileListing>>({})
   const [loadingDirectories, setLoadingDirectories] = useState<Record<string, boolean>>({})
   const [preview, setPreview] = useState<SessionFilePreview | null>(null)
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)
@@ -126,7 +127,9 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
     setIsLoadingRoots(true)
     setRootsError(null)
     try {
-      const nextRoots = await tipcClient.getTrackedSessionFileRoots({ sessionId }) as SessionFileRoot[]
+      const nextRoots = sessionId.startsWith("pending-") && conversationId
+        ? await tipcClient.hydrateConversationFileActivity({ sessionId, conversationId }) as SessionFileRoot[]
+        : await tipcClient.getTrackedSessionFileRoots({ sessionId }) as SessionFileRoot[]
       setRoots(nextRoots)
       setSelectedRootPath((current) => nextRoots.some((root) => root.path === current) ? current : (nextRoots[0]?.path ?? ""))
     } catch (error) {
@@ -137,30 +140,42 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
     } finally {
       setIsLoadingRoots(false)
     }
+  }, [conversationId, sessionId])
+
+  useEffect(() => {
+    if (!sessionId?.startsWith("pending-")) return undefined
+    return () => {
+      void tipcClient.clearTrackedSessionFileActivity({ sessionId }).catch((error: unknown) => {
+        console.warn("Failed to clear temporary session file roots", error)
+      })
+    }
   }, [sessionId])
 
   const loadDirectory = useCallback(async (directoryPath: string, options?: { force?: boolean }) => {
     if (!sessionId || !currentRoot) return
-    if (!options?.force && entriesByDirectory[directoryPath]) return
+    if (!options?.force && listingsByDirectory[directoryPath]) return
 
     setLoadingDirectories((current) => ({ ...current, [directoryPath]: true }))
     try {
-      const entries = await tipcClient.listTrackedSessionFiles({
+      const result = await tipcClient.listTrackedSessionFiles({
         sessionId,
         rootPath: currentRoot.path,
         directoryPath,
-      }) as SessionFileEntry[]
-      setEntriesByDirectory((current) => ({ ...current, [directoryPath]: entries }))
+      }) as SessionFileEntry[] | SessionFileListing
+      const listing = Array.isArray(result)
+        ? { entries: result, totalEntries: result.length, limit: result.length, truncated: false }
+        : result
+      setListingsByDirectory((current) => ({ ...current, [directoryPath]: listing }))
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to list files")
     } finally {
       setLoadingDirectories((current) => ({ ...current, [directoryPath]: false }))
     }
-  }, [currentRoot, entriesByDirectory, sessionId])
+  }, [currentRoot, listingsByDirectory, sessionId])
 
   const refreshLoadedDirectories = useCallback(async () => {
     if (!currentRoot) return
-    const targets = Object.keys(entriesByDirectory)
+    const targets = Object.keys(listingsByDirectory)
       .filter((directoryPath) => isWithinRootPath(currentRoot.path, directoryPath))
       .filter((directoryPath) => directoryPath === currentRoot.path || expandedDirectories[directoryPath])
       .filter((directoryPath, index, values) => values.indexOf(directoryPath) === index)
@@ -168,10 +183,10 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
     // just deleted or moved) cannot reject the whole refresh and make the
     // caller treat a successful filesystem mutation as a failure.
     await Promise.allSettled(targets.map((directoryPath) => loadDirectory(directoryPath, { force: true })))
-  }, [currentRoot, entriesByDirectory, expandedDirectories, loadDirectory])
+  }, [currentRoot, listingsByDirectory, expandedDirectories, loadDirectory])
 
   useEffect(() => {
-    setEntriesByDirectory({})
+    setListingsByDirectory({})
     setExpandedDirectories({})
     setPreview(null)
     setPreviewError(null)
@@ -194,7 +209,7 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
     if (!sessionId || !currentRoot || !selectedPath) {
       setPreview(null)
       setPreviewError(null)
-      return
+      return undefined
     }
 
     let cancelled = false
@@ -286,7 +301,8 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
   }, [currentRoot, dialogState, refreshLoadedDirectories, selectedPath, sessionId])
 
   const renderDirectoryEntries = useCallback((directoryPath: string): React.ReactNode => {
-    const entries = entriesByDirectory[directoryPath] ?? []
+    const listing = listingsByDirectory[directoryPath]
+    const entries = listing?.entries ?? []
     if (loadingDirectories[directoryPath]) {
       return <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground"><Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading…</div>
     }
@@ -300,9 +316,9 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
       const isSelected = selectedPath === entry.path
 
       return (
-        <div key={entry.path} className="space-y-1">
+        <div key={entry.path} className="min-w-0 space-y-1">
           <div className={cn(
-            "flex items-center gap-1 rounded-md px-1 py-0.5",
+            "flex min-w-0 items-center gap-1 rounded-md px-1 py-0.5",
             isSelected ? "bg-primary/10 text-primary" : "hover:bg-muted/50",
           )}>
             <button
@@ -316,7 +332,7 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
             </button>
             <button
               type="button"
-              className="flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-1 text-left text-sm"
+              className="flex min-w-0 flex-1 items-center gap-2 whitespace-nowrap rounded px-1 py-1 text-left text-sm"
               onClick={() => {
                 setSelectedPath(entry.path)
                 if (isDirectory && !expandedDirectories[entry.path]) {
@@ -325,22 +341,26 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
               }}
             >
               {isDirectory ? <FolderOpen className="h-4 w-4 shrink-0" /> : <FileText className="h-4 w-4 shrink-0" />}
-              <span className="truncate">{entry.name}</span>
+              <span className="truncate" title={entry.name}>{entry.name}</span>
             </button>
           </div>
           {isDirectory && isExpanded && (
-            <div className="ml-4 border-l border-border/40 pl-2">
+            <div className="ml-4 min-w-0 border-l border-border/40 pl-2">
               {renderDirectoryEntries(entry.path)}
             </div>
           )}
         </div>
       )
-    })
-  }, [entriesByDirectory, expandedDirectories, handleToggleDirectory, loadingDirectories, selectedPath])
+    }).concat(listing?.truncated ? (
+      <div key={`${directoryPath}:truncated`} className="py-1.5 pl-8 text-xs text-muted-foreground">
+        Showing first {listing.limit.toLocaleString()} of {listing.totalEntries.toLocaleString()} entries.
+      </div>
+    ) : [])
+  }, [expandedDirectories, handleToggleDirectory, listingsByDirectory, loadingDirectories, selectedPath])
 
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
-      <div className="flex flex-wrap items-center gap-2 border-b border-border/40 px-3 py-2">
+      <div className="flex flex-nowrap items-center gap-2 overflow-x-auto border-b border-border/40 px-3 py-2">
         <div className="min-w-[12rem] flex-1">
           <Select value={currentRoot?.path ?? ""} onValueChange={setSelectedRootPath} disabled={roots.length <= 1}>
             <SelectTrigger className="h-8 rounded-md border border-input bg-background px-2">
@@ -351,25 +371,25 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
             </SelectContent>
           </Select>
         </div>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void loadRoots()} disabled={isLoadingRoots}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap" onClick={() => void loadRoots()} disabled={isLoadingRoots}>
           <RefreshCw className={cn("h-3.5 w-3.5", isLoadingRoots && "animate-spin")} /> Refresh
         </Button>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDialogState({ mode: "create-file", value: buildDefaultCreatePath(selectedDirectoryBase, "file") })} disabled={!currentRoot}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap" onClick={() => setDialogState({ mode: "create-file", value: buildDefaultCreatePath(selectedDirectoryBase, "file") })} disabled={!currentRoot}>
           <FilePlus2 className="h-3.5 w-3.5" /> New file
         </Button>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDialogState({ mode: "create-folder", value: buildDefaultCreatePath(selectedDirectoryBase, "directory") })} disabled={!currentRoot}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap" onClick={() => setDialogState({ mode: "create-folder", value: buildDefaultCreatePath(selectedDirectoryBase, "directory") })} disabled={!currentRoot}>
           <FolderPlus className="h-3.5 w-3.5" /> New folder
         </Button>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDialogState({ mode: "move", value: selectedRelativePath === "." ? "" : selectedRelativePath })} disabled={!selectedPath || selectedRelativePath === "."}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap" onClick={() => setDialogState({ mode: "move", value: selectedRelativePath === "." ? "" : selectedRelativePath })} disabled={!selectedPath || selectedRelativePath === "."}>
           <Pencil className="h-3.5 w-3.5" /> Move / rename
         </Button>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void handleOpenPath("open")} disabled={!currentRoot}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap" onClick={() => void handleOpenPath("open")} disabled={!currentRoot}>
           <ExternalLink className="h-3.5 w-3.5" /> Open
         </Button>
-        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void handleOpenPath("reveal")} disabled={!currentRoot}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap" onClick={() => void handleOpenPath("reveal")} disabled={!currentRoot}>
           <FolderUp className="h-3.5 w-3.5" /> Reveal
         </Button>
-        <Button variant="outline" size="sm" className="gap-1.5 text-destructive hover:text-destructive" onClick={() => setDialogState({ mode: "delete" })} disabled={!selectedPath || selectedRelativePath === "."}>
+        <Button variant="outline" size="sm" className="shrink-0 gap-1.5 whitespace-nowrap text-destructive hover:text-destructive" onClick={() => setDialogState({ mode: "delete" })} disabled={!selectedPath || selectedRelativePath === "."}>
           <Trash2 className="h-3.5 w-3.5" /> Delete
         </Button>
       </div>
@@ -391,23 +411,24 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col gap-0 md:flex-row">
-          <div className="min-h-0 border-b border-border/40 md:w-[18rem] md:border-b-0 md:border-r">
+          <div className="flex max-h-[14rem] min-h-0 flex-col border-b border-border/40 md:max-h-none md:w-[18rem] md:border-b-0 md:border-r">
             <div className="border-b border-border/40 px-3 py-2 text-xs text-muted-foreground">
-              {currentRoot?.label} <span className="block truncate">{currentRoot?.path}</span>
+              <span className="block truncate font-medium text-foreground" title={currentRoot?.label}>{currentRoot?.label}</span>
+              <span className="block truncate" title={currentRoot?.path}>{currentRoot?.path}</span>
             </div>
-            <div className="min-h-0 overflow-y-auto px-2 py-2">
+            <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
               <button
                 type="button"
                 className={cn(
-                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium",
+                  "flex w-full min-w-0 items-center gap-2 whitespace-nowrap rounded-md px-2 py-1.5 text-left text-sm font-medium",
                   selectedRelativePath === "." ? "bg-primary/10 text-primary" : "hover:bg-muted/50",
                 )}
                 onClick={() => setSelectedPath(currentRoot?.path ?? null)}
               >
                 <FolderOpen className="h-4 w-4 shrink-0" />
-                <span className="truncate">{currentRoot?.label}</span>
+                <span className="truncate" title={currentRoot?.label}>{currentRoot?.label}</span>
               </button>
-              <div className="ml-4 mt-1 border-l border-border/40 pl-2">{currentRoot ? renderDirectoryEntries(currentRoot.path) : null}</div>
+              <div className="ml-4 mt-1 min-w-0 border-l border-border/40 pl-2">{currentRoot ? renderDirectoryEntries(currentRoot.path) : null}</div>
             </div>
           </div>
 
@@ -426,11 +447,11 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
               ) : previewError ? (
                 <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">{previewError}</div>
               ) : preview?.kind === "markdown" ? (
-                <div className="rounded-lg border bg-background p-3"><MarkdownRenderer content={preview.content ?? ""} /></div>
+                <div className="max-w-full overflow-x-hidden rounded-md border bg-background p-3 text-sm [overflow-wrap:anywhere]"><MarkdownRenderer content={preview.content ?? ""} /></div>
               ) : preview?.kind === "text" ? (
-                <pre className="rounded-lg border bg-background p-3 text-xs leading-5 text-foreground whitespace-pre-wrap break-words">{preview.content}</pre>
+                <pre className="max-w-full overflow-x-auto whitespace-pre-wrap break-words rounded-md border bg-background p-3 text-xs leading-5 text-foreground [overflow-wrap:anywhere]">{preview.content}</pre>
               ) : preview?.kind === "image" && preview.dataUrl ? (
-                <div className="flex min-h-full items-start justify-center"><img src={preview.dataUrl} alt={preview.name} className="max-h-full max-w-full rounded-lg border bg-background" /></div>
+                <div className="flex min-h-full items-start justify-center overflow-auto"><img src={preview.dataUrl} alt={preview.name} className="max-h-full max-w-full rounded-md border bg-background" /></div>
               ) : preview?.kind === "binary" ? (
                 <div className="rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">Binary preview is not available in-app for this file yet. Use Open or Reveal to inspect it in the OS.</div>
               ) : preview?.kind === "directory" ? (

--- a/apps/desktop/src/renderer/src/components/session-file-view.tsx
+++ b/apps/desktop/src/renderer/src/components/session-file-view.tsx
@@ -1,0 +1,482 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  FilePlus2,
+  FileText,
+  FolderOpen,
+  FolderPlus,
+  FolderUp,
+  Loader2,
+  Pencil,
+  RefreshCw,
+  Trash2,
+} from "lucide-react"
+import { toast } from "sonner"
+
+import { tipcClient } from "@renderer/lib/tipc-client"
+import { cn } from "@renderer/lib/utils"
+import { MarkdownRenderer } from "./markdown-renderer"
+import { Button } from "./ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog"
+import { Input } from "./ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select"
+
+type SessionFileRoot = { path: string; label: string }
+type SessionFileEntry = { path: string; relativePath: string; name: string; kind: "file" | "directory"; size?: number; modifiedAt: number }
+type SessionFilePreview = {
+  path: string
+  relativePath: string
+  name: string
+  kind: "directory" | "text" | "markdown" | "image" | "binary"
+  size: number
+  modifiedAt: number
+  content?: string
+  dataUrl?: string
+  truncated?: boolean
+}
+type FileDialogState =
+  | { mode: "create-file" | "create-folder" | "move"; value: string }
+  | { mode: "delete" }
+
+const normalizePath = (value?: string | null) => (value ?? "").replace(/\\/g, "/")
+const normalizeRelativePath = (value?: string | null) => normalizePath(value).replace(/^\/+/, "").replace(/\/$/, "")
+
+function getRelativePath(rootPath: string, targetPath?: string | null) {
+  const normalizedRoot = normalizePath(rootPath).replace(/\/$/, "")
+  const normalizedTarget = normalizePath(targetPath)
+  if (!normalizedTarget || normalizedTarget === normalizedRoot) return "."
+  if (normalizedTarget.startsWith(`${normalizedRoot}/`)) return normalizedTarget.slice(normalizedRoot.length + 1)
+  return normalizedTarget
+}
+
+function isWithinRootPath(rootPath: string, targetPath?: string | null) {
+  const normalizedRoot = normalizePath(rootPath).replace(/\/$/, "")
+  const normalizedTarget = normalizePath(targetPath)
+  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`)
+}
+
+function getParentRelativePath(relativePath?: string | null) {
+  const normalized = normalizeRelativePath(relativePath)
+  if (!normalized || normalized === ".") return ""
+  const segments = normalized.split("/")
+  segments.pop()
+  return segments.join("/")
+}
+
+function buildDefaultCreatePath(baseRelativePath: string, kind: "file" | "directory") {
+  const name = kind === "file" ? "new-file.txt" : "new-folder"
+  return normalizeRelativePath(baseRelativePath) ? `${normalizeRelativePath(baseRelativePath)}/${name}` : name
+}
+
+function formatTimestamp(value: number) {
+  return new Date(value).toLocaleString()
+}
+
+function formatBytes(size?: number) {
+  if (typeof size !== "number" || Number.isNaN(size)) return "—"
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function SessionFileView({ sessionId, className }: { sessionId?: string | null; className?: string }) {
+  const [roots, setRoots] = useState<SessionFileRoot[]>([])
+  const [isLoadingRoots, setIsLoadingRoots] = useState(false)
+  const [rootsError, setRootsError] = useState<string | null>(null)
+  const [selectedRootPath, setSelectedRootPath] = useState<string>("")
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>({})
+  const [entriesByDirectory, setEntriesByDirectory] = useState<Record<string, SessionFileEntry[]>>({})
+  const [loadingDirectories, setLoadingDirectories] = useState<Record<string, boolean>>({})
+  const [preview, setPreview] = useState<SessionFilePreview | null>(null)
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [dialogState, setDialogState] = useState<FileDialogState | null>(null)
+  const [isSubmittingDialog, setIsSubmittingDialog] = useState(false)
+
+  const currentRoot = useMemo(
+    () => roots.find((root) => root.path === selectedRootPath) ?? roots[0] ?? null,
+    [roots, selectedRootPath],
+  )
+  const selectedRelativePath = currentRoot ? getRelativePath(currentRoot.path, selectedPath) : "."
+  const selectedDirectoryBase = preview?.kind === "directory"
+    ? preview.relativePath
+    : getParentRelativePath(selectedRelativePath)
+
+  const loadRoots = useCallback(async () => {
+    if (!sessionId) {
+      setRoots([])
+      setSelectedRootPath("")
+      setSelectedPath(null)
+      setPreview(null)
+      setRootsError(null)
+      return
+    }
+
+    setIsLoadingRoots(true)
+    setRootsError(null)
+    try {
+      const nextRoots = await tipcClient.getTrackedSessionFileRoots({ sessionId }) as SessionFileRoot[]
+      setRoots(nextRoots)
+      setSelectedRootPath((current) => nextRoots.some((root) => root.path === current) ? current : (nextRoots[0]?.path ?? ""))
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to load session files"
+      setRootsError(message)
+      setRoots([])
+      setSelectedRootPath("")
+    } finally {
+      setIsLoadingRoots(false)
+    }
+  }, [sessionId])
+
+  const loadDirectory = useCallback(async (directoryPath: string, options?: { force?: boolean }) => {
+    if (!sessionId || !currentRoot) return
+    if (!options?.force && entriesByDirectory[directoryPath]) return
+
+    setLoadingDirectories((current) => ({ ...current, [directoryPath]: true }))
+    try {
+      const entries = await tipcClient.listTrackedSessionFiles({
+        sessionId,
+        rootPath: currentRoot.path,
+        directoryPath,
+      }) as SessionFileEntry[]
+      setEntriesByDirectory((current) => ({ ...current, [directoryPath]: entries }))
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to list files")
+    } finally {
+      setLoadingDirectories((current) => ({ ...current, [directoryPath]: false }))
+    }
+  }, [currentRoot, entriesByDirectory, sessionId])
+
+  const refreshLoadedDirectories = useCallback(async () => {
+    if (!currentRoot) return
+    const targets = Object.keys(entriesByDirectory)
+      .filter((directoryPath) => isWithinRootPath(currentRoot.path, directoryPath))
+      .filter((directoryPath) => directoryPath === currentRoot.path || expandedDirectories[directoryPath])
+      .filter((directoryPath, index, values) => values.indexOf(directoryPath) === index)
+    await Promise.all(targets.map((directoryPath) => loadDirectory(directoryPath, { force: true })))
+  }, [currentRoot, entriesByDirectory, expandedDirectories, loadDirectory])
+
+  useEffect(() => {
+    setEntriesByDirectory({})
+    setExpandedDirectories({})
+    setPreview(null)
+    setPreviewError(null)
+    void loadRoots()
+  }, [loadRoots])
+
+  useEffect(() => {
+    if (!currentRoot) {
+      setSelectedPath(null)
+      return
+    }
+    setExpandedDirectories((current) => ({ ...current, [currentRoot.path]: true }))
+    if (!selectedPath || !isWithinRootPath(currentRoot.path, selectedPath)) {
+      setSelectedPath(currentRoot.path)
+    }
+    void loadDirectory(currentRoot.path)
+  }, [currentRoot, loadDirectory, selectedPath])
+
+  useEffect(() => {
+    if (!sessionId || !currentRoot || !selectedPath) {
+      setPreview(null)
+      setPreviewError(null)
+      return
+    }
+
+    let cancelled = false
+    setIsLoadingPreview(true)
+    setPreviewError(null)
+    void tipcClient.readTrackedSessionFilePreview({
+      sessionId,
+      rootPath: currentRoot.path,
+      filePath: selectedPath,
+    }).then((nextPreview: SessionFilePreview) => {
+      if (!cancelled) setPreview(nextPreview)
+    }).catch((error: unknown) => {
+      if (!cancelled) {
+        setPreview(null)
+        setPreviewError(error instanceof Error ? error.message : "Failed to load file preview")
+      }
+    }).finally(() => {
+      if (!cancelled) setIsLoadingPreview(false)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [currentRoot, selectedPath, sessionId])
+
+  const handleToggleDirectory = useCallback((directoryPath: string) => {
+    setExpandedDirectories((current) => {
+      const nextExpanded = !current[directoryPath]
+      if (nextExpanded) void loadDirectory(directoryPath)
+      return { ...current, [directoryPath]: nextExpanded }
+    })
+  }, [loadDirectory])
+
+  const handleOpenPath = useCallback(async (mode: "open" | "reveal") => {
+    if (!sessionId || !currentRoot) return
+    const targetPath = selectedPath ?? currentRoot.path
+    try {
+      const result = mode === "open"
+        ? await tipcClient.openTrackedSessionPath({ sessionId, rootPath: currentRoot.path, targetPath })
+        : await tipcClient.revealTrackedSessionPath({ sessionId, rootPath: currentRoot.path, targetPath })
+      if (!result?.success) {
+        toast.error(result?.error || `Failed to ${mode} path`)
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : `Failed to ${mode} path`)
+    }
+  }, [currentRoot, selectedPath, sessionId])
+
+  const handleSubmitDialog = useCallback(async () => {
+    if (!sessionId || !currentRoot || !dialogState) return
+    setIsSubmittingDialog(true)
+    try {
+      if (dialogState.mode === "create-file" || dialogState.mode === "create-folder") {
+        const created = await tipcClient.createTrackedSessionFileEntry({
+          sessionId,
+          rootPath: currentRoot.path,
+          targetPath: dialogState.value,
+          kind: dialogState.mode === "create-file" ? "file" : "directory",
+        })
+        await refreshLoadedDirectories()
+        setSelectedPath(created?.path ?? currentRoot.path)
+        toast.success(dialogState.mode === "create-file" ? "File created" : "Folder created")
+      } else if (dialogState.mode === "move" && selectedPath) {
+        const moved = await tipcClient.moveTrackedSessionFileEntry({
+          sessionId,
+          rootPath: currentRoot.path,
+          sourcePath: selectedPath,
+          targetPath: dialogState.value,
+        })
+        await refreshLoadedDirectories()
+        setSelectedPath(moved?.path ?? currentRoot.path)
+        toast.success("Path updated")
+      } else if (dialogState.mode === "delete" && selectedPath) {
+        await tipcClient.deleteTrackedSessionFileEntry({
+          sessionId,
+          rootPath: currentRoot.path,
+          targetPath: selectedPath,
+        })
+        await refreshLoadedDirectories()
+        setSelectedPath(currentRoot.path)
+        toast.success("Path deleted")
+      }
+      setDialogState(null)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "File operation failed")
+    } finally {
+      setIsSubmittingDialog(false)
+    }
+  }, [currentRoot, dialogState, refreshLoadedDirectories, selectedPath, sessionId])
+
+  const renderDirectoryEntries = useCallback((directoryPath: string): React.ReactNode => {
+    const entries = entriesByDirectory[directoryPath] ?? []
+    if (loadingDirectories[directoryPath]) {
+      return <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground"><Loader2 className="h-3.5 w-3.5 animate-spin" /> Loading…</div>
+    }
+    if (entries.length === 0) {
+      return <div className="py-2 text-xs text-muted-foreground">No visible files yet.</div>
+    }
+
+    return entries.map((entry) => {
+      const isDirectory = entry.kind === "directory"
+      const isExpanded = !!expandedDirectories[entry.path]
+      const isSelected = selectedPath === entry.path
+
+      return (
+        <div key={entry.path} className="space-y-1">
+          <div className={cn(
+            "flex items-center gap-1 rounded-md px-1 py-0.5",
+            isSelected ? "bg-primary/10 text-primary" : "hover:bg-muted/50",
+          )}>
+            <button
+              type="button"
+              className="flex h-6 w-6 items-center justify-center rounded hover:bg-muted"
+              onClick={() => isDirectory && handleToggleDirectory(entry.path)}
+              aria-label={isExpanded ? `Collapse ${entry.name}` : `Expand ${entry.name}`}
+              disabled={!isDirectory}
+            >
+              {isDirectory ? (isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />) : <span className="h-3.5 w-3.5" />}
+            </button>
+            <button
+              type="button"
+              className="flex min-w-0 flex-1 items-center gap-2 rounded px-1 py-1 text-left text-sm"
+              onClick={() => {
+                setSelectedPath(entry.path)
+                if (isDirectory && !expandedDirectories[entry.path]) {
+                  handleToggleDirectory(entry.path)
+                }
+              }}
+            >
+              {isDirectory ? <FolderOpen className="h-4 w-4 shrink-0" /> : <FileText className="h-4 w-4 shrink-0" />}
+              <span className="truncate">{entry.name}</span>
+            </button>
+          </div>
+          {isDirectory && isExpanded && (
+            <div className="ml-4 border-l border-border/40 pl-2">
+              {renderDirectoryEntries(entry.path)}
+            </div>
+          )}
+        </div>
+      )
+    })
+  }, [entriesByDirectory, expandedDirectories, handleToggleDirectory, loadingDirectories, selectedPath])
+
+  return (
+    <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
+      <div className="flex flex-wrap items-center gap-2 border-b border-border/40 px-3 py-2">
+        <div className="min-w-[12rem] flex-1">
+          <Select value={currentRoot?.path ?? ""} onValueChange={setSelectedRootPath} disabled={roots.length <= 1}>
+            <SelectTrigger className="h-8 rounded-md border border-input bg-background px-2">
+              <SelectValue placeholder={isLoadingRoots ? "Loading workspaces…" : "No workspaces yet"} />
+            </SelectTrigger>
+            <SelectContent>
+              {roots.map((root) => <SelectItem key={root.path} value={root.path}>{root.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void loadRoots()} disabled={isLoadingRoots}>
+          <RefreshCw className={cn("h-3.5 w-3.5", isLoadingRoots && "animate-spin")} /> Refresh
+        </Button>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDialogState({ mode: "create-file", value: buildDefaultCreatePath(selectedDirectoryBase, "file") })} disabled={!currentRoot}>
+          <FilePlus2 className="h-3.5 w-3.5" /> New file
+        </Button>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDialogState({ mode: "create-folder", value: buildDefaultCreatePath(selectedDirectoryBase, "directory") })} disabled={!currentRoot}>
+          <FolderPlus className="h-3.5 w-3.5" /> New folder
+        </Button>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setDialogState({ mode: "move", value: selectedRelativePath === "." ? "" : selectedRelativePath })} disabled={!selectedPath || selectedRelativePath === "."}>
+          <Pencil className="h-3.5 w-3.5" /> Move / rename
+        </Button>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void handleOpenPath("open")} disabled={!currentRoot}>
+          <ExternalLink className="h-3.5 w-3.5" /> Open
+        </Button>
+        <Button variant="outline" size="sm" className="gap-1.5" onClick={() => void handleOpenPath("reveal")} disabled={!currentRoot}>
+          <FolderUp className="h-3.5 w-3.5" /> Reveal
+        </Button>
+        <Button variant="outline" size="sm" className="gap-1.5 text-destructive hover:text-destructive" onClick={() => setDialogState({ mode: "delete" })} disabled={!selectedPath || selectedRelativePath === "."}>
+          <Trash2 className="h-3.5 w-3.5" /> Delete
+        </Button>
+      </div>
+
+      {!sessionId ? (
+        <div className="m-3 rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">
+          File View becomes available once the session has a real session ID.
+        </div>
+      ) : rootsError ? (
+        <div className="m-3 rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {rootsError}
+        </div>
+      ) : roots.length === 0 ? (
+        <div className="m-3 rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center">
+          <h3 className="text-base font-medium">No tracked workspaces yet</h3>
+          <p className="mx-auto mt-1 max-w-sm text-sm text-muted-foreground">
+            File View will populate after the session works in a workspace or returns file paths in tool output.
+          </p>
+        </div>
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-0 md:flex-row">
+          <div className="min-h-0 border-b border-border/40 md:w-[18rem] md:border-b-0 md:border-r">
+            <div className="border-b border-border/40 px-3 py-2 text-xs text-muted-foreground">
+              {currentRoot?.label} <span className="block truncate">{currentRoot?.path}</span>
+            </div>
+            <div className="min-h-0 overflow-y-auto px-2 py-2">
+              <button
+                type="button"
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium",
+                  selectedRelativePath === "." ? "bg-primary/10 text-primary" : "hover:bg-muted/50",
+                )}
+                onClick={() => setSelectedPath(currentRoot?.path ?? null)}
+              >
+                <FolderOpen className="h-4 w-4 shrink-0" />
+                <span className="truncate">{currentRoot?.label}</span>
+              </button>
+              <div className="ml-4 mt-1 border-l border-border/40 pl-2">{currentRoot ? renderDirectoryEntries(currentRoot.path) : null}</div>
+            </div>
+          </div>
+
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="border-b border-border/40 px-3 py-2">
+              <div className="truncate text-sm font-medium">{selectedRelativePath === "." ? currentRoot?.label : selectedRelativePath}</div>
+              <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                <span>Kind: {preview?.kind ?? "—"}</span>
+                <span>Size: {formatBytes(preview?.size)}</span>
+                <span>Updated: {preview ? formatTimestamp(preview.modifiedAt) : "—"}</span>
+              </div>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-3">
+              {isLoadingPreview ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" /> Loading preview…</div>
+              ) : previewError ? (
+                <div className="rounded-lg border border-destructive/40 bg-destructive/5 px-4 py-3 text-sm text-destructive">{previewError}</div>
+              ) : preview?.kind === "markdown" ? (
+                <div className="rounded-lg border bg-background p-3"><MarkdownRenderer content={preview.content ?? ""} /></div>
+              ) : preview?.kind === "text" ? (
+                <pre className="rounded-lg border bg-background p-3 text-xs leading-5 text-foreground whitespace-pre-wrap break-words">{preview.content}</pre>
+              ) : preview?.kind === "image" && preview.dataUrl ? (
+                <div className="flex min-h-full items-start justify-center"><img src={preview.dataUrl} alt={preview.name} className="max-h-full max-w-full rounded-lg border bg-background" /></div>
+              ) : preview?.kind === "binary" ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">Binary preview is not available in-app for this file yet. Use Open or Reveal to inspect it in the OS.</div>
+              ) : preview?.kind === "directory" ? (
+                <div className="rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">Use the tree on the left to browse this workspace directory.</div>
+              ) : (
+                <div className="rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">Select a file or folder to inspect it.</div>
+              )}
+              {preview?.truncated && <div className="mt-2 text-xs text-muted-foreground">Preview truncated to keep File View responsive.</div>}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <Dialog open={!!dialogState} onOpenChange={(open) => !open && setDialogState(null)}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogState?.mode === "create-file" ? "Create file" : dialogState?.mode === "create-folder" ? "Create folder" : dialogState?.mode === "move" ? "Move or rename" : "Delete path"}
+            </DialogTitle>
+            <DialogDescription>
+              {dialogState?.mode === "delete"
+                ? `Delete ${selectedRelativePath}? This action cannot be undone.`
+                : "Paths are relative to the selected workspace root."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {dialogState?.mode === "delete" ? (
+            <div className="flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{selectedRelativePath}</span>
+            </div>
+          ) : (
+            <Input
+              autoFocus
+              value={dialogState?.value ?? ""}
+              onChange={(event) => setDialogState((current) => current && current.mode !== "delete" ? { ...current, value: event.target.value } : current)}
+              placeholder="relative/path"
+            />
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogState(null)} disabled={isSubmittingDialog}>Cancel</Button>
+            <Button variant={dialogState?.mode === "delete" ? "destructive" : "default"} onClick={() => void handleSubmitDialog()} disabled={isSubmittingDialog || (dialogState?.mode !== "delete" && !dialogState?.value?.trim())}>
+              {isSubmittingDialog ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              {dialogState?.mode === "delete" ? "Delete" : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/session-file-view.tsx
+++ b/apps/desktop/src/renderer/src/components/session-file-view.tsx
@@ -34,6 +34,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 type SessionFileRoot = { path: string; label: string }
 type SessionFileEntry = { path: string; relativePath: string; name: string; kind: "file" | "directory"; size?: number; modifiedAt: number }
 type SessionFileListing = { entries: SessionFileEntry[]; totalEntries: number; limit: number; truncated: boolean }
+type SessionFileActivityKind = "read" | "edited"
+type SessionFileActivity = { path: string; rootPath: string; relativePath: string; kind: SessionFileActivityKind; source: string; lastSeenAt: number }
 type SessionFilePreview = {
   path: string
   relativePath: string
@@ -98,6 +100,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>({})
   const [listingsByDirectory, setListingsByDirectory] = useState<Record<string, SessionFileListing>>({})
+  const [fileActivity, setFileActivity] = useState<SessionFileActivity[]>([])
   const [loadingDirectories, setLoadingDirectories] = useState<Record<string, boolean>>({})
   const [preview, setPreview] = useState<SessionFilePreview | null>(null)
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)
@@ -121,6 +124,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       setSelectedPath(null)
       setPreview(null)
       setRootsError(null)
+      setFileActivity([])
       return
     }
 
@@ -130,13 +134,16 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       const nextRoots = sessionId.startsWith("pending-") && conversationId
         ? await tipcClient.hydrateConversationFileActivity({ sessionId, conversationId }) as SessionFileRoot[]
         : await tipcClient.getTrackedSessionFileRoots({ sessionId }) as SessionFileRoot[]
+      const nextActivity = await tipcClient.getTrackedSessionFileActivity({ sessionId }) as SessionFileActivity[]
       setRoots(nextRoots)
+      setFileActivity(nextActivity)
       setSelectedRootPath((current) => nextRoots.some((root) => root.path === current) ? current : (nextRoots[0]?.path ?? ""))
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to load session files"
       setRootsError(message)
       setRoots([])
       setSelectedRootPath("")
+      setFileActivity([])
     } finally {
       setIsLoadingRoots(false)
     }
@@ -148,6 +155,15 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       void tipcClient.clearTrackedSessionFileActivity({ sessionId }).catch((error: unknown) => {
         console.warn("Failed to clear temporary session file roots", error)
       })
+    }
+  }, [sessionId])
+
+  const refreshFileActivity = useCallback(async () => {
+    if (!sessionId) return
+    try {
+      setFileActivity(await tipcClient.getTrackedSessionFileActivity({ sessionId }) as SessionFileActivity[])
+    } catch {
+      // File activity is supplemental; keep the browser usable if it cannot load.
     }
   }, [sessionId])
 
@@ -220,7 +236,10 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       rootPath: currentRoot.path,
       filePath: selectedPath,
     }).then((nextPreview: SessionFilePreview) => {
-      if (!cancelled) setPreview(nextPreview)
+      if (!cancelled) {
+        setPreview(nextPreview)
+        void refreshFileActivity()
+      }
     }).catch((error: unknown) => {
       if (!cancelled) {
         setPreview(null)
@@ -233,7 +252,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     return () => {
       cancelled = true
     }
-  }, [currentRoot, selectedPath, sessionId])
+  }, [currentRoot, refreshFileActivity, selectedPath, sessionId])
 
   const handleToggleDirectory = useCallback((directoryPath: string) => {
     setExpandedDirectories((current) => {
@@ -270,6 +289,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           kind: dialogState.mode === "create-file" ? "file" : "directory",
         })
         await refreshLoadedDirectories()
+        await refreshFileActivity()
         setSelectedPath(created?.path ?? currentRoot.path)
         toast.success(dialogState.mode === "create-file" ? "File created" : "Folder created")
       } else if (dialogState.mode === "move" && selectedPath) {
@@ -280,6 +300,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           targetPath: dialogState.value,
         })
         await refreshLoadedDirectories()
+        await refreshFileActivity()
         setSelectedPath(moved?.path ?? currentRoot.path)
         toast.success("Path updated")
       } else if (dialogState.mode === "delete" && selectedPath) {
@@ -289,6 +310,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           targetPath: selectedPath,
         })
         await refreshLoadedDirectories()
+        await refreshFileActivity()
         setSelectedPath(currentRoot.path)
         toast.success("Path deleted")
       }
@@ -298,7 +320,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     } finally {
       setIsSubmittingDialog(false)
     }
-  }, [currentRoot, dialogState, refreshLoadedDirectories, selectedPath, sessionId])
+  }, [currentRoot, dialogState, refreshFileActivity, refreshLoadedDirectories, selectedPath, sessionId])
 
   const renderDirectoryEntries = useCallback((directoryPath: string): React.ReactNode => {
     const listing = listingsByDirectory[directoryPath]
@@ -358,6 +380,38 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     ) : [])
   }, [expandedDirectories, handleToggleDirectory, listingsByDirectory, loadingDirectories, selectedPath])
 
+  const renderActivityGroup = useCallback((kind: SessionFileActivityKind, label: string) => {
+    const entries = fileActivity.filter((entry) => entry.kind === kind)
+    if (entries.length === 0) return null
+
+    return (
+      <div className="min-w-[12rem] flex-1">
+        <div className="mb-1 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          <span>{label}</span>
+          <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px]">{entries.length}</span>
+        </div>
+        <div className="max-h-24 space-y-1 overflow-y-auto pr-1">
+          {entries.map((entry) => (
+            <button
+              key={`${entry.kind}:${entry.path}`}
+              type="button"
+              className="flex w-full min-w-0 items-center gap-2 rounded px-1.5 py-1 text-left text-xs hover:bg-muted/60"
+              title={`${entry.relativePath} (${entry.source})`}
+              onClick={() => {
+                setSelectedRootPath(entry.rootPath)
+                setSelectedPath(entry.path)
+              }}
+            >
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <span className="min-w-0 flex-1 truncate">{entry.relativePath}</span>
+              <span className="shrink-0 truncate text-[10px] text-muted-foreground">{entry.source}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    )
+  }, [fileActivity])
+
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
       <div className="flex flex-nowrap items-center gap-2 overflow-x-auto border-b border-border/40 px-3 py-2">
@@ -393,6 +447,21 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           <Trash2 className="h-3.5 w-3.5" /> Delete
         </Button>
       </div>
+
+      {fileActivity.length > 0 && (
+        <div className="border-b border-border/40 px-3 py-2">
+          <div className="mb-2 flex min-w-0 items-center justify-between gap-2 text-xs">
+            <span className="font-medium text-foreground">Touched files</span>
+            <span className="shrink-0 text-muted-foreground">
+              {fileActivity.filter((entry) => entry.kind === "read").length} read · {fileActivity.filter((entry) => entry.kind === "edited").length} edited
+            </span>
+          </div>
+          <div className="flex min-w-0 flex-col gap-3 md:flex-row">
+            {renderActivityGroup("edited", "Edited")}
+            {renderActivityGroup("read", "Read")}
+          </div>
+        </div>
+      )}
 
       {!sessionId ? (
         <div className="m-3 rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/renderer/src/components/session-file-view.tsx
+++ b/apps/desktop/src/renderer/src/components/session-file-view.tsx
@@ -164,7 +164,10 @@ export function SessionFileView({ sessionId, className }: { sessionId?: string |
       .filter((directoryPath) => isWithinRootPath(currentRoot.path, directoryPath))
       .filter((directoryPath) => directoryPath === currentRoot.path || expandedDirectories[directoryPath])
       .filter((directoryPath, index, values) => values.indexOf(directoryPath) === index)
-    await Promise.all(targets.map((directoryPath) => loadDirectory(directoryPath, { force: true })))
+    // Use allSettled so a single failing reload (e.g. a directory that was
+    // just deleted or moved) cannot reject the whole refresh and make the
+    // caller treat a successful filesystem mutation as a failure.
+    await Promise.allSettled(targets.map((directoryPath) => loadDirectory(directoryPath, { force: true })))
   }, [currentRoot, entriesByDirectory, expandedDirectories, loadDirectory])
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/src/components/session-file-view.tsx
+++ b/apps/desktop/src/renderer/src/components/session-file-view.tsx
@@ -34,8 +34,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 type SessionFileRoot = { path: string; label: string }
 type SessionFileEntry = { path: string; relativePath: string; name: string; kind: "file" | "directory"; size?: number; modifiedAt: number }
 type SessionFileListing = { entries: SessionFileEntry[]; totalEntries: number; limit: number; truncated: boolean }
-type SessionFileActivityKind = "read" | "edited"
-type SessionFileActivity = { path: string; rootPath: string; relativePath: string; kind: SessionFileActivityKind; source: string; lastSeenAt: number }
 type SessionFilePreview = {
   path: string
   relativePath: string
@@ -100,7 +98,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
   const [expandedDirectories, setExpandedDirectories] = useState<Record<string, boolean>>({})
   const [listingsByDirectory, setListingsByDirectory] = useState<Record<string, SessionFileListing>>({})
-  const [fileActivity, setFileActivity] = useState<SessionFileActivity[]>([])
   const [loadingDirectories, setLoadingDirectories] = useState<Record<string, boolean>>({})
   const [preview, setPreview] = useState<SessionFilePreview | null>(null)
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)
@@ -124,7 +121,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       setSelectedPath(null)
       setPreview(null)
       setRootsError(null)
-      setFileActivity([])
       return
     }
 
@@ -134,16 +130,13 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       const nextRoots = sessionId.startsWith("pending-") && conversationId
         ? await tipcClient.hydrateConversationFileActivity({ sessionId, conversationId }) as SessionFileRoot[]
         : await tipcClient.getTrackedSessionFileRoots({ sessionId }) as SessionFileRoot[]
-      const nextActivity = await tipcClient.getTrackedSessionFileActivity({ sessionId }) as SessionFileActivity[]
       setRoots(nextRoots)
-      setFileActivity(nextActivity)
       setSelectedRootPath((current) => nextRoots.some((root) => root.path === current) ? current : (nextRoots[0]?.path ?? ""))
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to load session files"
       setRootsError(message)
       setRoots([])
       setSelectedRootPath("")
-      setFileActivity([])
     } finally {
       setIsLoadingRoots(false)
     }
@@ -155,15 +148,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
       void tipcClient.clearTrackedSessionFileActivity({ sessionId }).catch((error: unknown) => {
         console.warn("Failed to clear temporary session file roots", error)
       })
-    }
-  }, [sessionId])
-
-  const refreshFileActivity = useCallback(async () => {
-    if (!sessionId) return
-    try {
-      setFileActivity(await tipcClient.getTrackedSessionFileActivity({ sessionId }) as SessionFileActivity[])
-    } catch {
-      // File activity is supplemental; keep the browser usable if it cannot load.
     }
   }, [sessionId])
 
@@ -238,7 +222,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     }).then((nextPreview: SessionFilePreview) => {
       if (!cancelled) {
         setPreview(nextPreview)
-        void refreshFileActivity()
       }
     }).catch((error: unknown) => {
       if (!cancelled) {
@@ -252,7 +235,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     return () => {
       cancelled = true
     }
-  }, [currentRoot, refreshFileActivity, selectedPath, sessionId])
+  }, [currentRoot, selectedPath, sessionId])
 
   const handleToggleDirectory = useCallback((directoryPath: string) => {
     setExpandedDirectories((current) => {
@@ -289,7 +272,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           kind: dialogState.mode === "create-file" ? "file" : "directory",
         })
         await refreshLoadedDirectories()
-        await refreshFileActivity()
         setSelectedPath(created?.path ?? currentRoot.path)
         toast.success(dialogState.mode === "create-file" ? "File created" : "Folder created")
       } else if (dialogState.mode === "move" && selectedPath) {
@@ -300,7 +282,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           targetPath: dialogState.value,
         })
         await refreshLoadedDirectories()
-        await refreshFileActivity()
         setSelectedPath(moved?.path ?? currentRoot.path)
         toast.success("Path updated")
       } else if (dialogState.mode === "delete" && selectedPath) {
@@ -310,7 +291,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           targetPath: selectedPath,
         })
         await refreshLoadedDirectories()
-        await refreshFileActivity()
         setSelectedPath(currentRoot.path)
         toast.success("Path deleted")
       }
@@ -320,7 +300,7 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     } finally {
       setIsSubmittingDialog(false)
     }
-  }, [currentRoot, dialogState, refreshFileActivity, refreshLoadedDirectories, selectedPath, sessionId])
+  }, [currentRoot, dialogState, refreshLoadedDirectories, selectedPath, sessionId])
 
   const renderDirectoryEntries = useCallback((directoryPath: string): React.ReactNode => {
     const listing = listingsByDirectory[directoryPath]
@@ -380,38 +360,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
     ) : [])
   }, [expandedDirectories, handleToggleDirectory, listingsByDirectory, loadingDirectories, selectedPath])
 
-  const renderActivityGroup = useCallback((kind: SessionFileActivityKind, label: string) => {
-    const entries = fileActivity.filter((entry) => entry.kind === kind)
-    if (entries.length === 0) return null
-
-    return (
-      <div className="min-w-[12rem] flex-1">
-        <div className="mb-1 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-          <span>{label}</span>
-          <span className="rounded-full border border-border/60 px-1.5 py-0 text-[10px]">{entries.length}</span>
-        </div>
-        <div className="max-h-24 space-y-1 overflow-y-auto pr-1">
-          {entries.map((entry) => (
-            <button
-              key={`${entry.kind}:${entry.path}`}
-              type="button"
-              className="flex w-full min-w-0 items-center gap-2 rounded px-1.5 py-1 text-left text-xs hover:bg-muted/60"
-              title={`${entry.relativePath} (${entry.source})`}
-              onClick={() => {
-                setSelectedRootPath(entry.rootPath)
-                setSelectedPath(entry.path)
-              }}
-            >
-              <FileText className="h-3.5 w-3.5 shrink-0" />
-              <span className="min-w-0 flex-1 truncate">{entry.relativePath}</span>
-              <span className="shrink-0 truncate text-[10px] text-muted-foreground">{entry.source}</span>
-            </button>
-          ))}
-        </div>
-      </div>
-    )
-  }, [fileActivity])
-
   return (
     <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
       <div className="flex flex-nowrap items-center gap-2 overflow-x-auto border-b border-border/40 px-3 py-2">
@@ -447,21 +395,6 @@ export function SessionFileView({ sessionId, conversationId, className }: { sess
           <Trash2 className="h-3.5 w-3.5" /> Delete
         </Button>
       </div>
-
-      {fileActivity.length > 0 && (
-        <div className="border-b border-border/40 px-3 py-2">
-          <div className="mb-2 flex min-w-0 items-center justify-between gap-2 text-xs">
-            <span className="font-medium text-foreground">Touched files</span>
-            <span className="shrink-0 text-muted-foreground">
-              {fileActivity.filter((entry) => entry.kind === "read").length} read · {fileActivity.filter((entry) => entry.kind === "edited").length} edited
-            </span>
-          </div>
-          <div className="flex min-w-0 flex-col gap-3 md:flex-row">
-            {renderActivityGroup("edited", "Edited")}
-            {renderActivityGroup("read", "Read")}
-          </div>
-        </div>
-      )}
 
       {!sessionId ? (
         <div className="m-3 rounded-lg border border-dashed bg-muted/20 px-5 py-6 text-center text-sm text-muted-foreground">

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -156,6 +156,7 @@ const ActiveSessionTile = React.memo(function ActiveSessionTile({
   const savedConversationQueryKey = [
     "conversation",
     conversationIdForHydration,
+    sessionId,
     shouldHydrateFromConversation ? "hydrate" : activeHistoryMessageLimit,
   ] as const
   const cachedSavedConversation = queryClient.getQueryData<LoadedConversation>(savedConversationQueryKey)
@@ -185,6 +186,7 @@ const ActiveSessionTile = React.memo(function ActiveSessionTile({
       if (!conversationIdForHydration) return null
       return tipcClient.loadConversation({
         conversationId: conversationIdForHydration,
+        sessionId,
         ...(shouldHydrateFromConversation ? {} : { messageLimit: activeHistoryMessageLimit }),
       })
     },
@@ -681,11 +683,12 @@ export function Component() {
 
   // Load the saved conversation that is about to be resumed.
   const pendingResumeConversationQuery = useQuery({
-    queryKey: ["conversation", pendingResumeConversationId, pendingResumeHistoryMessageLimit],
+    queryKey: ["conversation", pendingResumeConversationId, pendingResumeSessionId, pendingResumeHistoryMessageLimit],
     queryFn: async () => {
       if (!pendingResumeConversationId) return null
       return tipcClient.loadConversation({
         conversationId: pendingResumeConversationId,
+        sessionId: pendingResumeSessionId,
         messageLimit: pendingResumeHistoryMessageLimit,
       })
     },


### PR DESCRIPTION
## Summary
- Add main-process session file browser support and TIPC endpoints.
- Add a renderer Session File View tab for session artifacts.
- Add coverage for session file browsing and agent progress response history.

## Testing
- Not run by me; this turn only fetched, checked out, pushed, and opened the PR.