### PR TITLE
Add download button to chat image lightbox

### DIFF
--- a/apps/desktop/src/renderer/src/components/markdown-renderer.layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.layout.test.ts
@@ -55,4 +55,12 @@ describe("markdown renderer layout", () => {
       "translate3d(${zoom.offsetX}px, ${zoom.offsetY}px, 0) scale(${zoom.scale})"
     )
   })
+
+  it("exposes a download action in the image lightbox controls", () => {
+    expect(markdownRendererSource).toContain('aria-label="Download image"')
+    expect(markdownRendererSource).toContain('title="Download image"')
+    expect(markdownRendererSource).toContain("handleDownload")
+    expect(markdownRendererSource).toContain("deriveImageDownloadFileName")
+    expect(markdownRendererSource).toContain('link.download = fileName')
+  })
 })

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.tsx
@@ -9,6 +9,7 @@ import {
   Brain,
   Copy,
   CheckCheck,
+  Download,
   PlayCircle,
   RotateCcw,
   X,
@@ -166,6 +167,80 @@ const DEFAULT_IMAGE_ZOOM_STATE: ImageZoomState = {
 
 const clampNumber = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value))
+
+const IMAGE_MIME_TO_EXTENSION: Record<string, string> = {
+  "image/png": "png",
+  "image/apng": "apng",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+}
+
+const FILENAME_DISALLOWED_CHARS_REGEX = /[\\/:*?"<>|\x00-\x1f]+/g
+const FILENAME_HAS_EXTENSION_REGEX = /\.[a-z0-9]{1,8}$/i
+
+const sanitizeDownloadBasename = (raw: string): string => {
+  const collapsed = raw
+    .replace(FILENAME_DISALLOWED_CHARS_REGEX, "_")
+    .replace(/\s+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[._]+/, "")
+  return collapsed.slice(0, 128)
+}
+
+const extensionFromMimeType = (mimeType?: string): string => {
+  if (!mimeType) return ""
+  const primary = mimeType.split(";")[0]?.trim().toLowerCase() ?? ""
+  return IMAGE_MIME_TO_EXTENSION[primary] ?? ""
+}
+
+export const deriveImageDownloadFileName = (
+  src: string,
+  alt?: string,
+  mimeType?: string,
+): string => {
+  const fallbackExtension = extensionFromMimeType(mimeType) || "png"
+
+  try {
+    const url = new URL(src)
+    if (url.protocol !== "data:") {
+      const segments = url.pathname.split("/").filter(Boolean)
+      const last = segments[segments.length - 1]
+      if (last) {
+        let decoded = last
+        try {
+          decoded = decodeURIComponent(last)
+        } catch {
+          // Fall back to the raw segment.
+        }
+        const sanitized = sanitizeDownloadBasename(decoded)
+        if (sanitized && FILENAME_HAS_EXTENSION_REGEX.test(sanitized)) {
+          return sanitized
+        }
+        if (sanitized) {
+          return `${sanitized}.${fallbackExtension}`
+        }
+      }
+    }
+  } catch {
+    // Not a parseable URL (e.g., relative or malformed); fall through.
+  }
+
+  if (alt) {
+    const sanitized = sanitizeDownloadBasename(alt)
+    if (sanitized) {
+      return FILENAME_HAS_EXTENSION_REGEX.test(sanitized)
+        ? sanitized
+        : `${sanitized}.${fallbackExtension}`
+    }
+  }
+
+  return `image.${fallbackExtension}`
+}
 
 const getContainedImageSize = (
   viewport: HTMLDivElement | null,
@@ -469,6 +544,47 @@ const ChatImage = ({ src, alt }: { src: string; alt?: string }) => {
     )
   }, [])
 
