### PR TITLE
Make read_more_context output and search usable

### DIFF
--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -247,6 +247,48 @@ describe('shrinkMessagesForLLM replacement policy', () => {
     expect(truncatedMessage?.content).toContain('-TAIL')
   })
 
+  it('describes what was elided inline at the cut point and keeps the ref in place', async () => {
+    const toolPayload = [
+      '[server:search] HEAD-MARKER',
+      'a'.repeat(1300),
+      'https://example.com/one https://example.com/two',
+      '{"status":"ok","results":[1,2,3],"items":[]}',
+      'b'.repeat(3000),
+      'TAIL-MARKER',
+    ].join(' ')
+
+    const result = await shrinkMessagesForLLM({
+      sessionId: 'session-elision',
+      messages: [
+        { role: 'system', content: 'system prompt' },
+        { role: 'user', content: 'inspect this result' },
+        { role: 'tool', content: toolPayload },
+      ],
+    })
+
+    expect(result.appliedStrategies).toContain('aggressive_truncate')
+    const truncated = result.messages.find((msg) => msg.content.includes('Large tool result truncated for context management'))
+    expect(truncated).toBeTruthy()
+    const content = truncated!.content
+
+    // head + tail are both kept inline so the gap is visible in place
+    expect(content).toContain('HEAD-MARKER')
+    expect(content).toContain('TAIL-MARKER')
+
+    // the marker self-describes the elided span: size, fingerprint, and ref
+    expect(content).toMatch(/≈\d+ chars elided/)
+    expect(content).toContain('contains:')
+    expect(content).toContain('URLs')
+    expect(content).toContain('JSON keys')
+
+    // ref is still recoverable from the inline marker
+    const contextRef = content.match(/Context ref: (ctx_[a-z0-9]+)/)?.[1]
+    expect(contextRef).toBeTruthy()
+    const recovered = readMoreContext('session-elision', contextRef!, { mode: 'search', query: 'example.com' })
+    expect(recovered).toEqual(expect.objectContaining({ success: true }))
+    expect(Number(recovered.matchCount)).toBeGreaterThan(0)
+  })
+
   it('does not re-truncate already truncated runtime tool output', async () => {
     const runtimeTruncated = [
       '[server:shell] {',
@@ -880,6 +922,22 @@ describe('registerContextRef export for MCP tool summarization', () => {
     expect(suggested.length).toBeGreaterThan(1)
     expect(suggested.some((s) => s.call.mode === 'search')).toBe(true)
     expect(suggested.some((s) => s.call.mode === 'head')).toBe(true)
+  })
+
+  it('overview surfaces a content digest of what the payload contains', () => {
+    const original = `{"status":"ok","results":[1,2]} see https://example.com/a and https://example.com/b`
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: original,
+    })
+
+    const overview = readMoreContext('session-mcp-ref', ref!)
+
+    expect(overview.success).toBe(true)
+    expect(typeof overview.contentDigest).toBe('string')
+    expect(String(overview.contentDigest)).toContain('URLs')
+    expect(String(overview.contentDigest)).toContain('JSON keys')
   })
 
   it('head/tail/window return nextWindow / previousWindow navigation hints', () => {

--- a/apps/desktop/src/main/context-budget.test.ts
+++ b/apps/desktop/src/main/context-budget.test.ts
@@ -850,4 +850,159 @@ describe('registerContextRef export for MCP tool summarization', () => {
     })
     expect(ref).toBeUndefined()
   })
+
+  it('overview includes description, scope, and suggested next calls', () => {
+    const original = `tool payload ${'z'.repeat(5000)} END`
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: original,
+      toolName: 'exa:web_search_advanced_exa',
+    })
+
+    const overview = readMoreContext('session-mcp-ref', ref!)
+
+    expect(overview.success).toBe(true)
+    expect(typeof overview.description).toBe('string')
+    expect(String(overview.description)).toContain('exa:web_search_advanced_exa')
+    expect(overview.searchScope).toBe('underlying_payload')
+
+    const scope = overview.scope as Record<string, unknown>
+    expect(scope).toEqual(expect.objectContaining({
+      kind: 'truncated_tool',
+      role: 'tool',
+      toolName: 'exa:web_search_advanced_exa',
+      totalChars: original.length,
+    }))
+
+    const suggested = overview.suggestedCalls as Array<{ description: string; call: Record<string, unknown> }>
+    expect(Array.isArray(suggested)).toBe(true)
+    expect(suggested.length).toBeGreaterThan(1)
+    expect(suggested.some((s) => s.call.mode === 'search')).toBe(true)
+    expect(suggested.some((s) => s.call.mode === 'head')).toBe(true)
+  })
+
+  it('head/tail/window return nextWindow / previousWindow navigation hints', () => {
+    const original = `START-${'y'.repeat(20000)}-MID-${'q'.repeat(20000)}-END`
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_payload',
+      role: 'user',
+      content: original,
+    })
+
+    const head = readMoreContext('session-mcp-ref', ref!, { mode: 'head', maxChars: 1000 })
+    expect(head.success).toBe(true)
+    expect(head.nextWindow).toEqual(expect.objectContaining({ mode: 'window', offset: 1000 }))
+    expect(head.previousWindow).toBeUndefined()
+
+    const tail = readMoreContext('session-mcp-ref', ref!, { mode: 'tail', maxChars: 1000 })
+    expect(tail.success).toBe(true)
+    expect(tail.previousWindow).toEqual(expect.objectContaining({ mode: 'window' }))
+    expect(tail.nextWindow).toBeUndefined()
+
+    const win = readMoreContext('session-mcp-ref', ref!, { mode: 'window', offset: 5000, length: 1000 })
+    expect(win.success).toBe(true)
+    expect(win.previousWindow).toEqual(expect.objectContaining({ mode: 'window' }))
+    expect(win.nextWindow).toEqual(expect.objectContaining({ mode: 'window', offset: 6000 }))
+
+    const fullHead = readMoreContext('session-mcp-ref', ref!, { mode: 'head', maxChars: 12000 })
+    expect(fullHead.success).toBe(true)
+    expect(fullHead.nextWindow).toEqual(expect.objectContaining({ mode: 'window', offset: 12000 }))
+  })
+
+  it('search finds case-, punctuation-, and underscore-insensitive matches via normalized matching', () => {
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: 'before HIDDEN_AUDIT_TOKEN=abc123 after',
+    })
+
+    const search = readMoreContext('session-mcp-ref', ref!, {
+      mode: 'search',
+      query: 'hidden audit token',
+    })
+
+    expect(search.success).toBe(true)
+    expect(Number(search.matchCount)).toBeGreaterThan(0)
+    const matches = search.matches as Array<Record<string, unknown>>
+    expect(matches[0].matchType).toBe('normalized')
+    expect(String(matches[0].excerpt)).toContain('HIDDEN_AUDIT_TOKEN')
+    expect(matches[0]).toEqual(expect.objectContaining({
+      matchedQuery: 'hidden audit token',
+    }))
+    expect(matches[0].expandCall).toEqual(expect.objectContaining({ mode: 'window' }))
+  })
+
+  it('labels exact, case-insensitive, and normalized matches with the right matchType', () => {
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: 'alpha BetaToken gamma delta foo_bar_value baz',
+    })
+
+    const exact = readMoreContext('session-mcp-ref', ref!, { mode: 'search', query: 'BetaToken' })
+    const exactMatches = exact.matches as Array<Record<string, unknown>>
+    expect(exactMatches[0]?.matchType).toBe('exact')
+
+    const ci = readMoreContext('session-mcp-ref', ref!, { mode: 'search', query: 'betatoken' })
+    const ciMatches = ci.matches as Array<Record<string, unknown>>
+    expect(ciMatches[0]?.matchType).toBe('case_insensitive')
+
+    const norm = readMoreContext('session-mcp-ref', ref!, { mode: 'search', query: 'foo bar value' })
+    const normMatches = norm.matches as Array<Record<string, unknown>>
+    expect(normMatches[0]?.matchType).toBe('normalized')
+    expect(String(normMatches[0]?.excerpt)).toContain('foo_bar_value')
+  })
+
+  it('zero-result searches explain what was tried and how to recover', () => {
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: 'nothing useful in here at all',
+    })
+
+    const search = readMoreContext('session-mcp-ref', ref!, { mode: 'search', query: 'completely-absent-thing' })
+
+    expect(search.success).toBe(true)
+    expect(search.matchCount).toBe(0)
+    expect(search.searchedChars).toBe('nothing useful in here at all'.length)
+    expect(search.searchScope).toBe('underlying_payload')
+
+    const tried = search.needlesTried as Array<Record<string, unknown>>
+    expect(Array.isArray(tried)).toBe(true)
+    expect(tried.length).toBeGreaterThan(0)
+    expect(tried.every((t) => t.found === false)).toBe(true)
+
+    expect(typeof search.suggestion).toBe('string')
+    expect(String(search.suggestion)).toContain('No matches')
+  })
+
+  it('search results include a per-match expandCall for fetching the surrounding window', () => {
+    const ref = registerContextRef('session-mcp-ref', {
+      kind: 'truncated_tool',
+      role: 'tool',
+      content: `prefix ${'x'.repeat(2000)} NEEDLE ${'y'.repeat(2000)} suffix`,
+    })
+
+    const search = readMoreContext('session-mcp-ref', ref!, {
+      mode: 'search',
+      query: 'NEEDLE',
+      maxChars: 400,
+    })
+
+    expect(search.success).toBe(true)
+    const matches = search.matches as Array<Record<string, unknown>>
+    expect(matches.length).toBe(1)
+    const expand = matches[0].expandCall as Record<string, number | string>
+    expect(expand.mode).toBe('window')
+    expect(typeof expand.offset).toBe('number')
+    expect(typeof expand.length).toBe('number')
+
+    const expanded = readMoreContext('session-mcp-ref', ref!, {
+      mode: 'window',
+      offset: expand.offset as number,
+      length: expand.length as number,
+    })
+    expect(String(expanded.excerpt)).toContain('NEEDLE')
+  })
 })

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -996,6 +996,7 @@ export function readMoreContext(
       preview: entry.preview,
       scope,
       description: describeContextKind(entry.kind, entry.toolName, entry.messageCount),
+      contentDigest: summarizeElidedSpan(entry.content) || undefined,
       searchScope: "underlying_payload",
       suggestedCalls: buildSuggestedCalls(totalChars),
     }
