### PR TITLE
Persist sidebar session groups to dataFolder with backups

### DIFF
--- a/apps/desktop/src/main/sidebar-state.ts
+++ b/apps/desktop/src/main/sidebar-state.ts
@@ -1,0 +1,89 @@
+import path from "path"
+import { dataFolder } from "./config"
+import { logApp } from "./debug"
+import { safeReadJsonFileSync, safeWriteJsonFileSync } from "./agents-files/safe-file"
+
+const SIDEBAR_STATE_PATH = path.join(dataFolder, "sidebar-state.json")
+const SIDEBAR_STATE_BACKUP_DIR = path.join(dataFolder, ".backups")
+const SIDEBAR_STATE_MAX_BACKUPS = 10
+
+export type SidebarStatePayload = {
+  groups: unknown[]
+  ungroupedOrder: string[]
+}
+
+type PersistedSidebarState = {
+  version: 1
+} & SidebarStatePayload
+
+const EMPTY_STATE: SidebarStatePayload = { groups: [], ungroupedOrder: [] }
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+function normalize(value: Partial<PersistedSidebarState> | undefined): SidebarStatePayload {
+  if (!value || typeof value !== "object") return { ...EMPTY_STATE }
+  const groups = Array.isArray(value.groups) ? value.groups : []
+  const ungroupedOrder = isStringArray(value.ungroupedOrder) ? value.ungroupedOrder : []
+  return { groups, ungroupedOrder }
+}
+
+export function loadSidebarState(): SidebarStatePayload {
+  try {
+    const persisted = safeReadJsonFileSync<Partial<PersistedSidebarState>>(SIDEBAR_STATE_PATH, {
+      backupDir: SIDEBAR_STATE_BACKUP_DIR,
+      defaultValue: {},
+    })
+    return normalize(persisted)
+  } catch (error) {
+    logApp("[sidebar-state] Failed to load persisted state:", error)
+    return { ...EMPTY_STATE }
+  }
+}
+
+function isEmptyPayload(payload: SidebarStatePayload): boolean {
+  return payload.groups.length === 0 && payload.ungroupedOrder.length === 0
+}
+
+/**
+ * Persist sidebar state.
+ *
+ * Safety net against renderer-side hydration races: refuse to overwrite a
+ * non-empty on-disk state with a completely empty payload unless the caller
+ * explicitly opts in via `force: true`. This is what protects against the
+ * class of bugs where a half-hydrated renderer echos `{ groups: [],
+ * ungroupedOrder: [] }` back to disk and silently wipes the user's groups.
+ *
+ * A genuine "user emptied everything" write still works because the renderer
+ * passes `force: true` once it knows the user actually intended an empty
+ * state (see active-agents-sidebar.tsx).
+ */
+export function saveSidebarState(
+  state: SidebarStatePayload,
+  options: { force?: boolean } = {},
+): { written: boolean; reason?: string } {
+  const next = normalize(state)
+  if (isEmptyPayload(next) && !options.force) {
+    const current = loadSidebarState()
+    if (!isEmptyPayload(current)) {
+      logApp(
+        "[sidebar-state] Refusing to overwrite non-empty state with empty payload (no force flag). " +
+          `Current groups=${current.groups.length}, ungroupedOrder=${current.ungroupedOrder.length}.`,
+      )
+      return { written: false, reason: "empty-payload-guard" }
+    }
+  }
+  const payload: PersistedSidebarState = { version: 1, ...next }
+  try {
+    safeWriteJsonFileSync(SIDEBAR_STATE_PATH, payload, {
+      backupDir: SIDEBAR_STATE_BACKUP_DIR,
+      maxBackups: SIDEBAR_STATE_MAX_BACKUPS,
+      skipIfUnchanged: true,
+    })
+    return { written: true }
+  } catch (error) {
+    logApp("[sidebar-state] Failed to persist state:", error)
+    return { written: false, reason: "write-error" }
+  }
+}

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -1605,6 +1605,25 @@ export const router = {
       return { activeSessions: active, completedSessions: completed }
     }),
 
+  // Sidebar groups + ungrouped session order are persisted to
+  // <dataFolder>/sidebar-state.json via the same safe-write/backup machinery
+  // every other piece of app state uses. Previously these lived only in the
+  // renderer's localStorage (under the Electron `userData` path), which has
+  // no `.backups/` rotation and is silently wiped by webview/profile resets.
+  getSidebarState: t.procedure.action(async () => {
+    const { loadSidebarState } = await import("./sidebar-state")
+    return loadSidebarState()
+  }),
+
+  setSidebarState: t.procedure
+    .input<{ groups: unknown[]; ungroupedOrder: string[]; force?: boolean }>()
+    .action(async ({ input }) => {
+      const { saveSidebarState } = await import("./sidebar-state")
+      const { force, ...payload } = input
+      const result = saveSidebarState(payload, { force })
+      return { success: result.written, reason: result.reason }
+    }),
+
   // Get the profile snapshot for a specific session
   // This allows the UI to display which profile a session is using
   getSessionProfileSnapshot: t.procedure

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -251,7 +251,11 @@ function writeBooleanToStorage(key: string, value: boolean): void {
   }
 }
 
