### PR TITLE
Pin large session view to latest message on open

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.scroll-behavior.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.scroll-behavior.test.ts
@@ -27,6 +27,18 @@ describe("agent progress scroll behavior", () => {
     expect(agentProgressSource).toContain("}, [clearPendingInitialScrollAttempts, scrollToBottom, shouldAutoScrollContent, visibleDisplayItems.length > 0, progress?.sessionId])")
   })
 
+  it("removes each fired initial-scroll timeout from the pending list so user scrolls can still disable auto-scroll", () => {
+    // Regression for #408 review: relying solely on the effect cleanup to clear
+    // pendingInitialScrollTimeoutsRef would leave stale ids in the list after
+    // the timeouts fire, preventing handleScroll from ever disabling auto-scroll.
+    expect(agentProgressSource).toContain(
+      "pendingInitialScrollTimeoutsRef.current =\n          pendingInitialScrollTimeoutsRef.current.filter((id) => id !== timeoutId)",
+    )
+    expect(agentProgressSource).toContain(
+      "pendingInitialScrollTimeoutsRef.current.length === 0",
+    )
+  })
+
   it("pins ACP sub-agent conversation updates without smooth-scroll lag while messages stream in", () => {
     expect(agentProgressSource).toContain("Keep ACP sub-agent conversation updates pinned in the same paint")
     expect(agentProgressSource).toContain("if (behavior === \"auto\") {\n      node.scrollTop = node.scrollHeight\n      return\n    }")

--- a/apps/desktop/src/renderer/src/components/agent-progress.scroll-behavior.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.scroll-behavior.test.ts
@@ -24,7 +24,7 @@ describe("agent progress scroll behavior", () => {
     expect(agentProgressSource).toContain("return clearPendingInitialScrollAttempts")
     expect(agentProgressSource).toContain("}, [clearPendingInitialScrollAttempts, progress?.sessionId])")
     expect(agentProgressSource).toContain("}, [shouldAutoScrollContent, visibleDisplayItems.length > 0])")
-    expect(agentProgressSource).toContain("}, [clearPendingInitialScrollAttempts, scrollToBottom, shouldAutoScrollContent, visibleDisplayItems.length > 0])")
+    expect(agentProgressSource).toContain("}, [clearPendingInitialScrollAttempts, scrollToBottom, shouldAutoScrollContent, visibleDisplayItems.length > 0, progress?.sessionId])")
   })
 
   it("pins ACP sub-agent conversation updates without smooth-scroll lag while messages stream in", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -4692,8 +4692,12 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       lastContentLengthRef.current = 0
       lastDisplayItemsCountRef.current = 0
       lastScrollContentHeightRef.current = 0
-      // Also reset auto-scroll state for new sessions
+      // Also reset auto-scroll state for new sessions. Update the ref
+      // synchronously too so the ResizeObserver doesn't race the state-sync
+      // effect on the first content commit of the new session (issue #408).
+      shouldAutoScrollRef.current = true
       setShouldAutoScroll(true)
+      setIsUserScrolling(false)
     }
   }, [clearPendingInitialScrollAttempts, progress?.sessionId])
 
@@ -4772,15 +4776,20 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     return () => observer.disconnect()
   }, [shouldAutoScrollContent, visibleDisplayItems.length > 0])
 
