### PR TITLE
Fix crash when dragging sidebar folder under another folder

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.folder-drop-crash.test.ts
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.folder-drop-crash.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const sidebarSource = readFileSync(new URL("./active-agents-sidebar.tsx", import.meta.url), "utf8")
+
+describe("active agents sidebar folder drag drop crash (issue #512)", () => {
+  it("guards getSessionDropPosition against a null currentTarget", () => {
+    expect(sidebarSource).toContain("const target = event.currentTarget as Element | null")
+    expect(sidebarSource).toContain('if (!target || typeof target.getBoundingClientRect !== "function") return "after"')
+  })
+
+  it("resolves the group-header drop position before scheduling the setState updater", () => {
+    const handlerStart = sidebarSource.indexOf("const handleGroupHeaderDrop = useCallback")
+    const handlerEnd = sidebarSource.indexOf("}, [clearSessionDragState, getDraggedGroupId, getSessionDropPosition])", handlerStart)
+    expect(handlerStart).toBeGreaterThan(-1)
+    expect(handlerEnd).toBeGreaterThan(handlerStart)
+
+    const handler = sidebarSource.slice(handlerStart, handlerEnd)
+    const positionAssignIdx = handler.indexOf("const position = getSessionDropPosition(event)")
+    const setSessionGroupsIdx = handler.indexOf("setSessionGroups((prev) => reorderSidebarSessionGroups(")
+    expect(positionAssignIdx).toBeGreaterThan(-1)
+    expect(setSessionGroupsIdx).toBeGreaterThan(positionAssignIdx)
+    expect(handler).not.toContain("targetGroupId,\n        getSessionDropPosition(event),")
+  })
+})

--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -1191,7 +1191,12 @@ export function ActiveAgentsSidebar({
   }, [draggingGroupId])
 
   const getSessionDropPosition = useCallback((event: React.DragEvent): SidebarSessionDropPosition => {
-    const rect = event.currentTarget.getBoundingClientRect()
+    // React clears `currentTarget` after the event handler returns, so any deferred
+    // caller (e.g. a setState updater) sees null here. Fall back to "after" rather
+    // than crashing — callers should resolve the position synchronously when possible.
+    const target = event.currentTarget as Element | null
+    if (!target || typeof target.getBoundingClientRect !== "function") return "after"
+    const rect = target.getBoundingClientRect()
     return event.clientY < rect.top + rect.height / 2 ? "before" : "after"
   }, [])
 
@@ -1335,11 +1340,14 @@ export function ActiveAgentsSidebar({
     event.preventDefault()
     event.stopPropagation()
     if (groupId !== targetGroupId) {
+      // Resolve the drop position synchronously — `event.currentTarget` is nulled
+      // out before React invokes the setState updater below.
+      const position = getSessionDropPosition(event)
       setSessionGroups((prev) => reorderSidebarSessionGroups(
         prev,
         groupId,
         targetGroupId,
-        getSessionDropPosition(event),
+        position,
       ))
     }
     clearSessionDragState()


### PR DESCRIPTION
## Summary

Fixes #512 — dragging one Active Agents sidebar folder under another no longer crashes the renderer.

## Root cause

`handleGroupHeaderDrop` passed `getSessionDropPosition(event)` as an argument to a `setSessionGroups` updater function:

```ts
setSessionGroups((prev) => reorderSidebarSessionGroups(
  prev,
  groupId,
  targetGroupId,
  getSessionDropPosition(event), // ← evaluated when React calls the updater, later
))
```

React invokes that updater *after* the event handler returns. By that point React has cleared `event.currentTarget`, so `event.currentTarget.getBoundingClientRect()` (line 1194) threw `TypeError: Cannot read properties of null (reading 'getBoundingClientRect')`. React Router then unmounted and recreated the sidebar tree — the exact stack from the bug report.

## Fix

- `active-agents-sidebar.tsx`: resolve the drop position synchronously in `handleGroupHeaderDrop` before scheduling `setSessionGroups`, so the position is captured while `currentTarget` is still live.
- Harden `getSessionDropPosition` to fall back to `"after"` when `currentTarget` is null or missing `getBoundingClientRect`, instead of crashing. Other call sites already evaluate synchronously, so this is purely defensive.

## Tests

- New `active-agents-sidebar.folder-drop-crash.test.ts` pins both invariants:
  - `getSessionDropPosition` guards against a null `currentTarget`.
  - `handleGroupHeaderDrop` captures the position *before* it calls `setSessionGroups`.
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/active-agents-sidebar` — 5 files / 31 tests pass.
- `pnpm --filter @dotagents/desktop typecheck:web` — clean.

Closes #512

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bk4U74GvGnVmWotF6VWQhp)_