### PR TITLE
Stop defaulting mobile to OpenAI when unconfigured

### DIFF
--- a/apps/mobile/src/lib/openaiClient.ts
+++ b/apps/mobile/src/lib/openaiClient.ts
@@ -153,11 +153,11 @@ export class OpenAIClient {
   }
 
   private normalizeBaseUrl(raw: string): string {
-    const normalized = normalizeApiBaseUrl(raw ?? '');
-    if (!normalized) {
-      throw new Error('OpenAIClient requires a baseUrl');
-    }
-    return normalized;
+    // Allow empty baseUrl at construction so unconfigured mobile clients (no
+    // remote-server pairing yet) don't crash on instantiation. Calls that
+    // actually need the URL — health(), chat(), etc. — will surface a clear
+    // error or natural network failure when invoked.
+    return normalizeApiBaseUrl(raw ?? '');
   }
 
   private authHeaders() {

--- a/apps/mobile/src/screens/ConnectionSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ConnectionSettingsScreen.tsx
@@ -15,8 +15,6 @@ import {
 } from '../lib/accessibility';
 import { resolveQrScannerActivation } from './connection-settings-qr';
 
-const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-
 function parseQRCode(data: string): { baseUrl?: string; apiKey?: string; model?: string } | null {
   try {
     const parsed = Linking.parse(data);
@@ -74,29 +72,22 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
     // Clear any previous error
     setConnectionError(null);
 
-    // Default to OpenAI URL if baseUrl is empty
-    if (!normalizedDraft.baseUrl) {
-      normalizedDraft.baseUrl = DEFAULT_OPENAI_BASE_URL;
-    }
-
-    const hasCustomUrl = normalizedDraft.baseUrl && normalizedDraft.baseUrl.replace(/\/+$/, '') !== DEFAULT_OPENAI_BASE_URL;
-    const hasApiKey = normalizedDraft.apiKey && normalizedDraft.apiKey.length > 0;
+    const hasBaseUrl = normalizedDraft.baseUrl.length > 0;
+    const hasApiKey = normalizedDraft.apiKey.length > 0;
 
     // On first-time setup, do not silently save a disconnected default config.
     if (!isConnected && !hasApiKey) {
-      setConnectionError('Enter an API key or scan a DotAgents QR code before saving');
+      setConnectionError('Scan the DotAgents QR code or enter your server URL and API key before saving');
       return;
     }
 
-    // Require API key when using a custom server URL
-    if (hasCustomUrl && !hasApiKey) {
-      setConnectionError('API Key is required when using a custom server URL');
-      return;
-    }
-
-    // Validate: if API key is set, base URL must also be set
-    if (hasApiKey && !normalizedDraft.baseUrl) {
+    if (hasApiKey && !hasBaseUrl) {
       setConnectionError('Base URL is required when an API key is provided');
+      return;
+    }
+
+    if (hasBaseUrl && !hasApiKey) {
+      setConnectionError('API key is required when a server URL is provided');
       return;
     }
 
@@ -205,8 +196,8 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
     }
   };
 
-  const resetBaseUrl = () => {
-    setDraft(prev => ({ ...prev, baseUrl: DEFAULT_OPENAI_BASE_URL }));
+  const clearBaseUrl = () => {
+    setDraft(prev => ({ ...prev, baseUrl: '' }));
   };
 
   // Connection status indicator
@@ -281,13 +272,13 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
         <View style={styles.labelRow}>
           <Text style={styles.label}>Base URL</Text>
           <TouchableOpacity
-            onPress={resetBaseUrl}
+            onPress={clearBaseUrl}
             style={styles.inlineActionButton}
             accessibilityRole="button"
-            accessibilityLabel={createButtonAccessibilityLabel('Reset base URL to default')}
-            accessibilityHint="Restores the default OpenAI-compatible base URL"
+            accessibilityLabel={createButtonAccessibilityLabel('Clear base URL')}
+            accessibilityHint="Clears the server URL so you can scan a fresh DotAgents QR code or paste a new one"
           >
-            <Text style={styles.resetText}>Reset to default</Text>
+            <Text style={styles.resetText}>Clear</Text>
           </TouchableOpacity>
         </View>
         <TextInput

--- a/apps/mobile/src/store/config.test.ts
+++ b/apps/mobile/src/store/config.test.ts
@@ -16,6 +16,16 @@ import {
   normalizeStoredConfig,
 } from './config';
 
+describe('DEFAULT_APP_CONFIG', () => {
+  // Mobile is a companion to the DotAgents desktop remote server, so a fresh
+  // install must not advertise OpenAI as a working default — that left the UI
+  // looking pre-configured while still disconnected.
+  it('starts unconfigured so the disconnected state is honest', () => {
+    expect(DEFAULT_APP_CONFIG.baseUrl).toBe('');
+    expect(DEFAULT_APP_CONFIG.apiKey).toBe('');
+  });
+});
+
 describe('normalizeStoredConfig', () => {
   it('backfills the handsfree defaults for older configs', () => {
     const normalized = normalizeStoredConfig({

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -4,7 +4,10 @@ import { normalizeApiBaseUrl } from '@dotagents/shared';
 
 export type AppConfig = {
   apiKey: string;
-  baseUrl: string; // OpenAI-compatible API base URL e.g., https://api.openai.com/v1
+  // OpenAI-compatible API base URL. Empty by default — mobile is a companion to the
+  // DotAgents desktop remote server, so the real URL is filled in by QR/deep-link
+  // pairing (or manual entry) rather than a misleading provider default.
+  baseUrl: string;
   model: string; // model name required by /v1/chat/completions
   handsFree?: boolean; // hands-free voice mode toggle (optional for backward compatibility)
   handsFreeMessageDebounceMs?: number; // silence window before auto-sending a hands-free message
@@ -57,7 +60,7 @@ function normalizeHandsFreeMessageDebounceMs(value?: number) {
 
 export const DEFAULT_APP_CONFIG: AppConfig = {
   apiKey: '',
-  baseUrl: 'https://api.openai.com/v1',
+  baseUrl: '',
   model: 'gpt-4.1-mini',
   handsFree: false,
   handsFreeMessageDebounceMs: DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS,

--- a/apps/mobile/tests/connection-settings-validation.test.js
+++ b/apps/mobile/tests/connection-settings-validation.test.js
@@ -10,14 +10,33 @@ const screenSource = fs.readFileSync(
 
 test('blocks first-time save when no API key is provided', () => {
   assert.match(screenSource, /if \(!isConnected && !hasApiKey\) \{/);
-  assert.match(screenSource, /Enter an API key or scan a DotAgents QR code before saving/);
-});
-
-test('keeps the custom URL validation after the no-key guard', () => {
   assert.match(
     screenSource,
-    /if \(!isConnected && !hasApiKey\) \{[\s\S]*?return;[\s\S]*?if \(hasCustomUrl && !hasApiKey\) \{/
+    /Scan the DotAgents QR code or enter your server URL and API key before saving/
   );
+});
+
+test('requires both server URL and API key together', () => {
+  // The previous "custom URL" branch existed because the screen silently filled
+  // in https://api.openai.com/v1 when the URL was blank, making the default
+  // appear configured. Now the URL must be supplied explicitly, so the
+  // validation is symmetric — neither field can be set without the other.
+  assert.match(
+    screenSource,
+    /if \(hasApiKey && !hasBaseUrl\) \{[\s\S]*?Base URL is required when an API key is provided/
+  );
+  assert.match(
+    screenSource,
+    /if \(hasBaseUrl && !hasApiKey\) \{[\s\S]*?API key is required when a server URL is provided/
+  );
+});
+
+test('does not silently default the base URL to api.openai.com', () => {
+  // Mobile is a companion to the DotAgents desktop remote server. A fresh
+  // install used to fall back to https://api.openai.com/v1 with an empty API
+  // key, which made the app look configured while being unreachable.
+  assert.doesNotMatch(screenSource, /https:\/\/api\.openai\.com\/v1[^']*['"]\s*\)\s*;?\s*$/m);
+  assert.doesNotMatch(screenSource, /DEFAULT_OPENAI_BASE_URL\s*=/);
 });
 
 test('exposes the API key visibility toggle as a button with a larger touch target', () => {
@@ -25,9 +44,12 @@ test('exposes the API key visibility toggle as a button with a larger touch targ
   assert.match(screenSource, /inlineActionButton:\s*\{[\s\S]*?createMinimumTouchTargetStyle\([\s\S]*?minSize:\s*44,/);
 });
 
-test('exposes the reset action as an accessible button with a descriptive label', () => {
-  assert.match(screenSource, /createButtonAccessibilityLabel\('Reset base URL to default'\)/);
-  assert.match(screenSource, /Restores the default OpenAI-compatible base URL/);
+test('exposes the clear action as an accessible button with a descriptive label', () => {
+  assert.match(screenSource, /createButtonAccessibilityLabel\('Clear base URL'\)/);
+  assert.match(
+    screenSource,
+    /Clears the server URL so you can scan a fresh DotAgents QR code or paste a new one/
+  );
 });
 
 test('surfaces a clear error when QR scanning cannot get camera permission', () => {


### PR DESCRIPTION
Closes #490.

## Summary

A fresh mobile install set `baseUrl` to `https://api.openai.com/v1` with an empty API key. That made the app look pre-configured while actually being unreachable, and the disconnected state card on `SessionListScreen` displayed the OpenAI URL — masking the fact that no DotAgents desktop remote server was paired. It also blocked local validation flows (like seeding Expo Web sessions to verify the #408 scroll fix), because the connection gate stayed closed while the UI implied otherwise.

This change positions mobile as a DotAgents-desktop companion by default:

- `DEFAULT_APP_CONFIG.baseUrl` is now `''`, so a fresh install is honestly unconfigured. `SessionListScreen`'s existing `{!!config.baseUrl && (...)}` guard already suppresses the URL line when empty, so the disconnected card no longer leaks `api.openai.com`.
- `OpenAIClient.normalizeBaseUrl` no longer throws on empty input. Instantiating a client with no URL is safe; failures surface naturally on the first `health()` / `chat()` call (which is what the recovery layer already expects).
- `ConnectionSettingsScreen.onSave` no longer silently fills in `https://api.openai.com/v1` when the field is blank. Validation is now symmetric — both `baseUrl` and `apiKey` must be supplied together — with a clear "Scan the DotAgents QR code or enter your server URL and API key before saving" message on first-time setup.
- The "Reset to default" button becomes "Clear" since there is no remote-provider default to revert to on mobile; it just empties the field so the user can scan a fresh QR code or paste a new URL.

QR / deep-link pairing (`dotagents://config?baseUrl=…&apiKey=…`) is untouched — it's the primary path on mobile, and it now lands on a config that didn't pretend to be paired beforehand.

## Test plan

- [x] `pnpm vitest run` for the curated mobile suite (108 tests pass), including the new `DEFAULT_APP_CONFIG` test that locks in the empty default and the existing `normalizeStoredConfig` behavior.
- [x] `node --test tests/*.js` — connection-settings-validation tests updated to match the new copy, error messages, and the `Clear` action; remaining failures match the pre-change baseline.
- [x] `tsc --noEmit` is clean.
- [ ] Manual: fresh Expo Web load shows "Connect DotAgents to get started" with no URL string beneath it, and "Test & Save" with an empty form returns the new clear error instead of silently saving an OpenAI URL.
- [ ] Manual: scanning the desktop QR code still fills both fields and pairs cleanly.

https://claude.ai/code/session_013M7w4AWDPueCAHxoHqiEZT

---
_Generated by [Claude Code](https://claude.ai/code/session_013M7w4AWDPueCAHxoHqiEZT)_