### PR TITLE
Nudge agents out of truncated execute_command inspection loops

### DIFF
--- a/apps/desktop/src/main/execute-command-thrash-detector.test.ts
+++ b/apps/desktop/src/main/execute-command-thrash-detector.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest"
+import {
+  EXECUTE_COMMAND_THRASH_NUDGE_TEXT,
+  ExecuteCommandThrashDetector,
+  extractExecuteCommandObservation,
+} from "./execute-command-thrash-detector"
+import type { MCPToolCall, MCPToolResult } from "./mcp-service"
+
+function executeCommandCall(command: string): MCPToolCall {
+  return { name: "execute_command", arguments: { command } }
+}
+
+function executeCommandSuccess(payload: {
+  command: string
+  cwd?: string
+  stdout?: string
+  outputTruncated?: boolean
+}): MCPToolResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          success: true,
+          command: payload.command,
+          cwd: payload.cwd ?? "/repo",
+          stdout: payload.stdout ?? "ok",
+          stderr: "",
+          ...(payload.outputTruncated ? { outputTruncated: true } : {}),
+        }),
+      },
+    ],
+    isError: false,
+  }
+}
+
+describe("extractExecuteCommandObservation", () => {
+  it("returns undefined for non-execute_command tool calls", () => {
+    const obs = extractExecuteCommandObservation(
+      { name: "read_more_context", arguments: {} },
+      executeCommandSuccess({ command: "head foo.txt" }),
+    )
+    expect(obs).toBeUndefined()
+  })
+
+  it("returns undefined when the tool result is an error", () => {
+    const errored: MCPToolResult = {
+      content: [{ type: "text", text: JSON.stringify({ success: false, error: "boom" }) }],
+      isError: true,
+    }
+    expect(extractExecuteCommandObservation(executeCommandCall("ls"), errored)).toBeUndefined()
+  })
+
+  it("flags outputTruncated:true in the structured payload", () => {
+    const obs = extractExecuteCommandObservation(
+      executeCommandCall("head -n 100000 build/forms.pdf"),
+      executeCommandSuccess({
+        command: "head -n 100000 build/forms.pdf",
+        outputTruncated: true,
+      }),
+    )
+    expect(obs).toEqual(
+      expect.objectContaining({
+        outputTruncated: true,
+        domainKey: expect.stringContaining("forms.pdf"),
+      }),
+    )
+  })
+
+  it("flags the inline [OUTPUT TRUNCATED:...] marker when the flag is missing", () => {
+    const obs = extractExecuteCommandObservation(
+      executeCommandCall("cat report.json"),
+      executeCommandSuccess({
+        command: "cat report.json",
+        stdout: "start\n\n... [OUTPUT TRUNCATED: 4321 bytes, ~120 lines total. ...] ...\n\nend",
+      }),
+    )
+    expect(obs?.outputTruncated).toBe(true)
+  })
+
+  it("returns outputTruncated=false for a normal short success", () => {
+    const obs = extractExecuteCommandObservation(
+      executeCommandCall("ls"),
+      executeCommandSuccess({ command: "ls", stdout: "a\nb\nc" }),
+    )
+    expect(obs).toEqual({ outputTruncated: false, domainKey: expect.any(String) })
+  })
+
+  it("falls back to regex scanning when the payload is not a parseable JSON object", () => {
+    const result: MCPToolResult = {
+      content: [
+        {
+          type: "text",
+          text: 'free-form text "success": true some prose "outputTruncated": true blah',
+        },
+      ],
+      isError: false,
+    }
+    const obs = extractExecuteCommandObservation(executeCommandCall("ls"), result)
+    expect(obs?.outputTruncated).toBe(true)
+  })
+
+  it("derives a domain key from cwd + file basenames in the command", () => {
+    const a = extractExecuteCommandObservation(
+      executeCommandCall("head -n 200 /tmp/forms/I-130A.pdf"),
+      executeCommandSuccess({ command: "head -n 200 /tmp/forms/I-130A.pdf", cwd: "/work" }),
+    )
+    const b = extractExecuteCommandObservation(
+      executeCommandCall("tail -n 50 /tmp/forms/I-130A.pdf"),
+      executeCommandSuccess({ command: "tail -n 50 /tmp/forms/I-130A.pdf", cwd: "/work" }),
+    )
+    expect(a?.domainKey).toBeDefined()
+    expect(a?.domainKey).toBe(b?.domainKey)
+  })
+})
+
+describe("ExecuteCommandThrashDetector", () => {
+  it("does not thrash on a single truncated execute_command", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    detector.record({ outputTruncated: true, domainKey: "/repo::a" })
+    expect(detector.evaluate()).toEqual(
+      expect.objectContaining({ thrashing: false, truncatedCount: 1 }),
+    )
+  })
+
+  it("triggers the synthesize nudge after 3 truncated execute_command results", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    detector.recordBatch([
+      { outputTruncated: true, domainKey: "/repo::a" },
+      { outputTruncated: true, domainKey: "/repo::b" },
+      { outputTruncated: true, domainKey: "/repo::c" },
+    ])
+    const evaluation = detector.evaluate()
+    expect(evaluation.thrashing).toBe(true)
+    expect(evaluation.reason).toBe("truncated")
+    expect(evaluation.message).toBe(EXECUTE_COMMAND_THRASH_NUDGE_TEXT)
+  })
+
+  it("triggers the nudge for repeated inspection of the same domain even without truncation", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    const sameKey = "/work::i-130a.pdf"
+    for (let i = 0; i < 5; i++) {
+      detector.record({ outputTruncated: false, domainKey: sameKey })
+    }
+    const evaluation = detector.evaluate()
+    expect(evaluation.thrashing).toBe(true)
+    expect(evaluation.reason).toBe("domain-overlap")
+    expect(evaluation.domainCount).toBeGreaterThanOrEqual(5)
+  })
+
+  it("does not thrash when 2 truncated results are interleaved with successful narrow commands", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    detector.recordBatch([
+      { outputTruncated: true, domainKey: "/repo::a" },
+      { outputTruncated: false, domainKey: "/repo::b" },
+      { outputTruncated: true, domainKey: "/repo::c" },
+      { outputTruncated: false, domainKey: "/repo::d" },
+    ])
+    expect(detector.evaluate().thrashing).toBe(false)
+  })
+
+  it("does not thrash on a diverse sequence of narrow, non-truncated commands", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    for (let i = 0; i < 6; i++) {
+      detector.record({ outputTruncated: false, domainKey: `/repo::file-${i}` })
+    }
+    expect(detector.evaluate().thrashing).toBe(false)
+  })
+
+  it("clears its window after markNudged so it doesn't double-fire next iteration", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    detector.recordBatch([
+      { outputTruncated: true, domainKey: "/repo::a" },
+      { outputTruncated: true, domainKey: "/repo::b" },
+      { outputTruncated: true, domainKey: "/repo::c" },
+    ])
+    expect(detector.evaluate().thrashing).toBe(true)
+    detector.markNudged(7)
+    expect(detector.wasNudgedAtIteration(7)).toBe(true)
+    expect(detector.evaluate().thrashing).toBe(false)
+
+    detector.record({ outputTruncated: true, domainKey: "/repo::d" })
+    expect(detector.evaluate().thrashing).toBe(false)
+  })
+
+  it("ages old observations out of the window so historic thrash does not pin the nudge", () => {
+    const detector = new ExecuteCommandThrashDetector()
+    detector.recordBatch([
+      { outputTruncated: true, domainKey: "/repo::a" },
+      { outputTruncated: true, domainKey: "/repo::b" },
+      { outputTruncated: true, domainKey: "/repo::c" },
+    ])
+    expect(detector.evaluate().thrashing).toBe(true)
+    detector.markNudged(1)
+
+    // After the nudge resets the window, a long stretch of productive narrow
+    // commands should keep the detector quiet.
+    for (let i = 0; i < 8; i++) {
+      detector.record({ outputTruncated: false, domainKey: `/repo::next-${i}` })
+    }
+    expect(detector.evaluate().thrashing).toBe(false)
+  })
+})

