### PR TITLE
Show source dates on recalled working notes in system prompt

### DIFF
--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -288,15 +288,20 @@ Skills are filesystem instructions. When a task matches a skill below, read its 
     expect(prompt).not.toContain("AVAILABLE TOOLS:")
   })
 
-  it("formats injected working notes from knowledge notes", async () => {
+  it("formats injected working notes from knowledge notes with their source date", async () => {
     const { constructSystemPrompt } = await import("./system-prompts")
+
+    // 2024-03-15T00:00:00Z and 2025-01-20T00:00:00Z so the date annotation is
+    // both human-readable and stable across machines/timezones.
+    const updatedArch = Date.UTC(2024, 2, 15)
+    const updatedRelease = Date.UTC(2025, 0, 20)
 
     const prompt = constructSystemPrompt([], undefined, false, undefined, undefined, undefined, undefined, [
       {
         id: "project-architecture",
         title: "Project Architecture",
         context: "auto",
-        updatedAt: 2,
+        updatedAt: updatedArch,
         tags: ["architecture"],
         summary: "Layered Electron app with workspace-overrides-global note loading.",
         body: "Longer details here.",
@@ -305,7 +310,7 @@ Skills are filesystem instructions. When a task matches a skill below, read its 
         id: "release-plan",
         title: "Release Plan",
         context: "auto",
-        updatedAt: 1,
+        updatedAt: updatedRelease,
         tags: ["release"],
         body: "# Milestones\nShip the staged rollout next week.",
       } as any,
@@ -313,9 +318,42 @@ Skills are filesystem instructions. When a task matches a skill below, read its 
 
     expect(prompt).toContain("WORKING NOTES")
     expect(prompt).toContain("context: auto")
-    expect(prompt).toContain("[project-architecture] Layered Electron app with workspace-overrides-global note loading.")
-    expect(prompt).toContain("[release-plan] Release Plan: Milestones Ship the staged rollout next week.")
+    expect(prompt).toContain("[project-architecture] (updated 2024-03-15) Layered Electron app with workspace-overrides-global note loading.")
+    expect(prompt).toContain("[release-plan] (updated 2025-01-20) Release Plan: Milestones Ship the staged rollout next week.")
+    // The header should teach the model to treat older entries as potentially stale.
+    expect(prompt).toMatch(/stale/i)
     expect(prompt).not.toContain("KNOWLEDGE FROM PREVIOUS SESSIONS")
+  })
+
+  it("falls back to created date or 'undated' when updatedAt is missing on a recalled note", async () => {
+    const { constructSystemPrompt } = await import("./system-prompts")
+
+    const createdAt = Date.UTC(2023, 5, 1)
+
+    const prompt = constructSystemPrompt([], undefined, false, undefined, undefined, undefined, undefined, [
+      {
+        id: "legacy-note",
+        title: "Legacy Note",
+        context: "auto",
+        createdAt,
+        // updatedAt deliberately missing
+        tags: [],
+        summary: "An older recalled snippet without an updated timestamp.",
+        body: "body",
+      } as any,
+      {
+        id: "ghost-note",
+        title: "Ghost Note",
+        context: "auto",
+        // no createdAt, no updatedAt
+        tags: [],
+        summary: "Source has no timestamps at all.",
+        body: "body",
+      } as any,
+    ] as any)
+
+    expect(prompt).toContain("[legacy-note] (created 2023-06-01) An older recalled snippet without an updated timestamp.")
+    expect(prompt).toContain("[ghost-note] (undated) Source has no timestamps at all.")
   })
 
   it("prefers direct execution over mandatory delegation for simple tasks", async () => {

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -26,6 +26,15 @@ function truncatePromptNoteText(text: string, maxChars: number): string {
   return `${text.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`
 }
 
+function formatPromptIsoDate(timestamp: number | undefined): string {
+  if (typeof timestamp !== "number" || !Number.isFinite(timestamp) || timestamp <= 0) {
+    return ""
+  }
+  const iso = new Date(timestamp).toISOString()
+  // YYYY-MM-DD (UTC). Stable across machines and easy for the model to compare to the CURRENT TIME line.
+  return iso.slice(0, 10)
+}
+
 function formatWorkingNotesForPrompt(notes: KnowledgeNote[], maxNotes: number = 6): string {
   if (!notes || notes.length === 0) return ""
 
@@ -36,7 +45,14 @@ function formatWorkingNotesForPrompt(notes: KnowledgeNote[], maxNotes: number = 
       const summary = truncatePromptNoteText(normalizePromptNoteText(note.summary ?? ''), 180)
       const body = truncatePromptNoteText(normalizePromptNoteText(note.body), 140)
       const fallback = body ? `${note.title}: ${body}` : note.title
-      return `- [${note.id}] ${summary || fallback}`
+      const updated = formatPromptIsoDate(note.updatedAt)
+      const created = formatPromptIsoDate(note.createdAt)
+      const dateLabel = updated
+        ? `updated ${updated}`
+        : created
+          ? `created ${created}`
+          : "undated"
+      return `- [${note.id}] (${dateLabel}) ${summary || fallback}`
     })
     .join("\n")
 }
@@ -379,7 +395,7 @@ export function constructSystemPrompt(
   // Only a tiny subset of context:auto knowledge notes should be injected at runtime.
   const formattedWorkingNotes = formatWorkingNotesForPrompt(workingNotes || [])
   if (formattedWorkingNotes) {
-    prompt += `\n\nWORKING NOTES:\nThese were injected from configured knowledge roots because their frontmatter sets context: auto. Prefer note summaries when present, keep this subset tiny, and leave most notes as context: search-only.\n\n${formattedWorkingNotes}`
+    prompt += `\n\nWORKING NOTES:\nThese were injected from configured knowledge roots because their frontmatter sets context: auto. Each entry is annotated with the date it was last updated; compare it to CURRENT TIME and treat older or undated entries as potentially stale. For time-sensitive requests ("today", "current", "now", "the thing we were working on"), do not answer from a stale note - verify by searching recent conversations/notes first, and if you must use a stale source, say so explicitly. Prefer note summaries when present, keep this subset tiny, and leave most notes as context: search-only.\n\n${formattedWorkingNotes}`
   }
 
   // Format full tool info for relevant tools only (when provided)


### PR DESCRIPTION
Closes #498.

## Why

When recalled knowledge notes (`context: auto`) were injected into the system prompt, each entry surfaced only its id and summary - with **no** indication of when the note was last updated. The bug from the issue: a user asked for points for the video they were making today, the assistant recalled an old Clawdbot/Moltbot video note, and presented it as today's video context because nothing in the recalled snippet signaled staleness.

The same `KnowledgeNote` carries `updatedAt`/`createdAt` timestamps (already shown on desktop knowledge cards), but the prompt formatter was throwing that signal away before the model ever saw it.

## What changed

### `apps/desktop/src/main/system-prompts.ts`

- New helper `formatPromptIsoDate(ts)` - converts a stored epoch-ms timestamp into a stable `YYYY-MM-DD` UTC string. UTC keeps the output deterministic across machines and trivially comparable to the existing CURRENT TIME line at the top of the prompt.
- `formatWorkingNotesForPrompt()` now appends a date annotation to every recalled entry:
  - `updated YYYY-MM-DD` (preferred, since `updatedAt` is the source of truth for staleness)
  - falls back to `created YYYY-MM-DD` when only `createdAt` is present
  - falls back to `undated` when neither is set
  - Output shape: `- [note-id] (updated 2025-01-20) summary text…` (additive - the bracketed id and the summary/fallback body are unchanged, so any consumer that grep'd for `[note-id]` still matches).
- The `WORKING NOTES:` header now teaches the model what the new annotation means and what to do about it: treat older / undated entries as potentially stale, verify against recent conversations/notes for time-sensitive requests ("today", "current", "now", "the thing we were working on"), and call out staleness explicitly if a stale source must be used. This is the system-prompt-side guardrail the issue asked for.

### `apps/desktop/src/main/system-prompts.test.ts`

- Existing "formats injected working notes" case was updated to use deterministic UTC timestamps (`Date.UTC(2024, 2, 15)` / `Date.UTC(2025, 0, 20)`) and now asserts each line contains the `(updated YYYY-MM-DD)` annotation, plus asserts the header mentions staleness.
- New case covers the two fallback branches: `createdAt`-only → `(created 2023-06-01)`, and no timestamps at all → `(undated)`.

## Issue acceptance criteria mapping

From #498:

- [x] **Show the source date / last updated date by default when using recalled notes.** - Every working-note line now carries a `(updated …)` / `(created …)` / `(undated)` annotation.
- [x] **For time-sensitive requests, do not answer from stale context unless recency is verified.** - The WORKING NOTES header now instructs the model to compare each entry to CURRENT TIME, verify against recent conversations/notes for time-sensitive requests, and disclose staleness explicitly if a stale source must be used.
- [x] **If the best match is old or undated, say so / continue searching.** - Covered by the same header guidance; `undated` is now an explicit label rather than silent omission.

## Out of scope (deferred)

The issue also touches search-result ranking ("recency boost for 'today'") and the broader question of dating other recall surfaces (e.g. prior-conversation snippets, generated knowledge summaries). Working-note injection is the surface that produced the original bug and is the most concentrated place to fix it; ranking + non-note recall surfaces are best handled as follow-ups so this PR stays small and reviewable.

## Test plan

- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/system-prompts.test.ts` - 18/18 pass.
- [x] `pnpm --filter @dotagents/desktop run typecheck:node` - clean.
- [ ] Manual: with a `context: auto` knowledge note loaded, start a session and verify the system prompt's WORKING NOTES block shows each note's `(updated YYYY-MM-DD)`.
- [ ] Manual: ask a time-sensitive question ("what was I working on today?") when the only matching auto-note is old, and confirm the assistant flags staleness rather than presenting the old note as current.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G9oV1ySDi5Vt522kw9ReVx)_