### PR TITLE
[codex] Add long agent loop Electron E2E

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -21,6 +21,7 @@
     "test:continue-replay": "vitest run src/main/llm.continue-replay.live.test.ts",
     "test:agent-loop-live": "npx tsx scripts/run-agent-loop-live-test.ts",
     "test:agent-loop-live:strict": "npx tsx scripts/run-agent-loop-live-test.ts --strict",
+    "test:e2e:agent-loop-long": "npx tsx scripts/run-agent-loop-long-e2e.ts",
     "test:autoresearch-replay": "vitest run src/main/llm.respond-to-user-history.test.ts -t AutoResearch",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",

--- a/apps/desktop/scripts/agent-loop-long-sandbox-mcp.ts
+++ b/apps/desktop/scripts/agent-loop-long-sandbox-mcp.ts
@@ -1,0 +1,114 @@
+import fs from "fs"
+import path from "path"
+import { Server } from "@modelcontextprotocol/sdk/server/index.js"
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js"
+import {
+  createLongAgentLoopSandboxToolState,
+  executeLongAgentLoopSandboxTool,
+  getLongAgentLoopSandboxPacket,
+  getLongAgentLoopSandboxToolDefinitions,
+  LONG_AGENT_LOOP_SANDBOX_DELAY_MS,
+  type LongAgentLoopSandboxPacketId,
+} from "../src/main/agent-loop-long-sandbox-fixture"
+
+function parseArg(name: string, fallback?: string): string | undefined {
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1] : fallback
+}
+
+function appendJsonl(filePath: string | undefined, payload: Record<string, unknown>): void {
+  if (!filePath) return
+  const resolved = path.resolve(filePath)
+  fs.mkdirSync(path.dirname(resolved), { recursive: true })
+  fs.appendFileSync(resolved, `${JSON.stringify(payload)}\n`)
+}
+
+const packetId = parseArg("--packet", process.env.LONG_AGENT_LOOP_SANDBOX_PACKET) as LongAgentLoopSandboxPacketId | undefined
+if (!packetId) {
+  console.error("[long-agent-loop-sandbox] Missing --packet <packetId>")
+  process.exit(1)
+}
+
+const packet = getLongAgentLoopSandboxPacket(packetId)
+const rawDelayMs = parseArg("--delay-ms", process.env.LONG_AGENT_LOOP_SANDBOX_DELAY_MS)
+const parsedDelayMs = rawDelayMs === undefined ? Number.NaN : Number(rawDelayMs)
+const delayMs = Number.isFinite(parsedDelayMs) ? parsedDelayMs : LONG_AGENT_LOOP_SANDBOX_DELAY_MS
+const logPath = parseArg("--log", process.env.LONG_AGENT_LOOP_SANDBOX_LOG)
+const state = createLongAgentLoopSandboxToolState()
+
+const server = new Server(
+  {
+    name: `dotagents-long-agent-loop-sandbox-${packet.id}`,
+    version: "0.1.0",
+  },
+  {
+    capabilities: {
+      tools: {},
+    },
+  },
+)
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: getLongAgentLoopSandboxToolDefinitions(),
+}))
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const startedAt = Date.now()
+  const toolName = request.params.name
+  const args = request.params.arguments && typeof request.params.arguments === "object"
+    ? request.params.arguments as Record<string, unknown>
+    : {}
+
+  appendJsonl(logPath, {
+    event: "tool_start",
+    packetId: packet.id,
+    toolName,
+    args,
+    startedAt,
+  })
+
+  const result = await executeLongAgentLoopSandboxTool(packet.id, toolName, args, {
+    delayMs,
+    state,
+  })
+
+  appendJsonl(logPath, {
+    event: "tool_end",
+    packetId: packet.id,
+    toolName,
+    isError: Boolean(result.isError),
+    startedAt,
+    endedAt: Date.now(),
+    durationMs: Date.now() - startedAt,
+    calledTools: Array.from(state.calledTools),
+  })
+
+  return result
+})
+
+async function main(): Promise<void> {
+  appendJsonl(logPath, {
+    event: "server_start",
+    packetId: packet.id,
+    delayMs,
+    startedAt: Date.now(),
+    receipt: packet.receipt,
+  })
+  console.error(`[long-agent-loop-sandbox] ${packet.id} started with ${delayMs}ms tool delay`)
+  await server.connect(new StdioServerTransport())
+}
+
+main().catch((error) => {
+  appendJsonl(logPath, {
+    event: "server_error",
+    packetId: packet.id,
+    error: error instanceof Error ? error.message : String(error),
+    at: Date.now(),
+  })
+  console.error("[long-agent-loop-sandbox] Failed:", error)
+  process.exit(1)
+})