-  // Initial scroll to bottom on mount and when first display item appears
+  // Initial scroll to bottom on mount, when first display item appears, and
+  // whenever the session changes. Large sessions render across many frames as
+  // markdown highlights and images settle, so a small number of early attempts
+  // can land in the middle. Schedule attempts that span a wider window
+  // (issue #408). The ResizeObserver above also continues to re-pin while
+  // shouldAutoScroll is true, so the last attempt only needs to outlast the
+  // initial layout settle.
   useEffect(() => {
     if (!shouldAutoScrollContent) return undefined
     if (!scrollContainerRef.current) return undefined
 
     clearPendingInitialScrollAttempts()
 
-    // Multiple attempts to ensure scrolling works with dynamic content
-    const scrollAttempts = [0, 50, 100, 200]
+    const scrollAttempts = [0, 50, 100, 200, 400, 800, 1500]
     pendingInitialScrollTimeoutsRef.current = scrollAttempts.map((delay) => {
       return setTimeout(() => {
         requestAnimationFrame(() => {
@@ -4791,7 +4800,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     })
 
     return clearPendingInitialScrollAttempts
-  }, [clearPendingInitialScrollAttempts, scrollToBottom, shouldAutoScrollContent, visibleDisplayItems.length > 0])
+  }, [clearPendingInitialScrollAttempts, scrollToBottom, shouldAutoScrollContent, visibleDisplayItems.length > 0, progress?.sessionId])
 
   // Make panel focusable when agent completes (overlay variant only)
   // This enables the continue conversation input to receive focus and be interactable
@@ -4815,9 +4824,16 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       setShouldAutoScroll(true)
       setIsUserScrolling(false)
     }
-    // If user scrolled up from bottom, stop auto-scroll
-    else if (!isAtBottom && shouldAutoScroll) {
-      clearPendingInitialScrollAttempts()
+    // If user scrolled up from bottom, stop auto-scroll. Ignore scroll events
+    // that fire while we still have pending initial scroll attempts: for large
+    // sessions, content can grow between a programmatic scrollTop assignment
+    // and the event being processed, leaving isAtBottom=false even though the
+    // user hasn't touched anything (issue #408).
+    else if (
+      !isAtBottom &&
+      shouldAutoScroll &&
+      pendingInitialScrollTimeoutsRef.current.length === 0
+    ) {
       setShouldAutoScroll(false)
       setIsUserScrolling(true)
     }

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -4790,14 +4790,23 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     clearPendingInitialScrollAttempts()
 
     const scrollAttempts = [0, 50, 100, 200, 400, 800, 1500]
-    pendingInitialScrollTimeoutsRef.current = scrollAttempts.map((delay) => {
-      return setTimeout(() => {
+    const scheduled = scrollAttempts.map((delay) => {
+      let timeoutId: ReturnType<typeof setTimeout>
+      timeoutId = setTimeout(() => {
+        // Remove this attempt's id so the pending list accurately reflects
+        // still-pending attempts. Without this, fired-but-not-cleared ids
+        // would keep handleScroll from ever disabling auto-scroll on real
+        // user scrolls (issue #408).
+        pendingInitialScrollTimeoutsRef.current =
+          pendingInitialScrollTimeoutsRef.current.filter((id) => id !== timeoutId)
         requestAnimationFrame(() => {
           if (!shouldAutoScrollRef.current) return
           scrollToBottom("auto")
         })
       }, delay)
+      return timeoutId
     })
+    pendingInitialScrollTimeoutsRef.current = scheduled
 
     return clearPendingInitialScrollAttempts
   }, [clearPendingInitialScrollAttempts, scrollToBottom, shouldAutoScrollContent, visibleDisplayItems.length > 0, progress?.sessionId])

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -1741,6 +1741,38 @@ export default function ChatScreen({ route, navigation }: any) {
   const isUserDraggingRef = useRef(false);
   // Track drag end timeout to prevent flaky behavior with rapid re-drags
   const dragEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // While true, the next content size change should snap to the bottom. Used to
+  // keep large sessions pinned to the latest message as messages render in
+  // multiple frames (issue #408).
+  const initialScrollPendingRef = useRef(false);
+  const initialScrollWindowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearInitialScrollWindow = useCallback(() => {
+    if (initialScrollWindowTimeoutRef.current) {
+      clearTimeout(initialScrollWindowTimeoutRef.current);
+      initialScrollWindowTimeoutRef.current = null;
+    }
+    initialScrollPendingRef.current = false;
+  }, []);
+
+  const beginInitialScrollWindow = useCallback(() => {
+    if (initialScrollWindowTimeoutRef.current) {
+      clearTimeout(initialScrollWindowTimeoutRef.current);
+    }
+    initialScrollPendingRef.current = true;
+    // Safety net: stop pinning to bottom after 2.5s so streaming-only updates
+    // can't get stuck snapping when the user wants to read history.
+    initialScrollWindowTimeoutRef.current = setTimeout(() => {
+      initialScrollPendingRef.current = false;
+      initialScrollWindowTimeoutRef.current = null;
+    }, 2500);
+  }, []);
+
+  const handleContentSizeChange = useCallback(() => {
+    if (initialScrollPendingRef.current && scrollViewRef.current) {
+      scrollViewRef.current.scrollToEnd({ animated: false });
+    }
+  }, []);
 
   // Cleanup: stop speech on unmount (#1078)
   useEffect(() => {
@@ -1768,7 +1800,9 @@ export default function ChatScreen({ route, navigation }: any) {
       dragEndTimeoutRef.current = null;
     }
     isUserDraggingRef.current = true;
-  }, []);
+    // User is taking control - stop snapping to bottom on content size changes.
+    clearInitialScrollWindow();
+  }, [clearInitialScrollWindow]);
 
   // Handle user ending drag - keep flag active briefly for momentum scroll
   const handleScrollEndDrag = useCallback(() => {
@@ -1814,6 +1848,22 @@ export default function ChatScreen({ route, navigation }: any) {
     });
   }, [messages.length]);
 
+  // When messages first arrive for a session (e.g. lazy-load from server
+  // completes after the session-change window expired), re-enter the initial
+  // scroll window so we still land at the latest message (issue #408).
+  const previousMessagesLengthRef = useRef(0);
+  useEffect(() => {
+    if (
+      messages.length > 0 &&
+      previousMessagesLengthRef.current === 0 &&
+      !isUserDraggingRef.current
+    ) {
+      beginInitialScrollWindow();
+      scrollViewRef.current?.scrollToEnd({ animated: false });
+    }
+    previousMessagesLengthRef.current = messages.length;
+  }, [messages.length, beginInitialScrollWindow]);
+
   // Scroll to bottom when messages change and auto-scroll is enabled
   // Uses debouncing to handle rapid streaming updates efficiently
   useEffect(() => {
@@ -1841,6 +1891,9 @@ export default function ChatScreen({ route, navigation }: any) {
       }
       if (dragEndTimeoutRef.current) {
         clearTimeout(dragEndTimeoutRef.current);
+      }
+      if (initialScrollWindowTimeoutRef.current) {
+        clearTimeout(initialScrollWindowTimeoutRef.current);
       }
     };
   }, []);
@@ -1986,15 +2039,20 @@ export default function ChatScreen({ route, navigation }: any) {
     ]);
   }, [handleDeletePromptConfirmed, isSavingPrompt, settingsClient]);
 