+  const [isDownloading, setIsDownloading] = useState(false)
+
+  const handleDownload = useCallback(async () => {
+    if (isDownloading) return
+    setIsDownloading(true)
+    let objectUrl: string | null = null
+    try {
+      const response = await fetch(src)
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      const blob = await response.blob()
+      objectUrl = URL.createObjectURL(blob)
+      const fileName = deriveImageDownloadFileName(src, alt, blob.type)
+      const link = document.createElement("a")
+      link.href = objectUrl
+      link.download = fileName
+      link.rel = "noopener"
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+    } catch (error) {
+      logUI("[MarkdownRenderer] image download failed", {
+        alt: label,
+        srcPreview: src.slice(0, 64),
+        error: error instanceof Error ? error.message : String(error),
+      })
+    } finally {
+      if (objectUrl) {
+        setTimeout(() => {
+          try {
+            URL.revokeObjectURL(objectUrl as string)
+          } catch {
+            // Already revoked.
+          }
+        }, 0)
+      }
+      setIsDownloading(false)
+    }
+  }, [alt, isDownloading, label, src])
+
   return (
     <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
       <DialogPrimitive.Trigger asChild>
@@ -569,6 +685,19 @@ const ChatImage = ({ src, alt }: { src: string; alt?: string }) => {
               onClick={resetZoom}
             >
               <RotateCcw className="h-4 w-4" />
+            </button>
+            <span className="mx-1 h-5 w-px bg-white/20" aria-hidden="true" />
+            <button
+              type="button"
+              className={LIGHTBOX_CONTROL_BUTTON_CLASS_NAME}
+              aria-label="Download image"
+              title="Download image"
+              disabled={isDownloading}
+              onClick={() => {
+                void handleDownload()
+              }}
+            >
+              <Download className="h-4 w-4" />
             </button>
           </div>
           <DialogPrimitive.Close

--- a/apps/desktop/src/renderer/src/components/markdown-renderer.urls.test.ts
+++ b/apps/desktop/src/renderer/src/components/markdown-renderer.urls.test.ts
@@ -36,4 +36,77 @@ describe("markdown renderer URL guardrails", () => {
       "data:image/webp;base64,UklGRg==",
     )
   })
+
+  describe("deriveImageDownloadFileName", () => {
+    it("uses the last path segment when it already includes an extension", () => {
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "assets://conversation-image/conv_1/abcd1234.png",
+        ),
+      ).toBe("abcd1234.png")
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "https://example.com/path/to/cool-photo.JPG?ts=1",
+        ),
+      ).toBe("cool-photo.JPG")
+    })
+
+    it("decodes percent-encoded URL segments before sanitizing", () => {
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "https://example.com/Screen%20Shot%202026.png",
+        ),
+      ).toBe("Screen_Shot_2026.png")
+    })
+
+    it("appends an extension derived from the blob MIME type when the URL has none", () => {
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "https://example.com/image",
+          undefined,
+          "image/webp",
+        ),
+      ).toBe("image.webp")
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "https://example.com/image",
+          undefined,
+          "image/jpeg; charset=binary",
+        ),
+      ).toBe("image.jpg")
+    })
+
+    it("falls back to alt text when the URL has no usable segment", () => {
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "data:image/png;base64,AAAA",
+          "Quarterly chart",
+          "image/png",
+        ),
+      ).toBe("Quarterly_chart.png")
+    })
+
+    it("defaults to image.<ext> when no hint is available", () => {
+      expect(
+        markdownRenderer.deriveImageDownloadFileName("data:image/png;base64,AAAA"),
+      ).toBe("image.png")
+      expect(
+        markdownRenderer.deriveImageDownloadFileName("not a url"),
+      ).toBe("image.png")
+    })
+
+    it("strips path traversal and disallowed filesystem characters", () => {
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "https://example.com/path/..%2Fevil.png",
+        ),
+      ).toBe("evil.png")
+      expect(
+        markdownRenderer.deriveImageDownloadFileName(
+          "data:image/png;base64,AAAA",
+          'bad: name/with*chars?.png',
+        ),
+      ).toBe("bad_name_with_chars_.png")
+    })
+  })
 })


### PR DESCRIPTION
Closes #507.

## Summary

Adds a **Download image** button to the desktop chat image preview (lightbox), so users can save a previewed image without right-clicking or opening dev tools.

The button sits in the lightbox's bottom control bar next to the existing Zoom out / Zoom in / Reset controls, separated by a thin divider so the zoom cluster stays visually grouped. Existing open/close, zoom, and pan interactions are unchanged.

## Behaviour

