### PR TITLE
Search prior conversations whenever agents need more context

### DIFF
--- a/apps/desktop/src/main/system-prompts-default.ts
+++ b/apps/desktop/src/main/system-prompts-default.ts
@@ -33,12 +33,10 @@ KNOWLEDGE NOTES:
 
 PAST CONVERSATIONS:
 - Prior DotAgents conversations are JSON in the runtime-supplied conversations directory
-- If the prompt includes an absolute conversations path, use it; otherwise infer the app-data folder in an OS-appropriate way
 - Use index.json to discover relevant conversations, then open matching conv_*.json files for full history when prior chat context would help
-- Whenever you determine you need more context before answering or proceeding - especially for continuation, status, debugging, or high-context planning requests - searching the conversations index and relevant conv_*.json history is a standard context-gathering step, not a last resort; do this before asking the user
+- You should be always searching the conversations index and relevant conv_*.json history is a standard context-gathering step, not a last resort; do this before asking the user
 - If recovered conversations contain enough facts to answer or continue, use them and respond; only ask the user when prior conversations do not contain the needed information, or when credentials/approval are required
-- Before asking the user for facts that may already be known, or whenever the current task likely relates to prior work, search relevant knowledge notes first and prior conversations second; always prefer knowledge notes over recalled conversation context when they conflict
-- For personal legal/immigration, health, finance, career, or other high-context planning, inspect both relevant knowledge notes and recent conversations with a shell/file tool before generic advice
+- Before asking the user for facts that may already be known, or whenever the current task likely relates to prior work, search relevant knowledge notes first and prior conversations second
 
 RUNTIME METADATA:
 - Runtime discovery metadata is file-backed. If the prompt or environment includes DOTAGENTS_RUNTIME_DIR, inspect agents.json, tools/index.json, and tools/schemas/ with shell commands instead of expecting list/schema helper tools.

--- a/apps/desktop/src/main/system-prompts-default.ts
+++ b/apps/desktop/src/main/system-prompts-default.ts
@@ -35,6 +35,8 @@ PAST CONVERSATIONS:
 - Prior DotAgents conversations are JSON in the runtime-supplied conversations directory
 - If the prompt includes an absolute conversations path, use it; otherwise infer the app-data folder in an OS-appropriate way
 - Use index.json to discover relevant conversations, then open matching conv_*.json files for full history when prior chat context would help
+- Whenever you determine you need more context before answering or proceeding - especially for continuation, status, debugging, or high-context planning requests - searching the conversations index and relevant conv_*.json history is a standard context-gathering step, not a last resort; do this before asking the user
+- If recovered conversations contain enough facts to answer or continue, use them and respond; only ask the user when prior conversations do not contain the needed information, or when credentials/approval are required
 - Before asking the user for facts that may already be known, or whenever the current task likely relates to prior work, search relevant knowledge notes first and prior conversations second; always prefer knowledge notes over recalled conversation context when they conflict
 - For personal legal/immigration, health, finance, career, or other high-context planning, inspect both relevant knowledge notes and recent conversations with a shell/file tool before generic advice
 

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -113,6 +113,54 @@ describe("constructSystemPrompt", () => {
     expect(prompt).not.toContain("Use save_memory")
   })
 