-  // Reset auto-scroll when session changes
+  // Reset auto-scroll when session changes. For large sessions the content
+  // height grows across multiple frames as messages render, so a single
+  // delayed scrollToEnd lands in the middle. Instead, enter an "initial scroll"
+  // window where onContentSizeChange keeps pinning to the bottom until the
+  // user drags or the window expires (issue #408).
   useEffect(() => {
     setShouldAutoScroll(true);
-    // Scroll to bottom when switching sessions
-    const timeoutId = setTimeout(() => {
-      scrollViewRef.current?.scrollToEnd({ animated: false });
-    }, 100);
-    return () => clearTimeout(timeoutId);
-  }, [sessionStore.currentSessionId]);
+    previousMessagesLengthRef.current = 0;
+    beginInitialScrollWindow();
+    scrollViewRef.current?.scrollToEnd({ animated: false });
+    return () => {
+      clearInitialScrollWindow();
+    };
+  }, [sessionStore.currentSessionId, beginInitialScrollWindow, clearInitialScrollWindow]);
 
   const lastLoadedSessionIdRef = useRef<string | null>(null);
   const pendingLazyLoadSessionIdRef = useRef<string | null>(null);
@@ -3629,6 +3687,7 @@ export default function ChatScreen({ route, navigation }: any) {
           onScroll={handleScroll}
           onScrollBeginDrag={handleScrollBeginDrag}
           onScrollEndDrag={handleScrollEndDrag}
+          onContentSizeChange={handleContentSizeChange}
           scrollEventThrottle={16}
         >
           {sessionStore.isLoadingMessages && messages.length === 0 && (


### PR DESCRIPTION
## Summary
Fixes #408. Opening a large session was landing in the middle of the conversation instead of at the latest message on both desktop and mobile. Content height grows across multiple frames as messages, markdown, and images render, so the existing scroll-to-bottom timers fired too early on big sessions.

### Desktop (`apps/desktop/src/renderer/src/components/agent-progress.tsx`)
- Re-run the initial scroll effect on session change (deps now include `progress?.sessionId`) and extend retries to 1.5s so they outlast the initial layout settle on large sessions.
- While initial scroll attempts are pending, ignore stale scroll events that would otherwise disable auto-scroll when content grew between a programmatic `scrollTop` assignment and the event being delivered.
- Sync `shouldAutoScrollRef` immediately on session change so the `ResizeObserver` re-pins on the first content commit (no race with the state-sync effect).

### Mobile (`apps/mobile/src/screens/ChatScreen.tsx`)
- Replace the fixed 100ms session-change scroll with an `onContentSizeChange`-driven "initial scroll" window that keeps pinning to the bottom as messages render, until the user drags or the 2.5s window expires.
- Re-enter the initial scroll window when messages first arrive asynchronously (lazy-loaded sessions from server).

## Test plan
- [x] `pnpm --filter @dotagents/desktop run typecheck:web`
- [x] `pnpm --filter @dotagents/mobile exec tsc --noEmit`
- [x] `pnpm --filter @dotagents/mobile run test` (97 tests pass)
- [x] `npx vitest run src/renderer/src/components/agent-progress` (61 tests pass; updated existing scroll-behavior dep assertion)
- [ ] Manual: open a session with hundreds of messages on desktop → lands at latest message
- [ ] Manual: switch between two large sessions on desktop → each lands at latest message
- [ ] Manual: open a large session on mobile (local) → lands at latest message
- [ ] Manual: open a large session on mobile that lazy-loads from server → lands at latest message after fetch completes
- [ ] Manual: scroll up during initial render → does not snap back, user-scroll intent respected after the 1.5/2.5s window

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXPUaPD1wPtJ2uarnGnvPN)_