### PR TITLE
Add create-repeat-task bundled skill (closes #470)

### DIFF
--- a/apps/desktop/resources/bundled-skills/create-repeat-task/SKILL.md
+++ b/apps/desktop/resources/bundled-skills/create-repeat-task/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: create-repeat-task
+description: "Use this skill when the user asks to create, edit, or reason about a repeat task — including phrases like 'create repeat task', 'recurring task', 'scheduled task', 'continuous task', 'same session continue', 'speak the result', or 'TTS for a task'. It teaches the canonical task.md frontmatter, the full set of scheduler/runtime options (intervalMinutes, schedule, runContinuously, continueInSession, speakOnTrigger, runOnStartup, profileId), and the safe edit workflow."
+---
+
+# Create Repeat Task
+
+## Overview
+
+A repeat task ("loop") is a DotAgents config object that runs a prompt against an agent on a schedule. It is a markdown file with YAML frontmatter at:
+
+- Global: `~/.agents/tasks/<task-id>/task.md`
+- Workspace (when `DOTAGENTS_WORKSPACE_DIR` is set): `${DOTAGENTS_WORKSPACE_DIR}/.agents/tasks/<task-id>/task.md`
+
+Workspace tasks override global tasks with the same `id`.
+
+The file format is parsed by `packages/core/src/agents-files/tasks.ts`. The runtime fields come from the `LoopConfig` interface in `packages/core/src/types.ts`.
+
+## When to use this skill
+
+Trigger on any of:
+
+- "create a repeat task", "make a recurring task", "schedule this"
+- "run this every N minutes/hours", "fire on startup"
+- "continuous task", "run continuously", "run back-to-back"
+- "same session continue", "keep the conversation context across runs"
+- "speak the result", "TTS for the task", "read it out when it's done"
+- "edit task `<id>`", "disable task `<id>`", "change the schedule of task `<id>`"
+
+## Discovery first
+
+Before editing, inspect:
+
+1. `~/.agents/tasks/` (and `${DOTAGENTS_WORKSPACE_DIR}/.agents/tasks/` if set) to see existing task IDs and conventions.
+2. The user's existing agent profiles (`~/.agents/agents/<id>/`) so you can pick a valid `profileId` when the user names an agent.
+3. The current schema at `packages/core/src/agents-files/tasks.ts` and `packages/core/src/types.ts` if you suspect the available fields have evolved past what this skill documents.
+
+If you find an existing task with the requested ID, prefer editing it in place over recreating it.
+
+## Frontmatter schema
+
+| Field               | Type                  | Default     | Notes                                                                                          |
+| ------------------- | --------------------- | ----------- | ---------------------------------------------------------------------------------------------- |
+| `kind`              | string (literal)      | `task`      | Always `task`. Required.                                                                       |
+| `id`                | string                | dir name    | Stable identifier. Falls back to the directory name, then to `name`, if omitted.               |
+| `name`              | string                | `id`        | Display name. Falls back to `id` if omitted.                                                   |
+| `intervalMinutes`   | number                | `60`        | Fixed interval in minutes between runs. Minimum `1`. Ignored when `schedule` is set.           |
+| `enabled`           | boolean               | `true`      | Set `false` to disable without deleting the task.                                               |
+| `profileId`         | string                | unset       | ID of the agent profile to run as. Omit to use the user's current default agent.                |
+| `runOnStartup`      | boolean               | `false`     | Fire once immediately on app start, before the first interval.                                  |
+| `speakOnTrigger`    | boolean               | `false`     | Run snoozed (silent), then unsnooze on completion so the renderer auto-plays TTS of the reply. |
+| `continueInSession` | boolean               | `false`     | Reuse the prior session/conversation so the agent retains context across runs.                  |
+| `lastSessionId`     | string                | unset       | Session ID resumed on the next run. Auto-populated; user may pin manually.                      |
+| `runContinuously`   | boolean               | `false`     | Start the next run immediately after the previous one finishes (zero-delay loop).               |
+| `schedule`          | JSON object as string | unset       | Wall-clock schedule. When present, supersedes `intervalMinutes`. See "Schedules" below.         |
+| `lastRunAt`         | number (ms epoch)     | unset       | Auto-managed timestamp. Do not hand-set unless the user explicitly asks.                        |
+
+The markdown body (everything after the closing `---`) is the **prompt** sent to the agent on each run. It may be empty but is usually a short instruction.
+
+## Schedules
+
+`schedule` must be a JSON string and is one of:
+
+- Daily — fires at each `HH:MM` (24h, machine local time) every day:
+  ```json
+  {"type":"daily","times":["09:00","17:00"]}
+  ```
+- Weekly — fires at each `HH:MM` on each listed day, where `0=Sunday … 6=Saturday`:
+  ```json
+  {"type":"weekly","times":["09:00"],"daysOfWeek":[1,2,3,4,5]}
+  ```
+
+Schedules with no valid times, or unknown `type`, are silently ignored — the task then falls back to `intervalMinutes`.
+
+## Continuous vs scheduled vs interval
+
+Pick exactly one cadence model and prefer the simplest that fits:
+
+- **Wall-clock schedule** (`schedule`): the user wants specific times of day or week.
+- **Continuous** (`runContinuously: true`): the user wants the task to run back-to-back with no delay between runs. `intervalMinutes` becomes a floor only when a run completes faster than expected — set it to `1` (the minimum) when running continuously.
+- **Interval** (`intervalMinutes`): the default. Use when the user says "every N minutes/hours".
+
+`runContinuously` and `schedule` should not be combined — `schedule` is ignored in continuous mode at runtime.
+
+## Same-session continuation
+
+Set `continueInSession: true` when the user wants the agent to remember previous iterations (for example, a long-running watchdog, a stateful queue worker, or a journaling task). On each run the loop service revives the prior session referenced by `lastSessionId`; if it can no longer be revived a fresh session is created and `lastSessionId` is updated automatically.
+
+If the user wants each run to start from a clean slate (the default for a simple summarizer), leave `continueInSession` off.
+
+## Speaking the result
+
+Set `speakOnTrigger: true` when the user wants the task to "speak" or "read out" the result. The task then runs snoozed (silent / hidden) and is unsnoozed on completion so the renderer auto-plays TTS for the final assistant message. Leaving this off keeps the run completely passive in the background.
+
+This is independent of any user-level TTS settings — those still control voice, language, and quality.
+
+## Workflow
+
+1. Confirm what the user wants the task to do (the prompt body) and how often it should run.
+2. Pick the cadence model: schedule, continuous, or interval.
+3. Pick an `id`. Prefer short, kebab-case, descriptive — e.g. `daily-standup`, `queue-processor`, `morning-summary`.
+4. Choose `profileId` if a specific agent should own the task; otherwise omit it.
+5. Decide `continueInSession` (state across runs?) and `speakOnTrigger` (TTS on completion?).
+6. Decide `runOnStartup` (fire immediately when the app boots?).
+7. Write `~/.agents/tasks/<id>/task.md` (or the workspace equivalent) using direct file editing, not app-specific config tools.
+8. Confirm with the user, then check it appears in Settings > Loops / Repeat Tasks and that `enabled` is correct.
+
+See `examples.md` (next to this `SKILL.md`) for ready-to-paste templates for each common shape.
+
+## Guardrails
+
+- Always set `kind: task`. The loader rejects files without it.
+- Keep `intervalMinutes` ≥ 1. Sub-minute cadence is only achievable via `runContinuously: true`.
+- Do not invent fields. Unknown frontmatter keys are ignored silently, so typos look like the option "didn't work".
+- `schedule` must be valid JSON on a single line — wrap it in double quotes carefully if your YAML formatter complains.
+- Do not hand-set `lastSessionId` or `lastRunAt` unless the user explicitly asks; they are auto-managed.
+- Never delete a task directory to "disable" it — set `enabled: false` instead.
+- If both global and workspace `.agents/tasks/<id>/` exist, ask the user which layer should own the change before editing.

--- a/apps/desktop/resources/bundled-skills/create-repeat-task/examples.md
+++ b/apps/desktop/resources/bundled-skills/create-repeat-task/examples.md
@@ -1,0 +1,156 @@
+# Repeat Task Examples
+
+Ready-to-paste templates for the most common shapes. Save each one to `~/.agents/tasks/<id>/task.md` (or the workspace-layer equivalent under `${DOTAGENTS_WORKSPACE_DIR}/.agents/`).
+
+## 1. Basic interval task
+
+Runs every 60 minutes (the default) using the user's current agent.
+
+```markdown
+---
+kind: task
+id: link-check
+name: Link Check
+enabled: true
+intervalMinutes: 60
+---
+
+Check the project README for broken links and report any that 404.
+```
+
+## 2. Fire-on-startup task
+
+Same as above, but also runs once immediately when the app boots.
+
+```markdown
+---
+kind: task
+id: morning-briefing
+name: Morning Briefing
+enabled: true
+intervalMinutes: 240
+runOnStartup: true
+---
+
+Summarize new emails and calendar events since I last logged in.
+```
+
+## 3. Wall-clock daily schedule
+
+Fires at 09:00 and 17:00 every day in the local timezone. `intervalMinutes` is ignored when `schedule` is present.
+
+```markdown
+---
+kind: task
+id: daily-standup
+name: Daily Standup Prep
+enabled: true
+intervalMinutes: 60
+schedule: {"type":"daily","times":["09:00","17:00"]}
+---
+
+List the three highest-priority tasks for today based on my notes and open issues.
+```
+
+## 4. Weekly schedule (weekdays only)
+
+Fires at 09:00 Monday through Friday (`daysOfWeek` uses `0=Sunday … 6=Saturday`).
+
+```markdown
+---
+kind: task
+id: weekly-review
+name: Weekly Review
+enabled: true
+intervalMinutes: 60
+schedule: {"type":"weekly","times":["09:00"],"daysOfWeek":[1,2,3,4,5]}
+---
+
+Summarize this week's commits and surface anything that still needs review.
+```
+
+## 5. Continuous task
+
+Starts the next run immediately after the previous one finishes — useful for queue workers and watchdogs. Set `intervalMinutes` to `1` (the minimum) as a safety floor.
+
+```markdown
+---
+kind: task
+id: queue-processor
+name: Process Queue
+enabled: true
+intervalMinutes: 1
+runContinuously: true
+profileId: background-worker
+---
+
+Pull the next item from the processing queue and handle it. If the queue is empty, report idle.
+```
+
+## 6. Same-session continuation
+
+Reuses the prior session/conversation across iterations so the agent retains context. The runtime auto-tracks `lastSessionId` after the first run — do not set it by hand.
+
+```markdown
+---
+kind: task
+id: ongoing-journal
+name: Ongoing Project Journal
+enabled: true
+intervalMinutes: 120
+continueInSession: true
+---
+
+Append today's progress to the running journal we've been keeping. Note any decisions or blockers since the last entry.
+```
+
+## 7. Speak the result (TTS)
+
+The task runs snoozed (silent) and is unsnoozed on completion so the renderer auto-plays TTS of the final assistant message. Per-user voice/language settings still apply.
+
+```markdown
+---
+kind: task
+id: hourly-news
+name: Hourly News Brief
+enabled: true
+intervalMinutes: 60
+speakOnTrigger: true
+profileId: news-anchor
+---
+
+Give me a 60-second brief on the top three tech headlines since the last brief, formatted for spoken delivery.
+```
+
+## 8. Pinned to a specific agent profile
+
+Use `profileId` when a specific agent should always own the task. Omit it to use the user's current default agent.
+
+```markdown
+---
+kind: task
+id: code-review-bot
+name: Auto Code Review
+enabled: true
+intervalMinutes: 30
+profileId: code-reviewer
+---
+
+Review any PR opened on this repo in the last 30 minutes and post inline comments for obvious issues.
+```
+
+## 9. Disable without deleting
+
+To pause a task without losing its config or history, set `enabled: false`. Do not delete the directory.
+
+```markdown
+---
+kind: task
+id: legacy-cleanup
+name: Legacy Cleanup
+enabled: false
+intervalMinutes: 1440
+---
+
+Sweep old artifacts from the build cache.
+```

--- a/apps/desktop/src/main/bundled-skills.test.ts
+++ b/apps/desktop/src/main/bundled-skills.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs"
 import path from "path"
 import { describe, expect, it } from "vitest"
-import { parseSkillMarkdown } from "@dotagents/core"
+import { parseSkillMarkdown, parseTaskMarkdown } from "@dotagents/core"
 
 describe("bundled dotagents config skill", () => {
   it("ships a parseable bundled config-admin skill with canonical .agents guidance", () => {
@@ -33,5 +33,78 @@ describe("bundled dotagents config skill", () => {
     )
 
     expect(fs.existsSync(skillPath)).toBe(false)
+  })
+})
+
+describe("bundled create-repeat-task skill", () => {
+  const skillDir = path.resolve(
+    process.cwd(),
+    "resources/bundled-skills/create-repeat-task",
+  )
+  const skillPath = path.join(skillDir, "SKILL.md")
+  const examplesPath = path.join(skillDir, "examples.md")
+
+  it("ships a parseable SKILL.md that triggers on repeat-task language and documents the runtime flags", () => {
+    expect(fs.existsSync(skillPath)).toBe(true)
+
+    const raw = fs.readFileSync(skillPath, "utf8")
+    const parsed = parseSkillMarkdown(raw, { filePath: skillPath })
+
+    expect(parsed).not.toBeNull()
+    expect(parsed?.id).toBe("create-repeat-task")
+    expect(parsed?.name).toBe("create-repeat-task")
+
+    // Trigger language so the agent loads it for the right prompts.
+    expect(parsed?.description).toMatch(/repeat task/i)
+    expect(parsed?.description).toMatch(/recurring task/i)
+    expect(parsed?.description).toMatch(/continuous/i)
+    expect(parsed?.description).toMatch(/same session/i)
+    expect(parsed?.description).toMatch(/TTS/)
+
+    // Canonical paths and frontmatter fields surfaced in instructions.
+    expect(parsed?.instructions).toContain("~/.agents/tasks/")
+    expect(parsed?.instructions).toContain("task.md")
+    expect(parsed?.instructions).toContain("kind: task")
+    expect(parsed?.instructions).toContain("intervalMinutes")
+    expect(parsed?.instructions).toContain("runContinuously")
+    expect(parsed?.instructions).toContain("continueInSession")
+    expect(parsed?.instructions).toContain("speakOnTrigger")
+    expect(parsed?.instructions).toContain("runOnStartup")
+    expect(parsed?.instructions).toContain("schedule")
+    expect(parsed?.instructions).toContain("profileId")
+  })
+
+  it("ships an examples.md whose task frontmatter blocks all parse as valid LoopConfigs", () => {
+    expect(fs.existsSync(examplesPath)).toBe(true)
+
+    const raw = fs.readFileSync(examplesPath, "utf8")
+
+    // Pull every fenced ```markdown ... ``` block — they each contain a task.md template.
+    const blocks = Array.from(raw.matchAll(/```markdown\n([\s\S]*?)```/g)).map(
+      (m) => m[1],
+    )
+    expect(blocks.length).toBeGreaterThanOrEqual(8)
+
+    const parsedTasks = blocks.map((body, i) => {
+      const task = parseTaskMarkdown(body, { fallbackId: `example-${i}` })
+      expect(task, `example block #${i} should parse`).not.toBeNull()
+      return task!
+    })
+
+    // Every example must declare an id and a non-empty prompt body.
+    for (const task of parsedTasks) {
+      expect(task.id.length).toBeGreaterThan(0)
+      expect(task.prompt.length).toBeGreaterThan(0)
+      expect(task.intervalMinutes).toBeGreaterThanOrEqual(1)
+    }
+
+    // The example set must demonstrate each of the headline runtime modes.
+    expect(parsedTasks.some((t) => t.runContinuously === true)).toBe(true)
+    expect(parsedTasks.some((t) => t.continueInSession === true)).toBe(true)
+    expect(parsedTasks.some((t) => t.speakOnTrigger === true)).toBe(true)
+    expect(parsedTasks.some((t) => t.runOnStartup === true)).toBe(true)
+    expect(parsedTasks.some((t) => t.schedule?.type === "daily")).toBe(true)
+    expect(parsedTasks.some((t) => t.schedule?.type === "weekly")).toBe(true)
+    expect(parsedTasks.some((t) => t.enabled === false)).toBe(true)
   })
 })


### PR DESCRIPTION
Closes #470.

## Summary

Adds a dedicated `create-repeat-task` bundled skill so agents have progressive, on-demand access to the full repeat-task config surface — including the runtime flags called out in #470 (`runContinuously`, `continueInSession`, `speakOnTrigger`) plus `runOnStartup`, `schedule`, `intervalMinutes`, and `profileId`. With this skill loaded, an agent asked to "create a recurring task" / "run continuously" / "speak the result when it's done" / "keep the conversation across runs" can produce a complete, valid `task.md` file without needing hidden implementation knowledge.

## Files added

- `apps/desktop/resources/bundled-skills/create-repeat-task/SKILL.md`
  - Trigger language for repeat-task / recurring / scheduled / continuous / same-session-continue / TTS phrasing.
  - Canonical file paths (`~/.agents/tasks/<id>/task.md` and the workspace layer).
  - Discovery-first workflow that points agents at the live schema in `packages/core/src/agents-files/tasks.ts` and `packages/core/src/types.ts` before editing.
  - Full frontmatter table with types, defaults, and notes for every supported field.
  - Schedule format reference (daily / weekly with `daysOfWeek` 0–6).
  - Decision guidance between interval, wall-clock schedule, and continuous modes.
  - Same-session continuation and TTS-on-completion notes.
  - Guardrails (`enabled: false` instead of deleting, do not hand-set `lastSessionId` / `lastRunAt`, etc.).
- `apps/desktop/resources/bundled-skills/create-repeat-task/examples.md`
  - Ready-to-paste templates for: basic interval, run-on-startup, daily schedule, weekly weekdays-only schedule, continuous, same-session continuation, TTS, profile-pinned, and disabled.

## Tests

- `apps/desktop/src/main/bundled-skills.test.ts` gains two cases:
  1. Parses the new SKILL.md via `parseSkillMarkdown` and asserts the trigger phrases and every documented runtime flag appear in instructions.
  2. Parses every fenced ` ```markdown ` task template inside `examples.md` through the canonical `parseTaskMarkdown` parser, then asserts that the full example set demonstrates each headline mode (`runContinuously`, `continueInSession`, `speakOnTrigger`, `runOnStartup`, daily schedule, weekly schedule, `enabled: false`).

## Validation

- `pnpm exec vitest run src/main/bundled-skills.test.ts` → 4/4 pass.
- `pnpm typecheck:node` → passes.

## Acceptance criteria mapping (from #470)

- [x] Progressively discoverable skill for creating repeat tasks.
- [x] Covers `continuous` (`runContinuously`) and same-session continuation (`continueInSession`).
- [x] TTS-on-completion (`speakOnTrigger`) documented with an example.
- [x] User can ask for a recurring/continuous task and the agent has the canonical schema, paths, and examples to author it without hidden knowledge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nwcu3FftQA9nK5rGwBQNbo)_