-function readSidebarSessionGroupsFromStorage(): SidebarSessionGroup[] {
+// Sidebar groups + ungrouped order are persisted via TIPC to
+// <dataFolder>/sidebar-state.json (with rotating backups). The two
+// localStorage helpers below only exist to migrate data forward from the
+// previous storage location on first run after upgrade.
+function readLegacySidebarGroupsFromLocalStorage(): SidebarSessionGroup[] {
   try {
     const stored = localStorage.getItem(SESSION_GROUPS_STORAGE_KEY)
     return stored ? normalizeSidebarSessionGroups(JSON.parse(stored)) : []
@@ -260,15 +264,7 @@ function readSidebarSessionGroupsFromStorage(): SidebarSessionGroup[] {
   }
 }
 
-function writeSidebarSessionGroupsToStorage(groups: SidebarSessionGroup[]): void {
-  try {
-    localStorage.setItem(SESSION_GROUPS_STORAGE_KEY, JSON.stringify(groups))
-  } catch {
-    // localStorage may be unavailable; ignore.
-  }
-}
-
-function readUngroupedSessionOrderFromStorage(): string[] {
+function readLegacyUngroupedOrderFromLocalStorage(): string[] {
   try {
     const stored = localStorage.getItem(UNGROUPED_SESSION_ORDER_STORAGE_KEY)
     return stored ? normalizeSidebarSessionKeyOrder(JSON.parse(stored)) : []
@@ -277,12 +273,10 @@ function readUngroupedSessionOrderFromStorage(): string[] {
   }
 }
 
-function writeUngroupedSessionOrderToStorage(sessionKeys: string[]): void {
+function clearLegacySidebarLocalStorage(): void {
   try {
-    localStorage.setItem(
-      UNGROUPED_SESSION_ORDER_STORAGE_KEY,
-      JSON.stringify(normalizeSidebarSessionKeyOrder(sessionKeys)),
-    )
+    localStorage.removeItem(SESSION_GROUPS_STORAGE_KEY)
+    localStorage.removeItem(UNGROUPED_SESSION_ORDER_STORAGE_KEY)
   } catch {
     // localStorage may be unavailable; ignore.
   }
@@ -409,12 +403,16 @@ export function ActiveAgentsSidebar({
   )
   const [editingConversationId, setEditingConversationId] = useState<string | null>(null)
   const [editingTitle, setEditingTitle] = useState("")
-  const [sessionGroups, setSessionGroups] = useState<SidebarSessionGroup[]>(
-    readSidebarSessionGroupsFromStorage,
-  )
-  const [ungroupedSessionOrder, setUngroupedSessionOrder] = useState<string[]>(
-    readUngroupedSessionOrderFromStorage,
-  )
+  // Hydrated from <dataFolder>/sidebar-state.json via TIPC on mount. Until
+  // hydration completes we keep the persist effects no-op so we never
+  // clobber the file with empty initial state during the first render.
+  // `lastPersistedSidebarStateRef` snapshots the JSON we last wrote (or
+  // hydrated) so the persist effect can skip echoing the hydrated value
+  // back to disk, which is the class of bug that previously wiped groups.
+  const [sessionGroups, setSessionGroups] = useState<SidebarSessionGroup[]>([])
+  const [ungroupedSessionOrder, setUngroupedSessionOrder] = useState<string[]>([])
+  const sidebarStateHydratedRef = useRef(false)
+  const lastPersistedSidebarStateRef = useRef<string | null>(null)
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null)
   const [editingGroupName, setEditingGroupName] = useState("")
   const [draggingSessionKey, setDraggingSessionKey] = useState<string | null>(null)
@@ -987,13 +985,72 @@ export function ActiveAgentsSidebar({
     writeBooleanToStorage(TASKS_SECTION_EXPANDED_STORAGE_KEY, tasksSectionExpanded)
   }, [tasksSectionExpanded])
 
+  // Hydrate sidebar state from the main-process JSON file (with rotating
+  // backups) on first mount. If the file is empty but legacy localStorage
+  // keys exist, migrate them forward then clear localStorage so this only
+  // runs once.
   useEffect(() => {
-    writeSidebarSessionGroupsToStorage(sessionGroups)
-  }, [sessionGroups])
+    let cancelled = false
+    void (async () => {
+      try {
+        const persisted = await tipcClient.getSidebarState()
+        const persistedGroups = normalizeSidebarSessionGroups(persisted?.groups ?? [])
+        const persistedOrder = normalizeSidebarSessionKeyOrder(persisted?.ungroupedOrder ?? [])
+
+        let groups = persistedGroups
+        let order = persistedOrder
+
+        const fileIsEmpty = persistedGroups.length === 0 && persistedOrder.length === 0
+        if (fileIsEmpty) {
+          const legacyGroups = readLegacySidebarGroupsFromLocalStorage()
+          const legacyOrder = readLegacyUngroupedOrderFromLocalStorage()
+          if (legacyGroups.length > 0 || legacyOrder.length > 0) {
+            groups = legacyGroups
+            order = legacyOrder
+            try {
+              await tipcClient.setSidebarState({ groups, ungroupedOrder: order, force: true })
+              clearLegacySidebarLocalStorage()
+            } catch (error) {
+              logUI("[sidebar] Failed to migrate legacy localStorage state:", error)
+            }
+          }
+        }
+
+        if (cancelled) return
+        // Record what we hydrated so the persist effect can skip writing the
+        // exact same payload back to disk (which would also bypass the
+        // main-process empty-payload guard if state is empty).
+        lastPersistedSidebarStateRef.current = JSON.stringify({ groups, ungroupedOrder: order })
+        setSessionGroups(groups)
+        setUngroupedSessionOrder(order)
+      } catch (error) {
+        logUI("[sidebar] Failed to hydrate persisted sidebar state:", error)
+      } finally {
+        if (!cancelled) sidebarStateHydratedRef.current = true
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
-    writeUngroupedSessionOrderToStorage(ungroupedSessionOrder)
-  }, [ungroupedSessionOrder])
+    if (!sidebarStateHydratedRef.current) return
+    const payload = { groups: sessionGroups, ungroupedOrder: ungroupedSessionOrder }
+    const serialized = JSON.stringify(payload)
+    // Skip if nothing actually changed since the last write/hydrate. This
+    // prevents echoing the hydrated value back and protects the main-process
+    // empty-payload guard from being bypassed by an unchanged-empty write.
+    if (serialized === lastPersistedSidebarStateRef.current) return
+    lastPersistedSidebarStateRef.current = serialized
+    // `force: true` here means "the user really did change something" -
+    // including emptying everything - so the main-process guard should
+    // accept the write. The guard exists for stale-hydration writes, not
+    // for genuine user edits.
+    void tipcClient
+      .setSidebarState({ ...payload, force: true })
+      .catch((error) => logUI("[sidebar] Failed to persist sidebar state:", error))
+  }, [sessionGroups, ungroupedSessionOrder])
 
   const focusSidebarSessionComposer = useCallback(() => {
     let attemptCount = 0


### PR DESCRIPTION
## Problem

Sidebar session groups (the "youtube", "personal", "visa" folders) were stored only in the renderer's `localStorage`, which:

- Lives in Chromium's leveldb at `~/Library/Application Support/@dotagents/desktop/Local Storage/leveldb/`, **not** in the app's own `dataFolder` where every other persisted file lives.
- Has no rotating-backup mechanism (unlike `config.json`, `agent-session-state.json`, etc., which all use `safeWriteJsonFileSync` with a `.backups/` directory).
- Is partitioned by Chromium origin. In dev, the renderer loads from `http://localhost:5173` or `:5174` depending on which port Vite picks — and the two origins have **separate** localStorage. Restarting `pnpm dev` and having Vite pick the other port silently orphans your groups.

Net result: groups have been lost twice now with no recovery path.

## Fix

Move sidebar groups to `<dataFolder>/sidebar-state.json` behind TIPC, using the same safe-write helpers (`safeReadJsonFileSync` / `safeWriteJsonFileSync`) that protect every other piece of app state.

### Files

- `apps/desktop/src/main/sidebar-state.ts` (new) — versioned JSON payload, `backupDir = <dataFolder>/.backups`, `maxBackups: 10`. Includes an **empty-payload guard** on `saveSidebarState` that refuses to overwrite a non-empty file with an empty payload unless the caller passes `force: true`. Defense-in-depth against renderer-side hydration bugs.
- `apps/desktop/src/main/tipc.ts` — adds `getSidebarState` and `setSidebarState` procedures.
- `apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx`:
  - Removes the four `localStorage` read/write helpers.
  - State starts empty and hydrates from `tipcClient.getSidebarState()` on mount.
  - One-time migration: if the file is empty but legacy localStorage keys exist, write them through TIPC then clear localStorage.
  - **Snapshot-skip on the persist effect**: tracks a `JSON.stringify` snapshot of the last hydrated/persisted state and short-circuits the effect when nothing has actually changed. This prevents the post-hydration `setSessionGroups(...)` from echoing back to disk, which is the bug that wiped the recovered `visa` group during initial development of this PR.

### Why two layers of defense

The renderer's snapshot-skip is the **primary** fix — it ensures the persist effect only fires on genuine user-driven state changes. The main-process empty-payload guard is the **safety net** for any future regression in renderer code or any other caller. Genuine empty writes (user deleted all their groups) still work because the renderer's persist effect passes `force: true` once the snapshot diverges.

## Validation

- `pnpm typecheck` — clean
- `pnpm --filter @dotagents/desktop test -- --run sidebar` — 100/100 pass

## Notes

- The "youtube" and "personal" groups that were lost in the original incident are **not** recoverable — they were gone from the leveldb log before this PR existed.
- Mobile (`apps/mobile/src/`) has no equivalent sidebar-groups feature today, so no mirror change was needed.
- This PR creates `<dataFolder>/sidebar-state.json` the first time the new code runs. The migration only runs once; afterwards the legacy localStorage keys are cleared.
