### PR TITLE
Drop garbled functions.<name>({...}) wrappers from replay history

### DIFF
--- a/apps/desktop/src/main/llm-continuation-guards.ts
+++ b/apps/desktop/src/main/llm-continuation-guards.ts
@@ -7,7 +7,10 @@ const RAW_TOOL_TRANSCRIPT_REGEX = /^\[[a-z0-9_:-]+\]\s*(?:ERROR:\s*)?(?:\{[\s\S]
 // syntax as plain text content instead of structured tool calls. This happens with
 // long conversations when the model starts outputting OpenAI-internal formats like
 // multi_tool_use.parallel or functions.* as text with garbled Unicode.
-const GARBLED_TOOL_CALL_TEXT_REGEX = /(?:multi_tool_use[.\s]|to=(?:multi_tool_use|functions)\.|recipient_name.*functions\.|\[Calling tools?:.*\].*(?:to=|json\s*\{))/i
+// The last alternative also catches bare top-level wrappers like
+// `functions.respond_to_user({ ... })` that show up without a `to=` prefix or
+// `[Calling tools: …]` placeholder.
+const GARBLED_TOOL_CALL_TEXT_REGEX = /(?:multi_tool_use[.\s]|to=(?:multi_tool_use|functions)\.|recipient_name.*functions\.|\[Calling tools?:.*\].*(?:to=|json\s*\{)|\bfunctions\.[a-zA-Z_][a-zA-Z0-9_]*\s*\(\s*\{)/i
 const PROGRESS_UPDATE_REGEX = /(?:^|[.!?]\s+)(?:let me|i'?ll|i will|i'm going to|now i'?ll|next i'?ll|working on it|still working on it|continuing|searching now)\b/i
 const NEXT_STEP_PROGRESS_REGEX = /(?:^|[.!?]\s+)(?:next(?:\s+item)?\s*(?::|[-—]))/i
 const NON_PROGRESS_SIGNOFF_REGEX = /(?:^|[.!?]\s+)(?:let me know if you need(?: anything else| more help| anything more)?|feel free to reach out if you need anything else)\b/i
@@ -142,6 +145,23 @@ export function isGarbledToolCallText(content?: string): boolean {
   const trimmed = typeof content === "string" ? content.trim() : ""
   if (!trimmed) return false
   return TOOL_CALL_PLACEHOLDER_REGEX.test(trimmed) || GARBLED_TOOL_CALL_TEXT_REGEX.test(trimmed)
+}
+
+// When the model emits real structured tool calls but ALSO emits garbled
+// tool-call-as-text in `content` (e.g. a plain "functions.respond_to_user({…})"
+// wrapper next to the structured call), persisting that text would replay it
+// back to the model as if the user had pasted it. Strip it in that case.
+// Plain prose alongside tool calls is allowed through unchanged.
+export function sanitizeAssistantContentForToolCalls(
+  content?: string,
+  toolCalls?: Array<{ name?: string; arguments?: unknown }>,
+): string {
+  const raw = typeof content === "string" ? content : ""
+  const hasStructuredToolCalls = Array.isArray(toolCalls) && toolCalls.length > 0
+  if (hasStructuredToolCalls && isGarbledToolCallText(raw)) {
+    return ""
+  }
+  return raw
 }
 
 export function isDeliverableResponseContent(content?: string): boolean {

--- a/apps/desktop/src/main/llm.continuation-guards.test.ts
+++ b/apps/desktop/src/main/llm.continuation-guards.test.ts
@@ -6,6 +6,7 @@ import {
   isProgressUpdateResponse,
   normalizeVerificationResultForCompletion,
   resolveIterationLimitFinalContent,
+  sanitizeAssistantContentForToolCalls,
 } from "./llm-continuation-guards"
 
 describe("continuation guard helpers", () => {
@@ -243,6 +244,49 @@ describe("continuation guard helpers", () => {
   it("only classifies actual placeholder-style tool text as garbled", () => {
     expect(isGarbledToolCallText('[Calling tools: execute_command]')).toBe(true)
     expect(isGarbledToolCallText('The new empty field is at @e33 (nth=4). Let me add the next item.')).toBe(false)
+  })
+
+  it("flags bare top-level functions.<name>({...}) wrappers as garbled", () => {
+    // Real example from #401: model emitted plain-text function-call syntax alongside
+    // a structured mark_work_complete tool call.
+    expect(isGarbledToolCallText('functions.respond_to_user({"text":"All done."})')).toBe(true)
+    expect(isGarbledToolCallText('functions.execute_command({ "command": "ls" })')).toBe(true)
+    expect(isDeliverableResponseContent('functions.respond_to_user({"text":"All done."})')).toBe(false)
+    // Prose mentioning the word "functions" without the call+object-literal shape
+    // should not be flagged.
+    expect(isGarbledToolCallText('The available functions include respond_to_user and execute_command.')).toBe(false)
+  })
+
+  it("strips garbled tool-call-as-text content when structured tool calls are present", () => {
+    // Real example from #401: assistant emits a plain-text functions.respond_to_user
+    // wrapper alongside a structured mark_work_complete tool call. The plain text
+    // must not be persisted, or it replays back to the model as user-pasted text.
+    expect(
+      sanitizeAssistantContentForToolCalls(
+        'functions.respond_to_user({"text":"All done."})',
+        [{ name: "mark_work_complete", arguments: {} }],
+      ),
+    ).toBe("")
+    // Without structured tool calls, the content is preserved (it's the regular
+    // garbled-text-loop guard's job to detect that case via isGarbledToolCallText).
+    expect(
+      sanitizeAssistantContentForToolCalls(
+        'functions.respond_to_user({"text":"All done."})',
+        undefined,
+      ),
+    ).toBe('functions.respond_to_user({"text":"All done."})')
+    // Legitimate prose alongside tool calls is preserved.
+    expect(
+      sanitizeAssistantContentForToolCalls(
+        "Running the tests now.",
+        [{ name: "execute_command", arguments: {} }],
+      ),
+    ).toBe("Running the tests now.")
+    // Empty content passes through.
+    expect(
+      sanitizeAssistantContentForToolCalls("", [{ name: "execute_command", arguments: {} }]),
+    ).toBe("")
+    expect(sanitizeAssistantContentForToolCalls(undefined, undefined)).toBe("")
   })
 
   it("treats common sign-offs as deliverable content", () => {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -68,6 +68,7 @@ import {
   normalizeMissingItemsList,
   normalizeVerificationResultForCompletion,
   resolveIterationLimitFinalContent,
+  sanitizeAssistantContentForToolCalls,
 } from "./llm-continuation-guards"
 import { buildVerificationMessagesFromAgentState } from "./llm-verification-replay"
 import { loadWorkingKnowledgeNotesForPrompt } from "./working-notes-runtime"
@@ -3057,8 +3058,15 @@ export async function processTranscriptWithAgentMode(
     const failedTools: string[] = []
 
     // Add assistant response with tool calls to conversation history BEFORE executing tools
-    // This ensures the tool call request is visible immediately in the UI
-    addMessage("assistant", llmResponse.content || "", llmResponse.toolCalls || [], undefined, undefined, displayOnlyMessageOptions)
+    // This ensures the tool call request is visible immediately in the UI.
+    // sanitizeAssistantContentForToolCalls drops garbled tool-call-as-text content
+    // (e.g. a plain "functions.respond_to_user({...})" wrapper) when structured tool
+    // calls are present, so it does not get replayed back to the model as user text.
+    const persistedAssistantContent = sanitizeAssistantContentForToolCalls(
+      llmResponse.content,
+      llmResponse.toolCalls,
+    )
+    addMessage("assistant", persistedAssistantContent, llmResponse.toolCalls || [], undefined, undefined, displayOnlyMessageOptions)
 
     // Emit progress update to show tool calls immediately
     emit({


### PR DESCRIPTION
## Summary

Closes the defensive-guard gap called out at the end of #401: when the model emits a plain-text `functions.respond_to_user({...})` (or similar) wrapper alongside a real structured tool call, persisting that text into conversation history replays it back to the model as if the user had pasted a tool transcript. That's what produced the malformed `functions.respond_to_user({ ... })` assistant turns the issue documented.

The primary "mobile branch endpoint" part of #401 is already implemented (remote-server `POST /v1/conversations/:id/branch` at `apps/desktop/src/main/remote-server.ts:6008` and mobile client `branchConversation` at `apps/mobile/src/lib/settingsApi.ts:1094`), so this PR focuses on the related guard.

## What changed

### `apps/desktop/src/main/llm-continuation-guards.ts`
- Extend `GARBLED_TOOL_CALL_TEXT_REGEX` to match bare top-level `functions.<name>({` wrappers (no `to=` prefix or `[Calling tools: …]` placeholder needed). The existing alternatives already covered `multi_tool_use.*`, `to=functions.*`, etc.; this adds the bare-wrapper case the issue called out.
- Add `sanitizeAssistantContentForToolCalls(content, toolCalls)` — returns `""` when structured tool calls are present AND the content matches `isGarbledToolCallText`, otherwise passes content through unchanged. Plain prose alongside tool calls (e.g. `"Running the tests now."`) is preserved.

### `apps/desktop/src/main/llm.ts`
- Use `sanitizeAssistantContentForToolCalls` at the single persist site that records `llmResponse.content` alongside `llmResponse.toolCalls` (was line 3061). Garbled text now drops out before it reaches `addMessage` / disk / replay; the structured tool call itself is untouched.

### `apps/desktop/src/main/llm.continuation-guards.test.ts`
- Adds a `isGarbledToolCallText` case covering `functions.respond_to_user({...})` and `functions.execute_command({...})`, plus a negative case for prose mentioning "functions" without the call+object shape.
- Adds a `sanitizeAssistantContentForToolCalls` case that asserts strip-on-tool-calls, pass-through without tool calls, prose preserved alongside tool calls, and empty/undefined input.

## Test plan

- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/llm.continuation-guards.test.ts` — 23/23 pass
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/llm.respond-to-user-history.test.ts` — 47/47 pass
- [x] `pnpm --filter @dotagents/desktop run typecheck:node` — clean
- [ ] Manual: in a session that produces both a structured `mark_work_complete` tool call and garbled `functions.respond_to_user({…})` plain-text content, confirm the persisted assistant message has empty `content` and the next turn does not see the wrapper in replay history.

## Out of scope

- The broader `#401` work (a server-side branch endpoint reachable from mobile) is already done — this PR only closes the related defensive-guard gap mentioned in the same issue.
- Mobile-side sanitization (`apps/mobile/src/lib/openaiClient.ts:sanitizeMessagesForRequest`) does not currently inspect `content`. If mobile reads back a contaminated server conversation, the desktop fix above already prevents new contamination at the source; remediating already-persisted bad history is a separate cleanup.

https://claude.ai/code/session_01RSWSRZsLGgkLdhZ67zfqzT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSWSRZsLGgkLdhZ67zfqzT)_