--- a/apps/desktop/src/main/execute-command-thrash-detector.ts
+++ b/apps/desktop/src/main/execute-command-thrash-detector.ts
@@ -1,0 +1,176 @@
+import type { MCPToolCall, MCPToolResult } from "./mcp-service"
+
+const EXECUTE_COMMAND_TOOL = "execute_command"
+
+// Window of recent successful execute_command observations we consider when
+// deciding whether the agent is thrashing on broad/truncated inspection. Sized
+// large enough to catch a 3-of-5 truncation cluster across a couple of mixed
+// tool batches without holding state forever.
+const HISTORY_WINDOW = 8
+
+// Min successful + truncated execute_command results inside the window before
+// we nudge the agent toward synthesis. The issue's observed thrash case had 56
+// truncated results in 89 tool calls; 3-of-N is the smallest signal that
+// reliably catches the pattern without firing on a single oversized output.
+const TRUNCATED_THRASH_THRESHOLD = 3
+
+// Min successful execute_command calls that share the same cwd + file basenames
+// before we treat repeated inspection of one domain as thrash. Set higher than
+// the truncated threshold because narrow repeated probes of one file can still
+// be legitimate progress (e.g. iterating on a fix).
+const DOMAIN_THRASH_THRESHOLD = 5
+
+export const EXECUTE_COMMAND_THRASH_NUDGE_TEXT =
+  "Recent execute_command results produced repeated/truncated inspection output. " +
+  "Stop broad inspection now. Summarize the concrete facts already gathered, " +
+  "produce the requested deliverable (or a minimal fill/action plan using known facts), " +
+  "and explicitly list any remaining unknowns. If another command is necessary, " +
+  "make it narrowly targeted (specific line ranges, single fields, exact paths) so " +
+  "the result is not truncated."
+
+export interface ExecuteCommandObservation {
+  outputTruncated: boolean
+  domainKey: string | undefined
+}
+
+export type ExecuteCommandThrashReason = "truncated" | "domain-overlap"
+
+export interface ExecuteCommandThrashEvaluation {
+  thrashing: boolean
+  reason: ExecuteCommandThrashReason | undefined
+  truncatedCount: number
+  domainCount: number
+  windowSize: number
+  message: string | undefined
+}
+
+const PATH_TOKEN_REGEX = /(?:\.\.?\/|\/)[\w./\-]+|\b[\w.\-]+\.[A-Za-z][A-Za-z0-9]{0,5}\b/g
+
+function safeParseJsonObject(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(text)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch {
+    // not a JSON object payload — caller falls back to text scanning
+  }
+  return undefined
+}
+
+function buildDomainKey(cwd: string | undefined, command: string | undefined): string | undefined {
+  if (!command) return undefined
+  const basenames = new Set<string>()
+  for (const match of command.match(PATH_TOKEN_REGEX) ?? []) {
+    const basename = match.split("/").filter(Boolean).pop()
+    if (!basename) continue
+    // Skip option-like fragments such as "-n" or argument values that are not file refs.
+    if (basename.startsWith("-")) continue
+    basenames.add(basename.toLowerCase())
+  }
+  if (basenames.size === 0) {
+    return cwd ? `${cwd}::no-paths` : undefined
+  }
+  return `${cwd ?? ""}::${[...basenames].sort().join(",")}`
+}
+
+export function extractExecuteCommandObservation(
+  toolCall: MCPToolCall,
+  result: MCPToolResult,
+): ExecuteCommandObservation | undefined {
+  if (toolCall.name !== EXECUTE_COMMAND_TOOL || result.isError) return undefined
+  const text = result.content.map((entry) => entry.text).join("\n")
+  const parsed = safeParseJsonObject(text)
+  if (parsed) {
+    if (parsed.success !== true) return undefined
+    const cwd = typeof parsed.cwd === "string" ? parsed.cwd : undefined
+    const command = typeof parsed.command === "string" ? parsed.command : undefined
+    const outputTruncated = parsed.outputTruncated === true
+      || /\[OUTPUT TRUNCATED:/i.test(typeof parsed.stdout === "string" ? parsed.stdout : "")
+    return {
+      outputTruncated,
+      domainKey: buildDomainKey(cwd, command),
+    }
+  }
+  // Fallback for payloads that aren't a tidy JSON object: scan the raw text.
+  if (!/"success"\s*:\s*true/.test(text)) return undefined
+  return {
+    outputTruncated: /"outputTruncated"\s*:\s*true/.test(text) || /\[OUTPUT TRUNCATED:/i.test(text),
+    domainKey: undefined,
+  }
+}
+
+export class ExecuteCommandThrashDetector {
+  private observations: ExecuteCommandObservation[] = []
+  private lastNudgedIteration: number | undefined
+
+  record(observation: ExecuteCommandObservation): void {
+    this.observations.push(observation)
+    if (this.observations.length > HISTORY_WINDOW) {
+      this.observations.splice(0, this.observations.length - HISTORY_WINDOW)
+    }
+  }
+
+  recordBatch(observations: ExecuteCommandObservation[]): void {
+    for (const observation of observations) this.record(observation)
+  }
+
+  evaluate(): ExecuteCommandThrashEvaluation {
+    const truncatedCount = this.observations.filter((o) => o.outputTruncated).length
+    const domainCounts = new Map<string, number>()
+    for (const observation of this.observations) {
+      if (!observation.domainKey) continue
+      domainCounts.set(observation.domainKey, (domainCounts.get(observation.domainKey) ?? 0) + 1)
+    }
+    let topDomainCount = 0
+    for (const count of domainCounts.values()) {
+      if (count > topDomainCount) topDomainCount = count
+    }
+
+    const baseEvaluation = {
+      truncatedCount,
+      domainCount: topDomainCount,
+      windowSize: this.observations.length,
+    }
+
+    if (truncatedCount >= TRUNCATED_THRASH_THRESHOLD) {
+      return {
+        ...baseEvaluation,
+        thrashing: true,
+        reason: "truncated",
+        message: EXECUTE_COMMAND_THRASH_NUDGE_TEXT,
+      }
+    }
+    if (topDomainCount >= DOMAIN_THRASH_THRESHOLD) {
+      return {
+        ...baseEvaluation,
+        thrashing: true,
+        reason: "domain-overlap",
+        message: EXECUTE_COMMAND_THRASH_NUDGE_TEXT,
+      }
+    }
+    return {
+      ...baseEvaluation,
+      thrashing: false,
+      reason: undefined,
+      message: undefined,
+    }
+  }
+
+  // After firing a nudge we clear the window so the next batch starts a fresh
+  // count. Otherwise the same observations would trip the threshold on every
+  // subsequent iteration until they aged out.
+  markNudged(iteration: number): void {
+    this.lastNudgedIteration = iteration
+    this.observations = []
+  }
+
+  wasNudgedAtIteration(iteration: number): boolean {
+    return this.lastNudgedIteration === iteration
+  }
+
+  reset(): void {
+    this.observations = []
+    this.lastNudgedIteration = undefined
+  }
+}

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -58,6 +58,10 @@ import {
 } from "./agent-run-utils"
 import { filterEphemeralMessages, isInternalNudgeContent } from "./conversation-history-utils"
 import {
+  ExecuteCommandThrashDetector,
+  extractExecuteCommandObservation,
+} from "./execute-command-thrash-detector"
+import {
   filterNamedItemsToAllowedTools,
 } from "./llm-tool-gating"
 import { sanitizeMessageContentForDisplay } from "@dotagents/shared"
@@ -2245,6 +2249,10 @@ export async function processTranscriptWithAgentMode(
   let lastExcludedToolCount = 0 // Track previous excluded count to avoid unnecessary system prompt rebuilds
   let cachedSystemPrompt: string | undefined // Cached rebuilt prompt when tools are excluded
   let suppressReadMoreContextAfterExactAnswer = false
+  // Detects when the model is stuck re-running broad/truncated `execute_command`
+  // probes against the same files instead of producing a deliverable. The
+  // detector lives for the lifetime of this run so observations span iterations.
+  const executeCommandThrashDetector = new ExecuteCommandThrashDetector()
 
   while (iteration < maxIterations) {
     iteration++
@@ -3388,11 +3396,38 @@ export async function processTranscriptWithAgentMode(
     const hasErrors = toolResults.some((result) => result.isError)
     const allToolsSuccessful = toolResults.length > 0 && !hasErrors
 
+    // Record this batch's successful execute_command results so the thrash
+    // detector can decide whether repeated broad/truncated inspection should
+    // count as forward progress. Errored / non-execute_command results are
+    // filtered inside extractExecuteCommandObservation.
+    const executeCommandObservations: ReturnType<typeof extractExecuteCommandObservation>[] = []
+    for (let i = 0; i < toolResults.length; i++) {
+      const observation = extractExecuteCommandObservation(toolCallsArray[i]!, toolResults[i])
+      if (observation) executeCommandObservations.push(observation)
+    }
+    if (executeCommandObservations.length > 0) {
+      executeCommandThrashDetector.recordBatch(
+        executeCommandObservations.filter((o): o is NonNullable<typeof o> => !!o),
+      )
+    }
+    const executeCommandThrashEvaluation = executeCommandThrashDetector.evaluate()
+    const batchIsExecuteCommandOnly =
+      toolCallsArray.length > 0
+      && toolCallsArray.every((toolCall) => toolCall.name === "execute_command")
+    // Treat a thrashy execute_command-only batch as "not real forward progress"
+    // for the verifier streak. Mixed batches (e.g. execute_command + write_file
+    // + mark_work_complete) still get the reset because they include genuine
+    // deliverable-shaped work.
+    const suppressVerificationResetForThrash =
+      executeCommandThrashEvaluation.thrashing
+      && batchIsExecuteCommandOnly
+      && !completionToolCalled
+
     // A successful real-work tool batch is forward progress, so it breaks any
     // verifier-failure streak. Communication-only tools such as respond_to_user
     // are intentionally excluded; otherwise a model that repeatedly talks but
     // never calls mark_work_complete can reset the verifier budget forever.
-    if (allToolsSuccessful && !onlyCommunicationTools) {
+    if (allToolsSuccessful && !onlyCommunicationTools && !suppressVerificationResetForThrash) {
       verificationFailCount = 0
     }
 
@@ -3418,6 +3453,21 @@ export async function processTranscriptWithAgentMode(
           ? `The latest read_more_context call returned the exact requested answer: ${exactAnswer}. Answer with that now; do not call read_more_context again.`
           : "The latest read_more_context call returned matching context. Use that returned context to answer now; avoid repeating read_more_context for the same query unless a specific detail is still missing.",
       )
+    }
+
+    // Synthesize-now nudge: when execute_command results indicate the agent is
+    // thrashing on broad/truncated inspection, push it toward producing a
+    // deliverable using what it already knows. Skipped when the batch already
+    // signalled completion so we don't second-guess a finished run.
+    if (
+      !completionSignalConfirmed
+      && !hasErrors
+      && executeCommandThrashEvaluation.thrashing
+      && executeCommandThrashEvaluation.message
+      && !executeCommandThrashDetector.wasNudgedAtIteration(iteration)
+    ) {
+      addEphemeralMessage("user", executeCommandThrashEvaluation.message)
+      executeCommandThrashDetector.markNudged(iteration)
     }
 
     if (hasErrors) {


### PR DESCRIPTION
Closes #502.

## Summary

Repeated successful but truncated `execute_command` calls were treated as unlimited forward progress: in `llm.ts`, every batch where `allToolsSuccessful && !onlyCommunicationTools` reset `verificationFailCount` to 0, so the agent could spin on broad PDF/file probes without the verifier-completion budget ever advancing. The motivating run from #502 ended with 89 tool calls, 56 truncated outputs, and no deliverable.

There was already a targeted nudge for repeated successful `read_more_context` calls in `llm.ts:3408`, but no equivalent guard for `execute_command` — which is exactly where the issue's truncation thrash lives.

## Change

Adds an in-run **execute_command thrash detector** that:

- Tracks the last **8** successful `execute_command` observations (window size kept bounded across iterations).
- Fires a synthesize-now nudge when either:
  - **≥3** of the last 8 successful results were truncated (`outputTruncated: true` or the inline `[OUTPUT TRUNCATED:...]` marker), or
  - **≥5** of them probe the same `cwd` + file-basename domain (broad re-inspection of one area without producing a deliverable).
- On a thrashy `execute_command`-only batch, also **suppresses the verifier-failure-count reset** so the verifier-completion limit keeps advancing. Mixed batches that include `write_file`/`mark_work_complete`/etc. still get the reset.
- After firing, the detector clears its observation window so a single recovery segment is what's bounded — a genuinely productive sequence of narrow follow-up commands isn't penalized.

The nudge text mirrors the issue's proposed wording:

> Recent execute_command results produced repeated/truncated inspection output. Stop broad inspection now. Summarize the concrete facts already gathered, produce the requested deliverable (or a minimal fill/action plan using known facts), and explicitly list any remaining unknowns. If another command is necessary, make it narrowly targeted (specific line ranges, single fields, exact paths) so the result is not truncated.

### Files

- `apps/desktop/src/main/execute-command-thrash-detector.ts` (new) — observation extractor, `ExecuteCommandThrashDetector` class, nudge text.
- `apps/desktop/src/main/execute-command-thrash-detector.test.ts` (new) — 14 unit tests covering extraction (truncation flag, inline marker fallback, JSON-parse fallback, errored/non-execute_command skips, domain-key derivation) and detector behavior (no thrash on 1 truncated, fires at 3 truncated, fires at 5 same-domain, doesn't fire on diverse narrow calls, post-nudge window reset, ageing).
- `apps/desktop/src/main/llm.ts` — instantiate the detector per `processTranscriptWithAgentMode` run, record execute_command observations after each tool batch, suppress `verificationFailCount = 0` on a thrashy execute_command-only batch, and inject the nudge via the existing `addEphemeralMessage("user", ...)` path right after the equivalent `read_more_context` nudge.

## Acceptance criteria mapping (from #502)

- [x] **Unit tests covering repeated successful truncated `execute_command` calls** — `execute-command-thrash-detector.test.ts`, including the 3-of-N truncated trigger case and the 2-truncated-no-thrash case.
- [x] **Repeated broad/truncated inspections receive a synthesis nudge instead of resetting progress indefinitely** — nudge text injected as an ephemeral user message; verifier-fail-count reset suppressed for execute_command-only thrashy batches.
- [x] **Genuinely productive sequence of targeted commands is not blocked** — diverse non-truncated runs covered by a dedicated test; after a nudge fires, the window resets so subsequent narrow probes don't keep tripping the threshold.
- [x] **Existing `read_more_context` exact-answer behavior remains unchanged** — that path is untouched; the new nudge sits alongside it under the same `!completionSignalConfirmed && !hasErrors` guard.
- [x] **UI-visible tool history remains intact** — only an ephemeral (non-persisted) user nudge is added; no tool results are hidden or rewritten.

## Test plan

- [x] `pnpm --filter @dotagents/desktop run typecheck:node` — clean.
- [x] `cd apps/desktop && npx vitest run src/main/execute-command-thrash-detector.test.ts` — 14/14 pass.
- [x] `cd apps/desktop && npx vitest run src/main/execute-command-thrash-detector.test.ts src/main/runtime-tools.execute-command.test.ts src/main/context-budget.test.ts` — 44/44 pass.
- [ ] Manual: reproduce a thrash session with repeated truncated `execute_command` calls and confirm the synthesize nudge appears in the conversation prompt; confirm a single targeted recovery command after the nudge does not refire it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015BwF4WRbCWAHekYynLhZQE)_