### PR TITLE
Make emergency stop durably cancel continuous tasks

### DIFF
--- a/apps/desktop/src/main/emergency-stop.test.ts
+++ b/apps/desktop/src/main/emergency-stop.test.ts
@@ -19,6 +19,7 @@ describe("emergencyStopAll", () => {
     const stopAllAgents = vi.fn(async () => {})
     const shutdown = vi.fn(async () => {})
     const clearSessionUserResponse = vi.fn()
+    const emergencyStopContinuousLoops = vi.fn(() => [])
 
     vi.doMock("./state", () => ({
       agentProcessManager: { emergencyStop, getActiveProcessCount },
@@ -33,6 +34,7 @@ describe("emergencyStopAll", () => {
     vi.doMock("./acp", () => ({ acpProcessManager: { stopAllAgents }, acpClientService: { cancelAllRuns } }))
     vi.doMock("./acp-service", () => ({ acpService: { shutdown } }))
     vi.doMock("./session-user-response-store", () => ({ clearSessionUserResponse }))
+    vi.doMock("./loop-service", () => ({ loopService: { emergencyStopContinuousLoops } }))
 
     const { emergencyStopAll } = await import("./emergency-stop")
 
@@ -42,5 +44,65 @@ describe("emergencyStopAll", () => {
     expect(emitAgentProgress).toHaveBeenCalledOnce()
     expect(cleanupSession).toHaveBeenCalledWith("session-1")
     expect(clearSessionUserResponse).not.toHaveBeenCalled()
+    expect(emergencyStopContinuousLoops).toHaveBeenCalledOnce()
+  })
+
+  it("durably stops continuously-running loops so they cannot auto-resume", async () => {
+    const stopAllSessions = vi.fn()
+    const cleanupSession = vi.fn()
+    const emergencyStop = vi.fn()
+    const getActiveProcessCount = vi.fn(() => 0)
+    const abortAll = vi.fn()
+    const emitAgentProgress = vi.fn(async () => {})
+    const getActiveSessions = vi.fn(() => [])
+    const shutdown = vi.fn(async () => {})
+    const emergencyStopContinuousLoops = vi.fn(() => ["loop-1", "loop-2"])
+
+    vi.doMock("./state", () => ({
+      agentProcessManager: { emergencyStop, getActiveProcessCount },
+      llmRequestAbortManager: { abortAll },
+      state: { agentSessions: new Map(), isAgentModeActive: true, agentIterationCount: 1 },
+      agentSessionStateManager: { stopAllSessions, cleanupSession },
+      toolApprovalManager: { cancelSessionApprovals: vi.fn() },
+    }))
+    vi.doMock("./emit-agent-progress", () => ({ emitAgentProgress }))
+    vi.doMock("./agent-session-tracker", () => ({ agentSessionTracker: { getActiveSessions } }))
+    vi.doMock("./message-queue-service", () => ({ messageQueueService: { pauseQueue: vi.fn() } }))
+    vi.doMock("./acp-service", () => ({ acpService: { shutdown } }))
+    vi.doMock("./loop-service", () => ({ loopService: { emergencyStopContinuousLoops } }))
+
+    const { emergencyStopAll } = await import("./emergency-stop")
+    await emergencyStopAll()
+
+    expect(emergencyStopContinuousLoops).toHaveBeenCalledOnce()
+  })
+
+  it("does not bubble loop-service failures out of emergency stop", async () => {
+    const emergencyStopContinuousLoops = vi.fn(() => {
+      throw new Error("disk full")
+    })
+    const emergencyStop = vi.fn()
+    const getActiveProcessCount = vi.fn(() => 0)
+
+    vi.doMock("./state", () => ({
+      agentProcessManager: { emergencyStop, getActiveProcessCount },
+      llmRequestAbortManager: { abortAll: vi.fn() },
+      state: { agentSessions: new Map(), isAgentModeActive: true, agentIterationCount: 0 },
+      agentSessionStateManager: { stopAllSessions: vi.fn(), cleanupSession: vi.fn() },
+      toolApprovalManager: { cancelSessionApprovals: vi.fn() },
+    }))
+    vi.doMock("./emit-agent-progress", () => ({ emitAgentProgress: vi.fn(async () => {}) }))
+    vi.doMock("./agent-session-tracker", () => ({ agentSessionTracker: { getActiveSessions: vi.fn(() => []) } }))
+    vi.doMock("./message-queue-service", () => ({ messageQueueService: { pauseQueue: vi.fn() } }))
+    vi.doMock("./acp-service", () => ({ acpService: { shutdown: vi.fn(async () => {}) } }))
+    vi.doMock("./loop-service", () => ({ loopService: { emergencyStopContinuousLoops } }))
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    const { emergencyStopAll } = await import("./emergency-stop")
+    await expect(emergencyStopAll()).resolves.toEqual({ before: 0, after: 0 })
+    expect(emergencyStopContinuousLoops).toHaveBeenCalledOnce()
+
+    errorSpy.mockRestore()
   })
 })

--- a/apps/desktop/src/main/emergency-stop.ts
+++ b/apps/desktop/src/main/emergency-stop.ts
@@ -3,6 +3,7 @@ import { emitAgentProgress } from "./emit-agent-progress"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { messageQueueService } from "./message-queue-service"
 import { acpService } from "./acp-service"
+import { loopService } from "./loop-service"
 
 /**
  * Centralized emergency stop: abort LLM requests, kill tracked child processes,
@@ -16,6 +17,16 @@ import { acpService } from "./acp-service"
 export async function emergencyStopAll(): Promise<{ before: number; after: number }> {
   // Signal all sessions to stop ASAP (both new session-based and legacy global)
   agentSessionStateManager.stopAllSessions()
+
+  // Durably stop continuously-running tasks so they don't auto-resume after the
+  // current iteration's session is aborted. Without this the loop scheduler
+  // would re-fire `executeLoop` with a 0ms delay and the "stopped" task would
+  // immediately pick back up.
+  try {
+    loopService.emergencyStopContinuousLoops()
+  } catch (error) {
+    console.error("[EmergencyStop] Error stopping continuous loops:", error)
+  }
 
   // Mark all active agent sessions as stopped in the tracker and emit progress updates
   try {

--- a/apps/desktop/src/main/loop-service.continuous.test.ts
+++ b/apps/desktop/src/main/loop-service.continuous.test.ts
@@ -34,12 +34,29 @@ describe("continuous repeat tasks", () => {
     const section = getSection(
       loopServiceSource,
       "  emergencyStopContinuousLoops(): string[] {",
-      "  private async executeLoop(",
+      "  startLoop(loopId: string): boolean {",
     )
 
     expect(section).toContain("isContinuousLoop(loop)")
     expect(section).toContain("enabled: false")
-    expect(section).toContain("this.saveLoop(updated)")
     expect(section).toContain("this.stopLoop(loop.id)")
+  })
+
+  it("mutates in-memory loop state before attempting persistence", () => {
+    // Critical for the persistence-failure path: if we persisted first and
+    // failed, the in-memory loop would still be `enabled: true` and the
+    // in-flight executeLoop()'s finally would reschedule. See PR #492 review.
+    const section = getSection(
+      loopServiceSource,
+      "  emergencyStopContinuousLoops(): string[] {",
+      "  startLoop(loopId: string): boolean {",
+    )
+
+    const inMemoryAssignIdx = section.indexOf("this.loops[i] = updated")
+    const persistCallIdx = section.indexOf("this.saveTask(updated)")
+
+    expect(inMemoryAssignIdx).toBeGreaterThanOrEqual(0)
+    expect(persistCallIdx).toBeGreaterThanOrEqual(0)
+    expect(inMemoryAssignIdx).toBeLessThan(persistCallIdx)
   })
 })

--- a/apps/desktop/src/main/loop-service.continuous.test.ts
+++ b/apps/desktop/src/main/loop-service.continuous.test.ts
@@ -27,4 +27,19 @@ describe("continuous repeat tasks", () => {
     expect(getNextDelaySection).toContain("if (isContinuousLoop(loop))")
     expect(getNextDelaySection).toContain("return 0")
   })
+
+  it("durably disables continuous loops on emergency stop", () => {
+    // Emergency stop must persist the cancel signal so the loop does not pick
+    // back up after the in-flight session aborts — see issue #379.
+    const section = getSection(
+      loopServiceSource,
+      "  emergencyStopContinuousLoops(): string[] {",
+      "  private async executeLoop(",
+    )
+
+    expect(section).toContain("isContinuousLoop(loop)")
+    expect(section).toContain("enabled: false")
+    expect(section).toContain("this.saveLoop(updated)")
+    expect(section).toContain("this.stopLoop(loop.id)")
+  })
 })

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -228,9 +228,17 @@ class LoopService {
    * Durably stop any continuously-running tasks so they do not auto-resume.
    *
    * Emergency stop is treated as an explicit cancel signal: each affected
-   * continuous loop is disabled (`enabled = false`) and persisted, its active
-   * timer is cleared, and the renderer is notified so the UI reflects the new
-   * state. The user must re-enable the task to start it again.
+   * continuous loop is disabled (`enabled = false`) in memory AND persisted,
+   * its active timer is cleared, and the renderer is notified so the UI
+   * reflects the new state. The user must re-enable the task to start it
+   * again.
+   *
+   * Persistence-failure safety: the in-memory `this.loops` entry is mutated
+   * BEFORE we attempt to persist, so an in-flight `executeLoop()` cannot
+   * pass the `latestLoop?.enabled` check in its `finally` block and
+   * reschedule, even if the on-disk write fails. Without this ordering, a
+   * failed `saveLoop()` would leave the in-memory record enabled and the
+   * continuous task would auto-resume — exactly the bug we're fixing.
    *
    * Non-continuous (interval / scheduled) tasks are intentionally left alone —
    * their next run is governed by a wall-clock schedule, not by the
@@ -241,18 +249,33 @@ class LoopService {
   emergencyStopContinuousLoops(): string[] {
     const disabled: string[] = []
 
-    for (const loop of this.loops) {
+    for (let i = 0; i < this.loops.length; i++) {
+      const loop = this.loops[i]
       if (!isContinuousLoop(loop)) continue
       if (!loop.enabled) continue
 
       const updated: LoopConfig = { ...loop, enabled: false }
-      if (this.saveLoop(updated)) {
-        this.stopLoop(loop.id)
-        disabled.push(loop.id)
-        logApp(`[LoopService] Emergency stop disabled continuous loop "${loop.name}" (${loop.id})`)
+
+      // Mutate in-memory state FIRST. This is the critical guard against
+      // auto-resume: `executeLoop()`'s finally re-reads via `getLoop()`,
+      // so even if the persistence call below fails, the reschedule check
+      // will see `enabled: false` and skip rescheduling.
+      this.loops[i] = updated
+
+      // Clear any pending timer for this loop.
+      this.stopLoop(loop.id)
+      disabled.push(loop.id)
+
+      // Best-effort persistence. `saveTask` already swallows write errors
+      // and returns false; we log loudly so the failure is investigable
+      // but do not unwind the in-memory cancel.
+      const persisted = this.saveTask(updated)
+      if (!persisted) {
+        logApp(
+          `[LoopService] Emergency stop: failed to persist disabled state for "${loop.name}" (${loop.id}); in-memory cancel still blocks auto-resume`,
+        )
       } else {
-        logApp(`[LoopService] Emergency stop: failed to persist disabled state for "${loop.name}" (${loop.id}); stopping timer anyway`)
-        this.stopLoop(loop.id)
+        logApp(`[LoopService] Emergency stop disabled continuous loop "${loop.name}" (${loop.id})`)
       }
     }
 

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -224,6 +224,45 @@ class LoopService {
     this.isStopping = false
   }
 
+  /**
+   * Durably stop any continuously-running tasks so they do not auto-resume.
+   *
+   * Emergency stop is treated as an explicit cancel signal: each affected
+   * continuous loop is disabled (`enabled = false`) and persisted, its active
+   * timer is cleared, and the renderer is notified so the UI reflects the new
+   * state. The user must re-enable the task to start it again.
+   *
+   * Non-continuous (interval / scheduled) tasks are intentionally left alone —
+   * their next run is governed by a wall-clock schedule, not by the
+   * just-interrupted execution.
+   *
+   * Returns the IDs of the loops that were disabled.
+   */
+  emergencyStopContinuousLoops(): string[] {
+    const disabled: string[] = []
+
+    for (const loop of this.loops) {
+      if (!isContinuousLoop(loop)) continue
+      if (!loop.enabled) continue
+
+      const updated: LoopConfig = { ...loop, enabled: false }
+      if (this.saveLoop(updated)) {
+        this.stopLoop(loop.id)
+        disabled.push(loop.id)
+        logApp(`[LoopService] Emergency stop disabled continuous loop "${loop.name}" (${loop.id})`)
+      } else {
+        logApp(`[LoopService] Emergency stop: failed to persist disabled state for "${loop.name}" (${loop.id}); stopping timer anyway`)
+        this.stopLoop(loop.id)
+      }
+    }
+
+    if (disabled.length > 0) {
+      notifyLoopsFolderChanged()
+    }
+
+    return disabled
+  }
+
   startLoop(loopId: string): boolean {
     const loop = this.getLoop(loopId)
     if (!loop) {


### PR DESCRIPTION
## Summary

Fixes #379 — emergency stop now durably cancels continuously-running repeat tasks instead of letting them auto-resume.

### Why it was broken

`LoopService.executeLoop()` reschedules a continuous task with a 0ms delay inside its `finally` block as long as the loop is `enabled` and `isStopping` is false. `emergencyStopAll()` aborted the in-flight session but never touched the scheduler, so the loop's `finally` would immediately fire `scheduleNextRun(loopId, 0)` and the "stopped" task picked right back up.

### The fix

- Added `LoopService.emergencyStopContinuousLoops()` that finds every continuous + enabled loop, persists `enabled = false` via `saveLoop`, clears its timer, and notifies the renderer via `loopsFolderChanged`. The reschedule guard in `executeLoop`'s `finally` already checks `latestLoop?.enabled`, so re-reading the persisted state is enough to suppress the requeue.
- `emergencyStopAll()` now calls `loopService.emergencyStopContinuousLoops()` right after `stopAllSessions()`. The call is wrapped in try/catch so a persistence failure can't break the rest of the kill-switch flow.
- Interval and wall-clock-scheduled tasks are intentionally left alone — their next run is governed by a schedule, not the just-interrupted execution, so emergency stop shouldn't disable them.
- The user has to explicitly re-enable a continuous task to start it again, matching the issue's expected behavior.

### Tests

- `emergency-stop.test.ts` — added two cases: emergency stop calls `emergencyStopContinuousLoops`, and a loop-service throw is swallowed without breaking the kill switch. Updated the existing test's mocks.
- `loop-service.continuous.test.ts` — added a source-level check that the new method disables continuous loops and stops their timers.

All 11 loop-service tests and all 3 emergency-stop tests pass locally; `pnpm typecheck:node` is clean.

## Test plan

- [ ] Create a continuous repeat task, start it, then hit the emergency stop hotkey — task should stop and stay stopped, and the UI should show it as disabled.
- [ ] Restart the app; the previously-stopped continuous task should remain disabled until re-enabled.
- [ ] Confirm interval / wall-clock scheduled tasks are unaffected by emergency stop and still fire on their next scheduled time.
- [ ] Confirm non-loop emergency-stop side effects (session abort, child process kill, message queue pause) still work.

Closes #379

---
_Generated by [Claude Code](https://claude.ai/code/session_01JffTKx8HRKeEj3JVfJkpnY)_