+  it("instructs agents to search prior conversations whenever they need more context", async () => {
+    const { DEFAULT_SYSTEM_PROMPT, constructSystemPrompt } = await import("./system-prompts")
+
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("Whenever you determine you need more context before answering or proceeding")
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("continuation, status, debugging, or high-context planning")
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("searching the conversations index and relevant conv_*.json history is a standard context-gathering step")
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("do this before asking the user")
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("If recovered conversations contain enough facts to answer or continue, use them and respond")
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("only ask the user when prior conversations do not contain the needed information, or when credentials/approval are required")
+    // The "knowledge notes take precedence" guarantee from #494 must remain intact
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("always prefer knowledge notes over recalled conversation context when they conflict")
+
+    const agentPrompt = constructSystemPrompt([
+      { name: "execute_command", description: "Execute command", inputSchema: { type: "object", properties: {} } },
+    ] as any, undefined, true)
+
+    expect(agentPrompt).toContain("whenever you need more context to answer or proceed")
+    expect(agentPrompt).toContain("search index.json then conv_*.json as a standard step before asking the user")
+    expect(agentPrompt).toContain("use the recovered context to answer or continue when sufficient")
+    expect(agentPrompt).toContain("Only ask the user when prior conversations do not contain the needed facts, or when credentials/approval are required")
+    expect(agentPrompt).toContain("Always prefer knowledge notes over recalled conversation context when they conflict")
+    // The old narrower phrasing should no longer be present in the agent-mode block
+    expect(agentPrompt).not.toContain("recover state before asking when the user wants to resume prior work")
+  })
+
+  it("teaches the minimal fallback prompt to search prior conversations when more context is needed", async () => {
+    const { constructMinimalSystemPrompt } = await import("./system-prompts")
+
+    const promptWithReadMore = constructMinimalSystemPrompt([
+      { name: "execute_command", description: "Execute command", inputSchema: { type: "object", properties: {} } },
+      { name: "read_more_context", description: "Read compacted context", inputSchema: { type: "object", properties: {} } },
+    ], true)
+
+    expect(promptWithReadMore).toContain("Whenever you need more context")
+    expect(promptWithReadMore).toContain("continuation, status, debugging, or high-context planning")
+    expect(promptWithReadMore).toContain("search the conversation store (index.json then conv_*.json) before asking")
+    expect(promptWithReadMore).toContain("use recovered context to answer or continue when sufficient")
+    expect(promptWithReadMore).not.toContain("If the user asks to resume or find prior context")
+
+    const promptWithoutReadMore = constructMinimalSystemPrompt([
+      { name: "execute_command", description: "Execute command", inputSchema: { type: "object", properties: {} } },
+    ], true)
+
+    expect(promptWithoutReadMore).toContain("search the conversation store (index.json then conv_*.json) before asking")
+    expect(promptWithoutReadMore).toContain("use recovered context to answer or continue when sufficient")
+    expect(promptWithoutReadMore).not.toContain("If the user asks to resume/find prior context")
+  })
+
   it("preserves knowledge note guidance in the minimal fallback prompt when file tools are available", async () => {
     const { constructMinimalSystemPrompt } = await import("./system-prompts")
 

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -158,7 +158,7 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
 
   sections.push(`LOCAL MEMORY & CONFIG:
 - Durable notes live in configured knowledge roots, defaulting to global/workspace .agents/knowledge; edit note/config files directly and keep context:auto rare
-- Prior conversations live under the runtime-supplied conversations directory; search index.json then conv_*.json, and recover state before asking when the user wants to resume prior work
+- Prior conversations live under the runtime-supplied conversations directory; whenever you need more context to answer or proceed - including continuation, status, debugging, and high-context planning - search index.json then conv_*.json as a standard step before asking the user, and use the recovered context to answer or continue when sufficient. Only ask the user when prior conversations do not contain the needed facts, or when credentials/approval are required. Always prefer knowledge notes over recalled conversation context when they conflict.
 - For personal legal/immigration, health, finance, career, or other high-context planning, inspect both knowledge notes and recent conversations with execute_command before generic advice
 - DotAgents config is layered global .agents plus workspace .agents when DOTAGENTS_WORKSPACE_DIR is set; for unfamiliar config edits, read the dotagents-config-admin SKILL.md path if it is listed under Available Skills`)
 
@@ -497,8 +497,8 @@ export function constructMinimalSystemPrompt(
 
   if (isAgentMode) {
     prompt += hasReadMoreContext
-      ? " Agent mode: continue with tools until the requested work is resolved. If the user asks to resume or find prior context, search the conversation store before asking follow-up questions."
-      : " Agent mode: continue with tools until the requested work is resolved. If the user asks to resume/find prior context, search the conversation store before asking."
+      ? " Agent mode: continue with tools until the requested work is resolved. Whenever you need more context - continuation, status, debugging, or high-context planning - search the conversation store (index.json then conv_*.json) before asking follow-up questions, and use recovered context to answer or continue when sufficient."
+      : " Agent mode: continue with tools until the requested work is resolved. Whenever you need more context - continuation, status, debugging, or high-context planning - search the conversation store (index.json then conv_*.json) before asking, and use recovered context to answer or continue when sufficient."
     if (hasReadMoreContext) {
       prompt += ' For compacted Context refs, call read_more_context(mode: "search") with the exact needed query when known; once the returned result contains the requested evidence, answer instead of searching again.'
     }


### PR DESCRIPTION
Closes #494.

## Why

Agents were instructed to search prior conversations only when "the user wants to resume prior work" or "the current task likely relates to prior work". In practice, agents often need more context (continuation, status, debugging, high-context planning) but ask the user instead of inspecting the conversation store first, breaking continuity across sessions and forcing users to re-explain things that already exist in prior `conv_*.json` files.

The issue asks us to strengthen the system prompt so prior-conversation lookup is a *standard context-gathering step* whenever agents determine they need more context, while keeping the existing "knowledge notes win on conflict" guarantee intact.

## What changed

### `apps/desktop/src/main/system-prompts-default.ts`

Expanded the `PAST CONVERSATIONS` section with two new bullets:

- "Whenever you determine you need more context before answering or proceeding — especially for continuation, status, debugging, or high-context planning requests — searching the conversations index and relevant `conv_*.json` history is a standard context-gathering step, not a last resort; do this before asking the user"
- "If recovered conversations contain enough facts to answer or continue, use them and respond; only ask the user when prior conversations do not contain the needed information, or when credentials/approval are required"

The existing "search relevant knowledge notes first and prior conversations second; always prefer knowledge notes over recalled conversation context when they conflict" guidance is unchanged, so the knowledge-note precedence guarantee from #494 still holds.

### `apps/desktop/src/main/system-prompts.ts`

`getAgentModeAdditions()` `LOCAL MEMORY & CONFIG` block: replaced the narrower "recover state before asking when the user wants to resume prior work" with the broader rule covering continuation/status/debugging/high-context planning, with the answer-from-recovered-context branch and the "only ask when credentials/approval are required" carve-out, plus the explicit knowledge-notes-win-on-conflict reminder.

`constructMinimalSystemPrompt()` agent-mode addendum: same broadening applied to both the `read_more_context` and non-`read_more_context` fallback variants, with explicit `index.json then conv_*.json` cues so the search target survives Tier-3 prompt shrinking.

### `apps/desktop/src/main/system-prompts.test.ts`

Two new tests:

1. `instructs agents to search prior conversations whenever they need more context` — asserts the new wording in `DEFAULT_SYSTEM_PROMPT` and in the full agent-mode prompt, plus that the narrower legacy phrase ("recover state before asking when the user wants to resume prior work") is gone, and that the knowledge-notes-precedence sentence is retained.
2. `teaches the minimal fallback prompt to search prior conversations when more context is needed` — asserts the same broadening in both minimal-fallback variants (with and without `read_more_context`).

## Issue acceptance criteria mapping

From #494:

- [x] **System prompt instructs agents: when they determine they need more context, search the conversations index and relevant `conv_*.json` history.** — New bullet in `PAST CONVERSATIONS`, mirrored in agent-mode `LOCAL MEMORY & CONFIG` and the minimal fallback.
- [x] **Agents use recovered context to answer or continue when sufficient.** — Explicit "If recovered conversations contain enough facts to answer or continue, use them and respond" / "use the recovered context to answer or continue when sufficient" wording.
- [x] **Agents only ask the user when prior conversations do not contain the needed facts, or when credentials/approval are required.** — Explicit carve-out included in each updated location.
- [x] **Knowledge notes should still take precedence over recalled conversation context when they conflict.** — Existing "always prefer knowledge notes over recalled conversation context when they conflict" line preserved in the default prompt and re-asserted in the agent-mode block.

## Test plan

- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/system-prompts.test.ts` — 19/19 pass (17 existing + 2 new).
- [x] `pnpm --filter @dotagents/desktop run typecheck:node` — clean.
- [ ] Manual: in a session, ask a follow-up that depends on prior conversation facts and confirm the agent searches `index.json` / `conv_*.json` (via `execute_command`) before asking instead of asking immediately.



---
_Generated by [Claude Code](https://claude.ai/code/session_013U4uSvYsMRjyLXC7m59sTp)_