### PR TITLE
Stop replaying tool messages as user input on Codex provider

### DIFF
--- a/apps/desktop/src/main/chatgpt-web-provider.test.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.test.ts
@@ -94,6 +94,61 @@ describe("chatgpt-web provider image input", () => {
     ])
   })
 
+  it("routes persisted tool messages through the developer role with provenance instead of as user input", async () => {
+    await setupChatGptWebProviderTest()
+    const { buildCodexInput } = await import("./chatgpt-web-provider")
+
+    const input = buildCodexInput([
+      { role: "system", content: "System prompt" },
+      { role: "user", content: "list the files" },
+      { role: "assistant", content: "I'll run a command." },
+      {
+        role: "tool",
+        content: '[execute_command] {"success":true,"stdout":"a.txt\\nb.txt"}',
+      },
+    ])
+
+    expect(input).toEqual([
+      { type: "message", role: "user", content: "list the files" },
+      { type: "message", role: "assistant", content: "I'll run a command." },
+      {
+        type: "message",
+        role: "developer",
+        content:
+          '[Internal tool execution result — not user input. Continue the task using this output.]\n[execute_command] {"success":true,"stdout":"a.txt\\nb.txt"}',
+      },
+    ])
+
+    for (const item of input) {
+      if (item.role === "user") {
+        const content = item.content
+        const text = typeof content === "string"
+          ? content
+          : (content as Array<{ type: string; text?: string }>)
+              .filter((part) => part.type === "input_text")
+              .map((part) => part.text || "")
+              .join("")
+        expect(text).not.toContain("[execute_command]")
+      }
+    }
+  })
+
+  it("preserves the developer-role tool provenance header even when the persisted tool content is empty", async () => {
+    await setupChatGptWebProviderTest()
+    const { buildCodexInput } = await import("./chatgpt-web-provider")
+
+    const input = buildCodexInput([{ role: "tool", content: "   " }])
+
+    expect(input).toEqual([
+      {
+        type: "message",
+        role: "developer",
+        content:
+          "[Internal tool execution result — not user input. Continue the task using this output.]",
+      },
+    ])
+  })
+
   it("leaves oversized conversation image assets as text instead of inlining them", async () => {
     const { tempDir } = await setupChatGptWebProviderTest()
     await fs.writeFile(path.join(tempDir, "large.png"), Buffer.alloc(8 * 1024 * 1024 + 1))

--- a/apps/desktop/src/main/chatgpt-web-provider.ts
+++ b/apps/desktop/src/main/chatgpt-web-provider.ts
@@ -659,10 +659,24 @@ function buildCodexMessageContent(content: string): CodexInputContent {
   return hasResolvedImage && parts.length > 0 ? parts : content
 }
 
+const CODEX_TOOL_RESULT_PROVENANCE_HEADER =
+  "[Internal tool execution result — not user input. Continue the task using this output.]"
+
 export function buildCodexInput(messages: ChatGptWebMessage[]): Array<Record<string, unknown>> {
   return messages
     .filter((message) => message.role !== "system")
     .map((message) => {
+      if (message.role === "tool") {
+        const body = message.content.trim()
+        const text = body
+          ? `${CODEX_TOOL_RESULT_PROVENANCE_HEADER}\n${body}`
+          : CODEX_TOOL_RESULT_PROVENANCE_HEADER
+        return {
+          type: "message",
+          role: "developer",
+          content: text,
+        }
+      }
       const role = message.role === "assistant" ? "assistant" : "user"
       return {
         type: "message",


### PR DESCRIPTION
## Summary

Fixes the narrowed-scope finding from #453: in `chatgpt-web-provider.ts`, `buildCodexInput()` mapped every non-`system` / non-`assistant` message to the `user` role. That meant persisted `role: "tool"` entries — which carry synthetic text such as `[execute_command] {"success":true,...}` — were sent to the ChatGPT Codex Responses API as user-authored text. The model could then narrate that text as if the user had pasted it.

## Change

- Route `role: "tool"` messages through the Codex `developer` role with an explicit `[Internal tool execution result — not user input. Continue the task using this output.]` header, so the model treats them as internal tool output instead of user input.
- Handle the empty-tool-content edge case so an empty tool message still surfaces only the provenance header (not an empty `user` message).
- Other roles (`assistant`, `user`, unknown) are unchanged.

This satisfies the issue's acceptance criterion that tool outputs be replayed with "explicit internal provenance, never as user-authored content." Because the persisted `ChatGptWebMessage` shape carries no `call_id`, switching to native Codex `function_call_output` items would require a larger upstream refactor; this PR is the minimal fix for the user-visible leak.

## Test plan

- [x] Added `buildCodexInput` test verifying a `role: "tool"` message is emitted as a `developer`-role item with the provenance header, and that no `user` item in the input contains the `[execute_command]` payload.
- [x] Added test for the empty-tool-content edge case.
- [x] `pnpm vitest run src/main/chatgpt-web-provider.test.ts` — 14/14 passing.
- [x] `pnpm vitest run src/main/llm-fetch.test.ts` — 45/45 passing (no regression in the Codex call path).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GQm6KR2GS3XX9JUSvj7KTm)_