--- a/apps/desktop/scripts/run-agent-loop-long-e2e.ts
+++ b/apps/desktop/scripts/run-agent-loop-long-e2e.ts
@@ -1,0 +1,887 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process"
+import fs from "fs"
+import net from "net"
+import os from "os"
+import path from "path"
+import {
+  LONG_AGENT_LOOP_SANDBOX_DELAY_MS,
+  longAgentLoopSandboxPackets,
+  type LongAgentLoopSandboxPacketId,
+} from "../src/main/agent-loop-long-sandbox-fixture"
+
+type CdpTarget = {
+  id: string
+  type: string
+  title: string
+  url: string
+  webSocketDebuggerUrl?: string
+}
+
+type AgentSession = {
+  id: string
+  conversationId?: string
+  conversationTitle?: string
+  status: "active" | "completed" | "error" | "stopped"
+  startTime: number
+  endTime?: number
+  lastActivity?: string
+}
+
+type SessionSnapshot = {
+  activeSessions: AgentSession[]
+  recentCompletedSessions: AgentSession[]
+  recentSessions?: AgentSession[]
+}
+
+type Scenario = {
+  packetId: LongAgentLoopSandboxPacketId
+  marker: string
+  serverName: string
+  prompt: string
+}
+
+class FatalWaitError extends Error {}
+
+const cwd = process.cwd()
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+const runId = new Date().toISOString().replace(/[:.]/g, "-")
+const outputRoot = path.join(cwd, "tmp", "e2e-agent-loop")
+const runDir = path.join(outputRoot, runId)
+const electronLogPath = path.join(runDir, "electron.log")
+const sandboxLogPath = path.join(runDir, "sandbox-tools.jsonl")
+const runnerMetricsPath = path.join(runDir, "runner-metrics.jsonl")
+const summaryPath = path.join(runDir, "summary.json")
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+async function timedStage<T>(name: string, fn: () => Promise<T> | T): Promise<T> {
+  const startedAt = performance.now()
+  appendJsonl(runnerMetricsPath, {
+    event: "stage_start",
+    stage: name,
+    at: Date.now(),
+    atIso: nowIso(),
+  })
+  try {
+    const result = await fn()
+    appendJsonl(runnerMetricsPath, {
+      event: "stage_end",
+      stage: name,
+      status: "pass",
+      at: Date.now(),
+      atIso: nowIso(),
+      durationMs: Math.round(performance.now() - startedAt),
+    })
+    return result
+  } catch (error) {
+    appendJsonl(runnerMetricsPath, {
+      event: "stage_end",
+      stage: name,
+      status: "fail",
+      at: Date.now(),
+      atIso: nowIso(),
+      durationMs: Math.round(performance.now() - startedAt),
+      error: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
+}
+
+function assertOptIn(): void {
+  if (process.env.LONG_AGENT_LOOP_E2E !== "1") {
+    throw new Error(
+      "LONG_AGENT_LOOP_E2E=1 is required. This test launches real Electron and uses real ChatGPT Web/Codex auth.",
+    )
+  }
+}
+
+function resolveCodexHome(): string {
+  return process.env.CODEX_HOME?.trim() || path.join(os.homedir(), ".codex")
+}
+
+function assertCodexAuth(): string {
+  const codexHome = resolveCodexHome()
+  const authPath = path.join(codexHome, "auth.json")
+  const parsed = JSON.parse(fs.readFileSync(authPath, "utf8")) as {
+    auth_mode?: string
+    tokens?: { access_token?: unknown }
+  }
+  if ((parsed.auth_mode && parsed.auth_mode !== "chatgpt") || typeof parsed.tokens?.access_token !== "string") {
+    throw new Error(`Codex ChatGPT auth was not found in ${authPath}`)
+  }
+  return codexHome
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("Failed to allocate a TCP port")))
+        return
+      }
+      const port = address.port
+      server.close(() => resolve(port))
+    })
+  })
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2))
+}
+
+function appendJsonl(filePath: string, payload: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.appendFileSync(filePath, `${JSON.stringify(payload)}\n`)
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs)
+  })
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer)
+  }) as Promise<T>
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function waitForProcessExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(true)
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      child.off("exit", onExit)
+      resolve(false)
+    }, timeoutMs)
+    const onExit = () => {
+      clearTimeout(timer)
+      resolve(true)
+    }
+    child.once("exit", onExit)
+  })
+}
+
+async function terminateProcessGroup(child: ChildProcessWithoutNullStreams, label: string): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const pid = child.pid
+  if (!pid) return
+  const targetPid = process.platform === "win32" ? pid : -pid
+  for (const signal of ["SIGTERM", "SIGKILL"] as const) {
+    try {
+      process.kill(targetPid, signal)
+      appendJsonl(runnerMetricsPath, {
+        event: "process_kill",
+        label,
+        pid,
+        targetPid,
+        signal,
+        at: Date.now(),
+      })
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+        appendJsonl(runnerMetricsPath, {
+          event: "process_kill_error",
+          label,
+          pid,
+          targetPid,
+          signal,
+          error: error instanceof Error ? error.message : String(error),
+          at: Date.now(),
+        })
+      }
+    }
+    if (await waitForProcessExit(child, signal === "SIGTERM" ? 3_000 : 1_000)) return
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`)
+  }
+  return response.json() as Promise<T>
+}
+
+class CdpClient {
+  private websocket: WebSocket | undefined
+  private nextId = 1
+  private pending = new Map<number, { resolve: (value: any) => void; reject: (error: Error) => void }>()
+
+  constructor(private readonly webSocketUrl: string) {}
+
+  async connect(): Promise<void> {
+    const websocket = new WebSocket(this.webSocketUrl)
+    this.websocket = websocket
+    await new Promise<void>((resolve, reject) => {
+      websocket.addEventListener("open", () => resolve(), { once: true })
+      websocket.addEventListener("error", () => reject(new Error("Failed to connect to renderer CDP websocket")), { once: true })
+    })
+    websocket.addEventListener("message", async (event) => {
+      const raw = typeof event.data === "string" ? event.data : await new Response(event.data).text()
+      const payload = JSON.parse(raw)
+      if (!payload.id) return
+      const request = this.pending.get(payload.id)
+      if (!request) return
+      this.pending.delete(payload.id)
+      if (payload.error) request.reject(new Error(payload.error.message || "Unknown CDP error"))
+      else request.resolve(payload.result)
+    })
+    await this.send("Runtime.enable")
+    await this.send("Performance.enable")
+  }
+
+  close(): void {
+    this.websocket?.close()
+  }
+
+  send<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    if (!this.websocket) throw new Error("CDP websocket is not connected")
+    const id = this.nextId++
+    this.websocket.send(JSON.stringify({ id, method, params }))
+    return new Promise<T>((resolve, reject) => this.pending.set(id, { resolve, reject }))
+  }
+
+  async evaluate<T>(expression: string, timeoutMs = 5_000): Promise<T> {
+    const result = await withTimeout(
+      this.send<{
+        result?: { value?: T }
+        exceptionDetails?: { text?: string; exception?: { description?: string } }
+      }>("Runtime.evaluate", {
+        expression,
+        awaitPromise: true,
+        returnByValue: true,
+        userGesture: true,
+      }),
+      timeoutMs,
+      "Runtime.evaluate",
+    )
+    if (result.exceptionDetails) {
+      throw new Error(result.exceptionDetails.exception?.description || result.exceptionDetails.text || "CDP evaluation failed")
+    }
+    return result.result?.value as T
+  }
+}
+
+function pickRendererTarget(targets: CdpTarget[]): CdpTarget {
+  const pages = targets.filter((target) => target.type === "page" && target.webSocketDebuggerUrl)
+  const main = pages.find((target) => !target.url.includes("/panel")) ?? pages[0]
+  if (!main) throw new Error("No renderer page target found on the CDP endpoint")
+  return main
+}
+
+async function waitForRendererTarget(port: number, appProcess: ChildProcessWithoutNullStreams): Promise<CdpTarget> {
+  const startedAt = Date.now()
+  let lastError: unknown
+  while (Date.now() - startedAt < 90_000) {
+    if (appProcess.exitCode !== null) {
+      throw new Error(`Electron exited before CDP became available with code ${appProcess.exitCode}`)
+    }
+    try {
+      const targets = await fetchJson<CdpTarget[]>(`http://127.0.0.1:${port}/json/list`)
+      const target = pickRendererTarget(targets)
+      if (target.webSocketDebuggerUrl) return target
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(500)
+  }
+  throw new Error(`Timed out waiting for Electron CDP target: ${lastError instanceof Error ? lastError.message : String(lastError)}`)
+}
+
+async function waitFor<T>(
+  label: string,
+  timeoutMs: number,
+  fn: () => Promise<T | undefined | false | null>,
+  intervalMs = 1_000,
+): Promise<T> {
+  const startedAt = Date.now()
+  let lastError: unknown
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const result = await fn()
+      if (result) return result
+    } catch (error) {
+      if (error instanceof FatalWaitError) throw error
+      lastError = error
+    }
+    await sleep(intervalMs)
+  }
+  throw new Error(`${label} timed out${lastError instanceof Error ? `: ${lastError.message}` : ""}`)
+}
+
+function jsString(value: string): string {
+  return JSON.stringify(value)
+}
+
+async function clickByLabel(cdp: CdpClient, label: string): Promise<void> {
+  const clicked = await cdp.evaluate<boolean>(`
+    (() => {
+      const label = ${jsString(label)}
+      const elements = Array.from(document.querySelectorAll('button, [role="button"], a'))
+      const element = elements.find((node) =>
+        node.getAttribute('aria-label') === label ||
+        node.getAttribute('title') === label ||
+        (node.textContent || '').trim() === label
+      )
+      if (!element) return false
+      element.scrollIntoView({ block: 'center', inline: 'center' })
+      element.click()
+      return true
+    })()
+  `)
+  if (!clicked) throw new Error(`Could not find clickable element: ${label}`)
+}
+
+async function fillMessageAndSend(cdp: CdpClient, text: string): Promise<void> {
+  await waitFor("message input", 15_000, async () => {
+    return cdp.evaluate<boolean>(`Boolean(document.querySelector('textarea[aria-label="Message input"]'))`)
+  }, 250)
+
+  await cdp.evaluate<boolean>(`
+    (() => {
+      const textarea = document.querySelector('textarea[aria-label="Message input"]')
+      if (!textarea) return false
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set
+      setter?.call(textarea, ${jsString(text)})
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+      textarea.dispatchEvent(new Event('change', { bubbles: true }))
+      return true
+    })()
+  `)
+
+  await waitFor("enabled Send button", 10_000, async () => {
+    return cdp.evaluate<boolean>(`
+      (() => {
+        const buttons = Array.from(document.querySelectorAll('button'))
+        return buttons.some((button) => (button.textContent || '').trim() === 'Send' && !button.disabled)
+      })()
+    `)
+  }, 250)
+
+  const sent = await cdp.evaluate<boolean>(`
+    (() => {
+      const buttons = Array.from(document.querySelectorAll('button'))
+      const button = buttons.find((node) => (node.textContent || '').trim() === 'Send' && !node.disabled)
+      if (!button) return false
+      button.click()
+      return true
+    })()
+  `)
+  if (!sent) throw new Error("Could not click Send")
+}
+
+async function invokeIpc<T>(cdp: CdpClient, channel: string, input?: unknown, timeoutMs = 5_000): Promise<T> {
+  const hasInput = arguments.length >= 3
+  return cdp.evaluate<T>(`
+    window.electron.ipcRenderer.invoke(${jsString(channel)}${hasInput ? `, ${JSON.stringify(input)}` : ""})
+  `, timeoutMs)
+}
+
+function createScenarios(): Scenario[] {
+  return (["aurora", "boreal", "cedar"] as const).map((packetId) => {
+    const serverName = `sandbox_${packetId}`
+    const marker = `Long E2E sandbox audit ${packetId.toUpperCase()}`
+    return {
+      packetId,
+      marker,
+      serverName,
+      prompt: [
+        `${marker}.`,
+        `Audit the sandbox case packet using only tools from the ${serverName} MCP server.`,
+        "Identify the only release candidate that satisfies all hidden fixture constraints.",
+        "Do not answer from the prompt alone; the decisive evidence is only available from tools.",
+        "Use at least these discovery tools before the final answer: list_cases, read_case_file, search_case_notes, read_run_log, summarize_findings.",
+        "Then call write_final_audit for the candidate you selected.",
+        "Final answer requirements: include the final audit receipt, selected release candidate ID, hidden constraint token, and cited case IDs.",
+      ].join("\n"),
+    }
+  })
+}
+
+function prepareConfig(appDataDir: string, userDataDir: string, codexHome: string, scenarios: Scenario[]): void {
+  const appId = "app.dotagents.long-agent-loop-e2e"
+  const appConfigDir = path.join(appDataDir, appId)
+  const serverScript = path.join(cwd, "scripts", "agent-loop-long-sandbox-mcp.ts")
+  const model = process.env.LONG_AGENT_LOOP_MODEL || "gpt-5.4-mini"
+  const parsedDelayMs = Number(process.env.LONG_AGENT_LOOP_SANDBOX_DELAY_MS)
+  const delayMs = Number.isFinite(parsedDelayMs) ? parsedDelayMs : LONG_AGENT_LOOP_SANDBOX_DELAY_MS
+
+  fs.mkdirSync(appConfigDir, { recursive: true })
+  fs.mkdirSync(userDataDir, { recursive: true })
+
+  writeJson(path.join(appConfigDir, "config.json"), {
+    onboardingCompleted: true,
+    floatingPanelAutoShow: false,
+    hidePanelWhenMainFocused: false,
+    ttsEnabled: false,
+    ttsAutoPlay: false,
+    langfuseEnabled: false,
+    mcpRequireApprovalBeforeToolCall: false,
+    mcpMessageQueueEnabled: true,
+    mcpParallelToolExecution: false,
+    mcpUnlimitedIterations: false,
+    mcpMaxIterations: 10,
+    mcpVerifyCompletionEnabled: true,
+    mcpVerifyRetryCount: 1,
+    mcpFinalSummaryEnabled: false,
+    apiRetryCount: 1,
+    apiRetryBaseDelay: 500,
+    apiRetryMaxDelay: 2_000,
+    agentProviderId: "chatgpt-web",
+    mcpToolsProviderId: "chatgpt-web",
+    agentChatgptWebModel: model,
+    mcpToolsChatgptWebModel: model,
+    openaiReasoningEffort: "low",
+    codexTextVerbosity: "low",
+    chatgptWebBaseUrl: "https://chatgpt.com",
+    mcpConfig: {
+      mcpServers: Object.fromEntries(scenarios.map((scenario) => [
+        scenario.serverName,
+        {
+          transport: "stdio",
+          command: pnpm,
+          args: [
+            "exec",
+            "tsx",
+            serverScript,
+            "--packet",
+            scenario.packetId,
+            "--delay-ms",
+            String(delayMs),
+            "--log",
+            sandboxLogPath,
+          ],
+          env: {
+            CODEX_HOME: codexHome,
+            LONG_AGENT_LOOP_SANDBOX_LOG: sandboxLogPath,
+          },
+          timeout: 30_000,
+        },
+      ])),
+    },
+  })
+
+  writeJson(path.join(userDataDir, "agent-profiles.json"), {
+    currentProfileId: "long-agent-loop-e2e-profile",
+    profiles: [
+      {
+        id: "long-agent-loop-e2e-profile",
+        name: "long-agent-loop-e2e",
+        displayName: "Long Agent Loop E2E",
+        description: "Opt-in long-running Electron E2E profile.",
+        systemPrompt: [
+          "You are running a deterministic DotAgents Electron E2E.",
+          "Use the sandbox MCP tools requested by the user.",
+          "Do not use shell or filesystem tools for the sandbox audit.",
+          "Call the final audit tool before giving the final answer.",
+        ].join("\n"),
+        guidelines: "",
+        connection: { type: "internal" },
+        isStateful: false,
+        role: "chat-agent",
+        enabled: true,
+        isBuiltIn: false,
+        isUserProfile: true,
+        isAgentTarget: false,
+        isDefault: true,
+        toolConfig: {
+          allServersDisabledByDefault: false,
+          disabledServers: [],
+          disabledTools: [],
+          enabledRuntimeTools: ["mark_work_complete"],
+        },
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ],
+  })
+}
+
+function startElectron(env: NodeJS.ProcessEnv, remoteDebuggingPort: number, userDataDir: string): ChildProcessWithoutNullStreams {
+  const child = spawn(
+    pnpm,
+    [
+      "exec",
+      "electron-vite",
+      "dev",
+      "--watch",
+      "--",
+      `--user-data-dir=${userDataDir}`,
+    ],
+    {
+      cwd,
+      env: {
+        ...env,
+        REMOTE_DEBUGGING_PORT: String(remoteDebuggingPort),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+    },
+  )
+
+  const logStream = fs.createWriteStream(electronLogPath, { flags: "a" })
+  child.stdout.pipe(logStream)
+  child.stderr.pipe(logStream)
+  child.on("exit", (code, signal) => {
+    appendJsonl(runnerMetricsPath, { event: "electron_exit", code, signal, at: Date.now() })
+  })
+  child.on("close", () => logStream.end())
+  return child
+}
+
+function startPerfRecorder(remoteDebuggingPort: number): ChildProcessWithoutNullStreams {
+  const outputDir = path.relative(cwd, runDir)
+  const child = spawn(
+    pnpm,
+    [
+      "exec",
+      "tsx",
+      "scripts/renderer-perf-recorder.ts",
+      "--port",
+      String(remoteDebuggingPort),
+      "--duration-seconds",
+      "300",
+      "--metrics-interval-ms",
+      "1000",
+      "--output-dir",
+      outputDir,
+      "--label",
+      "long-agent-loop-renderer",
+    ],
+    { cwd, env: process.env, stdio: ["ignore", "pipe", "pipe"], detached: process.platform !== "win32" },
+  )
+  const logStream = fs.createWriteStream(path.join(runDir, "renderer-perf-recorder.log"), { flags: "a" })
+  child.stdout.pipe(logStream)
+  child.stderr.pipe(logStream)
+  child.on("close", () => logStream.end())
+  return child
+}
+
+async function startScenario(cdp: CdpClient, scenario: Scenario): Promise<void> {
+  await waitFor("Start text session button", 20_000, async () => {
+    try {
+      await clickByLabel(cdp, "Start text session")
+      return true
+    } catch {
+      return false
+    }
+  }, 500)
+  await fillMessageAndSend(cdp, scenario.prompt)
+  await waitFor(`session ${scenario.packetId} to appear`, 30_000, async () => {
+    const sessions = await invokeIpc<SessionSnapshot>(cdp, "getAgentSessions", undefined, 5_000)
+    const allSessions = [...sessions.activeSessions, ...sessions.recentCompletedSessions]
+    return allSessions.some((session) => session.conversationTitle?.includes(scenario.marker))
+  }, 500)
+}
+
+async function clickSessionByMarker(cdp: CdpClient, marker: string): Promise<number> {
+  const startedAt = performance.now()
+  const result = await cdp.evaluate<{ clicked: boolean; text?: string }>(`
+    (() => {
+      const marker = ${jsString(marker)}
+      const elements = Array.from(document.querySelectorAll('button, [role="button"], [class*="cursor-pointer"], a'))
+      const element = elements.find((node) => (node.textContent || '').includes(marker))
+      if (!element) return { clicked: false }
+      element.scrollIntoView({ block: 'center', inline: 'nearest' })
+      element.click()
+      return { clicked: true, text: (element.textContent || '').slice(0, 240) }
+    })()
+  `, 2_000)
+  if (!result.clicked) throw new Error(`Could not click session row for ${marker}`)
+  return Math.round(performance.now() - startedAt)
+}
+
+async function captureHeartbeat(cdp: CdpClient, scenarios: Scenario[]): Promise<{
+  domTextLength: number
+  domTextHash: number
+  activeCount: number
+  completedCount: number
+  sessionActivities: Record<string, string | undefined>
+  jsHeapUsedSize?: number
+}> {
+  const [dom, sessions, performanceMetrics] = await Promise.all([
+    cdp.evaluate<{ textLength: number; hash: number }>(`
+      (() => {
+        const text = document.body?.innerText || ''
+        let hash = 0
+        for (let i = 0; i < text.length; i += 1) hash = ((hash << 5) - hash + text.charCodeAt(i)) | 0
+        return { textLength: text.length, hash }
+      })()
+    `, 2_000),
+    invokeIpc<SessionSnapshot>(cdp, "getAgentSessions", undefined, 2_000),
+    cdp.send<{ metrics: Array<{ name: string; value: number }> }>("Performance.getMetrics"),
+  ])
+  const metrics = Object.fromEntries(performanceMetrics.metrics.map((metric) => [metric.name, metric.value]))
+  const allSessions = [...sessions.activeSessions, ...sessions.recentCompletedSessions]
+  return {
+    domTextLength: dom.textLength,
+    domTextHash: dom.hash,
+    activeCount: sessions.activeSessions.length,
+    completedCount: sessions.recentCompletedSessions.length,
+    sessionActivities: Object.fromEntries(scenarios.map((scenario) => {
+      const session = allSessions.find((candidate) => candidate.conversationTitle?.includes(scenario.marker))
+      return [scenario.packetId, session?.lastActivity]
+    })),
+    jsHeapUsedSize: metrics.JSHeapUsedSize,
+  }
+}
+
+function parseSandboxLog(): Array<Record<string, unknown>> {
+  if (!fs.existsSync(sandboxLogPath)) return []
+  return fs.readFileSync(sandboxLogPath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>)
+}
+
+function getToolSummary(packetId: LongAgentLoopSandboxPacketId) {
+  const entries = parseSandboxLog().filter((entry) => entry.packetId === packetId && entry.event === "tool_end")
+  const toolNames = entries.map((entry) => String(entry.toolName || ""))
+  return {
+    total: entries.length,
+    distinct: Array.from(new Set(toolNames)).filter(Boolean),
+    entries,
+  }
+}
+
+async function waitForCompletion(cdp: CdpClient, scenarios: Scenario[]): Promise<Map<LongAgentLoopSandboxPacketId, AgentSession>> {
+  const completedByPacket = new Map<LongAgentLoopSandboxPacketId, AgentSession>()
+  let lastDomHash: number | undefined
+  let lastActivitySnapshot = ""
+  let lastChangeAt = Date.now()
+  let lastSwitchAt = 0
+
+  await waitFor("all long agent sessions to complete", 240_000, async () => {
+    let heartbeat: Awaited<ReturnType<typeof captureHeartbeat>>
+    try {
+      heartbeat = await captureHeartbeat(cdp, scenarios)
+    } catch (error) {
+      throw new FatalWaitError(`Renderer heartbeat failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+    const activitySnapshot = JSON.stringify(heartbeat.sessionActivities)
+    const changed = heartbeat.domTextHash !== lastDomHash || activitySnapshot !== lastActivitySnapshot
+    if (changed) {
+      lastChangeAt = Date.now()
+      lastDomHash = heartbeat.domTextHash
+      lastActivitySnapshot = activitySnapshot
+    }
+
+    if (heartbeat.activeCount > 0 && Date.now() - lastChangeAt > 45_000) {
+      throw new FatalWaitError("Renderer heartbeat stopped changing while sessions were active")
+    }
+
+    if (Date.now() - lastSwitchAt > 8_000) {
+      const activeScenario = scenarios.find((scenario) => !completedByPacket.has(scenario.packetId))
+      if (activeScenario) {
+        const switchDurationMs = await clickSessionByMarker(cdp, activeScenario.marker)
+        appendJsonl(runnerMetricsPath, {
+          event: "session_switch",
+          packetId: activeScenario.packetId,
+          switchDurationMs,
+          at: Date.now(),
+        })
+        if (switchDurationMs > 2_000) {
+          throw new FatalWaitError(`Session switch for ${activeScenario.packetId} took ${switchDurationMs}ms`)
+        }
+        lastSwitchAt = Date.now()
+      }
+    }
+
+    const sessions = await invokeIpc<SessionSnapshot>(cdp, "getAgentSessions", undefined, 5_000)
+    const allSessions = [...sessions.activeSessions, ...sessions.recentCompletedSessions]
+    for (const scenario of scenarios) {
+      const session = allSessions.find((candidate) => candidate.conversationTitle?.includes(scenario.marker))
+      if (session && session.status !== "active") {
+        completedByPacket.set(scenario.packetId, session)
+      }
+    }
+
+    appendJsonl(runnerMetricsPath, {
+      event: "heartbeat",
+      at: Date.now(),
+      ...heartbeat,
+      completedPackets: Array.from(completedByPacket.keys()),
+    })
+
+    return completedByPacket.size === scenarios.length ? completedByPacket : undefined
+  }, 2_000)
+
+  return completedByPacket
+}
+
+async function verifyScenario(cdp: CdpClient, scenario: Scenario, session: AgentSession): Promise<Record<string, unknown>> {
+  const packet = longAgentLoopSandboxPackets[scenario.packetId]
+  const toolSummary = getToolSummary(scenario.packetId)
+  const durationMs = (session.endTime ?? Date.now()) - session.startTime
+  const conversation = session.conversationId
+    ? await invokeIpc<{ messages?: Array<{ role?: string; content?: string }> }>(
+      cdp,
+      "loadConversation",
+      { conversationId: session.conversationId, messageLimit: 200 },
+      10_000,
+    )
+    : { messages: [] }
+  const conversationText = (conversation.messages ?? []).map((message) => message.content ?? "").join("\n")
+  const finalAssistant = [...(conversation.messages ?? [])].reverse().find((message) => message.role === "assistant")?.content ?? ""
+  const bodyTextAfterSwitch = await (async () => {
+    await clickSessionByMarker(cdp, scenario.marker)
+    await sleep(500)
+    return cdp.evaluate<string>("document.body?.innerText || ''", 2_000)
+  })()
+  const hasToolHistory = (conversation.messages ?? []).some((message) => message.role === "tool") ||
+    bodyTextAfterSwitch.includes("write_final_audit") ||
+    bodyTextAfterSwitch.includes("read_run_log")
+
+  const checks = {
+    packetId: scenario.packetId,
+    sessionId: session.id,
+    conversationId: session.conversationId,
+    status: session.status,
+    durationMs,
+    toolCallsTotal: toolSummary.total,
+    distinctTools: toolSummary.distinct,
+    finalIncludesReceipt: finalAssistant.includes(packet.receipt) || conversationText.includes(packet.receipt),
+    finalIncludesWinner: finalAssistant.includes(packet.winningCandidateId) || conversationText.includes(packet.winningCandidateId),
+    finalIncludesHiddenToken: finalAssistant.includes(packet.hiddenToken) || conversationText.includes(packet.hiddenToken),
+    historyIncludesPrompt: conversationText.includes(scenario.marker),
+    hasToolHistory,
+    renderedAfterSwitch: bodyTextAfterSwitch.includes(scenario.marker) &&
+      bodyTextAfterSwitch.includes(packet.winningCandidateId),
+  }
+
+  const failures = [
+    checks.status !== "completed" ? `session ended with status ${checks.status}` : undefined,
+    checks.durationMs <= 60_000 ? `session duration was ${checks.durationMs}ms` : undefined,
+    checks.toolCallsTotal < 5 ? `only ${checks.toolCallsTotal} tool calls were recorded` : undefined,
+    checks.distinctTools.length < 5 ? `only ${checks.distinctTools.length} distinct tools were recorded` : undefined,
+    !checks.finalIncludesReceipt ? `missing receipt ${packet.receipt}` : undefined,
+    !checks.finalIncludesWinner ? `missing winner ${packet.winningCandidateId}` : undefined,
+    !checks.finalIncludesHiddenToken ? `missing hidden token ${packet.hiddenToken}` : undefined,
+    !checks.historyIncludesPrompt ? "conversation history does not include the user prompt" : undefined,
+    !checks.hasToolHistory ? "conversation/renderer history does not include tool activity" : undefined,
+    !checks.renderedAfterSwitch ? "renderer did not show the expected session history after switching" : undefined,
+  ].filter(Boolean)
+
+  if (failures.length > 0) {
+    throw new Error(`${scenario.packetId} failed verification: ${failures.join("; ")}`)
+  }
+
+  return checks
+}
+
+async function main(): Promise<void> {
+  const suiteStartedAt = performance.now()
+  await timedStage("preflight", () => {
+    assertOptIn()
+    return assertCodexAuth()
+  })
+  const codexHome = assertCodexAuth()
+  fs.mkdirSync(runDir, { recursive: true })
+
+  const scenarios = createScenarios()
+  const appDataDir = path.join(runDir, "app-data")
+  const userDataDir = path.join(runDir, "user-data")
+  const homeDir = path.join(runDir, "home")
+  await timedStage("prepare-isolated-config", () => {
+    fs.mkdirSync(path.join(homeDir, ".agents"), { recursive: true })
+    prepareConfig(appDataDir, userDataDir, codexHome, scenarios)
+  })
+
+  const remoteDebuggingPort = await timedStage("allocate-cdp-port", () => getFreePort())
+  const env = {
+    ...process.env,
+    APP_ID: "app.dotagents.long-agent-loop-e2e",
+    CODEX_HOME: codexHome,
+    DOTAGENTS_APP_DATA_DIR: appDataDir,
+    DOTAGENTS_USER_DATA_DIR: userDataDir,
+    HOME: homeDir,
+    REMOTE_DEBUGGING_PORT: String(remoteDebuggingPort),
+    ELECTRON_DISABLE_SECURITY_WARNINGS: "1",
+  }
+
+  writeJson(path.join(runDir, "run-meta.json"), {
+    runId,
+    remoteDebuggingPort,
+    appDataDir,
+    userDataDir,
+    homeDir,
+    codexHome,
+    delayMs: Number.isFinite(Number(process.env.LONG_AGENT_LOOP_SANDBOX_DELAY_MS))
+      ? Number(process.env.LONG_AGENT_LOOP_SANDBOX_DELAY_MS)
+      : LONG_AGENT_LOOP_SANDBOX_DELAY_MS,
+    scenarios: scenarios.map(({ packetId, marker, serverName }) => ({ packetId, marker, serverName })),
+  })
+
+  const electron = await timedStage("launch-electron", () => startElectron(env, remoteDebuggingPort, userDataDir))
+  let perfRecorder: ChildProcessWithoutNullStreams | undefined
+  let cdp: CdpClient | undefined
+
+  try {
+    const target = await timedStage("wait-for-renderer-cdp-target", () => waitForRendererTarget(remoteDebuggingPort, electron))
+    cdp = new CdpClient(target.webSocketDebuggerUrl!)
+    await timedStage("connect-renderer-cdp", () => cdp!.connect())
+    perfRecorder = await timedStage("start-renderer-perf-recorder", () => startPerfRecorder(remoteDebuggingPort))
+
+    await timedStage("wait-for-main-app-shell", () => waitFor("main app shell", 30_000, async () => {
+      const body = await cdp!.evaluate<string>("document.body?.innerText || ''")
+      return body.includes("DotAgents") || body.includes("Start text session")
+    }, 500))
+
+    for (const scenario of scenarios) {
+      await timedStage(`start-session-${scenario.packetId}`, () => startScenario(cdp!, scenario))
+    }
+
+    await timedStage("wait-for-all-sessions-active", () => waitFor("all sessions active", 45_000, async () => {
+      const sessions = await invokeIpc<SessionSnapshot>(cdp!, "getAgentSessions", undefined, 5_000)
+      return scenarios.every((scenario) =>
+        sessions.activeSessions.some((session) => session.conversationTitle?.includes(scenario.marker)),
+      )
+    }, 1_000))
+
+    const completed = await timedStage("wait-for-all-sessions-complete", () => waitForCompletion(cdp!, scenarios))
+    const verification = []
+    for (const scenario of scenarios) {
+      const session = completed.get(scenario.packetId)
+      if (!session) throw new Error(`Missing completed session for ${scenario.packetId}`)
+      verification.push(await timedStage(`verify-session-${scenario.packetId}`, () => verifyScenario(cdp!, scenario, session)))
+    }
+
+    writeJson(summaryPath, {
+      status: "pass",
+      runId,
+      artifactsDir: runDir,
+      totalDurationMs: Math.round(performance.now() - suiteStartedAt),
+      verification,
+    })
+    console.log(`Long agent-loop Electron E2E passed. Artifacts: ${runDir}`)
+  } finally {
+    await timedStage("cleanup", async () => {
+      cdp?.close()
+      if (perfRecorder) await terminateProcessGroup(perfRecorder, "renderer-perf-recorder")
+      await terminateProcessGroup(electron, "electron-vite")
+    })
+  }
+}
+
+main().then(() => {
+  process.exit(0)
+}).catch((error) => {
+  writeJson(summaryPath, {
+    status: "fail",
+    runId,
+    artifactsDir: runDir,
+    error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
+  })
+  console.error("[long-agent-loop-e2e] Failed:", error)
+  console.error(`[long-agent-loop-e2e] Artifacts: ${runDir}`)
+  process.exit(1)
+})

--- a/apps/desktop/src/main/adapters/electron-path-resolver.ts
+++ b/apps/desktop/src/main/adapters/electron-path-resolver.ts
@@ -8,14 +8,23 @@ import type { PathResolver } from "@dotagents/core"
  */
 export class ElectronPathResolver implements PathResolver {
   getUserDataPath(): string {
+    if (process.env.DOTAGENTS_USER_DATA_DIR?.trim()) {
+      return process.env.DOTAGENTS_USER_DATA_DIR.trim()
+    }
     return app.getPath("userData")
   }
 
   getConfigPath(): string {
+    if (process.env.DOTAGENTS_USER_DATA_DIR?.trim()) {
+      return process.env.DOTAGENTS_USER_DATA_DIR.trim()
+    }
     return app.getPath("userData")
   }
 
   getAppDataPath(): string {
+    if (process.env.DOTAGENTS_APP_DATA_DIR?.trim()) {
+      return process.env.DOTAGENTS_APP_DATA_DIR.trim()
+    }
     return app.getPath("appData")
   }
 

--- a/apps/desktop/src/main/agent-loop-long-sandbox-fixture.test.ts
+++ b/apps/desktop/src/main/agent-loop-long-sandbox-fixture.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import {
+  LONG_AGENT_LOOP_REQUIRED_TOOL_SEQUENCE,
+  LONG_AGENT_LOOP_SANDBOX_DELAY_MS,
+  createLongAgentLoopSandboxToolState,
+  executeLongAgentLoopSandboxTool,
+  getLongAgentLoopSandboxPacket,
+  getLongAgentLoopSandboxToolDefinitions,
+} from "./agent-loop-long-sandbox-fixture"
+
+describe("long agent-loop sandbox fixture", () => {
+  it("defines the delayed tools required by the long Electron E2E", () => {
+    expect(LONG_AGENT_LOOP_SANDBOX_DELAY_MS).toBeGreaterThanOrEqual(12_000)
+    expect(getLongAgentLoopSandboxToolDefinitions().map((tool) => tool.name)).toEqual([
+      "list_cases",
+      "read_case_file",
+      "search_case_notes",
+      "read_run_log",
+      "summarize_findings",
+      "write_final_audit",
+    ])
+    expect(LONG_AGENT_LOOP_REQUIRED_TOOL_SEQUENCE).toEqual([
+      "list_cases",
+      "read_case_file",
+      "search_case_notes",
+      "read_run_log",
+      "summarize_findings",
+    ])
+  })
+
+  it("keeps final audit evidence gated behind the discovery tools", async () => {
+    const state = createLongAgentLoopSandboxToolState()
+    const packet = getLongAgentLoopSandboxPacket("aurora")
+
+    const earlyFinal = await executeLongAgentLoopSandboxTool(
+      "aurora",
+      "write_final_audit",
+      { candidateId: packet.winningCandidateId, rationale: "too early" },
+      { delayMs: 0, state },
+    )
+    expect(earlyFinal.isError).toBe(true)
+    expect(earlyFinal.content[0].text).toContain("missingTools")
+
+    await executeLongAgentLoopSandboxTool("aurora", "list_cases", {}, { delayMs: 0, state })
+    await executeLongAgentLoopSandboxTool("aurora", "read_case_file", { candidateId: "RC-A17" }, { delayMs: 0, state })
+    await executeLongAgentLoopSandboxTool("aurora", "search_case_notes", { query: "hidden constraints" }, { delayMs: 0, state })
+    await executeLongAgentLoopSandboxTool("aurora", "read_run_log", { candidateId: "RC-A17" }, { delayMs: 0, state })
+    await executeLongAgentLoopSandboxTool(
+      "aurora",
+      "summarize_findings",
+      { candidateId: "RC-A17", evidence: "case and run evidence" },
+      { delayMs: 0, state },
+    )
+
+    const finalAudit = await executeLongAgentLoopSandboxTool(
+      "aurora",
+      "write_final_audit",
+      { candidateId: "RC-A17", rationale: "LOCK-AUR-771, iad-fallback, zephyr-green" },
+      { delayMs: 0, state },
+    )
+
+    expect(finalAudit.isError).toBe(false)
+    expect(finalAudit.content[0].text).toContain(packet.receipt)
+    expect(finalAudit.content[0].text).toContain(packet.hiddenToken)
+    expect(finalAudit.content[0].text).toContain("CASE-AUR-104")
+  })
+})

--- a/apps/desktop/src/main/agent-loop-long-sandbox-fixture.ts
+++ b/apps/desktop/src/main/agent-loop-long-sandbox-fixture.ts
@@ -1,0 +1,390 @@
+export const LONG_AGENT_LOOP_SANDBOX_DELAY_MS = 12_500
+
+export const LONG_AGENT_LOOP_REQUIRED_TOOL_SEQUENCE = [
+  "list_cases",
+  "read_case_file",
+  "search_case_notes",
+  "read_run_log",
+  "summarize_findings",
+] as const
+
+export type LongAgentLoopSandboxPacketId = "aurora" | "boreal" | "cedar"
+
+type SandboxCandidate = {
+  id: string
+  label: string
+  caseIds: string[]
+  channel: string
+  caseFile: string
+  runLog: string
+}
+
+type SandboxPacket = {
+  id: LongAgentLoopSandboxPacketId
+  title: string
+  winningCandidateId: string
+  receipt: string
+  hiddenToken: string
+  hiddenConstraints: string[]
+  candidates: SandboxCandidate[]
+}
+
+type SandboxToolResult = {
+  content: Array<{ type: "text"; text: string }>
+  isError?: boolean
+}
+
+export type LongAgentLoopSandboxToolState = {
+  calledTools: Set<string>
+}
+
+export const longAgentLoopSandboxPackets: Record<LongAgentLoopSandboxPacketId, SandboxPacket> = {
+  aurora: {
+    id: "aurora",
+    title: "Aurora service release packet",
+    winningCandidateId: "RC-A17",
+    receipt: "FINAL_AUDIT_RECEIPT=AURORA-RC-A17-VEGA",
+    hiddenToken: "HIDDEN_CONSTRAINT_TOKEN=AURORA-LOCK-771",
+    hiddenConstraints: [
+      "Must preserve migration lockfile hash LOCK-AUR-771.",
+      "Must include the iad-fallback routing guard.",
+      "Must pass the zephyr-green audit lane.",
+    ],
+    candidates: [
+      {
+        id: "RC-A17",
+        label: "Aurora candidate A17",
+        caseIds: ["CASE-AUR-104", "CASE-AUR-118"],
+        channel: "canary-ring-2",
+        caseFile: [
+          "CASE-AUR-104: migration lockfile hash LOCK-AUR-771 is preserved.",
+          "CASE-AUR-118: iad-fallback routing guard is enabled for regional failover.",
+          "Candidate note: rollout channel canary-ring-2 has no unresolved blocker.",
+        ].join("\n"),
+        runLog: [
+          "run=AUR-2026-05-rc-a17",
+          "zephyr-green audit lane: pass",
+          "latency budget: 184ms p95",
+          "regression pack: pass",
+        ].join("\n"),
+      },
+      {
+        id: "RC-A28",
+        label: "Aurora candidate A28",
+        caseIds: ["CASE-AUR-205"],
+        channel: "canary-ring-4",
+        caseFile: "CASE-AUR-205: migration lockfile hash changed to LOCK-AUR-778.",
+        runLog: "run=AUR-2026-05-rc-a28\nzephyr-green audit lane: fail\nregional failover: skipped",
+      },
+    ],
+  },
+  boreal: {
+    id: "boreal",
+    title: "Boreal worker release packet",
+    winningCandidateId: "RC-B42",
+    receipt: "FINAL_AUDIT_RECEIPT=BOREAL-RC-B42-NOVA",
+    hiddenToken: "HIDDEN_CONSTRAINT_TOKEN=BOREAL-CACHE-314",
+    hiddenConstraints: [
+      "Must retain cache seed CACHE-BOR-314.",
+      "Must prove the oslo-shadow replay finished cleanly.",
+      "Must include the atlas-blue signer attestation.",
+    ],
+    candidates: [
+      {
+        id: "RC-B42",
+        label: "Boreal candidate B42",
+        caseIds: ["CASE-BOR-302", "CASE-BOR-319"],
+        channel: "worker-ring-1",
+        caseFile: [
+          "CASE-BOR-302: cache seed CACHE-BOR-314 retained across restart.",
+          "CASE-BOR-319: atlas-blue signer attestation is attached.",
+          "Candidate note: worker-ring-1 drain completed without orphaned jobs.",
+        ].join("\n"),
+        runLog: [
+          "run=BOR-2026-05-rc-b42",
+          "oslo-shadow replay: pass",
+          "queue drain: pass",
+          "signer attestation: atlas-blue",
+        ].join("\n"),
+      },
+      {
+        id: "RC-B31",
+        label: "Boreal candidate B31",
+        caseIds: ["CASE-BOR-211"],
+        channel: "worker-ring-3",
+        caseFile: "CASE-BOR-211: cache seed CACHE-BOR-309 retained, not CACHE-BOR-314.",
+        runLog: "run=BOR-2026-05-rc-b31\noslo-shadow replay: fail\nsigner attestation: atlas-blue",
+      },
+    ],
+  },
+  cedar: {
+    id: "cedar",
+    title: "Cedar desktop release packet",
+    winningCandidateId: "RC-C09",
+    receipt: "FINAL_AUDIT_RECEIPT=CEDAR-RC-C09-LUMA",
+    hiddenToken: "HIDDEN_CONSTRAINT_TOKEN=CEDAR-PANEL-909",
+    hiddenConstraints: [
+      "Must keep panel session key PANEL-CED-909 stable while switching sessions.",
+      "Must pass the tahoe-silver renderer responsiveness lane.",
+      "Must preserve config merge marker MERGE-CED-612.",
+    ],
+    candidates: [
+      {
+        id: "RC-C09",
+        label: "Cedar candidate C09",
+        caseIds: ["CASE-CED-501", "CASE-CED-612"],
+        channel: "desktop-ring-0",
+        caseFile: [
+          "CASE-CED-501: panel session key PANEL-CED-909 remains stable during session switching.",
+          "CASE-CED-612: config merge marker MERGE-CED-612 is preserved.",
+          "Candidate note: desktop-ring-0 includes the latest history renderer patch.",
+        ].join("\n"),
+        runLog: [
+          "run=CED-2026-05-rc-c09",
+          "tahoe-silver renderer responsiveness lane: pass",
+          "session switching probe: pass",
+          "history placement audit: pass",
+        ].join("\n"),
+      },
+      {
+        id: "RC-C15",
+        label: "Cedar candidate C15",
+        caseIds: ["CASE-CED-518"],
+        channel: "desktop-ring-2",
+        caseFile: "CASE-CED-518: panel session key PANEL-CED-900 observed during session switching.",
+        runLog: "run=CED-2026-05-rc-c15\ntahoe-silver renderer responsiveness lane: pass\nhistory placement audit: fail",
+      },
+    ],
+  },
+}
+
+export function createLongAgentLoopSandboxToolState(): LongAgentLoopSandboxToolState {
+  return { calledTools: new Set<string>() }
+}
+
+export function getLongAgentLoopSandboxPacket(packetId: string): SandboxPacket {
+  const packet = longAgentLoopSandboxPackets[packetId as LongAgentLoopSandboxPacketId]
+  if (!packet) {
+    throw new Error(`Unknown long agent-loop sandbox packet: ${packetId}`)
+  }
+  return packet
+}
+
+export function getLongAgentLoopSandboxToolDefinitions() {
+  return [
+    {
+      name: "list_cases",
+      description: "List release candidates and visible case IDs in the sandbox packet.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        required: [],
+      },
+    },
+    {
+      name: "read_case_file",
+      description: "Read the visible case file for one release candidate.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          candidateId: { type: "string", description: "Candidate ID such as RC-A17." },
+        },
+        required: ["candidateId"],
+      },
+    },
+    {
+      name: "search_case_notes",
+      description: "Search hidden packet notes for release constraints.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query for hidden release constraints." },
+        },
+        required: ["query"],
+      },
+    },
+    {
+      name: "read_run_log",
+      description: "Read the synthetic run log for one release candidate.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          candidateId: { type: "string", description: "Candidate ID such as RC-A17." },
+        },
+        required: ["candidateId"],
+      },
+    },
+    {
+      name: "summarize_findings",
+      description: "Summarize whether one candidate satisfies the hidden constraints.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          candidateId: { type: "string", description: "Candidate ID to summarize." },
+          evidence: { type: "string", description: "Short evidence collected from prior tool calls." },
+        },
+        required: ["candidateId", "evidence"],
+      },
+    },
+    {
+      name: "write_final_audit",
+      description: "Write the final sandbox audit and return the receipt for the correct candidate.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          candidateId: { type: "string", description: "Candidate ID selected as the release candidate." },
+          rationale: { type: "string", description: "Evidence-based rationale with case IDs." },
+        },
+        required: ["candidateId", "rationale"],
+      },
+    },
+  ] as const
+}
+
+function makeTextResult(payload: unknown, isError = false): SandboxToolResult {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    isError,
+  }
+}
+
+function findCandidate(packet: SandboxPacket, candidateId: unknown): SandboxCandidate | undefined {
+  if (typeof candidateId !== "string") return undefined
+  return packet.candidates.find((candidate) => candidate.id.toLowerCase() === candidateId.toLowerCase())
+}
+
+function missingPrerequisiteTools(state: LongAgentLoopSandboxToolState): string[] {
+  return LONG_AGENT_LOOP_REQUIRED_TOOL_SEQUENCE.filter((toolName) => !state.calledTools.has(toolName))
+}
+
+async function delay(ms: number): Promise<void> {
+  if (ms <= 0) return
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export async function executeLongAgentLoopSandboxTool(
+  packetId: LongAgentLoopSandboxPacketId,
+  toolName: string,
+  args: Record<string, unknown> | undefined,
+  options: {
+    delayMs?: number
+    state?: LongAgentLoopSandboxToolState
+  } = {},
+): Promise<SandboxToolResult> {
+  const packet = getLongAgentLoopSandboxPacket(packetId)
+  const state = options.state ?? createLongAgentLoopSandboxToolState()
+  const delayMs = options.delayMs ?? LONG_AGENT_LOOP_SANDBOX_DELAY_MS
+
+  await delay(delayMs)
+
+  if (toolName === "write_final_audit") {
+    const missingTools = missingPrerequisiteTools(state)
+    state.calledTools.add(toolName)
+    if (missingTools.length > 0) {
+      return makeTextResult({
+        ok: false,
+        packetId: packet.id,
+        error: "Final audit is not available until the discovery tools have been used.",
+        missingTools,
+      }, true)
+    }
+
+    const candidate = findCandidate(packet, args?.candidateId)
+    if (!candidate) {
+      return makeTextResult({
+        ok: false,
+        packetId: packet.id,
+        error: `Unknown candidate: ${String(args?.candidateId ?? "")}`,
+      }, true)
+    }
+
+    const isWinner = candidate.id === packet.winningCandidateId
+    return makeTextResult({
+      ok: isWinner,
+      packetId: packet.id,
+      selectedCandidateId: candidate.id,
+      winningCandidateId: packet.winningCandidateId,
+      receipt: isWinner ? packet.receipt : undefined,
+      hiddenToken: isWinner ? packet.hiddenToken : undefined,
+      caseIds: candidate.caseIds,
+      rationaleRequiredInFinalAnswer: isWinner
+        ? `Answer with ${packet.receipt}, ${candidate.id}, ${candidate.caseIds.join(", ")}, and ${packet.hiddenToken}.`
+        : "Selected candidate does not satisfy all hidden fixture constraints.",
+      constraints: isWinner ? packet.hiddenConstraints : undefined,
+    }, !isWinner)
+  }
+
+  state.calledTools.add(toolName)
+
+  if (toolName === "list_cases") {
+    return makeTextResult({
+      packetId: packet.id,
+      title: packet.title,
+      candidates: packet.candidates.map((candidate) => ({
+        id: candidate.id,
+        label: candidate.label,
+        caseIds: candidate.caseIds,
+        channel: candidate.channel,
+      })),
+      nextStep: "Read case files and hidden notes before choosing a release candidate.",
+    })
+  }
+
+  if (toolName === "read_case_file") {
+    const candidate = findCandidate(packet, args?.candidateId)
+    if (!candidate) {
+      return makeTextResult({ ok: false, error: `Unknown candidate: ${String(args?.candidateId ?? "")}` }, true)
+    }
+    return makeTextResult({
+      packetId: packet.id,
+      candidateId: candidate.id,
+      caseIds: candidate.caseIds,
+      caseFile: candidate.caseFile,
+    })
+  }
+
+  if (toolName === "search_case_notes") {
+    return makeTextResult({
+      packetId: packet.id,
+      query: String(args?.query ?? ""),
+      hiddenToken: packet.hiddenToken,
+      hiddenConstraints: packet.hiddenConstraints,
+      note: "These constraints are intentionally absent from the user prompt.",
+    })
+  }
+
+  if (toolName === "read_run_log") {
+    const candidate = findCandidate(packet, args?.candidateId)
+    if (!candidate) {
+      return makeTextResult({ ok: false, error: `Unknown candidate: ${String(args?.candidateId ?? "")}` }, true)
+    }
+    return makeTextResult({
+      packetId: packet.id,
+      candidateId: candidate.id,
+      runLog: candidate.runLog,
+    })
+  }
+
+  if (toolName === "summarize_findings") {
+    const candidate = findCandidate(packet, args?.candidateId)
+    if (!candidate) {
+      return makeTextResult({ ok: false, error: `Unknown candidate: ${String(args?.candidateId ?? "")}` }, true)
+    }
+    const isWinner = candidate.id === packet.winningCandidateId
+    return makeTextResult({
+      packetId: packet.id,
+      candidateId: candidate.id,
+      satisfiesHiddenConstraints: isWinner,
+      expectedCandidateId: packet.winningCandidateId,
+      caseIds: candidate.caseIds,
+      hiddenToken: isWinner ? packet.hiddenToken : undefined,
+      summary: isWinner
+        ? `${candidate.id} satisfies the hidden constraints for ${packet.title}.`
+        : `${candidate.id} is missing at least one hidden constraint for ${packet.title}.`,
+      evidenceReceived: String(args?.evidence ?? ""),
+    })
+  }
+
+  state.calledTools.add(toolName)
+  return makeTextResult({ ok: false, packetId: packet.id, error: `Unknown sandbox tool: ${toolName}` }, true)
+}

--- a/apps/desktop/src/main/agent-profile-service.ts
+++ b/apps/desktop/src/main/agent-profile-service.ts
@@ -38,8 +38,10 @@ import {
 /**
  * Path to the agent profiles storage file.
  */
+const userDataFolder = process.env.DOTAGENTS_USER_DATA_DIR?.trim() || app.getPath("userData")
+
 export const agentProfilesPath = path.join(
-  app.getPath("userData"),
+  userDataFolder,
   "agent-profiles.json"
 )
 
@@ -47,13 +49,13 @@ export const agentProfilesPath = path.join(
  * Path to the agent profile conversations storage file.
  */
 export const agentProfileConversationsPath = path.join(
-  app.getPath("userData"),
+  userDataFolder,
   "agent-profile-conversations.json"
 )
 
 // Legacy paths for migration
-const legacyProfilesPath = path.join(app.getPath("userData"), "profiles.json")
-const legacyPersonasPath = path.join(app.getPath("userData"), "personas.json")
+const legacyProfilesPath = path.join(userDataFolder, "profiles.json")
+const legacyPersonasPath = path.join(userDataFolder, "personas.json")
 
 // ============================================================================
 // Validation Helpers (ported from the legacy profile service)

--- a/apps/desktop/src/main/config.ts
+++ b/apps/desktop/src/main/config.ts
@@ -24,6 +24,10 @@ function resolveDesktopAppId(): string {
   return process.env.APP_ID?.trim() || DEFAULT_APP_ID
 }
 
+function resolveDesktopAppDataRoot(): string {
+  return process.env.DOTAGENTS_APP_DATA_DIR?.trim() || app.getPath("appData")
+}
+
 function copyMissingRecursive(sourcePath: string, destinationPath: string): void {
   if (!fs.existsSync(sourcePath)) return
 
@@ -43,7 +47,7 @@ function copyMissingRecursive(sourcePath: string, destinationPath: string): void
 }
 
 function migrateLegacyDesktopAppData(activeAppId: string): void {
-  const appDataRoot = app.getPath("appData")
+  const appDataRoot = resolveDesktopAppDataRoot()
   const targetDataFolder = path.join(appDataRoot, activeAppId)
   const knownAppIds = Array.from(new Set([DEFAULT_APP_ID, "dotagents", activeAppId]))
 
@@ -72,8 +76,8 @@ if (!container.has(ServiceTokens.PathResolver)) {
 }
 
 // Backward-compatible module-level constants for existing desktop callers.
-// These use Electron's app.getPath() directly to be available at module load time.
-export const dataFolder = path.join(app.getPath("appData"), appId)
+// Keep these available at module load time; opt-in E2E can override the app-data root.
+export const dataFolder = path.join(resolveDesktopAppDataRoot(), appId)
 export const recordingsFolder = path.join(dataFolder, "recordings")
 export const conversationsFolder = path.join(dataFolder, "conversations")
 export const configPath = path.join(dataFolder, "config.json")

--- a/docs/test-results/agent-loop/README.md
+++ b/docs/test-results/agent-loop/README.md
@@ -24,3 +24,32 @@ enabled by default. Set `LIVE_AGENT_LOOP_LLM_JUDGE=0` to disable that extra judg
 call. Use `pnpm --filter @dotagents/desktop run test:agent-loop-live:strict` or
 set `LIVE_AGENT_LOOP_LLM_JUDGE_REQUIRED=1` to make a failed judge verdict fail
 the live test rather than only recording `llmJudge*` metric fields.
+
+## Long Electron Agent-Loop E2E
+
+The long real-Electron suite is intentionally opt-in because it launches the
+desktop app, uses real ChatGPT Web/Codex auth, starts three concurrent sessions,
+and waits for delayed sandbox MCP tools. It is not part of normal `pnpm test`,
+`pnpm typecheck`, or PR CI.
+
+Prerequisites:
+
+- A valid Codex ChatGPT auth file at `$CODEX_HOME/auth.json` or `~/.codex/auth.json`.
+- No existing desktop dev process using the Electron/Vite dev ports.
+- Network access to ChatGPT Web/Codex.
+
+Run:
+
+```bash
+LONG_AGENT_LOOP_E2E=1 \
+  pnpm --filter @dotagents/desktop run test:e2e:agent-loop-long
+```
+
+Artifacts are written under `apps/desktop/tmp/e2e-agent-loop/<run-id>/`,
+including Electron logs, sandbox MCP tool-call JSONL, renderer CDP metrics/trace
+files from `scripts/renderer-perf-recorder.ts`, runner heartbeat metrics, and
+`summary.json`.
+
+Expected runtime is a few minutes. Each sandbox tool waits about 12.5 seconds,
+and each of the three sessions must execute at least five distinct sandbox tool
+calls before the final audit receipt can be returned.


### PR DESCRIPTION
## Summary

- Add an opt-in real Electron E2E for three concurrent long-running agent sessions through the desktop UI.
- Add a deterministic sandbox MCP fixture/server with delayed tools and hidden evidence requirements.
- Add isolated app-data/user-data overrides so the E2E does not mutate normal desktop state.
- Document prerequisites, command, artifacts, and expected runtime for the long suite.

## Validation

- `pnpm --filter @dotagents/desktop run typecheck:node`
- `pnpm --filter @dotagents/desktop exec vitest run src/main/agent-loop-long-sandbox-fixture.test.ts`
- `LONG_AGENT_LOOP_E2E=1 /usr/bin/time -p pnpm --filter @dotagents/desktop run test:e2e:agent-loop-long`
  - Passed with artifacts in `apps/desktop/tmp/e2e-agent-loop/2026-05-25T01-08-23-871Z/`
  - Shell wall time: `159.68s`
  - Runner total: `158.631s`
  - Session durations: `115.269s`, `135.299s`, `150.432s`
  - Tool calls per session: `8`, `9`, `10`
  - Session switch latency: min `6ms`, max `25ms`, avg `10.05ms`

## Notes

This suite remains opt-in behind `LONG_AGENT_LOOP_E2E=1` and is not wired into normal tests, typecheck, or CI.