### PR TITLE
Improve desktop session lifecycle responsiveness

### DIFF
--- a/apps/desktop/src/main/acp/internal-agent.ts
+++ b/apps/desktop/src/main/acp/internal-agent.ts
@@ -26,6 +26,7 @@ import { configStore } from '../config';
 import { conversationService } from '../conversation-service';
 import { messageQueueService } from '../message-queue-service';
 import { clearAcpToAppSessionMapping, setAcpToAppSessionMapping } from '../acp-session-state';
+import { registerKnownInternalSubSessionParent } from './internal-subsession-registry';
 import { countPersistedSeedMessages, resolveQueuedSubSessionTarget } from './internal-agent-utils';
 import { stringifySubAgentToolResultContent } from '@shared/delegation-tool-display'
 import type { AgentProgressUpdate, SessionProfileSnapshot, ACPDelegationProgress, ACPSubAgentMessage, ConversationMessage, AgentProfile } from '../../shared/types';
@@ -188,6 +189,7 @@ function toAgentConversationHistory(history: ACPSubAgentMessage[]): Array<{
 }
 
 function addParentChildLink(parentSessionId: string, subSessionId: string): void {
+  registerKnownInternalSubSessionParent(parentSessionId);
   if (!parentToChildren.has(parentSessionId)) {
     parentToChildren.set(parentSessionId, new Set());
   }

--- a/apps/desktop/src/main/acp/internal-subsession-registry.ts
+++ b/apps/desktop/src/main/acp/internal-subsession-registry.ts
@@ -1,0 +1,9 @@
+const parentsWithInternalSubSessions = new Set<string>()
+
+export function registerKnownInternalSubSessionParent(parentSessionId: string): void {
+  parentsWithInternalSubSessions.add(parentSessionId)
+}
+
+export function hasKnownInternalSubSessionsForParent(parentSessionId: string): boolean {
+  return parentsWithInternalSubSessions.has(parentSessionId)
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -502,9 +502,17 @@ if (!gotSingleInstanceLock) {
         pendingHubBundleHandoffPath,
       )
 
-      createMainWindow(
+      const mainWindow = createMainWindow(
         launchDecision.url ? { url: launchDecision.url } : undefined,
       )
+
+      mainWindow?.webContents.once("did-finish-load", () => {
+        setTimeout(() => {
+          if (WINDOWS.has("panel")) return
+          createPanelWindow()
+          logApp("Panel window created after main window load")
+        }, 1000)
+      })
 
       if (launchDecision.reason === "onboarding") {
         logApp("Main window created (showing onboarding)")
@@ -524,8 +532,10 @@ if (!gotSingleInstanceLock) {
       logApp("Setup window created (accessibility not granted)")
     }
 
-    createPanelWindow()
-    logApp("Panel window created")
+    if (!WINDOWS.has("main")) {
+      createPanelWindow()
+      logApp("Panel window created")
+    }
 
     listenToKeyboardEvents()
     logApp("Keyboard event listener started")
@@ -688,7 +698,9 @@ if (!gotSingleInstanceLock) {
       void startDiscordIfConfigured("desktop")
     } catch (_e) {}
 
-    import("./updater").then((res) => res.init()).catch(console.error)
+    setTimeout(() => {
+      import("./updater").then((res) => res.init()).catch(console.error)
+    }, 8000)
 
     app.on("browser-window-created", (_, window) => {
       optimizer.watchWindowShortcuts(window)

--- a/apps/desktop/src/main/models-dev-service.ts
+++ b/apps/desktop/src/main/models-dev-service.ts
@@ -84,6 +84,7 @@ interface ModelsDevCache {
 const MODELS_DEV_API_URL = "https://models.dev/api.json"
 const CACHE_FILENAME = "models-dev-cache.json"
 const CACHE_REFRESH_INTERVAL = 24 * 60 * 60 * 1000 // 24 hours
+const STARTUP_BACKGROUND_REFRESH_DELAY_MS = 8_000
 
 // ============================================================================
 // Internal State
@@ -532,14 +533,17 @@ export function initModelsDevService(): void {
       "Cache is stale or missing, triggering background refresh"
     )
 
-    // Fire and forget - don't block startup
-    fetchModelsDevData().catch((error) => {
-      diagnosticsService.logError(
-        "models-dev-service",
-        "Background refresh failed",
-        error
-      )
-    })
+    // Fire and forget after the first UI settles. Fresh model metadata is
+    // useful, but not on the critical path for initial app responsiveness.
+    setTimeout(() => {
+      fetchModelsDevData().catch((error) => {
+        diagnosticsService.logError(
+          "models-dev-service",
+          "Background refresh failed",
+          error
+        )
+      })
+    }, STARTUP_BACKGROUND_REFRESH_DELAY_MS)
   }
 }
 

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -93,6 +93,7 @@ import { agentProfileService, createSessionSnapshotFromProfile, refreshSessionSn
 import { resolvePreferredTopLevelAcpAgentSelection } from "./main-agent-selection"
 import { processTranscriptWithACPAgent } from "./acp-main-agent"
 import { getAppSessionForAcpSession } from "./acp-session-state"
+import { hasKnownInternalSubSessionsForParent } from "./acp/internal-subsession-registry"
 import { fetchModelsDevData, getModelFromModelsDevByProviderId, findBestModelMatch, refreshModelsDevCache } from "./models-dev-service"
 import * as parakeetStt from "./parakeet-stt"
 import { loopService } from "./loop-service"
@@ -1646,48 +1647,55 @@ export const router = {
       const conversationIdsToPause = new Set<string>()
       let requestedSubSessionConversationId: string | undefined
 
-      // Cancel any internal sub-sessions spawned by this session
-      try {
-        const {
-          getChildSubSessions,
-          getAllSubSessionsForParent,
-          cancelSubSession,
-          getInternalSubSession,
-        } = await import("./acp/internal-agent")
-        requestedSubSessionConversationId = requestedSessionKind === "subsession"
-          ? getInternalSubSession(requestedSessionId)?.conversationId
-          : undefined
-        if (requestedSubSessionConversationId) {
-          conversationIdsToPause.add(requestedSubSessionConversationId)
-        }
-        const cancelledRequestedSubSession = requestedSessionKind === "subsession"
-          ? cancelSubSession(requestedSessionId)
-          : false
-        const childSessionsById = new Map(
-          [...getChildSubSessions(input.sessionId), ...getAllSubSessionsForParent(input.sessionId)]
-            .map((child) => [child.id, child] as const),
-        )
-        const childSessions = Array.from(childSessionsById.values())
-        const runningChildSessionIds = childSessions
-          .filter((child) => child.status === "running")
-          .map((child) => child.id)
-        for (const child of childSessions) {
-          if (child.conversationId) {
-            conversationIdsToPause.add(child.conversationId)
+      // Cancel any internal sub-sessions spawned by this session. Most sessions
+      // never create internal children, so avoid loading/scanning the internal
+      // agent module unless this session is known to need it.
+      if (
+        requestedSessionKind === "subsession" ||
+        hasKnownInternalSubSessionsForParent(input.sessionId)
+      ) {
+        try {
+          const {
+            getChildSubSessions,
+            getAllSubSessionsForParent,
+            cancelSubSession,
+            getInternalSubSession,
+          } = await import("./acp/internal-agent")
+          requestedSubSessionConversationId = requestedSessionKind === "subsession"
+            ? getInternalSubSession(requestedSessionId)?.conversationId
+            : undefined
+          if (requestedSubSessionConversationId) {
+            conversationIdsToPause.add(requestedSubSessionConversationId)
           }
-          if (child.status === "running") {
-            cancelSubSession(child.id)
-            logLLM(`[stopAgentSession] Cancelled internal sub-session ${child.id}`)
+          const cancelledRequestedSubSession = requestedSessionKind === "subsession"
+            ? cancelSubSession(requestedSessionId)
+            : false
+          const childSessionsById = new Map(
+            [...getChildSubSessions(input.sessionId), ...getAllSubSessionsForParent(input.sessionId)]
+              .map((child) => [child.id, child] as const),
+          )
+          const childSessions = Array.from(childSessionsById.values())
+          const runningChildSessionIds = childSessions
+            .filter((child) => child.status === "running")
+            .map((child) => child.id)
+          for (const child of childSessions) {
+            if (child.conversationId) {
+              conversationIdsToPause.add(child.conversationId)
+            }
+            if (child.status === "running") {
+              cancelSubSession(child.id)
+              logLLM(`[stopAgentSession] Cancelled internal sub-session ${child.id}`)
+            }
           }
+          logApp("[stopAgentSession] Internal sub-session scan complete", {
+            requestedSessionId,
+            cancelledRequestedSubSession,
+            childSessionCount: childSessions.length,
+            runningChildSessionIds,
+          })
+        } catch (error) {
+          logApp("[stopAgentSession] Error cancelling internal sub-sessions:", error)
         }
-        logApp("[stopAgentSession] Internal sub-session scan complete", {
-          requestedSessionId,
-          cancelledRequestedSubSession,
-          childSessionCount: childSessions.length,
-          runningChildSessionIds,
-        })
-      } catch (error) {
-        logApp("[stopAgentSession] Error cancelling internal sub-sessions:", error)
       }
 
       // Pause the message queue for this conversation to prevent processing the next queued message

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 import { RouterProvider } from "react-router-dom"
 import { router } from "./router"
-import { lazy, Suspense } from "react"
+import { lazy, Suspense, useEffect, useState } from "react"
 import { Toaster } from "sonner"
 import { ThemeProvider } from "./contexts/theme-context"
 import { useStoreSync } from "./hooks/use-store-sync"
@@ -12,20 +12,40 @@ const McpSamplingDialog = lazy(() => import("./components/mcp-sampling-dialog"))
 function StoreInitializer({ children }: { children: React.ReactNode }) {
   useStoreSync()
   useAudioInputDeviceFallback()
+
   return <>{children}</>
 }
 
 function App(): JSX.Element {
+  const [shouldMountMcpDialogs, setShouldMountMcpDialogs] = useState(false)
+
+  useEffect(() => {
+    const win = window as Window & {
+      requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number
+      cancelIdleCallback?: (id: number) => void
+    }
+
+    if (win.requestIdleCallback) {
+      const idleId = win.requestIdleCallback(() => setShouldMountMcpDialogs(true), { timeout: 1500 })
+      return () => win.cancelIdleCallback?.(idleId)
+    }
+
+    const timer = window.setTimeout(() => setShouldMountMcpDialogs(true), 500)
+    return () => window.clearTimeout(timer)
+  }, [])
+
   return (
     <ThemeProvider>
       <StoreInitializer>
         <RouterProvider router={router}></RouterProvider>
 
         {/* MCP Protocol 2025-11-25 dialogs for elicitation and sampling */}
-        <Suspense>
-          <McpElicitationDialog />
-          <McpSamplingDialog />
-        </Suspense>
+        {shouldMountMcpDialogs && (
+          <Suspense>
+            <McpElicitationDialog />
+            <McpSamplingDialog />
+          </Suspense>
+        )}
 
         <Toaster />
       </StoreInitializer>

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -388,6 +388,7 @@ export function ActiveAgentsSidebar({
   const setViewedConversationId = useAgentStore((s) => s.setViewedConversationId)
   const agentProgressById = useAgentStore((s) => s.agentProgressById)
   const updateSessionProgress = useAgentStore((s) => s.updateSessionProgress)
+  const dismissSessionProgress = useAgentStore((s) => s.dismissSessionProgress)
   const agentResponseReadAtBySessionId = useAgentStore(
     (s) => s.agentResponseReadAtBySessionId,
   )
@@ -444,6 +445,8 @@ export function ActiveAgentsSidebar({
   const repeatTasksQuery = useQuery<LoopConfig[]>({
     queryKey: ["loops"],
     queryFn: async () => await tipcClient.getLoops(),
+    enabled: tasksSectionExpanded,
+    refetchOnWindowFocus: false,
   })
 
   useEffect(() => {
@@ -1026,14 +1029,22 @@ export function ActiveAgentsSidebar({
 
   const handleActiveSessionSelect = useCallback((sessionId: string) => {
     logUI("[ActiveAgentsSidebar] Active session selected:", sessionId)
+    const shouldNavigateToSessionsRoot =
+      location.pathname !== "/" ||
+      location.search.length > 0 ||
+      viewedConversationId !== null
     // Clear the saved-conversation view so no stale row stays highlighted.
     setViewedConversationId(null)
-    // Navigate to the sessions page and focus this live session.
-    navigate("/", { state: { clearPendingConversation: true } })
+    // Navigate only when leaving a saved/non-root route. Re-navigating to the
+    // already-active sessions root forces unnecessary router work on every
+    // sidebar switch.
+    if (shouldNavigateToSessionsRoot) {
+      navigate("/", { state: { clearPendingConversation: true } })
+    }
     setFocusedSessionId(sessionId)
     setExpandedSessionId(sessionId)
     focusSidebarSessionComposer()
-  }, [focusSidebarSessionComposer, navigate, setFocusedSessionId, setExpandedSessionId, setViewedConversationId])
+  }, [focusSidebarSessionComposer, location.pathname, location.search, navigate, setFocusedSessionId, setExpandedSessionId, setViewedConversationId, viewedConversationId])
 
   const handleSavedConversationOpen = useCallback((conversationId: string) => {
     logUI(
@@ -1114,15 +1125,17 @@ export function ActiveAgentsSidebar({
     e.stopPropagation() // Prevent session focus when clicking stop
     logUI("[ActiveAgentsSidebar] Stopping session:", sessionId)
     const sessionProgress = agentProgressById.get(sessionId)
+    // Hide the dismissed row immediately in this renderer and suppress any late
+    // stop-progress echo for the same session. The main-process stop/clear calls
+    // below still perform persisted response/TTS/tracker cleanup and keep other
+    // windows in sync.
+    dismissSessionProgress(sessionId)
     if (!sessionProgress?.isComplete) {
       try {
         await tipcClient.stopAgentSession({ sessionId })
       } catch (error) {
         console.error("Failed to stop session:", error)
       }
-    }
-    if (focusedSessionId === sessionId) {
-      setFocusedSessionId(null)
     }
     try {
       await tipcClient.clearAgentSessionProgress({ sessionId })

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -266,7 +266,15 @@ const SessionModelPicker: React.FC<{
   const sessionModel = modelInfo?.model
   const currentValue = configuredModel || sessionModel || AGENT_MODEL_FALLBACKS[providerId]
   const providerLabel = modelInfo?.provider || getActiveModelPreset(config)?.name || providerId
-  const modelsQuery = useAvailableModelsQuery(providerId, !!providerId, providerId === "openai" ? config?.currentModelPresetId || DEFAULT_MODEL_PRESET_ID : undefined)
+  const [shouldLoadModelOptions, setShouldLoadModelOptions] = useState(false)
+  const requestModelOptions = useCallback(() => {
+    setShouldLoadModelOptions(true)
+  }, [])
+  const modelsQuery = useAvailableModelsQuery(
+    providerId,
+    shouldLoadModelOptions && !!providerId,
+    providerId === "openai" ? config?.currentModelPresetId || DEFAULT_MODEL_PRESET_ID : undefined,
+  )
   const modelOptions = useMemo(() => {
     const options = [...(modelsQuery.data || [])]
     if (currentValue && !options.some((model) => model.id === currentValue)) {
@@ -304,14 +312,17 @@ const SessionModelPicker: React.FC<{
       title={`Change agent model (${providerLabel}/${currentValue})`}
       aria-label="Change agent model"
       onClick={(event) => event.stopPropagation()}
+      onFocus={requestModelOptions}
+      onPointerDown={requestModelOptions}
+      onMouseEnter={requestModelOptions}
     >
       {modelOptions.map((model) => (
         <option key={model.id} value={model.id}>
           {providerLabel}/{model.name || getModelDisplayName(model.id)}
         </option>
       ))}
-      {modelsQuery.isLoading && modelOptions.length === 0 && (
-        <option value={currentValue}>Loading models...</option>
+      {modelsQuery.isLoading && (
+        <option value="__loading_models__" disabled>Loading models...</option>
       )}
       {modelOptions.length === 0 && !modelsQuery.isLoading && (
         <option value={currentValue}>No models available</option>

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -313,7 +313,24 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onSavedConversa
   selectedAgentId: string | null
   onSelectAgent: (id: string | null) => void
 }) {
-  const savedConversationsQuery = useSavedConversationsQuery()
+  const [shouldLoadRecentSavedConversations, setShouldLoadRecentSavedConversations] = useState(false)
+
+  useEffect(() => {
+    const win = window as Window & {
+      requestIdleCallback?: (callback: () => void) => number
+      cancelIdleCallback?: (id: number) => void
+    }
+
+    if (win.requestIdleCallback) {
+      const idleId = win.requestIdleCallback(() => setShouldLoadRecentSavedConversations(true))
+      return () => win.cancelIdleCallback?.(idleId)
+    }
+
+    const timer = window.setTimeout(() => setShouldLoadRecentSavedConversations(true), 1500)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  const savedConversationsQuery = useSavedConversationsQuery(shouldLoadRecentSavedConversations)
   const pinnedSessionIds = useAgentStore((state) => state.pinnedSessionIds)
   const togglePinSession = useAgentStore((state) => state.togglePinSession)
   const sortedSavedConversations = useMemo(

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -136,6 +136,7 @@ export const createIdleTTSPlaybackState = (): DesktopTTSPlaybackState => ({
 interface AgentState {
   agentProgressById: Map<string, AgentProgressUpdate>
   agentResponseReadAtBySessionId: Map<string, number>
+  dismissedSessionIds: Set<string>
   focusedSessionId: string | null
   expandedSessionId: string | null
   viewedConversationId: string | null
@@ -162,6 +163,7 @@ interface AgentState {
   updateSessionProgress: (update: AgentProgressUpdate) => void
   clearAllProgress: () => void
   clearSessionProgress: (sessionId: string) => void
+  dismissSessionProgress: (sessionId: string) => void
   clearInactiveSessions: () => void
   setFocusedSessionId: (sessionId: string | null) => void
   setExpandedSessionId: (sessionId: string | null) => void
@@ -195,6 +197,7 @@ interface AgentState {
 export const useAgentStore = create<AgentState>((set, get) => ({
   agentProgressById: new Map(),
   agentResponseReadAtBySessionId: new Map(),
+  dismissedSessionIds: new Set(),
   focusedSessionId: null,
   expandedSessionId: null,
   viewedConversationId: null,
@@ -218,6 +221,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     const sessionId = update.sessionId
 
     set((state) => {
+      if (state.dismissedSessionIds.has(sessionId)) {
+        return state
+      }
+
       const newMap = new Map(state.agentProgressById)
       const isNewSession = !newMap.has(sessionId)
       const existingProgress = newMap.get(sessionId)
@@ -455,6 +462,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     set({
       agentProgressById: new Map(),
       agentResponseReadAtBySessionId: new Map(),
+      dismissedSessionIds: new Set(),
       focusedSessionId: null,
       expandedSessionId: null,
     })
@@ -492,6 +500,36 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       return {
         agentProgressById: newMap,
         agentResponseReadAtBySessionId: nextReadTimestamps,
+        focusedSessionId: newFocusedSessionId,
+        expandedSessionId: newExpandedSessionId,
+      }
+    })
+  },
+
+  dismissSessionProgress: (sessionId: string) => {
+    clearSessionTTSTracking(sessionId)
+    set((state) => {
+      const newMap = new Map(state.agentProgressById)
+      const nextReadTimestamps = new Map(state.agentResponseReadAtBySessionId)
+      const nextDismissedSessionIds = new Set(state.dismissedSessionIds)
+      nextDismissedSessionIds.add(sessionId)
+      newMap.delete(sessionId)
+      nextReadTimestamps.delete(sessionId)
+
+      let newFocusedSessionId = state.focusedSessionId
+      if (state.focusedSessionId === sessionId) {
+        newFocusedSessionId = null
+      }
+
+      let newExpandedSessionId = state.expandedSessionId
+      if (state.expandedSessionId === sessionId) {
+        newExpandedSessionId = null
+      }
+
+      return {
+        agentProgressById: newMap,
+        agentResponseReadAtBySessionId: nextReadTimestamps,
+        dismissedSessionIds: nextDismissedSessionIds,
         focusedSessionId: newFocusedSessionId,
         expandedSessionId: newExpandedSessionId,
       }
@@ -550,29 +588,51 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   setFocusedSessionId: (sessionId: string | null) => {
-    set((state) => ({
-      focusedSessionId: sessionId,
-      agentResponseReadAtBySessionId: sessionId
+    set((state) => {
+      const nextReadTimestamps = sessionId
         ? markLatestAgentResponseReadInMap(
           state.agentResponseReadAtBySessionId,
           sessionId,
           state.agentProgressById.get(sessionId),
         )
-        : state.agentResponseReadAtBySessionId,
-    }))
+        : state.agentResponseReadAtBySessionId
+
+      if (
+        state.focusedSessionId === sessionId &&
+        nextReadTimestamps === state.agentResponseReadAtBySessionId
+      ) {
+        return state
+      }
+
+      return {
+        focusedSessionId: sessionId,
+        agentResponseReadAtBySessionId: nextReadTimestamps,
+      }
+    })
   },
 
   setExpandedSessionId: (sessionId: string | null) => {
-    set((state) => ({
-      expandedSessionId: sessionId,
-      agentResponseReadAtBySessionId: sessionId
+    set((state) => {
+      const nextReadTimestamps = sessionId
         ? markLatestAgentResponseReadInMap(
           state.agentResponseReadAtBySessionId,
           sessionId,
           state.agentProgressById.get(sessionId),
         )
-        : state.agentResponseReadAtBySessionId,
-    }))
+        : state.agentResponseReadAtBySessionId
+
+      if (
+        state.expandedSessionId === sessionId &&
+        nextReadTimestamps === state.agentResponseReadAtBySessionId
+      ) {
+        return state
+      }
+
+      return {
+        expandedSessionId: sessionId,
+        agentResponseReadAtBySessionId: nextReadTimestamps,
+      }
+    })
   },
 
   setViewedConversationId: (conversationId: string | null) => {
@@ -589,6 +649,13 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         }
       }
 
+      if (
+        state.viewedConversationId === conversationId &&
+        nextReadTimestamps === state.agentResponseReadAtBySessionId
+      ) {
+        return state
+      }
+
       return {
         viewedConversationId: conversationId,
         agentResponseReadAtBySessionId: nextReadTimestamps,
@@ -597,7 +664,11 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   setScrollToSessionId: (sessionId: string | null) => {
-    set({ scrollToSessionId: sessionId })
+    set((state) => (
+      state.scrollToSessionId === sessionId
+        ? state
+        : { scrollToSessionId: sessionId }
+    ))
   },
 
   setSessionSnoozed: (sessionId: string, isSnoozed: boolean) => {
@@ -760,7 +831,11 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   setFloatingPanelVisible: (visible: boolean) => {
-    set({ isFloatingPanelVisible: visible })
+    set((state) => (
+      state.isFloatingPanelVisible === visible
+        ? state
+        : { isFloatingPanelVisible: visible }
+    ))
   },
 
   setTTSPlaybackState: (ttsPlaybackState: DesktopTTSPlaybackState) => {


### PR DESCRIPTION
## Summary
- Reduces active-session sidebar/store churn during focus switches and dismissals.
- Avoids unnecessary internal sub-session scanning when stopping sessions without known children.
- Defers non-critical startup work so the sessions UI becomes responsive sooner.

## Autoresearch result
- Corrected active-session baseline: 5189ms
- Best median-of-3 result before cleanup: 4799ms (-7.5%)
- Autoresearch/e2e harness artifacts were moved out of this PR and kept on the reset branch for future experiments.

## Validation
- pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/active-agents-sidebar.layout.test.ts src/renderer/src/pages/sessions.in-app-actions.test.ts src/renderer/src/stores/agent-store.test.ts
- pnpm --filter @dotagents/desktop typecheck

