### PR TITLE
Add pull-to-refresh to mobile sessions list

### DIFF
--- a/apps/mobile/src/screens/SessionListScreen.tsx
+++ b/apps/mobile/src/screens/SessionListScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, useCallback } from 'react';
-import { View, Text, FlatList, TouchableOpacity, Pressable, StyleSheet, Alert, Platform, Image, GestureResponderEvent, TextInput, useWindowDimensions, Modal } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, Pressable, StyleSheet, Alert, Platform, Image, GestureResponderEvent, TextInput, useWindowDimensions, Modal, RefreshControl } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { EventEmitter } from 'expo-modules-core';
 import { Ionicons } from '@expo/vector-icons';
@@ -688,6 +688,19 @@ export default function SessionListScreen({ navigation }: Props) {
     return undefined;
   }, [config.baseUrl, config.apiKey]);
 
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  const handleRefreshSessions = useCallback(async () => {
+    if (!settingsClient) return;
+    setIsManualRefreshing(true);
+    try {
+      await sessionStore.syncWithServer(settingsClient);
+    } catch (error) {
+      console.warn('Pull-to-refresh sessions sync failed', error);
+    } finally {
+      setIsManualRefreshing(false);
+    }
+  }, [settingsClient, sessionStore]);
+
   const handleDeleteSession = useCallback((session: SessionListItem) => {
     const doDelete = async () => {
       const serverConversationId = sessionStore.sessions.find(item => item.id === session.id)?.serverConversationId;
@@ -1116,6 +1129,14 @@ export default function SessionListScreen({ navigation }: Props) {
         contentContainerStyle={filteredSessions.length === 0 ? styles.emptyList : styles.list}
         ListEmptyComponent={hasActiveSearch ? SearchEmptyState : EmptyState}
         keyboardShouldPersistTaps="handled"
+        refreshControl={settingsClient ? (
+          <RefreshControl
+            refreshing={isManualRefreshing || sessionStore.isSyncing}
+            onRefresh={handleRefreshSessions}
+            tintColor={theme.colors.primary}
+            colors={[theme.colors.primary]}
+          />
+        ) : undefined}
       />
 
       {/* Rapid Fire hold-to-speak button */}


### PR DESCRIPTION
## Summary
- Add a `RefreshControl` to the mobile `SessionListScreen` FlatList, wired to the existing `sessionStore.syncWithServer` path so a pull-down gesture fetches the latest sessions.
- Reflect both the manual refresh and any in-flight background sync via `isSyncing`, so the spinner stays visible while work is happening.
- Refresh control is only attached when a `settingsClient` is configured (baseUrl + apiKey), matching how the rest of the screen guards server calls.

## Test plan
- [ ] On a phone with a configured connection, open the sessions list and pull down — verify the native refresh spinner appears, sessions update, and the spinner disappears when the sync completes.
- [ ] Pull-to-refresh works when the list is empty, when filtered by search, and in the archived tab.
- [ ] With no connection configured, the gesture is a no-op (no crash, no spinner).
- [ ] If a background sync is already running, the spinner stays visible until it completes.

Closes #501.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJARqPavKaijMYc1rZGrFu)_