- Clicking the button `fetch()`s the currently previewed image (works for `http(s)://`, `data:`, and the in-app `assets://conversation-image/...` protocol thanks to its `corsEnabled` / `supportFetchAPI` privileges in `serve.ts`).
- The blob is downloaded via a temporary `<a download="...">` element so the user gets a proper save flow with a sensible filename.
- A new helper `deriveImageDownloadFileName(src, alt?, mimeType?)` picks the filename in this order:
  1. Last path segment of the URL when it has an extension (percent-decoded, sanitized).
  2. Last path segment + an extension inferred from the blob MIME type.
  3. Sanitized alt text (with MIME-inferred extension).
  4. Default `image.<ext>`.
  - Skips URL extraction for `data:` URIs (their pathnames are useless for filenames).
  - Strips path-traversal markers and Windows-disallowed characters (`\ / : * ? " < > |` and control bytes), collapses whitespace/underscores, and caps the basename at 128 chars.
- A short re-entrancy guard (`isDownloading`) disables the button during the in-flight fetch, and a `try/finally` revokes the object URL after the click fires.
- Failures are logged via the existing `logUI(...)` helper and don't throw to the UI.

## Acceptance criteria mapping (from #507)

- [x] **Image previews in chat expose a download image action.** — Visible button in the lightbox controls bar with `aria-label="Download image"` and matching `title`.
- [x] **Clicking the action downloads the image without right-click / dev tools.** — Anchor `download` attribute drives a normal save flow.
- [x] **Downloaded file uses a sensible filename when available.** — URL last segment → alt text → MIME-typed default; sanitized for filesystem safety.
- [x] **Works for generated, uploaded, and fetched image assets in chat.** — Generated/uploaded assets use `assets://conversation-image/...` (handled by the privileged Electron protocol), fetched images use `http(s)`/`data:` — all hit the same `fetch()` path.
- [x] **Preserves existing preview interactions.** — Zoom, pan, double-click reset, overlay-click close, and `Esc` close paths are untouched; the new button is `pointer-events`-isolated inside the existing control cluster.

## Files

- `apps/desktop/src/renderer/src/components/markdown-renderer.tsx`
  - Added `Download` icon import.
  - New module helpers: `IMAGE_MIME_TO_EXTENSION`, `FILENAME_DISALLOWED_CHARS_REGEX`, `FILENAME_HAS_EXTENSION_REGEX`, `sanitizeDownloadBasename`, `extensionFromMimeType`, and the exported `deriveImageDownloadFileName`.
  - Inside `ChatImage`: `isDownloading` state, `handleDownload` callback, and the new Download button in the lightbox control bar.
- `apps/desktop/src/renderer/src/components/markdown-renderer.layout.test.ts`
  - New case asserting the lightbox exposes the Download control and uses `deriveImageDownloadFileName` + `link.download = fileName`.
- `apps/desktop/src/renderer/src/components/markdown-renderer.urls.test.ts`
  - Six new cases covering `deriveImageDownloadFileName`: extension preservation, percent-decoding, MIME-derived extension, alt fallback, default `image.<ext>`, and path-traversal/disallowed-char sanitization.

## Scope

Desktop only. Mobile (`apps/mobile/src/ui/MarkdownRenderer.tsx`) currently renders images inline without a lightbox/preview modal, so there's no "preview experience" to attach a download action to there yet — best handled as a follow-up once a mobile preview lands.

## Test plan

- [x] `pnpm --filter @dotagents/desktop run typecheck:web` — clean.
- [x] `pnpm --filter @dotagents/desktop run typecheck:node` — clean.
- [x] `cd apps/desktop && npx vitest run src/renderer/src/components/markdown-renderer.layout.test.ts src/renderer/src/components/markdown-renderer.urls.test.ts` — 15/15 pass.
- [x] `cd apps/desktop && npx vitest run src/renderer/src/components/agent-progress.response-history.test.ts` — 25/25 pass (no regression in markdown rendering paths).
- [ ] Manual: open a chat with an `assets://conversation-image/...` attachment, open the lightbox, click the new Download button, and confirm a save dialog (or direct download) with a sensible filename.
- [ ] Manual: same flow for an `https://...` external image and a `data:image/...` inline image.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcQj15YeH37EZodgEgTcdK)_