@@ -1302,11 +1303,69 @@ function isLikelyPayloadLikeMessage(message: LLMMessage): boolean {
     || startsWithJsonLikeArray(content)
 }
 
+/**
+ * Build a compact, deterministic fingerprint of an elided span so the inline
+ * truncation marker can tell the model *what* was cut without it having to
+ * call read_more_context. Cheap regex scans only — no allocation of the whole
+ * span beyond what the matches need.
+ */
+function summarizeElidedSpan(span: string): string {
+  if (!span) return ""
+  const parts: string[] = []
+
+  const urlCount = (span.match(/https?:\/\/[^\s"'<>)\]]+/g) || []).length
+  if (urlCount > 0) parts.push(`${urlCount} URL${urlCount === 1 ? "" : "s"}`)
+
+  const stackFrames = (span.match(/\n\s+at\s+\S/g) || []).length
+  const hasTraceback = /Traceback \(most recent call last\)/.test(span)
+  if (hasTraceback || stackFrames >= 2) {
+    parts.push("stack trace")
+  } else {
+    const errorMentions = (span.match(/\b(?:error|exception|failed|panic)\b/gi) || []).length
+    if (errorMentions > 0) parts.push(`${errorMentions} error mention${errorMentions === 1 ? "" : "s"}`)
+  }
+
+  const codeBlocks = Math.floor((span.match(/```/g) || []).length / 2)
+  if (codeBlocks > 0) parts.push(`${codeBlocks} code block${codeBlocks === 1 ? "" : "s"}`)
+
+  const keySet = new Set<string>()
+  const keyRe = /"([A-Za-z0-9_-]{1,40})"\s*:/g
+  let keyMatch: RegExpExecArray | null
+  while (keySet.size < 12 && (keyMatch = keyRe.exec(span)) !== null) {
+    keySet.add(keyMatch[1])
+  }
+  if (keySet.size > 0) {
+    const shown = Array.from(keySet).slice(0, 6)
+    const more = keySet.size > shown.length ? ", …" : ""
+    parts.push(`JSON keys: ${shown.join(", ")}${more}`)
+  }
+
+  if (parts.length === 0) {
+    const lineCount = span.split("\n").length
+    if (lineCount > 1) parts.push(`${lineCount} lines of text`)
+  }
+
+  return parts.join(", ")
+}
+
+/**
+ * Build the inline elision marker placed at the cut point. Surfaces the
+ * approximate size of the gap, a content fingerprint of what was removed, and
+ * the Context ref to expand it — so the model sees the gap *in place* and
+ * usually never needs a follow-up read_more_context call.
+ */
+function buildElisionMarker(marker: string, removedChars: number, elidedSpan: string, contextRef?: string): string {
+  const digest = summarizeElidedSpan(elidedSpan)
+  const digestNote = digest ? ` · contains: ${digest}` : ""
+  const refNote = contextRef ? ` · Context ref: ${contextRef}` : ""
+  return `${marker} (≈${removedChars} chars elided${digestNote}${refNote})`
+}
+
 function truncateWithMarker(
   content: string,
   keepChars: number,
   marker: string,
-  options?: { preserveTail?: boolean },
+  options?: { preserveTail?: boolean; contextRef?: string },
 ): string {
   if (content.length <= keepChars) return content
   const preserveTail = options?.preserveTail === true && keepChars >= 200
@@ -1317,11 +1376,13 @@ function truncateWithMarker(
     const tailChars = Math.floor(keepChars / 2)
     const head = content.slice(0, headChars).trimEnd()
     const tail = content.slice(content.length - tailChars).trimStart()
-    return `${head}\n\n${marker} (${removedChars} chars omitted)\n\n${tail}`
+    const elidedSpan = content.slice(headChars, content.length - tailChars)
+    return `${head}\n\n${buildElisionMarker(marker, removedChars, elidedSpan, options?.contextRef)}\n\n${tail}`
   }
 
   const head = content.slice(0, keepChars).trimEnd()
-  return `${head}\n\n${marker} (${removedChars} chars omitted)`
+  const elidedSpan = content.slice(keepChars)
+  return `${head}\n\n${buildElisionMarker(marker, removedChars, elidedSpan, options?.contextRef)}`
 }
 
 function isTruncationProtectedMessage(message: LLMMessage): boolean {
@@ -1910,10 +1971,10 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
       content: msg.content,
       toolName: toolName !== "unknown" ? toolName : undefined,
     })
-    const truncatedContent = addContextRefNote(
-      truncateWithMarker(msg.content, keepChars, marker, { preserveTail: isToolResultLike }),
-      contextRef,
-    )
+    const truncatedContent = truncateWithMarker(msg.content, keepChars, marker, {
+      preserveTail: true,
+      contextRef: contextRef ?? undefined,
+    })
 
     if (truncatedContent !== msg.content) {
       messages[i] = {

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -638,6 +638,271 @@ function upsertArchiveHistoryRef(sessionId: string, archivedMessages: LLMMessage
   return ref
 }
 
+function describeContextKind(
+  kind: ContextRefKind,
+  toolName: string | undefined,
+  messageCount: number | undefined,
+): string {
+  switch (kind) {
+    case "truncated_tool":
+      return toolName
+        ? `Full output from tool '${toolName}'. The inline message excerpt was shortened to fit the context budget; this ref holds the original payload.`
+        : `Full tool output. The inline message excerpt was shortened to fit the context budget; this ref holds the original payload.`
+    case "truncated_payload":
+      return `Full payload from a large conversation message that was inlined as a shortened excerpt. This ref holds the original content.`
+    case "batch_summary":
+      return messageCount && messageCount > 0
+        ? `Original contents of ${messageCount} earlier-conversation message${messageCount === 1 ? "" : "s"} that were replaced inline by a brief summary.`
+        : `Original contents of earlier-conversation messages that were replaced inline by a brief summary.`
+    case "archived_history":
+      return messageCount && messageCount > 0
+        ? `Archived background history: ${messageCount} message${messageCount === 1 ? "" : "s"} moved out of the live window. Original raw contents are stored here.`
+        : `Archived background history that was moved out of the live conversation window. Original raw contents are stored here.`
+    case "dropped_messages":
+      return messageCount && messageCount > 0
+        ? `${messageCount} older message${messageCount === 1 ? "" : "s"} dropped from the live window. Original raw contents are stored here.`
+        : `Older messages dropped from the live window. Original raw contents are stored here.`
+  }
+}
+
+function buildSuggestedCalls(
+  totalChars: number,
+): Array<{ description: string; call: Record<string, unknown> }> {
+  const suggestions: Array<{ description: string; call: Record<string, unknown> }> = [
+    {
+      description: "Find specific text (case-, punctuation-, and underscore-insensitive)",
+      call: { mode: "search", query: "<term>" },
+    },
+  ]
+  if (totalChars > 1500) {
+    const span = Math.min(totalChars, 4000)
+    suggestions.push({
+      description: "Read the first portion",
+      call: { mode: "head", maxChars: span },
+    })
+    suggestions.push({
+      description: "Read the last portion",
+      call: { mode: "tail", maxChars: span },
+    })
+    suggestions.push({
+      description: "Read a specific window",
+      call: { mode: "window", offset: 0, length: span },
+    })
+  } else {
+    suggestions.push({
+      description: "Read the full content",
+      call: { mode: "head", maxChars: Math.min(totalChars, 12000) },
+    })
+  }
+  return suggestions
+}
+
+function buildScopeLabel(entry: ContextRefEntry): Record<string, unknown> {
+  return {
+    kind: entry.kind,
+    role: entry.role,
+    ...(entry.toolName ? { toolName: entry.toolName } : {}),
+    ...(typeof entry.messageCount === "number" ? { messageCount: entry.messageCount } : {}),
+    totalChars: entry.totalChars,
+  }
+}
+
+function buildRangeNavigationHints(
+  totalChars: number,
+  start: number,
+  end: number,
+  maxChars: number,
+): { previousWindow?: Record<string, number | string>; nextWindow?: Record<string, number | string> } {
+  const step = Math.max(100, Math.min(maxChars, 12000))
+  const hints: { previousWindow?: Record<string, number | string>; nextWindow?: Record<string, number | string> } = {}
+  if (start > 0) {
+    const prevStart = Math.max(0, start - step)
+    hints.previousWindow = { mode: "window", offset: prevStart, length: start - prevStart }
+  }
+  if (end < totalChars) {
+    hints.nextWindow = { mode: "window", offset: end, length: Math.min(step, totalChars - end) }
+  }
+  return hints
+}
+
+function buildNormalizedIndex(content: string): { normalized: string; origIndex: number[] } {
+  const normalizedChars: string[] = []
+  const origIndex: number[] = []
+  for (let i = 0; i < content.length; i++) {
+    const code = content.charCodeAt(i)
+    const isDigit = code >= 0x30 && code <= 0x39
+    const isUpper = code >= 0x41 && code <= 0x5a
+    const isLower = code >= 0x61 && code <= 0x7a
+    if (isDigit || isUpper || isLower) {
+      normalizedChars.push(isUpper ? String.fromCharCode(code + 32) : content[i])
+      origIndex.push(i)
+    }
+  }
+  return { normalized: normalizedChars.join(""), origIndex }
+}
+
+function normalizeSearchQuery(query: string): string {
+  return query.replace(/[^A-Za-z0-9]+/g, "").toLowerCase()
+}
+
+type SearchMatchType = "exact" | "case_insensitive" | "normalized" | "token"
+
+interface SearchMatchRecord {
+  start: number
+  end: number
+  matchStart: number
+  matchEnd: number
+  excerpt: string
+  matchedQuery: string
+  matchType: SearchMatchType
+  returnedChars: number
+  expandCall: Record<string, number | string>
+}
+
+interface NeedleTried {
+  needle: string
+  matchType: SearchMatchType
+  found: boolean
+}
+
+function appendMatchAtRange(
+  matches: SearchMatchRecord[],
+  content: string,
+  totalChars: number,
+  matchStart: number,
+  matchEnd: number,
+  maxChars: number,
+  matchedQuery: string,
+  matchType: SearchMatchType,
+): void {
+  const matchLen = matchEnd - matchStart
+  const desiredBefore = Math.floor(maxChars / 4)
+  const desiredAfter = Math.floor(maxChars / 2)
+  let start = matchStart
+  let end = Math.min(totalChars, matchStart + maxChars)
+  if (matchLen < maxChars) {
+    const availableContextChars = maxChars - matchLen
+    const totalDesiredContext = desiredBefore + desiredAfter
+    const contextBefore = Math.min(
+      desiredBefore,
+      Math.floor((availableContextChars * desiredBefore) / Math.max(1, totalDesiredContext)),
+    )
+    const contextAfter = availableContextChars - contextBefore
+    start = Math.max(0, matchStart - contextBefore)
+    end = Math.min(totalChars, matchEnd + contextAfter)
+  }
+  if (matches.some((m) => start < m.end && end > m.start)) return
+  const excerpt = content.slice(start, end)
+  matches.push({
+    start,
+    end,
+    matchStart,
+    matchEnd,
+    excerpt,
+    matchedQuery,
+    matchType,
+    returnedChars: excerpt.length,
+    expandCall: { mode: "window", offset: start, length: end - start },
+  })
+}
+
+function searchContextContent(
+  content: string,
+  totalChars: number,
+  query: string,
+  maxChars: number,
+): { matches: SearchMatchRecord[]; needlesTried: NeedleTried[] } {
+  const matches: SearchMatchRecord[] = []
+  const needlesTried: NeedleTried[] = []
+  const LIMIT = 5
+
+  if (query.length > 0) {
+    const initialLen = matches.length
+    let cursor = 0
+    while (cursor <= content.length && matches.length < LIMIT) {
+      const foundAt = content.indexOf(query, cursor)
+      if (foundAt === -1) break
+      appendMatchAtRange(matches, content, totalChars, foundAt, foundAt + query.length, maxChars, query, "exact")
+      cursor = foundAt + Math.max(1, query.length)
+    }
+    needlesTried.push({ needle: query, matchType: "exact", found: matches.length > initialLen })
+  }
+
+  if (matches.length === 0) {
+    const lowerQuery = query.toLowerCase()
+    if (lowerQuery.length > 0) {
+      const lowerContent = content.toLowerCase()
+      const initialLen = matches.length
+      let cursor = 0
+      while (cursor <= lowerContent.length && matches.length < LIMIT) {
+        const foundAt = lowerContent.indexOf(lowerQuery, cursor)
+        if (foundAt === -1) break
+        appendMatchAtRange(
+          matches,
+          content,
+          totalChars,
+          foundAt,
+          foundAt + lowerQuery.length,
+          maxChars,
+          query,
+          "case_insensitive",
+        )
+        cursor = foundAt + Math.max(1, lowerQuery.length)
+      }
+      needlesTried.push({ needle: query, matchType: "case_insensitive", found: matches.length > initialLen })
+    }
+  }
+
+  if (matches.length === 0) {
+    const normalizedQuery = normalizeSearchQuery(query)
+    if (normalizedQuery.length >= 2) {
+      const { normalized: normalizedContent, origIndex } = buildNormalizedIndex(content)
+      const initialLen = matches.length
+      let cursor = 0
+      while (cursor <= normalizedContent.length && matches.length < LIMIT) {
+        const foundAt = normalizedContent.indexOf(normalizedQuery, cursor)
+        if (foundAt === -1) break
+        const origStart = origIndex[foundAt]
+        const origEnd = origIndex[foundAt + normalizedQuery.length - 1] + 1
+        appendMatchAtRange(matches, content, totalChars, origStart, origEnd, maxChars, query, "normalized")
+        cursor = foundAt + normalizedQuery.length
+      }
+      needlesTried.push({ needle: normalizedQuery, matchType: "normalized", found: matches.length > initialLen })
+    }
+  }
+
+  if (matches.length === 0) {
+    const tokens = collectContextSearchNeedles(query).filter((needle) => needle !== query)
+    const lowerContent = content.toLowerCase()
+    for (const token of tokens) {
+      if (matches.length >= LIMIT) break
+      const lowerToken = token.toLowerCase()
+      if (lowerToken.length === 0) continue
+      const initialLen = matches.length
+      let cursor = 0
+      while (cursor <= lowerContent.length && matches.length < LIMIT) {
+        const foundAt = lowerContent.indexOf(lowerToken, cursor)
+        if (foundAt === -1) break
+        appendMatchAtRange(
+          matches,
+          content,
+          totalChars,
+          foundAt,
+          foundAt + lowerToken.length,
+          maxChars,
+          token,
+          "token",
+        )
+        cursor = foundAt + Math.max(1, lowerToken.length)
+      }
+      needlesTried.push({ needle: token, matchType: "token", found: matches.length > initialLen })
+      if (matches.length > initialLen) break
+    }
+  }
+
+  return { matches, needlesTried }
+}
+
 function collectContextSearchNeedles(query: string): string[] {
   const trimmed = query.trim()
   const seen = new Set<string>()
@@ -716,6 +981,7 @@ export function readMoreContext(
   const modeMaxChars = mode === "search" ? 2500 : 12000
   const maxChars = Math.max(100, Math.min(options.maxChars ?? defaultMaxChars, modeMaxChars))
   const totalChars = entry.totalChars
+  const scope = buildScopeLabel(entry)
 
   if (mode === "overview") {
     return {
@@ -728,17 +994,25 @@ export function readMoreContext(
       messageCount: entry.messageCount,
       totalChars,
       preview: entry.preview,
+      scope,
+      description: describeContextKind(entry.kind, entry.toolName, entry.messageCount),
+      searchScope: "underlying_payload",
+      suggestedCalls: buildSuggestedCalls(totalChars),
     }
   }
 
   if (mode === "head") {
+    const returnedChars = Math.min(maxChars, totalChars)
+    const end = returnedChars
     return {
       success: true,
       contextRef,
       mode,
       totalChars,
-      returnedChars: Math.min(maxChars, totalChars),
+      returnedChars,
       excerpt: entry.content.slice(0, maxChars),
+      scope,
+      ...buildRangeNavigationHints(totalChars, 0, end, maxChars),
     }
   }
 
@@ -752,6 +1026,8 @@ export function readMoreContext(
       start,
       returnedChars: totalChars - start,
       excerpt: entry.content.slice(start),
+      scope,
+      ...buildRangeNavigationHints(totalChars, start, totalChars, maxChars),
     }
   }
 
@@ -769,6 +1045,8 @@ export function readMoreContext(
       end,
       returnedChars: end - start,
       excerpt: entry.content.slice(start, end),
+      scope,
+      ...buildRangeNavigationHints(totalChars, start, end, maxChars),
     }
   }
 
@@ -780,66 +1058,44 @@ export function readMoreContext(
         contextRef,
         mode,
         error: "query is required for search mode",
+        scope,
       }
     }
 
-    const haystack = entry.content.toLowerCase()
-    const matches: Array<{ start: number; end: number; excerpt: string; matchedQuery?: string }> = []
-    const searchNeedles = collectContextSearchNeedles(query)
-    for (const searchNeedle of searchNeedles) {
-      const needle = searchNeedle.toLowerCase()
-      let cursor = 0
-      while (cursor < haystack.length && matches.length < 5) {
-        const foundAt = haystack.indexOf(needle, cursor)
-        if (foundAt === -1) break
-        const desiredBefore = Math.floor(maxChars / 4)
-        const desiredAfter = Math.floor(maxChars / 2)
-        let start = foundAt
-        let end = Math.min(totalChars, foundAt + maxChars)
+    const { matches, needlesTried } = searchContextContent(entry.content, totalChars, query, maxChars)
 
-        if (needle.length < maxChars) {
-          const totalDesiredContext = desiredBefore + desiredAfter
-          const availableContextChars = maxChars - needle.length
-          const contextBefore = Math.min(
-            desiredBefore,
-            Math.floor((availableContextChars * desiredBefore) / Math.max(1, totalDesiredContext)),
-          )
-          const contextAfter = availableContextChars - contextBefore
-
-          start = Math.max(0, foundAt - contextBefore)
-          end = Math.min(totalChars, foundAt + needle.length + contextAfter)
-        }
-
-        const overlapsExisting = matches.some((match) => start < match.end && end > match.start)
-        if (!overlapsExisting) {
-          matches.push({
-            start,
-            end,
-            excerpt: entry.content.slice(start, end),
-            ...(searchNeedle === query ? {} : { matchedQuery: searchNeedle }),
-          })
-        }
-        cursor = foundAt + Math.max(1, needle.length)
-      }
-      if (matches.length > 0) break
-    }
-
-    return {
+    const baseResponse: Record<string, unknown> = {
       success: true,
       contextRef,
       mode,
       query,
       totalChars,
+      searchedChars: totalChars,
+      searchScope: "underlying_payload",
       matchCount: matches.length,
       matches,
+      needlesTried,
+      scope,
     }
+
+    if (matches.length === 0) {
+      const triedDescriptors = needlesTried
+        .map((n) => `${n.matchType}:'${n.needle}'`)
+        .join(", ")
+      baseResponse.suggestion = totalChars === 0
+        ? "The underlying payload is empty; nothing to search."
+        : `No matches found for the query or any of its tokens in the full ${totalChars}-char payload (tried ${triedDescriptors || "none"}). Try a shorter substring, switch to mode='head' or mode='tail' to read the actual content, or use mode='window' with a specific offset.`
+    }
+
+    return baseResponse
   }
 
   return {
     success: false,
     contextRef,
     mode,
-    error: `Unsupported mode: ${mode}`,
+    error: `Unsupported mode: ${mode}. Supported modes: overview, head, tail, window, search.`,
+    scope,
   }
 }
 

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -149,7 +149,7 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
   },
   {
     name: "read_more_context",
-    description: "Read a specific slice of earlier compacted context using a Context ref shown in truncated or summarized messages. Prefer overview/search/window reads over fetching large heads or tails.",
+    description: "Read a specific slice of earlier compacted context using a Context ref shown in truncated or summarized messages. Acts as a scoped document navigator over the full underlying payload (not just the inline excerpt). Start with mode='overview' to see what the ref covers and get suggested next calls. Use mode='search' for case-, punctuation-, and underscore-insensitive lookup; each match is labeled with matchType and includes an expandCall for fetching surrounding text. head/tail/window results include nextWindow/previousWindow hints so you can keep paging without guessing offsets.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary

Closes #473.

`read_more_context` was hard to use because it behaved like a thin substring slicer over hidden context: opaque output, brittle exact-string search, and silent zero-result failures. This change turns it into a small scoped document navigator with self-describing responses — **and reduces how often it needs to be called at all** by making the truncation point itself self-describing.

### In-place elision (reduce the need to call the tool)
Previously a truncated message kept only a head and appended an opaque `Context ref: ctx_...` at the very end. Now truncation happens *in place* with a self-describing marker at the cut point:

```
…HEAD… [Large tool result truncated for context management.] (≈12000 chars elided · contains: 3 URLs, stack trace, JSON keys: status, results, items · Context ref: ctx_ab12cd34) …TAIL…
```

- The marker reports the **approximate size of the gap**, a cheap **content fingerprint** of what was removed (URL count, stack trace, code blocks, JSON keys, or line count), and the **Context ref** to expand it.
- Payload-like messages now also keep a **tail** (previously head-only), so every truncated message shows head + tail + an in-place description of the gap between them.
- The model sees *where* the gap is and *what it holds*, so it can usually answer without a follow-up `read_more_context` call — attacking the root cause (lossy compaction the agent later regrets) rather than only the retrieval ergonomics.
- `overview` gains a matching `contentDigest` field so the navigator and the inline marker agree on what the payload contains.

### `overview`
- `description`: plain-English summary of what the ref covers (truncated tool output, archived history, batch-summary source, etc.), including the originating tool name and message count when available.
- `scope`: structured `{ kind, role, toolName?, messageCount?, totalChars }` label tied to the originating item.
- `searchScope: &#34;underlying_payload&#34;` so it&#39;s obvious search runs over the full original content, not the inline excerpt.
- `suggestedCalls`: ready-to-use follow-up calls (`search`, `head`, `tail`, `window`) sized to the payload.

### `search`
- Tries strategies in order until one finds matches: **exact** → **case_insensitive** → **normalized** (alphanumeric-only, lowercase — so `hidden audit token` finds `HIDDEN_AUDIT_TOKEN` and `foo bar value` finds `foo_bar_value`) → **tokenized** fallback.
- Each match is labeled with `matchType`, `matchedQuery`, `matchStart`/`matchEnd`, `start`/`end`, `returnedChars`, and an `expandCall` (`{ mode: &#34;window&#34;, offset, length }`) for fetching the surrounding window.
- Zero-result searches now return `needlesTried` (with `found: false` per attempt), `searchedChars`, and a human-readable `suggestion` explaining what to try next instead of failing silently.

### Navigation hints
- `head`, `tail`, and `window` responses include `nextWindow` / `previousWindow` calls when applicable, so paging through long payloads no longer requires guessing offsets.

### Backwards compatibility
All new fields are additive — the existing JSON shape (`success`, `contextRef`, `mode`, `totalChars`, `matchCount`, `matches[].excerpt`, etc.) is preserved, so existing callers keep working. The inline marker still contains the verbatim `Context ref: ctx_...` token, so existing ref extraction keeps working.

## Test plan
- [x] `pnpm exec vitest run src/main/context-budget.test.ts` — 34/34 pass (8 new tests covering description/scope/suggestedCalls, normalized + matchType labeling, navigation hints, zero-result suggestion, `expandCall` round-trip, the in-place elision marker, and the overview `contentDigest`).
- [x] `pnpm run typecheck:node` clean.
- [x] Adjacent suites (`system-prompts`, `mcp-service.option-b`, `runtime-tools.execute-command`) still green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9nv3N6WFCPnuq94wgCkvA)_