### PR TITLE
Eliminate voice input modal initial VAD/waveform dead period

### DIFF
--- a/apps/desktop/src/renderer/src/lib/recorder.test.ts
+++ b/apps/desktop/src/renderer/src/lib/recorder.test.ts
@@ -12,9 +12,35 @@ class MockMediaRecorder {
   stop = vi.fn()
 }
 
+class MockAnalyserNode {
+  minDecibels = 0
+  fftSize = 2048
+  frequencyBinCount = 1024
+  getByteTimeDomainData(_array: Uint8Array) {}
+  getByteFrequencyData(_array: Uint8Array) {}
+}
+
+class MockMediaStreamSource {
+  connect = vi.fn()
+  disconnect = vi.fn()
+}
+
+const audioContextInstances: MockAudioContext[] = []
+class MockAudioContext {
+  createMediaStreamSource = vi.fn(() => new MockMediaStreamSource())
+  createAnalyser = vi.fn(() => new MockAnalyserNode())
+  close = vi.fn()
+  constructor() {
+    audioContextInstances.push(this)
+  }
+}
+
 describe("Recorder audio input fallback", () => {
   beforeEach(() => {
     vi.stubGlobal("MediaRecorder", MockMediaRecorder as any)
+    vi.stubGlobal("AudioContext", MockAudioContext as any)
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1) as any)
+    vi.stubGlobal("cancelAnimationFrame", vi.fn() as any)
   })
 
   afterEach(() => {
@@ -64,5 +90,72 @@ describe("Recorder audio input fallback", () => {
 
     await expect(recorder.startRecording("missing-mic")).rejects.toEqual({ name: "NotAllowedError" })
     expect(getUserMedia).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("Recorder visualizer startup latency", () => {
+  beforeEach(() => {
+    audioContextInstances.length = 0
+    vi.stubGlobal("MediaRecorder", MockMediaRecorder as any)
+    vi.stubGlobal("AudioContext", MockAudioContext as any)
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1) as any)
+    vi.stubGlobal("cancelAnimationFrame", vi.fn() as any)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it("initializes the audio analyser before MediaRecorder.onstart fires", async () => {
+    const stream = { getTracks: () => [] } as unknown as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValueOnce(stream)
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } })
+
+    const { Recorder } = await import("./recorder")
+    const recorder = new Recorder()
+
+    const visualizerEvents: number[] = []
+    recorder.on("visualizer-data", (rms) => visualizerEvents.push(rms))
+
+    await recorder.startRecording()
+
+    // The audio context (and therefore the analyser + RAF loop emitting
+    // visualizer-data) must be live as soon as startRecording resolves —
+    // i.e. before MediaRecorder.onstart has a chance to fire. Previously
+    // the analyser was deferred to onstart, leaving the modal visually
+    // dead for the ~hundreds of ms MediaRecorder took to fire onstart.
+    expect(audioContextInstances).toHaveLength(1)
+    expect(audioContextInstances[0].createMediaStreamSource).toHaveBeenCalledWith(stream)
+    expect(audioContextInstances[0].createAnalyser).toHaveBeenCalled()
+    expect(requestAnimationFrame).toHaveBeenCalled()
+    expect(recorder.mediaRecorder).not.toBeNull()
+    expect((recorder.mediaRecorder as unknown as MockMediaRecorder).start).toHaveBeenCalledTimes(1)
+
+    // onstart has not fired yet, but the analyser is already running.
+    // Triggering onstart should not re-construct the analyser.
+    const rafCallsBeforeOnstart = (requestAnimationFrame as unknown as ReturnType<typeof vi.fn>).mock.calls.length
+    ;(recorder.mediaRecorder as unknown as MockMediaRecorder).onstart?.()
+    expect(audioContextInstances).toHaveLength(1)
+    const rafCallsAfterOnstart = (requestAnimationFrame as unknown as ReturnType<typeof vi.fn>).mock.calls.length
+    expect(rafCallsAfterOnstart).toBe(rafCallsBeforeOnstart)
+  })
+
+  it("tears down the analyser when stopRecording is called", async () => {
+    const stream = { getTracks: () => [{ stop: vi.fn() }] } as unknown as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValueOnce(stream)
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } })
+
+    const cancelRaf = vi.fn()
+    vi.stubGlobal("cancelAnimationFrame", cancelRaf as any)
+
+    const { Recorder } = await import("./recorder")
+    const recorder = new Recorder()
+
+    await recorder.startRecording()
+    recorder.stopRecording()
+
+    expect(cancelRaf).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/renderer/src/lib/recorder.ts
+++ b/apps/desktop/src/renderer/src/lib/recorder.ts
@@ -111,6 +111,13 @@ export class Recorder extends EventEmitter<{
 
     const stream = (this.stream = await getUserMediaAudioStream(deviceId))
 
+    // Wire up the analyser + waveform RAF loop as soon as the stream is
+    // available so visualizer-data starts flowing immediately. MediaRecorder's
+    // onstart callback can take a few hundred ms to fire, and gating the
+    // analyser on it left the voice modal visibly dead for that window.
+    const stopAnalysing = this.analyseAudio(stream)
+    this.once("destroy", stopAnalysing)
+
     const mediaRecorder = (this.mediaRecorder = new MediaRecorder(stream, {
       audioBitsPerSecond: 128e3,
     }))
@@ -121,8 +128,6 @@ export class Recorder extends EventEmitter<{
     mediaRecorder.onstart = () => {
       startTime = Date.now()
       this.emit("record-start")
-      const stopAnalysing = this.analyseAudio(stream)
-      this.once("destroy", stopAnalysing)
     }
 
     mediaRecorder.ondataavailable = (event) => {


### PR DESCRIPTION
Closes #496.

## Summary

The desktop voice input modal had a visible ~hundreds-of-ms dead window after opening: no waveform bars, no VAD response, until eventually the visualizer "woke up". That made the mic feel unresponsive and made users worry the start of their speech was being missed.

## Root cause

`apps/desktop/src/renderer/src/lib/recorder.ts` constructed the `AudioContext` + `AnalyserNode` and started the `requestAnimationFrame` loop emitting `visualizer-data` events **inside** the `MediaRecorder.onstart` callback:

```ts
mediaRecorder.onstart = () => {
  startTime = Date.now()
  this.emit("record-start")
  const stopAnalysing = this.analyseAudio(stream)   // ← deferred
  this.once("destroy", stopAnalysing)
}
mediaRecorder.start(100)
```

`MediaRecorder.onstart` fires only once the encoder has spun up — empirically a few hundred ms on Chromium. The analyser only needs the `MediaStream`, which is already available the moment `getUserMedia()` resolves, so gating it on `onstart` was producing the dead window for no reason.

## Fix

Start the analyser + RAF loop synchronously as soon as we have the stream:

```ts
const stream = (this.stream = await getUserMediaAudioStream(deviceId))

// Wire up the analyser + waveform RAF loop as soon as the stream is
// available so visualizer-data starts flowing immediately. MediaRecorder's
// onstart callback can take a few hundred ms to fire, and gating the
// analyser on it left the voice modal visibly dead for that window.
const stopAnalysing = this.analyseAudio(stream)
this.once("destroy", stopAnalysing)

const mediaRecorder = (this.mediaRecorder = new MediaRecorder(stream, {
  audioBitsPerSecond: 128e3,
}))
// ...
mediaRecorder.onstart = () => {
  startTime = Date.now()
  this.emit("record-start")
}
```

`record-start` is intentionally still emitted from `MediaRecorder.onstart`, preserving its "recording has actually begun" semantics for the existing consumers in `panel.tsx` (which forwards it to the main process via `tipcClient.recordEvent({ type: "start" })`) and `onboarding.tsx`. The cleanup path is unchanged — `stopAnalysing` is still attached to the `destroy` event fired by `stopRecording()`.

## Why this is the minimal fix

- The analyser graph is independent of the `MediaRecorder` lifecycle; it only reads from the `MediaStream`, which has been live since `getUserMedia()` resolved.
- No new dependencies, no UI changes, no readiness-state plumbing required.
- `panel.tsx` and `onboarding.tsx` consumers of `record-start` see no behaviour change because the event timing is preserved.

## Test plan

- [x] `pnpm exec vitest run src/renderer/src/lib/recorder.test.ts` — 4/4 pass (2 new cases).
  - New: "initializes the audio analyser before MediaRecorder.onstart fires" — asserts the `AudioContext` is constructed and `requestAnimationFrame` is scheduled the moment `startRecording()` resolves, and that firing `onstart` afterwards does not re-construct the analyser.
  - New: "tears down the analyser when stopRecording is called" — asserts `cancelAnimationFrame` runs on stop.
  - Existing fallback tests updated to stub `AudioContext` / `requestAnimationFrame` now that the analyser runs synchronously in `startRecording()`.
- [x] `pnpm exec vitest run src/renderer/src/components/session-action-dialog.voice.test.tsx` — 1/1 pass (no regression in the modal voice-mode cleanup path).
- [x] `pnpm exec vitest run src/renderer/src/lib` — 129/129 pass.
- [x] `pnpm run typecheck:web` — clean.
- [x] `pnpm run typecheck:node` — clean.
- [ ] Manual: open the voice input modal and confirm the waveform bars start animating immediately on open, with no visible dead window before frames begin flowing.
- [ ] Manual: confirm `panel.tsx` push-to-talk start sound / state and `onboarding.tsx` voice flow still trigger at the same point as before (i.e. when `MediaRecorder.onstart` fires).

## Out of scope

`apps/mobile` uses a different recording stack (native Android speech recognizer + `useSpeechRecognizer` / `useHandsFreeController`), not this `recorder.ts`, so it's untouched. Issue #496 is specifically about the desktop main-app voice modal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NLEetnKKMo3xbzoHXftHfS)_