### PR TITLE
feat(desktop): add command queue state and actions to agent-store

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -398,6 +398,17 @@ export function ActiveAgentsSidebar({
   const isCommandQueueActive = useAgentStore((s) => s.isCommandQueueActive)
   const enterCommandQueue = useAgentStore((s) => s.enterCommandQueue)
   const exitCommandQueue = useAgentStore((s) => s.exitCommandQueue)
+  // First-run discoverability: nudge users once they have 2+ live agents.
+  // Stored client-side so the cue stops the moment they try it (or dismiss).
+  const [commandQueueDiscovered, setCommandQueueDiscovered] = useState(
+    () => readBooleanFromStorage("command-queue-discovered", false),
+  )
+  useEffect(() => {
+    if (isCommandQueueActive && !commandQueueDiscovered) {
+      writeBooleanToStorage("command-queue-discovered", true)
+      setCommandQueueDiscovered(true)
+    }
+  }, [isCommandQueueActive, commandQueueDiscovered])
   const [visibleSavedConversationCount, setVisibleSavedConversationCount] = useState<number | null>(null)
   const [visibleTaskConversationCount, setVisibleTaskConversationCount] = useState(
     SIDEBAR_PAST_SESSIONS_PAGE_SIZE,
@@ -1557,25 +1568,47 @@ export function ActiveAgentsSidebar({
                 </div>
               )}
               <div className="ml-auto flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant={isCommandQueueActive ? "default" : "outline"}
-                  size="sm"
-                  className={cn(
-                    "h-8 w-8 shrink-0 rounded-md px-0 shadow-sm",
-                    isCommandQueueActive && "bg-blue-500 text-white hover:bg-blue-600",
-                  )}
-                  onClick={isCommandQueueActive ? exitCommandQueue : enterCommandQueue}
-                  title={
-                    isCommandQueueActive
-                      ? "Exit command queue (Esc)"
-                      : `Enter multi-agent command queue (${typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac") ? "⌘" : "Ctrl"}+Shift+K)`
+                {(() => {
+                  let liveTopLevelCount = 0
+                  for (const [, progress] of agentProgressById.entries()) {
+                    if (!progress.isComplete && !progress.parentSessionId) liveTopLevelCount++
                   }
-                  aria-label={isCommandQueueActive ? "Exit command queue" : "Enter multi-agent command queue"}
-                  aria-pressed={isCommandQueueActive}
-                >
-                  <Layers className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                </Button>
+                  const showDiscoveryPulse =
+                    !isCommandQueueActive && !commandQueueDiscovered && liveTopLevelCount >= 2
+                  return (
+                    <Button
+                      type="button"
+                      variant={isCommandQueueActive ? "default" : "outline"}
+                      size="sm"
+                      className={cn(
+                        "relative h-8 w-8 shrink-0 rounded-md px-0 shadow-sm",
+                        isCommandQueueActive && "bg-blue-500 text-white hover:bg-blue-600",
+                        showDiscoveryPulse && "ring-2 ring-blue-500/40",
+                      )}
+                      onClick={isCommandQueueActive ? exitCommandQueue : enterCommandQueue}
+                      title={
+                        isCommandQueueActive
+                          ? "Exit command queue (Esc)"
+                          : showDiscoveryPulse
+                            ? `Try it: cycle through ${liveTopLevelCount} agents with one input (${SHORTCUT_MOD_SYMBOL}+Shift+K)`
+                            : `Enter multi-agent command queue (${SHORTCUT_MOD_SYMBOL}+Shift+K)`
+                      }
+                      aria-label={isCommandQueueActive ? "Exit command queue" : "Enter multi-agent command queue"}
+                      aria-pressed={isCommandQueueActive}
+                    >
+                      <Layers className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      {showDiscoveryPulse && (
+                        <span
+                          aria-hidden="true"
+                          className="absolute -right-0.5 -top-0.5 flex h-2.5 w-2.5"
+                        >
+                          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-500 opacity-75" />
+                          <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-blue-500" />
+                        </span>
+                      )}
+                    </Button>
+                  )
+                })()}
                 {onClearInactiveSessions && inactiveSessionCount > 0 && (
                   <Button
                     type="button"

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -5,6 +5,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Layers,
   Pin,
   Play,
   X,
@@ -394,6 +395,9 @@ export function ActiveAgentsSidebar({
   const pinnedSessionIds = useAgentStore((s) => s.pinnedSessionIds)
   const archivedSessionIds = useAgentStore((s) => s.archivedSessionIds)
   const toggleArchiveSession = useAgentStore((s) => s.toggleArchiveSession)
+  const isCommandQueueActive = useAgentStore((s) => s.isCommandQueueActive)
+  const enterCommandQueue = useAgentStore((s) => s.enterCommandQueue)
+  const exitCommandQueue = useAgentStore((s) => s.exitCommandQueue)
   const [visibleSavedConversationCount, setVisibleSavedConversationCount] = useState<number | null>(null)
   const [visibleTaskConversationCount, setVisibleTaskConversationCount] = useState(
     SIDEBAR_PAST_SESSIONS_PAGE_SIZE,
@@ -1553,6 +1557,25 @@ export function ActiveAgentsSidebar({
                 </div>
               )}
               <div className="ml-auto flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant={isCommandQueueActive ? "default" : "outline"}
+                  size="sm"
+                  className={cn(
+                    "h-8 w-8 shrink-0 rounded-md px-0 shadow-sm",
+                    isCommandQueueActive && "bg-blue-500 text-white hover:bg-blue-600",
+                  )}
+                  onClick={isCommandQueueActive ? exitCommandQueue : enterCommandQueue}
+                  title={
+                    isCommandQueueActive
+                      ? "Exit command queue (Esc)"
+                      : `Enter multi-agent command queue (${typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac") ? "⌘" : "Ctrl"}+Shift+K)`
+                  }
+                  aria-label={isCommandQueueActive ? "Exit command queue" : "Enter multi-agent command queue"}
+                  aria-pressed={isCommandQueueActive}
+                >
+                  <Layers className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                </Button>
                 {onClearInactiveSessions && inactiveSessionCount > 0 && (
                   <Button
                     type="button"

--- a/apps/desktop/src/renderer/src/components/agent-command-bar.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-command-bar.layout.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const commandBarSource = readFileSync(
+  new URL("./agent-command-bar.tsx", import.meta.url),
+  "utf8",
+)
+
+describe("agent command bar shortcuts", () => {
+  it("uses modified bracket shortcuts for queue navigation instead of Tab", () => {
+    expect(commandBarSource).toContain(
+      "const PREVIOUS_ENTRY_SHORTCUT = `${SHORTCUT_MOD_PREFIX}[`",
+    )
+    expect(commandBarSource).toContain(
+      "const NEXT_ENTRY_SHORTCUT = `${SHORTCUT_MOD_PREFIX}]`",
+    )
+    expect(commandBarSource).toContain('if (isPlainMod && e.key === "[")')
+    expect(commandBarSource).toContain('if (isPlainMod && e.key === "]")')
+    expect(commandBarSource).toContain('[NEXT_ENTRY_SHORTCUT, "next"]')
+    expect(commandBarSource).toContain('[PREVIOUS_ENTRY_SHORTCUT, "prev"]')
+    expect(commandBarSource).not.toContain('e.key === "Tab"')
+    expect(commandBarSource).not.toContain('"Shift+Tab"')
+  })
+})

--- a/apps/desktop/src/renderer/src/components/agent-command-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-command-bar.tsx
@@ -76,7 +76,7 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
 
   // Focus textarea and clear text when active entry changes
   useEffect(() => {
-    if (!isCommandQueueActive) return
+    if (!isCommandQueueActive) return undefined
     setText("")
     const t = window.setTimeout(() => {
       textareaRef.current?.focus()

--- a/apps/desktop/src/renderer/src/components/agent-command-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-command-bar.tsx
@@ -15,15 +15,24 @@ import {
 } from "lucide-react"
 import { useMutation } from "@tanstack/react-query"
 
-const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac")
-const SHORTCUT_MOD = IS_MAC ? "⌘" : "Ctrl"
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  navigator.platform.toLowerCase().includes("mac")
+const SHORTCUT_MOD_PREFIX = IS_MAC ? "⌘" : "Ctrl+"
+const PREVIOUS_ENTRY_SHORTCUT = `${SHORTCUT_MOD_PREFIX}[`
+const NEXT_ENTRY_SHORTCUT = `${SHORTCUT_MOD_PREFIX}]`
+const SKIP_ENTRY_SHORTCUT = `${SHORTCUT_MOD_PREFIX}S`
+const NEW_SLOT_SHORTCUT = `${SHORTCUT_MOD_PREFIX}N`
 
 interface AgentCommandBarProps {
   onOpenSessionDialog: (initialText: string, onSubmitted: () => void) => void
   className?: string
 }
 
-export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommandBarProps) {
+export function AgentCommandBar({
+  onOpenSessionDialog,
+  className,
+}: AgentCommandBarProps) {
   const isCommandQueueActive = useAgentStore((s) => s.isCommandQueueActive)
   const commandQueue = useAgentStore((s) => s.commandQueue)
   const commandQueueIndex = useAgentStore((s) => s.commandQueueIndex)
@@ -33,7 +42,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
   const goBackCommandQueue = useAgentStore((s) => s.goBackCommandQueue)
   const skipCommandEntry = useAgentStore((s) => s.skipCommandEntry)
   const appendNewSlot = useAgentStore((s) => s.appendNewSlot)
-  const appendUserMessageToSession = useAgentStore((s) => s.appendUserMessageToSession)
+  const appendUserMessageToSession = useAgentStore(
+    (s) => s.appendUserMessageToSession,
+  )
 
   const [text, setText] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -70,9 +81,10 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
   } as const
 
   const cfg = entryConfig[currentEntry?.kind ?? "new"]
-  const progressPercent = commandQueue.length > 0
-    ? Math.round((commandQueueIndex / commandQueue.length) * 100)
-    : 0
+  const progressPercent =
+    commandQueue.length > 0
+      ? Math.round((commandQueueIndex / commandQueue.length) * 100)
+      : 0
 
   // Focus textarea and clear text when active entry changes
   useEffect(() => {
@@ -85,7 +97,11 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
   }, [isCommandQueueActive, commandQueueIndex])
 
   const sendMutation = useMutation({
-    mutationFn: async (vars: { message: string; conversationId?: string; sessionId?: string }) => {
+    mutationFn: async (vars: {
+      message: string
+      conversationId?: string
+      sessionId?: string
+    }) => {
       return tipcClient.createMcpTextInput({
         text: vars.message,
         conversationId: vars.conversationId,
@@ -99,7 +115,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
         appendUserMessageToSession(vars.sessionId, vars.message)
       }
       if (vars.conversationId) {
-        queryClient.invalidateQueries({ queryKey: ["conversation", vars.conversationId] })
+        queryClient.invalidateQueries({
+          queryKey: ["conversation", vars.conversationId],
+        })
         queryClient.invalidateQueries({ queryKey: ["conversation-history"] })
       }
     },
@@ -130,54 +148,71 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
       setIsSubmitting(false)
     }
   }, [
-    text, isSubmitting, currentEntry, currentConversationId, currentSessionId,
-    sendMutation, advanceCommandQueue, onOpenSessionDialog,
+    text,
+    isSubmitting,
+    currentEntry,
+    currentConversationId,
+    currentSessionId,
+    sendMutation,
+    advanceCommandQueue,
+    onOpenSessionDialog,
   ])
 
-  const handleTextareaKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    const isMod = e.metaKey || e.ctrlKey
+  const handleTextareaKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const isMod = e.metaKey || e.ctrlKey
+      const isPlainMod = isMod && !e.altKey && !e.shiftKey
 
-    if (e.key === "Tab") {
-      e.preventDefault()
-      if (e.shiftKey) {
+      if (isPlainMod && e.key === "[") {
+        e.preventDefault()
         goBackCommandQueue()
-      } else {
+        return
+      }
+
+      if (isPlainMod && e.key === "]") {
+        e.preventDefault()
         advanceCommandQueue()
+        return
       }
-      return
-    }
 
-    if (e.key === "Escape") {
-      e.preventDefault()
-      if (text) {
-        setText("")
-      } else {
-        exitCommandQueue()
+      if (!isMod && e.key === "Escape") {
+        e.preventDefault()
+        if (text) {
+          setText("")
+        } else {
+          exitCommandQueue()
+        }
+        return
       }
-      return
-    }
 
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault()
-      void handleSubmit()
-      return
-    }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault()
+        void handleSubmit()
+        return
+      }
 
-    if (isMod && !e.shiftKey && e.key === "s") {
-      e.preventDefault()
-      skipCommandEntry()
-      return
-    }
+      if (isPlainMod && e.key.toLowerCase() === "s") {
+        e.preventDefault()
+        skipCommandEntry()
+        return
+      }
 
-    if (isMod && !e.shiftKey && e.key === "n") {
-      e.preventDefault()
-      appendNewSlot()
-      return
-    }
-  }, [
-    text, goBackCommandQueue, advanceCommandQueue, exitCommandQueue,
-    handleSubmit, skipCommandEntry, appendNewSlot,
-  ])
+      if (isPlainMod && e.key.toLowerCase() === "n") {
+        e.preventDefault()
+        appendNewSlot()
+        return
+      }
+    },
+    [
+      text,
+      goBackCommandQueue,
+      advanceCommandQueue,
+      exitCommandQueue,
+      handleSubmit,
+      skipCommandEntry,
+      appendNewSlot,
+    ],
+  )
 
   const adjustHeight = useCallback((el: HTMLTextAreaElement) => {
     el.style.height = "auto"
@@ -193,14 +228,14 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
   return (
     <div
       className={cn(
-        "border-t bg-background shadow-[0_-4px_20px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.3)]",
+        "bg-background border-t shadow-[0_-4px_20px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.3)]",
         className,
       )}
       role="region"
       aria-label="Multi-agent command queue"
     >
       {/* Progress bar */}
-      <div className="h-0.5 bg-muted/60">
+      <div className="bg-muted/60 h-0.5">
         <div
           className="h-full bg-blue-500 transition-all duration-300 ease-out"
           style={{ width: `${progressPercent}%` }}
@@ -210,9 +245,12 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
 
       {/* Header strip */}
       <div className="flex items-center gap-2 border-b px-3 py-1.5">
-        <div className="flex items-center gap-1.5 shrink-0">
-          <Layers className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-          <span className="text-[11px] font-semibold tabular-nums text-muted-foreground">
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Layers
+            className="text-muted-foreground h-3.5 w-3.5"
+            aria-hidden="true"
+          />
+          <span className="text-muted-foreground text-[11px] font-semibold tabular-nums">
             {commandQueueIndex + 1} / {commandQueue.length}
           </span>
         </div>
@@ -224,7 +262,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
             </span>
           ) : (
             <span className="text-xs">
-              <span className={cn("font-semibold", cfg.colorClass)}>{cfg.action}</span>
+              <span className={cn("font-semibold", cfg.colorClass)}>
+                {cfg.action}
+              </span>
               <span className="text-muted-foreground"> · {currentTitle}</span>
             </span>
           )}
@@ -237,9 +277,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
             variant="ghost"
             onClick={goBackCommandQueue}
             disabled={isFirstEntry}
-            title={`Previous entry (Shift+Tab)`}
+            title={`Previous entry (${PREVIOUS_ENTRY_SHORTCUT})`}
             aria-label="Previous entry"
-            className="h-6 w-6 text-muted-foreground disabled:opacity-30"
+            className="text-muted-foreground h-6 w-6 disabled:opacity-30"
           >
             <ArrowLeft className="h-3 w-3" aria-hidden="true" />
           </Button>
@@ -249,9 +289,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
             variant="ghost"
             onClick={advanceCommandQueue}
             disabled={isLastEntry}
-            title="Next entry (Tab)"
+            title={`Next entry (${NEXT_ENTRY_SHORTCUT})`}
             aria-label="Next entry"
-            className="h-6 w-6 text-muted-foreground disabled:opacity-30"
+            className="text-muted-foreground h-6 w-6 disabled:opacity-30"
           >
             <ArrowRight className="h-3 w-3" aria-hidden="true" />
           </Button>
@@ -260,9 +300,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
             size="sm-icon"
             variant="ghost"
             onClick={skipCommandEntry}
-            title={`Skip to end (${SHORTCUT_MOD}S)`}
+            title={`Skip to end (${SKIP_ENTRY_SHORTCUT})`}
             aria-label="Skip current entry"
-            className="h-6 w-6 text-muted-foreground"
+            className="text-muted-foreground h-6 w-6"
           >
             <SkipForward className="h-3 w-3" aria-hidden="true" />
           </Button>
@@ -271,9 +311,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
             size="sm-icon"
             variant="ghost"
             onClick={appendNewSlot}
-            title={`Add new task slot (${SHORTCUT_MOD}N)`}
+            title={`Add new task slot (${NEW_SLOT_SHORTCUT})`}
             aria-label="Add new session slot"
-            className="h-6 w-6 text-muted-foreground"
+            className="text-muted-foreground h-6 w-6"
           >
             <Plus className="h-3 w-3" aria-hidden="true" />
           </Button>
@@ -284,7 +324,7 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
             onClick={exitCommandQueue}
             title="Exit command queue (Esc)"
             aria-label="Exit command queue"
-            className="h-6 w-6 text-muted-foreground"
+            className="text-muted-foreground h-6 w-6"
           >
             <X className="h-3 w-3" aria-hidden="true" />
           </Button>
@@ -306,9 +346,9 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
           aria-label={cfg.placeholder}
           disabled={isBusy}
           className={cn(
-            "min-h-[2rem] flex-1 resize-none rounded-md border bg-muted/30 px-3 py-1.5",
-            "text-sm text-foreground placeholder:text-muted-foreground/60",
-            "focus:outline-none focus:ring-1 focus:ring-blue-500/40 focus:border-blue-500/40",
+            "bg-muted/30 min-h-[2rem] flex-1 resize-none rounded-md border px-3 py-1.5",
+            "text-foreground placeholder:text-muted-foreground/60 text-sm",
+            "focus:border-blue-500/40 focus:outline-none focus:ring-1 focus:ring-blue-500/40",
             "disabled:opacity-50",
           )}
           style={{ overflowY: "hidden" }}
@@ -328,17 +368,17 @@ export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommand
 
       {/* Hotkey hint footer */}
       <div
-        className="flex items-center gap-4 border-t bg-muted/20 px-3 py-1"
+        className="bg-muted/20 flex items-center gap-4 border-t px-3 py-1"
         aria-hidden="true"
       >
         {[
-          ["Tab", "next"],
-          ["Shift+Tab", "prev"],
-          [`${SHORTCUT_MOD}S`, "skip"],
-          [`${SHORTCUT_MOD}N`, "new task"],
+          [NEXT_ENTRY_SHORTCUT, "next"],
+          [PREVIOUS_ENTRY_SHORTCUT, "prev"],
+          [SKIP_ENTRY_SHORTCUT, "skip"],
+          [NEW_SLOT_SHORTCUT, "new task"],
           ["Esc", "exit"],
         ].map(([key, label]) => (
-          <span key={key} className="text-[10px] text-muted-foreground">
+          <span key={key} className="text-muted-foreground text-[10px]">
             <kbd className="font-mono">{key}</kbd> {label}
           </span>
         ))}

--- a/apps/desktop/src/renderer/src/components/agent-command-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-command-bar.tsx
@@ -1,0 +1,348 @@
+import React, { useState, useRef, useEffect, useCallback } from "react"
+import { cn } from "@renderer/lib/utils"
+import { Button } from "@renderer/components/ui/button"
+import { tipcClient } from "@renderer/lib/tipc-client"
+import { useAgentStore } from "@renderer/stores"
+import { queryClient } from "@renderer/lib/queries"
+import {
+  ArrowLeft,
+  ArrowRight,
+  Plus,
+  SkipForward,
+  X,
+  Send,
+  Layers,
+} from "lucide-react"
+import { useMutation } from "@tanstack/react-query"
+
+const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac")
+const SHORTCUT_MOD = IS_MAC ? "⌘" : "Ctrl"
+
+interface AgentCommandBarProps {
+  onOpenSessionDialog: (initialText: string, onSubmitted: () => void) => void
+  className?: string
+}
+
+export function AgentCommandBar({ onOpenSessionDialog, className }: AgentCommandBarProps) {
+  const isCommandQueueActive = useAgentStore((s) => s.isCommandQueueActive)
+  const commandQueue = useAgentStore((s) => s.commandQueue)
+  const commandQueueIndex = useAgentStore((s) => s.commandQueueIndex)
+  const agentProgressById = useAgentStore((s) => s.agentProgressById)
+  const exitCommandQueue = useAgentStore((s) => s.exitCommandQueue)
+  const advanceCommandQueue = useAgentStore((s) => s.advanceCommandQueue)
+  const goBackCommandQueue = useAgentStore((s) => s.goBackCommandQueue)
+  const skipCommandEntry = useAgentStore((s) => s.skipCommandEntry)
+  const appendNewSlot = useAgentStore((s) => s.appendNewSlot)
+  const appendUserMessageToSession = useAgentStore((s) => s.appendUserMessageToSession)
+
+  const [text, setText] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const submitInFlightRef = useRef(false)
+
+  const currentEntry = commandQueue[commandQueueIndex] ?? null
+  const currentProgress = currentEntry?.sessionId
+    ? agentProgressById.get(currentEntry.sessionId)
+    : null
+  const currentTitle = currentProgress?.conversationTitle ?? "Untitled"
+  const currentConversationId = currentProgress?.conversationId
+  const currentSessionId = currentEntry?.sessionId
+
+  const entryConfig = {
+    new: {
+      placeholder: "Describe a new task to dispatch...",
+      action: "Dispatch",
+      colorClass: "text-emerald-600 dark:text-emerald-400",
+      btnClass: "bg-emerald-600 hover:bg-emerald-700 text-white",
+    },
+    steer: {
+      placeholder: "Steer this agent mid-run...",
+      action: "Steer",
+      colorClass: "text-blue-600 dark:text-blue-400",
+      btnClass: "bg-blue-600 hover:bg-blue-700 text-white",
+    },
+    reply: {
+      placeholder: "Reply to this agent...",
+      action: "Reply",
+      colorClass: "text-violet-600 dark:text-violet-400",
+      btnClass: "bg-violet-600 hover:bg-violet-700 text-white",
+    },
+  } as const
+
+  const cfg = entryConfig[currentEntry?.kind ?? "new"]
+  const progressPercent = commandQueue.length > 0
+    ? Math.round((commandQueueIndex / commandQueue.length) * 100)
+    : 0
+
+  // Focus textarea and clear text when active entry changes
+  useEffect(() => {
+    if (!isCommandQueueActive) return
+    setText("")
+    const t = window.setTimeout(() => {
+      textareaRef.current?.focus()
+    }, 50)
+    return () => window.clearTimeout(t)
+  }, [isCommandQueueActive, commandQueueIndex])
+
+  const sendMutation = useMutation({
+    mutationFn: async (vars: { message: string; conversationId?: string; sessionId?: string }) => {
+      return tipcClient.createMcpTextInput({
+        text: vars.message,
+        conversationId: vars.conversationId,
+        sessionId: vars.sessionId,
+        fromTile: true,
+        startSnoozed: false,
+      })
+    },
+    onSuccess: (data, vars) => {
+      if (vars.sessionId && !data?.queued) {
+        appendUserMessageToSession(vars.sessionId, vars.message)
+      }
+      if (vars.conversationId) {
+        queryClient.invalidateQueries({ queryKey: ["conversation", vars.conversationId] })
+        queryClient.invalidateQueries({ queryKey: ["conversation-history"] })
+      }
+    },
+  })
+
+  const handleSubmit = useCallback(async () => {
+    if (!text.trim() || isSubmitting || submitInFlightRef.current) return
+    submitInFlightRef.current = true
+    setIsSubmitting(true)
+    try {
+      if (currentEntry?.kind === "new") {
+        const capturedText = text
+        setText("")
+        onOpenSessionDialog(capturedText, () => advanceCommandQueue())
+        return
+      }
+      await sendMutation.mutateAsync({
+        message: text,
+        conversationId: currentConversationId,
+        sessionId: currentSessionId,
+      })
+      setText("")
+      advanceCommandQueue()
+    } catch (error) {
+      console.error("[AgentCommandBar] Submit failed:", error)
+    } finally {
+      submitInFlightRef.current = false
+      setIsSubmitting(false)
+    }
+  }, [
+    text, isSubmitting, currentEntry, currentConversationId, currentSessionId,
+    sendMutation, advanceCommandQueue, onOpenSessionDialog,
+  ])
+
+  const handleTextareaKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const isMod = e.metaKey || e.ctrlKey
+
+    if (e.key === "Tab") {
+      e.preventDefault()
+      if (e.shiftKey) {
+        goBackCommandQueue()
+      } else {
+        advanceCommandQueue()
+      }
+      return
+    }
+
+    if (e.key === "Escape") {
+      e.preventDefault()
+      if (text) {
+        setText("")
+      } else {
+        exitCommandQueue()
+      }
+      return
+    }
+
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      void handleSubmit()
+      return
+    }
+
+    if (isMod && !e.shiftKey && e.key === "s") {
+      e.preventDefault()
+      skipCommandEntry()
+      return
+    }
+
+    if (isMod && !e.shiftKey && e.key === "n") {
+      e.preventDefault()
+      appendNewSlot()
+      return
+    }
+  }, [
+    text, goBackCommandQueue, advanceCommandQueue, exitCommandQueue,
+    handleSubmit, skipCommandEntry, appendNewSlot,
+  ])
+
+  const adjustHeight = useCallback((el: HTMLTextAreaElement) => {
+    el.style.height = "auto"
+    el.style.height = `${Math.min(el.scrollHeight, 120)}px`
+  }, [])
+
+  if (!isCommandQueueActive) return null
+
+  const isFirstEntry = commandQueueIndex === 0
+  const isLastEntry = commandQueueIndex >= commandQueue.length - 1
+  const isBusy = isSubmitting || sendMutation.isPending
+
+  return (
+    <div
+      className={cn(
+        "border-t bg-background shadow-[0_-4px_20px_rgba(0,0,0,0.08)] dark:shadow-[0_-4px_20px_rgba(0,0,0,0.3)]",
+        className,
+      )}
+      role="region"
+      aria-label="Multi-agent command queue"
+    >
+      {/* Progress bar */}
+      <div className="h-0.5 bg-muted/60">
+        <div
+          className="h-full bg-blue-500 transition-all duration-300 ease-out"
+          style={{ width: `${progressPercent}%` }}
+          aria-hidden="true"
+        />
+      </div>
+
+      {/* Header strip */}
+      <div className="flex items-center gap-2 border-b px-3 py-1.5">
+        <div className="flex items-center gap-1.5 shrink-0">
+          <Layers className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          <span className="text-[11px] font-semibold tabular-nums text-muted-foreground">
+            {commandQueueIndex + 1} / {commandQueue.length}
+          </span>
+        </div>
+
+        <div className="min-w-0 flex-1 overflow-hidden">
+          {currentEntry?.kind === "new" ? (
+            <span className={cn("text-xs font-semibold", cfg.colorClass)}>
+              Dispatch new agent
+            </span>
+          ) : (
+            <span className="text-xs">
+              <span className={cn("font-semibold", cfg.colorClass)}>{cfg.action}</span>
+              <span className="text-muted-foreground"> · {currentTitle}</span>
+            </span>
+          )}
+        </div>
+
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
+          <Button
+            type="button"
+            size="sm-icon"
+            variant="ghost"
+            onClick={goBackCommandQueue}
+            disabled={isFirstEntry}
+            title={`Previous entry (Shift+Tab)`}
+            aria-label="Previous entry"
+            className="h-6 w-6 text-muted-foreground disabled:opacity-30"
+          >
+            <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm-icon"
+            variant="ghost"
+            onClick={advanceCommandQueue}
+            disabled={isLastEntry}
+            title="Next entry (Tab)"
+            aria-label="Next entry"
+            className="h-6 w-6 text-muted-foreground disabled:opacity-30"
+          >
+            <ArrowRight className="h-3 w-3" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm-icon"
+            variant="ghost"
+            onClick={skipCommandEntry}
+            title={`Skip to end (${SHORTCUT_MOD}S)`}
+            aria-label="Skip current entry"
+            className="h-6 w-6 text-muted-foreground"
+          >
+            <SkipForward className="h-3 w-3" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm-icon"
+            variant="ghost"
+            onClick={appendNewSlot}
+            title={`Add new task slot (${SHORTCUT_MOD}N)`}
+            aria-label="Add new session slot"
+            className="h-6 w-6 text-muted-foreground"
+          >
+            <Plus className="h-3 w-3" aria-hidden="true" />
+          </Button>
+          <Button
+            type="button"
+            size="sm-icon"
+            variant="ghost"
+            onClick={exitCommandQueue}
+            title="Exit command queue (Esc)"
+            aria-label="Exit command queue"
+            className="h-6 w-6 text-muted-foreground"
+          >
+            <X className="h-3 w-3" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Adaptive input area */}
+      <div className="flex items-end gap-2 px-3 py-2">
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={(e) => {
+            setText(e.target.value)
+            adjustHeight(e.target)
+          }}
+          onKeyDown={handleTextareaKeyDown}
+          placeholder={cfg.placeholder}
+          rows={1}
+          aria-label={cfg.placeholder}
+          disabled={isBusy}
+          className={cn(
+            "min-h-[2rem] flex-1 resize-none rounded-md border bg-muted/30 px-3 py-1.5",
+            "text-sm text-foreground placeholder:text-muted-foreground/60",
+            "focus:outline-none focus:ring-1 focus:ring-blue-500/40 focus:border-blue-500/40",
+            "disabled:opacity-50",
+          )}
+          style={{ overflowY: "hidden" }}
+        />
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => void handleSubmit()}
+          disabled={!text.trim() || isBusy}
+          className={cn("shrink-0", cfg.btnClass)}
+          aria-label={`${cfg.action} and advance`}
+        >
+          <Send className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+          {cfg.action}
+        </Button>
+      </div>
+
+      {/* Hotkey hint footer */}
+      <div
+        className="flex items-center gap-4 border-t bg-muted/20 px-3 py-1"
+        aria-hidden="true"
+      >
+        {[
+          ["Tab", "next"],
+          ["Shift+Tab", "prev"],
+          [`${SHORTCUT_MOD}S`, "skip"],
+          [`${SHORTCUT_MOD}N`, "new task"],
+          ["Esc", "exit"],
+        ].map(([key, label]) => (
+          <span key={key} className="text-[10px] text-muted-foreground">
+            <kbd className="font-mono">{key}</kbd> {label}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -19,6 +19,7 @@ import { useTTSPlaybackController } from "@renderer/lib/tts-playback-controller"
 import { applySelectedAgentToNextSession as applySelectedAgentForNextSession } from "@renderer/lib/apply-selected-agent"
 import { hasUnreadAgentResponse } from "@renderer/lib/sidebar-sessions"
 import { useAgentStore } from "@renderer/stores"
+import { AgentCommandBar } from "@renderer/components/agent-command-bar"
 import {
   Clock,
   PanelLeftClose,
@@ -86,6 +87,9 @@ export const Component = () => {
   const agentResponseReadAtBySessionId = useAgentStore(
     (s) => s.agentResponseReadAtBySessionId,
   )
+  const isCommandQueueActive = useAgentStore((s) => s.isCommandQueueActive)
+  const enterCommandQueue = useAgentStore((s) => s.enterCommandQueue)
+  const exitCommandQueue = useAgentStore((s) => s.exitCommandQueue)
 
   const { data: sessionData, refetch: refetchSessionData } =
     useQuery<SessionListResponse>({
@@ -213,6 +217,33 @@ export const Component = () => {
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
   }, [])
+
+  useEffect(() => {
+    const handleCommandQueueHotkey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      const tagName = target?.tagName?.toLowerCase()
+      const isEditable =
+        target?.isContentEditable ||
+        tagName === "input" ||
+        tagName === "textarea" ||
+        tagName === "select"
+
+      if (isEditable) return
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || !event.shiftKey) return
+      if (event.key.toLowerCase() !== "k") return
+
+      event.preventDefault()
+      event.stopPropagation()
+      if (isCommandQueueActive) {
+        exitCommandQueue()
+      } else {
+        enterCommandQueue()
+      }
+    }
+
+    window.addEventListener("keydown", handleCommandQueueHotkey)
+    return () => window.removeEventListener("keydown", handleCommandQueueHotkey)
+  }, [isCommandQueueActive, enterCommandQueue, exitCommandQueue])
 
   const handleStartTextSession = useCallback(async () => {
     const applied = await applySelectedAgentToNextSession()
@@ -882,6 +913,12 @@ export const Component = () => {
               }}
             />
           </div>
+          <AgentCommandBar
+            onOpenSessionDialog={(initialText, onSubmitted) => {
+              void applySelectedAgentToNextSession()
+              openSessionActionDialog({ mode: "text", initialText, onSubmitted })
+            }}
+          />
         </div>
       </div>
 

--- a/apps/desktop/src/renderer/src/stores/agent-store.ts
+++ b/apps/desktop/src/renderer/src/stores/agent-store.ts
@@ -119,6 +119,13 @@ const mergeDelegationStep = (
   }
 }
 
+export type CommandQueueEntryKind = 'new' | 'steer' | 'reply'
+
+export interface CommandQueueEntry {
+  kind: CommandQueueEntryKind
+  sessionId?: string
+}
+
 export type SessionViewMode = 'grid' | 'list' | 'kanban'
 export type SessionFilter = 'all' | 'active' | 'completed' | 'error'
 export type SessionSortBy = 'recent' | 'oldest' | 'status'
@@ -190,6 +197,18 @@ interface AgentState {
 
   setFloatingPanelVisible: (visible: boolean) => void
   setTTSPlaybackState: (state: DesktopTTSPlaybackState) => void
+
+  // Command queue for rapid multi-agent coordination
+  isCommandQueueActive: boolean
+  commandQueue: CommandQueueEntry[]
+  commandQueueIndex: number
+
+  enterCommandQueue: () => void
+  exitCommandQueue: () => void
+  advanceCommandQueue: () => void
+  goBackCommandQueue: () => void
+  skipCommandEntry: () => void
+  appendNewSlot: () => void
 }
 
 export const useAgentStore = create<AgentState>((set, get) => ({
@@ -201,6 +220,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   scrollToSessionId: null,
   messageQueuesByConversation: new Map(),
   pausedQueueConversations: new Set(),
+
+  isCommandQueueActive: false,
+  commandQueue: [],
+  commandQueueIndex: 0,
 
   viewMode: 'grid' as SessionViewMode,
   filter: 'all' as SessionFilter,
@@ -438,10 +461,35 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         )
       }
 
+      // Auto-update command queue when sessions change state
+      let updatedCommandQueue = state.commandQueue
+      if (state.isCommandQueueActive && !isDelegatedSubagentProgress(mergedUpdate) && !isDelegationOnlyProgressUpdate(update)) {
+        const existingEntryIdx = state.commandQueue.findIndex((e) => e.sessionId === sessionId)
+        if (existingEntryIdx !== -1 && state.commandQueue[existingEntryIdx].kind === 'steer') {
+          if (mergedUpdate.isComplete || mergedUpdate.conversationState === 'needs_input') {
+            updatedCommandQueue = state.commandQueue.map((e, i) =>
+              i === existingEntryIdx ? { kind: 'reply' as const, sessionId: e.sessionId } : e,
+            )
+          }
+        } else if (existingEntryIdx === -1 && isNewSession) {
+          const entryKind: CommandQueueEntryKind = mergedUpdate.isComplete ? 'reply' : 'steer'
+          let insertAt = state.commandQueue.length
+          for (let i = state.commandQueue.length - 1; i >= 0; i--) {
+            if (state.commandQueue[i].kind !== 'new') { insertAt = i + 1; break }
+          }
+          updatedCommandQueue = [
+            ...state.commandQueue.slice(0, insertAt),
+            { kind: entryKind, sessionId },
+            ...state.commandQueue.slice(insertAt),
+          ]
+        }
+      }
+
       return {
         agentProgressById: newMap,
         agentResponseReadAtBySessionId: nextReadTimestamps,
         focusedSessionId: newFocusedSessionId,
+        ...(updatedCommandQueue !== state.commandQueue ? { commandQueue: updatedCommandQueue } : {}),
       }
     })
   },
@@ -700,6 +748,108 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     return get().pausedQueueConversations.has(conversationId)
   },
 
+  enterCommandQueue: () => {
+    set((state) => {
+      const sessions = Array.from(state.agentProgressById.entries())
+        .filter(([, p]) => !isDelegatedSubagentProgress(p) && !p.isSnoozed)
+        .sort((a, b) => getProgressActivityTimestamp(b[1]) - getProgressActivityTimestamp(a[1]))
+
+      const entries: CommandQueueEntry[] = []
+
+      for (const [sessionId, progress] of sessions) {
+        if (progress.conversationState === 'needs_input') {
+          entries.push({ kind: 'reply', sessionId })
+        }
+      }
+      for (const [sessionId, progress] of sessions) {
+        if ((progress.isComplete || progress.conversationState === 'complete') && progress.conversationState !== 'needs_input') {
+          entries.push({ kind: 'reply', sessionId })
+        }
+      }
+      for (const [sessionId, progress] of sessions) {
+        if (!progress.isComplete && progress.conversationState === 'running') {
+          entries.push({ kind: 'steer', sessionId })
+        }
+      }
+      entries.push({ kind: 'new' })
+
+      const firstEntry = entries[0]
+      const firstSessionId = firstEntry?.kind !== 'new' ? (firstEntry?.sessionId ?? null) : null
+
+      return {
+        isCommandQueueActive: true,
+        commandQueue: entries,
+        commandQueueIndex: 0,
+        ...(firstSessionId ? { focusedSessionId: firstSessionId, expandedSessionId: firstSessionId } : {}),
+      }
+    })
+  },
+
+  exitCommandQueue: () => {
+    set({ isCommandQueueActive: false, commandQueue: [], commandQueueIndex: 0 })
+  },
+
+  advanceCommandQueue: () => {
+    set((state) => {
+      if (!state.isCommandQueueActive) return state
+      const nextIndex = state.commandQueueIndex + 1
+      if (nextIndex >= state.commandQueue.length) {
+        return { isCommandQueueActive: false, commandQueue: [], commandQueueIndex: 0 }
+      }
+      const nextEntry = state.commandQueue[nextIndex]
+      const nextSessionId = nextEntry.kind !== 'new' ? (nextEntry.sessionId ?? null) : null
+      return {
+        commandQueueIndex: nextIndex,
+        ...(nextSessionId ? { focusedSessionId: nextSessionId, expandedSessionId: nextSessionId } : {}),
+      }
+    })
+  },
+
+  goBackCommandQueue: () => {
+    set((state) => {
+      if (!state.isCommandQueueActive || state.commandQueueIndex <= 0) return state
+      const prevIndex = state.commandQueueIndex - 1
+      const prevEntry = state.commandQueue[prevIndex]
+      const prevSessionId = prevEntry.kind !== 'new' ? (prevEntry.sessionId ?? null) : null
+      return {
+        commandQueueIndex: prevIndex,
+        ...(prevSessionId ? { focusedSessionId: prevSessionId, expandedSessionId: prevSessionId } : {}),
+      }
+    })
+  },
+
+  skipCommandEntry: () => {
+    set((state) => {
+      if (!state.isCommandQueueActive || state.commandQueue.length <= 1) return state
+      const current = state.commandQueue[state.commandQueueIndex]
+      const rest = state.commandQueue.filter((_, i) => i !== state.commandQueueIndex)
+      const newQueue = [...rest, current]
+      const newIndex = Math.min(state.commandQueueIndex, newQueue.length - 1)
+      const nextEntry = newQueue[newIndex]
+      const nextSessionId = nextEntry.kind !== 'new' ? (nextEntry.sessionId ?? null) : null
+      return {
+        commandQueue: newQueue,
+        commandQueueIndex: newIndex,
+        ...(nextSessionId ? { focusedSessionId: nextSessionId, expandedSessionId: nextSessionId } : {}),
+      }
+    })
+  },
+
+  appendNewSlot: () => {
+    set((state) => {
+      if (!state.isCommandQueueActive) return state
+      let lastNewIdx = -1
+      for (let i = state.commandQueue.length - 1; i >= 0; i--) {
+        if (state.commandQueue[i].kind === 'new') { lastNewIdx = i; break }
+      }
+      if (lastNewIdx !== -1) {
+        return { commandQueueIndex: lastNewIdx }
+      }
+      const newQueue = [...state.commandQueue, { kind: 'new' as const }]
+      return { commandQueue: newQueue, commandQueueIndex: newQueue.length - 1 }
+    })
+  },
+
   // View settings actions
   setViewMode: (mode: SessionViewMode) => {
     set({ viewMode: mode })
@@ -812,3 +962,15 @@ export const useTTSPlaybackState = () => {
 export const useIsTTSPlaybackActive = (playbackId: string | null | undefined) => {
   return useAgentStore((state) => !!playbackId && state.ttsPlaybackState.playbackId === playbackId)
 }
+
+export const useIsCommandQueueActive = () =>
+  useAgentStore((state) => state.isCommandQueueActive)
+
+export const useCommandQueueState = () =>
+  useAgentStore((state) => ({
+    isActive: state.isCommandQueueActive,
+    queue: state.commandQueue,
+    index: state.commandQueueIndex,
+    current: state.commandQueue[state.commandQueueIndex] ?? null,
+    total: state.commandQueue.length,
+  }))

--- a/apps/desktop/src/renderer/src/stores/index.ts
+++ b/apps/desktop/src/renderer/src/stores/index.ts
@@ -1,5 +1,5 @@
 // Zustand stores for state management
-export { useAgentStore, useAgentSessionProgress, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused, useIsFloatingPanelVisible, useTTSPlaybackState, useIsTTSPlaybackActive } from './agent-store'
-export type { SessionViewMode, SessionFilter, SessionSortBy } from './agent-store'
+export { useAgentStore, useAgentSessionProgress, useAgentProgress, useIsAgentProcessing, useMessageQueue, useIsQueuePaused, useIsFloatingPanelVisible, useTTSPlaybackState, useIsTTSPlaybackActive, useIsCommandQueueActive, useCommandQueueState } from './agent-store'
+export type { SessionViewMode, SessionFilter, SessionSortBy, CommandQueueEntryKind, CommandQueueEntry } from './agent-store'
 export { useConversationStore } from './conversation-store'
 

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -14,6 +14,7 @@ import SkillEditScreen from './src/screens/SkillEditScreen';
 import { AppConfig, ConfigContext, useConfig, saveConfig } from './src/store/config';
 import { SessionContext, useSessions } from './src/store/sessions';
 import { MessageQueueContext, useMessageQueue } from './src/store/message-queue';
+import { CommandQueueContext, useCommandQueue } from './src/store/command-queue';
 import { ConnectionManagerContext, useConnectionManagerProvider } from './src/store/connectionManager';
 import { TunnelConnectionContext, useTunnelConnectionProvider } from './src/store/tunnelConnection';
 import { ProfileContext, useProfileProvider } from './src/store/profile';
@@ -84,6 +85,7 @@ function Navigation() {
   const cfg = useConfig();
   const sessionStore = useSessions();
   const messageQueueStore = useMessageQueue();
+  const commandQueueStore = useCommandQueue();
   const navigationRef = useNavigationContainerRef();
   const isNavigationReady = useRef(false);
   const [currentRouteName, setCurrentRouteName] = useState('Sessions');
@@ -481,6 +483,7 @@ function Navigation() {
     <ConfigContext.Provider value={cfg}>
       <ProfileContext.Provider value={profileProvider}>
         <SessionContext.Provider value={sessionStore}>
+          <CommandQueueContext.Provider value={commandQueueStore}>
           <MessageQueueContext.Provider value={messageQueueStore}>
             <ConnectionManagerContext.Provider value={connectionManager}>
               <TunnelConnectionContext.Provider value={tunnelConnection}>
@@ -589,6 +592,7 @@ function Navigation() {
               </TunnelConnectionContext.Provider>
             </ConnectionManagerContext.Provider>
           </MessageQueueContext.Provider>
+          </CommandQueueContext.Provider>
         </SessionContext.Provider>
       </ProfileContext.Provider>
     </ConfigContext.Provider>

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -33,6 +33,8 @@ import {
 } from '../store/config';
 import { useSessionContext } from '../store/sessions';
 import { useMessageQueueContext } from '../store/message-queue';
+import { useCommandQueueContext } from '../store/command-queue';
+import { AgentCommandBar } from '../ui/AgentCommandBar';
 import { MessageQueuePanel } from '../ui/MessageQueuePanel';
 import { ResponseHistoryPanel } from '../ui/ResponseHistoryPanel';
 import { speakRemoteTts, stopRemoteTts } from '../lib/remoteTts';
@@ -627,6 +629,7 @@ export default function ChatScreen({ route, navigation }: any) {
   const { config, setConfig } = useConfigContext();
   const sessionStore = useSessionContext();
   const messageQueue = useMessageQueueContext();
+  const commandQueue = useCommandQueueContext();
   const connectionManager = useConnectionManager();
   const { connectionInfo } = useTunnelConnection();
   const { currentProfile } = useProfile();
@@ -4792,6 +4795,15 @@ export default function ChatScreen({ route, navigation }: any) {
           </View>
         </KeyboardAvoidingView>
       </Modal>
+      <AgentCommandBar
+        onSend={async (text, conversationId, sessionId) => {
+          await send(text);
+        }}
+        onDispatch={(text, onSubmitted) => {
+          setInput(text);
+          onSubmitted();
+        }}
+      />
     </KeyboardAvoidingView>
   );
 }

--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -8,6 +8,8 @@ import { spacing, radius, Theme } from '../ui/theme';
 import { useConfigContext } from '../store/config';
 import { useSessionContext, SessionStore, normalizeSessionTitleText } from '../store/sessions';
 import { useConnectionManager } from '../store/connectionManager';
+import { useCommandQueueContext } from '../store/command-queue';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTunnelConnection } from '../store/tunnelConnection';
 import { useProfile } from '../store/profile';
 import { ConnectionStatusIndicator } from '../ui/ConnectionStatusIndicator';
@@ -618,6 +620,50 @@ export default function SessionListScreen({ navigation }: Props) {
     navigation.navigate('SplitChat');
   }, [navigation]);
 
+  const commandQueueStore = useCommandQueueContext();
+  const [commandQueueDiscovered, setCommandQueueDiscovered] = useState(false);
+  useEffect(() => {
+    AsyncStorage.getItem('command-queue-discovered-mobile')
+      .then((v) => setCommandQueueDiscovered(v === 'true'))
+      .catch(() => undefined);
+  }, []);
+
+  const handleEnterCommandQueue = useCallback(() => {
+    // Take the most recent non-archived sessions so the queue stays focused on
+    // current work rather than every chat the user has ever opened.
+    const inputs = sessionStore.sessions
+      .filter((s) => !s.isArchived && !isStubSession(s))
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, 10)
+      .map((s) => {
+        const isActive = connectionManager.isConnectionActive(s.id);
+        return {
+          sessionId: s.id,
+          conversationId: s.serverConversationId,
+          title: s.title || 'Untitled',
+          isComplete: !isActive,
+          conversationState: isActive ? 'running' : 'complete',
+        };
+      });
+    commandQueueStore.enterCommandQueue(inputs);
+    if (!commandQueueDiscovered) {
+      AsyncStorage.setItem('command-queue-discovered-mobile', 'true').catch(() => undefined);
+      setCommandQueueDiscovered(true);
+    }
+    navigation.navigate('Chat');
+  }, [sessionStore, connectionManager, commandQueueStore, commandQueueDiscovered, navigation]);
+
+  // Show discovery pulse when 2+ sessions exist and the queue hasn't been used.
+  const liveSessionCount = useMemo(
+    () =>
+      sessionStore.sessions.filter(
+        (s) => !s.isArchived && !isStubSession(s),
+      ).length,
+    [sessionStore.sessions],
+  );
+  const showCommandQueuePulse =
+    !commandQueueStore.isActive && !commandQueueDiscovered && liveSessionCount >= 2;
+
   const handleOpenConnectionSettings = useCallback((openScanner = false) => {
     if (openScanner) {
       navigation.navigate('ConnectionSettings', { openScanner: true });
@@ -667,6 +713,31 @@ export default function SessionListScreen({ navigation }: Props) {
             compact
           />
           <TouchableOpacity
+            onPress={handleEnterCommandQueue}
+            style={styles.headerSettingsButton}
+            accessibilityRole="button"
+            accessibilityLabel={createButtonAccessibilityLabel('Enter multi-agent command queue')}
+            accessibilityHint="Cycle through your agents through one input bar"
+          >
+            <View>
+              <Ionicons name="layers-outline" size={18} color={theme.colors.foreground} />
+              {showCommandQueuePulse && (
+                <View
+                  pointerEvents="none"
+                  style={{
+                    position: 'absolute',
+                    top: -2,
+                    right: -2,
+                    width: 8,
+                    height: 8,
+                    borderRadius: 4,
+                    backgroundColor: '#3b82f6',
+                  }}
+                />
+              )}
+            </View>
+          </TouchableOpacity>
+          <TouchableOpacity
             onPress={handleOpenSplitView}
             style={styles.headerSettingsButton}
             accessibilityRole="button"
@@ -696,7 +767,7 @@ export default function SessionListScreen({ navigation }: Props) {
         </View>
       ),
     });
-  }, [navigation, styles, theme, connectionInfo.state, connectionInfo.retryCount, currentProfile, setAgentSelectorVisible, handleCreateSession, handleOpenSettings, handleOpenSplitView]);
+  }, [navigation, styles, theme, connectionInfo.state, connectionInfo.retryCount, currentProfile, setAgentSelectorVisible, handleCreateSession, handleOpenSettings, handleOpenSplitView, handleEnterCommandQueue, showCommandQueuePulse]);
 
   if (!sessionStore.ready || !isInitialized) {
     return (

--- a/apps/mobile/src/store/command-queue.ts
+++ b/apps/mobile/src/store/command-queue.ts
@@ -1,0 +1,132 @@
+import { createContext, useContext, useState, useCallback } from 'react';
+
+export type CommandQueueEntryKind = 'new' | 'steer' | 'reply';
+
+export interface CommandQueueEntry {
+  kind: CommandQueueEntryKind;
+  sessionId?: string;
+  conversationId?: string;
+  title?: string;
+}
+
+export interface CommandQueueSessionInput {
+  sessionId: string;
+  conversationId?: string;
+  title?: string;
+  isComplete: boolean;
+  conversationState?: string;
+}
+
+export interface CommandQueueStore {
+  isActive: boolean;
+  queue: CommandQueueEntry[];
+  index: number;
+  current: CommandQueueEntry | null;
+  total: number;
+  enterCommandQueue: (sessions: CommandQueueSessionInput[]) => void;
+  exitCommandQueue: () => void;
+  advanceQueue: () => void;
+  goBackQueue: () => void;
+  skipCurrent: () => void;
+  appendNewSlot: () => void;
+}
+
+export function useCommandQueue(): CommandQueueStore {
+  const [isActive, setIsActive] = useState(false);
+  const [queue, setQueue] = useState<CommandQueueEntry[]>([]);
+  const [index, setIndex] = useState(0);
+
+  const enterCommandQueue = useCallback((sessions: CommandQueueSessionInput[]) => {
+    const entries: CommandQueueEntry[] = [];
+
+    for (const s of sessions) {
+      if (s.conversationState === 'needs_input') {
+        entries.push({ kind: 'reply', sessionId: s.sessionId, conversationId: s.conversationId, title: s.title });
+      }
+    }
+    for (const s of sessions) {
+      if (s.isComplete && s.conversationState !== 'needs_input') {
+        entries.push({ kind: 'reply', sessionId: s.sessionId, conversationId: s.conversationId, title: s.title });
+      }
+    }
+    for (const s of sessions) {
+      if (!s.isComplete && (!s.conversationState || s.conversationState === 'running')) {
+        entries.push({ kind: 'steer', sessionId: s.sessionId, conversationId: s.conversationId, title: s.title });
+      }
+    }
+    entries.push({ kind: 'new' });
+
+    setQueue(entries);
+    setIndex(0);
+    setIsActive(true);
+  }, []);
+
+  const exitCommandQueue = useCallback(() => {
+    setIsActive(false);
+    setQueue([]);
+    setIndex(0);
+  }, []);
+
+  const advanceQueue = useCallback(() => {
+    setIndex((prev) => {
+      const next = prev + 1;
+      if (next >= queue.length) {
+        setIsActive(false);
+        setQueue([]);
+        return 0;
+      }
+      return next;
+    });
+  }, [queue.length]);
+
+  const goBackQueue = useCallback(() => {
+    setIndex((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const skipCurrent = useCallback(() => {
+    setQueue((prev) => {
+      if (prev.length <= 1) return prev;
+      const current = prev[index];
+      const rest = prev.filter((_, i) => i !== index);
+      return [...rest, current];
+    });
+    setIndex((prev) => Math.min(prev, queue.length - 1));
+  }, [index, queue.length]);
+
+  const appendNewSlot = useCallback(() => {
+    setQueue((prev) => {
+      let lastNewIdx = -1;
+      for (let i = prev.length - 1; i >= 0; i--) {
+        if (prev[i].kind === 'new') { lastNewIdx = i; break; }
+      }
+      if (lastNewIdx !== -1) {
+        setIndex(lastNewIdx);
+        return prev;
+      }
+      setIndex(prev.length);
+      return [...prev, { kind: 'new' }];
+    });
+  }, []);
+
+  return {
+    isActive,
+    queue,
+    index,
+    current: queue[index] ?? null,
+    total: queue.length,
+    enterCommandQueue,
+    exitCommandQueue,
+    advanceQueue,
+    goBackQueue,
+    skipCurrent,
+    appendNewSlot,
+  };
+}
+
+export const CommandQueueContext = createContext<CommandQueueStore | null>(null);
+
+export function useCommandQueueContext(): CommandQueueStore {
+  const ctx = useContext(CommandQueueContext);
+  if (!ctx) throw new Error('CommandQueueContext missing');
+  return ctx;
+}

--- a/apps/mobile/src/ui/AgentCommandBar.tsx
+++ b/apps/mobile/src/ui/AgentCommandBar.tsx
@@ -1,0 +1,244 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+} from 'react-native';
+import { useTheme } from './ThemeProvider';
+import { spacing, radius } from './theme';
+import { useCommandQueueContext } from '../store/command-queue';
+
+interface AgentCommandBarProps {
+  onSend: (text: string, conversationId?: string, sessionId?: string) => Promise<void>;
+  onDispatch: (text: string, onSubmitted: () => void) => void;
+}
+
+export function AgentCommandBar({ onSend, onDispatch }: AgentCommandBarProps) {
+  const { theme } = useTheme();
+  const {
+    isActive,
+    queue,
+    index,
+    current,
+    exitCommandQueue,
+    advanceQueue,
+    goBackQueue,
+    skipCurrent,
+    appendNewSlot,
+  } = useCommandQueueContext();
+
+  const [text, setText] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const inputRef = useRef<TextInput>(null);
+
+  const actionConfig = {
+    new: { placeholder: 'Describe a new task to dispatch...', button: 'Dispatch', color: '#10b981' },
+    steer: { placeholder: 'Steer this agent mid-run...', button: 'Steer', color: '#3b82f6' },
+    reply: { placeholder: 'Reply to this agent...', button: 'Reply', color: '#8b5cf6' },
+  } as const;
+
+  const cfg = actionConfig[current?.kind ?? 'new'];
+  const progressPercent = queue.length > 0 ? index / queue.length : 0;
+
+  useEffect(() => {
+    if (isActive) {
+      setText('');
+      const t = setTimeout(() => inputRef.current?.focus(), 120);
+      return () => clearTimeout(t);
+    }
+  }, [isActive, index]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!text.trim() || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      if (current?.kind === 'new') {
+        const captured = text;
+        setText('');
+        onDispatch(captured, () => advanceQueue());
+        return;
+      }
+      await onSend(text, current?.conversationId, current?.sessionId);
+      setText('');
+      advanceQueue();
+    } catch (e) {
+      console.error('[AgentCommandBar] submit failed:', e);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [text, isSubmitting, current, onSend, onDispatch, advanceQueue]);
+
+  if (!isActive) return null;
+
+  const currentTitle = current?.title ?? 'Untitled';
+  const styles = createStyles(theme);
+
+  return (
+    <View style={styles.container}>
+      {/* Progress bar */}
+      <View style={styles.progressTrack}>
+        <View style={[styles.progressFill, { width: `${progressPercent * 100}%` as any }]} />
+      </View>
+
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.counter} numberOfLines={1}>
+          {index + 1}/{queue.length}
+        </Text>
+        {current?.kind === 'new' ? (
+          <Text style={[styles.actionLabel, { color: cfg.color }]} numberOfLines={1}>
+            Dispatch new agent
+          </Text>
+        ) : (
+          <Text style={styles.titleRow} numberOfLines={1}>
+            <Text style={[styles.actionLabel, { color: cfg.color }]}>{cfg.button} · </Text>
+            <Text style={styles.titleText}>{currentTitle}</Text>
+          </Text>
+        )}
+        <View style={styles.headerActions}>
+          <TouchableOpacity
+            onPress={goBackQueue}
+            style={styles.iconBtn}
+            accessibilityLabel="Previous entry"
+            disabled={index === 0}
+          >
+            <Text style={[styles.iconBtnText, index === 0 && styles.iconBtnDisabled]}>←</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={advanceQueue}
+            style={styles.iconBtn}
+            accessibilityLabel="Next entry"
+            disabled={index >= queue.length - 1}
+          >
+            <Text style={[styles.iconBtnText, index >= queue.length - 1 && styles.iconBtnDisabled]}>→</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={skipCurrent} style={styles.iconBtn} accessibilityLabel="Skip">
+            <Text style={styles.iconBtnText}>⇥</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={appendNewSlot} style={styles.iconBtn} accessibilityLabel="Add new task">
+            <Text style={styles.iconBtnText}>+</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={exitCommandQueue} style={styles.iconBtn} accessibilityLabel="Exit">
+            <Text style={styles.iconBtnText}>✕</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {/* Input row */}
+      <View style={styles.inputRow}>
+        <TextInput
+          ref={inputRef}
+          style={[styles.input, { color: theme.colors.foreground, borderColor: theme.colors.border, backgroundColor: theme.colors.card }]}
+          value={text}
+          onChangeText={setText}
+          placeholder={cfg.placeholder}
+          placeholderTextColor={theme.colors.mutedForeground}
+          multiline
+          editable={!isSubmitting}
+          onSubmitEditing={handleSubmit}
+          accessibilityLabel={cfg.placeholder}
+        />
+        <TouchableOpacity
+          onPress={handleSubmit}
+          style={[styles.sendBtn, { backgroundColor: cfg.color, opacity: !text.trim() || isSubmitting ? 0.5 : 1 }]}
+          disabled={!text.trim() || isSubmitting}
+          accessibilityLabel={`${cfg.button} and advance`}
+        >
+          <Text style={styles.sendBtnText}>{cfg.button}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+function createStyles(theme: any) {
+  return StyleSheet.create({
+    container: {
+      borderTopWidth: 1,
+      borderTopColor: theme.colors.border,
+      backgroundColor: theme.colors.background,
+    },
+    progressTrack: {
+      height: 2,
+      backgroundColor: theme.colors.muted ?? theme.colors.border,
+    },
+    progressFill: {
+      height: '100%' as any,
+      backgroundColor: '#3b82f6',
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.md,
+      paddingVertical: 6,
+      borderBottomWidth: 1,
+      borderBottomColor: theme.colors.border,
+      gap: 6,
+    },
+    counter: {
+      fontSize: 10,
+      fontWeight: '700',
+      color: theme.colors.mutedForeground,
+      minWidth: 28,
+    },
+    titleRow: {
+      flex: 1,
+      fontSize: 11,
+    },
+    titleText: {
+      color: theme.colors.mutedForeground,
+    },
+    actionLabel: {
+      fontWeight: '700',
+      fontSize: 11,
+    },
+    headerActions: {
+      flexDirection: 'row',
+      gap: 2,
+      marginLeft: 'auto',
+    },
+    iconBtn: {
+      width: 26,
+      height: 26,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    iconBtnText: {
+      fontSize: 14,
+      color: theme.colors.mutedForeground,
+    },
+    iconBtnDisabled: {
+      opacity: 0.3,
+    },
+    inputRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-end',
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      gap: spacing.sm,
+    },
+    input: {
+      flex: 1,
+      borderWidth: 1,
+      borderRadius: radius.md,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      fontSize: 14,
+      maxHeight: 100,
+    },
+    sendBtn: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      borderRadius: radius.md,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    sendBtnText: {
+      color: '#ffffff',
+      fontWeight: '700',
+      fontSize: 13,
+    },
+  });
+}

--- a/docs-site/docs/configuration/shortcuts.md
+++ b/docs-site/docs/configuration/shortcuts.md
@@ -11,42 +11,42 @@ Every hotkey and shortcut available in DotAgents.
 
 ## Voice Controls
 
-| Shortcut | Platform | Action |
-|----------|----------|--------|
-| Hold `Ctrl` | macOS, Linux | Start voice recording (dictation) |
-| Hold `Ctrl+/` | Windows | Start voice recording (dictation) |
-| Release `Ctrl` / `Ctrl+/` | All | Stop recording and transcribe |
-| `Fn` | macOS | Toggle dictation on/off |
-| Hold `Ctrl+Alt` | macOS | Start recording in agent mode |
-| Release `Ctrl+Alt` | macOS | Stop recording, process with tools |
+| Shortcut                  | Platform     | Action                             |
+| ------------------------- | ------------ | ---------------------------------- |
+| Hold `Ctrl`               | macOS, Linux | Start voice recording (dictation)  |
+| Hold `Ctrl+/`             | Windows      | Start voice recording (dictation)  |
+| Release `Ctrl` / `Ctrl+/` | All          | Stop recording and transcribe      |
+| `Fn`                      | macOS        | Toggle dictation on/off            |
+| Hold `Ctrl+Alt`           | macOS        | Start recording in agent mode      |
+| Release `Ctrl+Alt`        | macOS        | Stop recording, process with tools |
 
 ## Input
 
-| Shortcut | Platform | Action |
-|----------|----------|--------|
-| `Ctrl+T` | macOS, Linux | Open text input overlay |
-| `Ctrl+Shift+T` | Windows | Open text input overlay |
+| Shortcut       | Platform     | Action                  |
+| -------------- | ------------ | ----------------------- |
+| `Ctrl+T`       | macOS, Linux | Open text input overlay |
+| `Ctrl+Shift+T` | Windows      | Open text input overlay |
 
 ## System
 
-| Shortcut | Platform | Action |
-|----------|----------|--------|
-| `Ctrl+Shift+Escape` | All | Emergency stop — kill all active agents |
+| Shortcut            | Platform | Action                                  |
+| ------------------- | -------- | --------------------------------------- |
+| `Ctrl+Shift+Escape` | All      | Emergency stop — kill all active agents |
 
 ## Multi-Agent Command Queue
 
 The [command queue](/desktop/command-queue) lets you cycle through multiple agents through one adaptive input bar.
 
-| Shortcut | Action |
-|----------|--------|
-| `Ctrl+Shift+K` (`⌘+Shift+K` on macOS) | Enter or exit the command queue |
-| `Tab` | Advance to next entry |
-| `Shift+Tab` | Go back to previous entry |
-| `Enter` | Submit message and auto-advance |
-| `Shift+Enter` | New line |
-| `Ctrl+N` (`⌘+N` on macOS) | Append a new dispatch slot |
-| `Ctrl+S` (`⌘+S` on macOS) | Skip current entry to end of queue |
-| `Esc` | Clear input — press again to exit |
+| Shortcut                              | Action                             |
+| ------------------------------------- | ---------------------------------- |
+| `Ctrl+Shift+K` (`⌘+Shift+K` on macOS) | Enter or exit the command queue    |
+| `Ctrl+]` (`⌘+]` on macOS)             | Advance to next entry              |
+| `Ctrl+[` (`⌘+[` on macOS)             | Go back to previous entry          |
+| `Enter`                               | Submit message and auto-advance    |
+| `Shift+Enter`                         | New line                           |
+| `Ctrl+N` (`⌘+N` on macOS)             | Append a new dispatch slot         |
+| `Ctrl+S` (`⌘+S` on macOS)             | Skip current entry to end of queue |
+| `Esc`                                 | Clear input — press again to exit  |
 
 ## Voice Flow Summary
 
@@ -60,12 +60,12 @@ Emergency Stop:     Ctrl+Shift+Escape → All agents stopped
 
 ## Mobile
 
-| Action | Gesture |
-|--------|---------|
-| Voice input | Press and hold mic button |
-| Send transcript | Release mic button |
+| Action          | Gesture                    |
+| --------------- | -------------------------- |
+| Voice input     | Press and hold mic button  |
+| Send transcript | Release mic button         |
 | Edit transcript | Release while in edit mode |
-| Hands-free mode | Toggle mic icon in header |
+| Hands-free mode | Toggle mic icon in header  |
 
 ---
 

--- a/docs-site/docs/configuration/shortcuts.md
+++ b/docs-site/docs/configuration/shortcuts.md
@@ -33,6 +33,21 @@ Every hotkey and shortcut available in DotAgents.
 |----------|----------|--------|
 | `Ctrl+Shift+Escape` | All | Emergency stop — kill all active agents |
 
+## Multi-Agent Command Queue
+
+The [command queue](/desktop/command-queue) lets you cycle through multiple agents through one adaptive input bar.
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+Shift+K` (`⌘+Shift+K` on macOS) | Enter or exit the command queue |
+| `Tab` | Advance to next entry |
+| `Shift+Tab` | Go back to previous entry |
+| `Enter` | Submit message and auto-advance |
+| `Shift+Enter` | New line |
+| `Ctrl+N` (`⌘+N` on macOS) | Append a new dispatch slot |
+| `Ctrl+S` (`⌘+S` on macOS) | Skip current entry to end of queue |
+| `Esc` | Clear input — press again to exit |
+
 ## Voice Flow Summary
 
 ```

--- a/docs-site/docs/desktop/command-queue.md
+++ b/docs-site/docs/desktop/command-queue.md
@@ -17,14 +17,14 @@ You're running 3+ agents in parallel and want to:
 - Send mid-run guidance to running agents ("focus on X first")
 - Reply to each agent's report in the order they finish
 
-Without the queue, this requires clicking between sessions, hunting for the right composer, and remembering whose turn is next. With the queue, one input bar adapts to whichever session is "in focus" and `Tab` advances.
+Without the queue, this requires clicking between sessions, hunting for the right composer, and remembering whose turn is next. With the queue, one input bar adapts to whichever session is "in focus" and `Ctrl+]` (`⌘+]` on macOS) advances.
 
 ## How to enter
 
-| Method | Where |
-|---|---|
-| **`Ctrl+Shift+K`** (`⌘+Shift+K` on macOS) | From anywhere in the app |
-| Click the **Layers icon** | Sidebar header, next to the New Session button |
+| Method                                    | Where                                          |
+| ----------------------------------------- | ---------------------------------------------- |
+| **`Ctrl+Shift+K`** (`⌘+Shift+K` on macOS) | From anywhere in the app                       |
+| Click the **Layers icon**                 | Sidebar header, next to the New Session button |
 
 The bar appears at the bottom of the main panel and stays visible until you exit.
 
@@ -32,11 +32,11 @@ The bar appears at the bottom of the main panel and stays visible until you exit
 
 The bar's label, color, and submit button change based on what the current session needs:
 
-| State | Action | What it does |
-|---|---|---|
-| Session not yet created | **Dispatch** (green) | Spawns a new agent with your text |
-| Running / mid-task | **Steer** (blue) | Sends a guidance message to a live agent |
-| Complete / needs input | **Reply** (violet) | Continues the conversation |
+| State                   | Action               | What it does                             |
+| ----------------------- | -------------------- | ---------------------------------------- |
+| Session not yet created | **Dispatch** (green) | Spawns a new agent with your text        |
+| Running / mid-task      | **Steer** (blue)     | Sends a guidance message to a live agent |
+| Complete / needs input  | **Reply** (violet)   | Continues the conversation               |
 
 The queue auto-seeds with one entry per active session (sorted: `needs_input` first, then `complete`, then `running`) plus one trailing **Dispatch** slot for new agents. As sessions complete during the session, the queue auto-promotes `steer` → `reply`.
 
@@ -44,16 +44,16 @@ The queue auto-seeds with one entry per active session (sorted: `needs_input` fi
 
 All shortcuts work while the input is focused.
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl+Shift+K` / `⌘+Shift+K` | Enter or exit the queue |
-| `Tab` | Advance to next entry |
-| `Shift+Tab` | Go back to previous entry |
-| `Enter` | Submit current message and advance |
-| `Shift+Enter` | New line in the input |
-| `Ctrl+N` / `⌘+N` | Append a new dispatch slot at the end |
-| `Ctrl+S` / `⌘+S` | Skip current entry (rotate to back of queue) |
-| `Esc` | Clear input — second press exits the queue |
+| Shortcut                     | Action                                       |
+| ---------------------------- | -------------------------------------------- |
+| `Ctrl+Shift+K` / `⌘+Shift+K` | Enter or exit the queue                      |
+| `Ctrl+]` / `⌘+]`             | Advance to next entry                        |
+| `Ctrl+[` / `⌘+[`             | Go back to previous entry                    |
+| `Enter`                      | Submit current message and advance           |
+| `Shift+Enter`                | New line in the input                        |
+| `Ctrl+N` / `⌘+N`             | Append a new dispatch slot at the end        |
+| `Ctrl+S` / `⌘+S`             | Skip current entry (rotate to back of queue) |
+| `Esc`                        | Clear input — second press exits the queue   |
 
 ## Auto-advance and routing
 

--- a/docs-site/docs/desktop/command-queue.md
+++ b/docs-site/docs/desktop/command-queue.md
@@ -1,0 +1,81 @@
+---
+sidebar_position: 3
+sidebar_label: "Command Queue"
+---
+
+# Multi-Agent Command Queue
+
+A keyboard-driven coordination mode for running multiple agents at once. Cycle through every session through a single adaptive input bar — dispatch new agents, steer running ones, and reply to completed ones without manually switching context.
+
+---
+
+## When to use it
+
+You're running 3+ agents in parallel and want to:
+
+- Dispatch several new tasks back-to-back
+- Send mid-run guidance to running agents ("focus on X first")
+- Reply to each agent's report in the order they finish
+
+Without the queue, this requires clicking between sessions, hunting for the right composer, and remembering whose turn is next. With the queue, one input bar adapts to whichever session is "in focus" and `Tab` advances.
+
+## How to enter
+
+| Method | Where |
+|---|---|
+| **`Ctrl+Shift+K`** (`⌘+Shift+K` on macOS) | From anywhere in the app |
+| Click the **Layers icon** | Sidebar header, next to the New Session button |
+
+The bar appears at the bottom of the main panel and stays visible until you exit.
+
+## The three modes
+
+The bar's label, color, and submit button change based on what the current session needs:
+
+| State | Action | What it does |
+|---|---|---|
+| Session not yet created | **Dispatch** (green) | Spawns a new agent with your text |
+| Running / mid-task | **Steer** (blue) | Sends a guidance message to a live agent |
+| Complete / needs input | **Reply** (violet) | Continues the conversation |
+
+The queue auto-seeds with one entry per active session (sorted: `needs_input` first, then `complete`, then `running`) plus one trailing **Dispatch** slot for new agents. As sessions complete during the session, the queue auto-promotes `steer` → `reply`.
+
+## Keyboard shortcuts
+
+All shortcuts work while the input is focused.
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+Shift+K` / `⌘+Shift+K` | Enter or exit the queue |
+| `Tab` | Advance to next entry |
+| `Shift+Tab` | Go back to previous entry |
+| `Enter` | Submit current message and advance |
+| `Shift+Enter` | New line in the input |
+| `Ctrl+N` / `⌘+N` | Append a new dispatch slot at the end |
+| `Ctrl+S` / `⌘+S` | Skip current entry (rotate to back of queue) |
+| `Esc` | Clear input — second press exits the queue |
+
+## Auto-advance and routing
+
+When you submit:
+
+- The message routes to whatever session the current entry points at
+- For `new` entries, the standard session-creation dialog opens, and the queue advances after the new session is dispatched
+- The next pending session becomes the focused tile in the sidebar, so the rest of the UI follows along
+
+## Skip vs. Hold
+
+- **Skip** (`Ctrl+S`) rotates the current entry to the end of the queue — you'll see it again after everyone else
+- **Exit** (`Esc` on an empty input) drops the queue entirely; sessions are unaffected
+
+Both are safe: nothing is lost. Open the queue again later and any sessions still in need of input will reappear.
+
+## Mobile
+
+The same queue is available in the mobile app via the **Layers button** in the chat list header. Tap to enter; the bar slides up over the chat composer. The session-cycling controls (◀ ▶ ⇥ + ✕) live in the bar's header row.
+
+## Related
+
+- **[Keyboard Shortcuts](../configuration/shortcuts)** — full hotkey reference
+- **[Desktop Overview](./overview)** — full desktop feature set
+- **[Agent Delegation](../agents/delegation)** — how parent agents spawn subagents (the queue surfaces those too)

--- a/docs-site/docs/desktop/overview.md
+++ b/docs-site/docs/desktop/overview.md
@@ -17,6 +17,7 @@ Built with Electron, React, and Rust, the desktop app provides:
 - **Multi-agent system** — Specialized agents with distinct skills and tools
 - **MCP tool execution** — Connect to any tool via the Model Context Protocol
 - **Real-time progress** — Watch agents think and act step by step
+- **[Command queue](./command-queue)** — `Ctrl+Shift+K` to cycle through multiple agents through one adaptive input bar
 - **Cross-platform** — macOS (full support), Windows, and Linux
 - **Remote server** — Optional local HTTP API for mobile pairing, operator dashboards, and automation
 

--- a/docs-site/docs/mobile/overview.md
+++ b/docs-site/docs/mobile/overview.md
@@ -25,6 +25,7 @@ Built with Expo SDK 54 and React Native, the mobile app provides a portable inte
 - Session history with search
 - QR code connection setup
 - Split chat view for multi-agent conversations
+- [Multi-agent command queue](../desktop/command-queue) — tap the Layers button in the chat list header to rapidly dispatch, steer, and reply across multiple sessions
 
 ## Supported Platforms
 


### PR DESCRIPTION
Introduces CommandQueueEntry types, isCommandQueueActive/commandQueue/
commandQueueIndex state, and six actions (enterCommandQueue,
exitCommandQueue, advanceCommandQueue, goBackCommandQueue,
skipCommandEntry, appendNewSlot) for rapid multi-agent coordination.

Also hooks updateSessionProgress to auto-promote steer→reply entries
when a session completes mid-queue, and auto-enqueue new top-level
sessions that appear while the queue is active.

https://claude.ai/code/session_018xrF5SGMrmbiVbmZ98UNSY