### PR TITLE
Add hands-free speaker mode with TTS-aware mic gating

### DIFF
--- a/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
+++ b/apps/desktop/src/renderer/src/components/session-action-dialog.tsx
@@ -10,6 +10,11 @@ import { queryClient } from "@renderer/lib/queries"
 import { cn } from "@renderer/lib/utils"
 import { playSound } from "@renderer/lib/sound"
 import { useAgentStore } from "@renderer/stores"
+import {
+  HANDS_FREE_AUDIO_CONSTRAINTS,
+  evaluateHandsFreeSubmit,
+  isTTSAudible,
+} from "@renderer/lib/hands-free-coordinator"
 
 export type SessionActionDialogMode = "text" | "voice"
 
@@ -61,6 +66,11 @@ export function SessionActionDialog({
   const recorderRef = useRef<Recorder | null>(null)
   const shouldSubmitVoiceRef = useRef(false)
   const isClosedRef = useRef(false)
+  const recordingStartedAtRef = useRef<number>(0)
+  const ttsLastAudibleEndedAtRef = useRef<number | null>(null)
+  const ttsAudibleDuringRecordingRef = useRef<boolean>(false)
+
+  const ttsPlaybackState = useAgentStore((state) => state.ttsPlaybackState)
 
   const canUpdateDialogState = () => isMountedRef.current && !isClosedRef.current
 
@@ -157,6 +167,35 @@ export function SessionActionDialog({
           return
         }
 
+        const handsFreeConfig = await tipcClient.getConfig()
+        if (handsFreeConfig?.handsFreeSpeakerMode) {
+          const recordingEndedAt = Date.now()
+          const verdict = evaluateHandsFreeSubmit({
+            ttsState: useAgentStore.getState().ttsPlaybackState,
+            recordingStartedAt: recordingStartedAtRef.current || recordingEndedAt - duration,
+            recordingEndedAt,
+            ttsLastAudibleEndedAt: ttsAudibleDuringRecordingRef.current
+              ? ttsLastAudibleEndedAtRef.current ?? recordingEndedAt
+              : ttsLastAudibleEndedAtRef.current,
+          })
+          if (!verdict.shouldSubmit) {
+            if (!canHandleRecorderCallback(recorder, true)) return
+            shouldSubmitVoiceRef.current = false
+            setIsSubmitting(false)
+            const message = verdict.reason === "tts-active"
+              ? "Waiting for assistant to finish speaking…"
+              : "Skipped capture that overlapped assistant speech — try again."
+            setStatusMessage(message)
+            if (verdict.reason !== "tts-active") {
+              toast.message(message)
+            }
+            if (canUpdateDialogState()) {
+              await startVoiceRecording()
+            }
+            return
+          }
+        }
+
         try {
           playSound("end_record")
           if (!canHandleRecorderCallback(recorder, true)) return
@@ -200,7 +239,16 @@ export function SessionActionDialog({
       if (!canUpdateDialogState()) return
       setRecording(true)
       const config = await tipcClient.getConfig()
-      await recorder.startRecording(config?.audioInputDeviceId)
+      recordingStartedAtRef.current = Date.now()
+      ttsAudibleDuringRecordingRef.current = false
+      const handsFree = config?.handsFreeSpeakerMode
+      if (handsFree && isTTSAudible(useAgentStore.getState().ttsPlaybackState)) {
+        ttsAudibleDuringRecordingRef.current = true
+      }
+      await recorder.startRecording({
+        deviceId: config?.audioInputDeviceId,
+        ...(handsFree ? HANDS_FREE_AUDIO_CONSTRAINTS : {}),
+      })
     } catch (error) {
       stopRecorder()
       if (!canUpdateDialogState()) return
@@ -239,6 +287,23 @@ export function SessionActionDialog({
       stopRecorder()
     }
   }, [open, mode])
+
+  // Track whether TTS was audible at any point during the active recording
+  // window. Used by hands-free mode to drop captures that overlap the
+  // assistant's own speech, plus to expose a tail-window suppression after
+  // playback ends.
+  useEffect(() => {
+    if (!open || mode !== "voice") return
+    const audible = isTTSAudible(ttsPlaybackState)
+    if (audible) {
+      if (recording) {
+        ttsAudibleDuringRecordingRef.current = true
+      }
+      ttsLastAudibleEndedAtRef.current = null
+    } else if (ttsLastAudibleEndedAtRef.current === null && ttsPlaybackState?.updatedAt) {
+      ttsLastAudibleEndedAtRef.current = ttsPlaybackState.updatedAt
+    }
+  }, [open, mode, recording, ttsPlaybackState])
 
   useEffect(() => {
     if (!open || mode !== "voice" || !recording || isSubmitting) return undefined

--- a/apps/desktop/src/renderer/src/components/session-action-dialog.voice.test.tsx
+++ b/apps/desktop/src/renderer/src/components/session-action-dialog.voice.test.tsx
@@ -43,7 +43,10 @@ async function loadSessionActionDialog(runtime: ReturnType<typeof createHookRunt
   const soundMock = { playSound: vi.fn(async () => undefined) }
   const tipcClientMock = { tipcClient: { createMcpTextInput: vi.fn(), createMcpRecording: vi.fn(), getConfig: vi.fn(async () => null) } }
   const queryClientMock = { queryClient: { invalidateQueries: vi.fn(async () => undefined) } }
-  const storeMock = { useAgentStore: { getState: () => ({ appendUserMessageToSession: vi.fn() }) } }
+  const idleTTSPlaybackState = { playbackId: null, status: "idle", currentTime: 0, duration: 0, volume: 1, muted: false, updatedAt: 0 }
+  const useAgentStore: any = (selector?: (state: any) => any) => (typeof selector === "function" ? selector({ ttsPlaybackState: idleTTSPlaybackState }) : idleTTSPlaybackState)
+  useAgentStore.getState = () => ({ appendUserMessageToSession: vi.fn(), ttsPlaybackState: idleTTSPlaybackState })
+  const storeMock = { useAgentStore }
 
   vi.doMock("react", () => runtime.reactMock)
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)

--- a/apps/desktop/src/renderer/src/lib/hands-free-coordinator.test.ts
+++ b/apps/desktop/src/renderer/src/lib/hands-free-coordinator.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest"
+import type { DesktopTTSPlaybackState } from "@shared/types"
+import {
+  HANDS_FREE_TAIL_MS,
+  evaluateHandsFreeSubmit,
+  isLikelyFeedbackPairing,
+  isTTSAudible,
+} from "./hands-free-coordinator"
+
+const buildState = (overrides: Partial<DesktopTTSPlaybackState> = {}): DesktopTTSPlaybackState => ({
+  playbackId: "pb-1",
+  status: "idle",
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  muted: false,
+  updatedAt: 0,
+  ...overrides,
+})
+
+describe("isTTSAudible", () => {
+  it("treats playing/loading states as audible", () => {
+    expect(isTTSAudible(buildState({ status: "playing" }))).toBe(true)
+    expect(isTTSAudible(buildState({ status: "loading" }))).toBe(true)
+  })
+
+  it("ignores muted or zero-volume playback", () => {
+    expect(isTTSAudible(buildState({ status: "playing", muted: true }))).toBe(false)
+    expect(isTTSAudible(buildState({ status: "playing", volume: 0 }))).toBe(false)
+  })
+
+  it("treats idle/paused/ended/error states as silent", () => {
+    expect(isTTSAudible(buildState({ status: "idle" }))).toBe(false)
+    expect(isTTSAudible(buildState({ status: "paused" }))).toBe(false)
+    expect(isTTSAudible(buildState({ status: "ended" }))).toBe(false)
+    expect(isTTSAudible(buildState({ status: "error" }))).toBe(false)
+  })
+
+  it("returns false when there is no playback state", () => {
+    expect(isTTSAudible(null)).toBe(false)
+    expect(isTTSAudible(undefined)).toBe(false)
+  })
+})
+
+describe("evaluateHandsFreeSubmit", () => {
+  it("submits when no TTS overlap and no tail window", () => {
+    const result = evaluateHandsFreeSubmit({
+      ttsState: buildState({ status: "idle" }),
+      recordingStartedAt: 1000,
+      recordingEndedAt: 2000,
+      ttsLastAudibleEndedAt: null,
+      now: 5000,
+    })
+    expect(result.shouldSubmit).toBe(true)
+  })
+
+  it("blocks when TTS is currently audible", () => {
+    const result = evaluateHandsFreeSubmit({
+      ttsState: buildState({ status: "playing" }),
+      recordingStartedAt: 1000,
+      recordingEndedAt: 2000,
+      ttsLastAudibleEndedAt: null,
+      now: 2000,
+    })
+    expect(result.shouldSubmit).toBe(false)
+    expect(result.reason).toBe("tts-active")
+  })
+
+  it("blocks when TTS ended during the recording window", () => {
+    const result = evaluateHandsFreeSubmit({
+      ttsState: buildState({ status: "ended" }),
+      recordingStartedAt: 1000,
+      recordingEndedAt: 3000,
+      ttsLastAudibleEndedAt: 1500,
+      now: 3000,
+    })
+    expect(result.shouldSubmit).toBe(false)
+    expect(result.reason).toBe("recording-overlapped-tts")
+  })
+
+  it("blocks when the recording ends within the tail window after TTS", () => {
+    const ttsEnd = 2500
+    const result = evaluateHandsFreeSubmit({
+      ttsState: buildState({ status: "ended" }),
+      recordingStartedAt: 3000,
+      recordingEndedAt: 3200,
+      ttsLastAudibleEndedAt: ttsEnd,
+      tailMs: HANDS_FREE_TAIL_MS,
+      now: ttsEnd + 200,
+    })
+    expect(result.shouldSubmit).toBe(false)
+    expect(result.reason).toBe("within-tts-tail")
+  })
+
+  it("allows submission past the tail window", () => {
+    const ttsEnd = 1000
+    const result = evaluateHandsFreeSubmit({
+      ttsState: buildState({ status: "ended" }),
+      recordingStartedAt: 2000,
+      recordingEndedAt: 2500,
+      ttsLastAudibleEndedAt: ttsEnd,
+      tailMs: 500,
+      now: 3000,
+    })
+    expect(result.shouldSubmit).toBe(true)
+  })
+})
+
+describe("isLikelyFeedbackPairing", () => {
+  it("flags the default-default pairing", () => {
+    expect(isLikelyFeedbackPairing({})).toBe(true)
+  })
+
+  it("flags built-in laptop pairings via shared brand tokens", () => {
+    expect(
+      isLikelyFeedbackPairing({
+        inputDeviceId: "abc",
+        outputDeviceId: "xyz",
+        inputLabel: "MacBook Pro Microphone",
+        outputLabel: "MacBook Pro Speakers",
+      }),
+    ).toBe(true)
+  })
+
+  it("does not flag a headset paired with system speakers", () => {
+    expect(
+      isLikelyFeedbackPairing({
+        inputDeviceId: "headset",
+        outputDeviceId: "speakers",
+        inputLabel: "Jabra Evolve 20 Microphone",
+        outputLabel: "MacBook Pro Speakers",
+      }),
+    ).toBe(false)
+  })
+
+  it("does not flag default mic with explicit external output", () => {
+    expect(
+      isLikelyFeedbackPairing({
+        outputDeviceId: "external",
+        outputLabel: "External USB DAC",
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/hands-free-coordinator.ts
+++ b/apps/desktop/src/renderer/src/lib/hands-free-coordinator.ts
@@ -1,0 +1,128 @@
+import type { DesktopTTSPlaybackState } from "@shared/types"
+import type { RecorderAudioConstraints } from "@renderer/lib/recorder"
+
+// Tail window after TTS playback ends during which captured audio is still
+// considered likely to contain echo of the assistant's own response. Speaker
+// rooms and BT headsets vary, so we keep this conservative.
+export const HANDS_FREE_TAIL_MS = 750
+
+// Constraints we apply to getUserMedia when hands-free speaker mode is on.
+// Browsers route these through the WebRTC audio processing module, which is
+// enough to cover headset/laptop-speaker pairings without a custom DSP.
+export const HANDS_FREE_AUDIO_CONSTRAINTS: Required<RecorderAudioConstraints> = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
+}
+
+// TTS statuses that mean the assistant is (or just was) emitting audio
+// through the speakers and we should not treat captured mic input as a
+// fresh user turn.
+const ACTIVE_TTS_STATUSES = new Set<DesktopTTSPlaybackState["status"]>([
+  "loading",
+  "playing",
+])
+
+export const isTTSAudible = (state: DesktopTTSPlaybackState | null | undefined): boolean => {
+  if (!state) return false
+  if (state.muted) return false
+  if (state.volume !== undefined && state.volume <= 0) return false
+  return ACTIVE_TTS_STATUSES.has(state.status)
+}
+
+export interface HandsFreeSubmitEvaluation {
+  shouldSubmit: boolean
+  reason?:
+    | "tts-active"
+    | "recording-overlapped-tts"
+    | "within-tts-tail"
+}
+
+export interface EvaluateHandsFreeSubmitArgs {
+  ttsState: DesktopTTSPlaybackState | null | undefined
+  recordingStartedAt: number
+  recordingEndedAt: number
+  // Optional: when the active playback last transitioned from "playing"/"loading"
+  // to a non-audible status. Treated as "TTS ended at this timestamp" so we can
+  // suppress a short tail window after playback finishes.
+  ttsLastAudibleEndedAt?: number | null
+  // The window after TTS ends during which captured audio is still likely echo.
+  tailMs?: number
+  now?: number
+}
+
+// Decide whether a finalized hands-free recording should be submitted as a
+// new user turn. We block when TTS is currently audible, when TTS was audible
+// at any point during the recording window, or when the recording ended within
+// the configured tail window after playback stopped. These rules together stop
+// the assistant's own speaker output from becoming the next user message
+// without needing a separate audio-fingerprint pass.
+export const evaluateHandsFreeSubmit = ({
+  ttsState,
+  recordingStartedAt,
+  recordingEndedAt,
+  ttsLastAudibleEndedAt,
+  tailMs = HANDS_FREE_TAIL_MS,
+  now = Date.now(),
+}: EvaluateHandsFreeSubmitArgs): HandsFreeSubmitEvaluation => {
+  if (isTTSAudible(ttsState)) {
+    return { shouldSubmit: false, reason: "tts-active" }
+  }
+
+  if (
+    ttsLastAudibleEndedAt &&
+    ttsLastAudibleEndedAt >= recordingStartedAt &&
+    ttsLastAudibleEndedAt <= recordingEndedAt
+  ) {
+    return { shouldSubmit: false, reason: "recording-overlapped-tts" }
+  }
+
+  if (ttsLastAudibleEndedAt && now - ttsLastAudibleEndedAt < tailMs) {
+    return { shouldSubmit: false, reason: "within-tts-tail" }
+  }
+
+  return { shouldSubmit: true }
+}
+
+export interface SameDeviceFeedbackInput {
+  inputLabel?: string | null
+  outputLabel?: string | null
+  inputDeviceId?: string
+  outputDeviceId?: string
+}
+
+// Heuristic that flags device pairings likely to feed the assistant's own
+// audio back into the microphone. We trigger when both sides resolve to the
+// system default (or no explicit selection) or when their labels share a
+// distinctive substring (e.g. "MacBook Pro Speakers" / "MacBook Pro
+// Microphone"). Headset and external-mic pairings do not match.
+export const isLikelyFeedbackPairing = ({
+  inputLabel,
+  outputLabel,
+  inputDeviceId,
+  outputDeviceId,
+}: SameDeviceFeedbackInput): boolean => {
+  const inputDefault = !inputDeviceId || inputDeviceId === "default"
+  const outputDefault = !outputDeviceId || outputDeviceId === "default"
+  if (inputDefault && outputDefault) return true
+
+  if (!inputLabel || !outputLabel) return false
+
+  const normalize = (value: string) =>
+    value
+      .toLowerCase()
+      .replace(/\b(microphone|mic|input|speakers?|output|built[- ]?in|internal)\b/g, " ")
+      .replace(/[^a-z0-9]+/g, " ")
+      .trim()
+
+  const normalizedInput = normalize(inputLabel)
+  const normalizedOutput = normalize(outputLabel)
+  if (!normalizedInput || !normalizedOutput) return false
+
+  if (normalizedInput === normalizedOutput) return true
+
+  // Share a meaningful token (e.g. brand/model word) — heuristic only.
+  const inputTokens = new Set(normalizedInput.split(/\s+/).filter((token) => token.length >= 4))
+  const outputTokens = normalizedOutput.split(/\s+/).filter((token) => token.length >= 4)
+  return outputTokens.some((token) => inputTokens.has(token))
+}

--- a/apps/desktop/src/renderer/src/lib/recorder.test.ts
+++ b/apps/desktop/src/renderer/src/lib/recorder.test.ts
@@ -65,4 +65,66 @@ describe("Recorder audio input fallback", () => {
     await expect(recorder.startRecording("missing-mic")).rejects.toEqual({ name: "NotAllowedError" })
     expect(getUserMedia).toHaveBeenCalledTimes(1)
   })
+
+  it("forwards hands-free audio constraints alongside the configured device", async () => {
+    const stream = { getTracks: () => [] } as unknown as MediaStream
+    const getUserMedia = vi.fn().mockResolvedValueOnce(stream)
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia },
+    })
+
+    const { Recorder } = await import("./recorder")
+    const recorder = new Recorder()
+
+    await recorder.startRecording({
+      deviceId: "preferred-mic",
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    })
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1)
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: {
+        deviceId: { exact: "preferred-mic" },
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+      video: false,
+    })
+  })
+
+  it("preserves hands-free audio constraints when falling back from an invalid device", async () => {
+    const stream = { getTracks: () => [] } as unknown as MediaStream
+    const getUserMedia = vi
+      .fn()
+      .mockRejectedValueOnce({ name: "OverconstrainedError" })
+      .mockResolvedValueOnce(stream)
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia },
+    })
+
+    vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { Recorder } = await import("./recorder")
+    const recorder = new Recorder()
+
+    await recorder.startRecording({
+      deviceId: "missing-mic",
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    })
+
+    expect(getUserMedia).toHaveBeenNthCalledWith(2, {
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+      video: false,
+    })
+  })
 })

--- a/apps/desktop/src/renderer/src/lib/recorder.ts
+++ b/apps/desktop/src/renderer/src/lib/recorder.ts
@@ -9,24 +9,53 @@ const isInvalidAudioInputDeviceError = (error: unknown) => {
   return name === "OverconstrainedError" || name === "NotFoundError"
 }
 
-const getUserMediaAudioStream = async (deviceId?: string) => {
+export interface RecorderAudioConstraints {
+  echoCancellation?: boolean
+  noiseSuppression?: boolean
+  autoGainControl?: boolean
+}
+
+export interface RecorderStartOptions extends RecorderAudioConstraints {
+  deviceId?: string
+}
+
+const normalizeStartOptions = (input?: string | RecorderStartOptions): RecorderStartOptions => {
+  if (!input) return {}
+  if (typeof input === "string") return { deviceId: input }
+  return input
+}
+
+const buildAudioConstraints = (options: RecorderStartOptions, includeDeviceId: boolean): MediaTrackConstraints | true => {
+  const constraints: MediaTrackConstraints = {}
+  if (includeDeviceId && options.deviceId) {
+    constraints.deviceId = { exact: options.deviceId }
+  }
+  if (options.echoCancellation !== undefined) constraints.echoCancellation = options.echoCancellation
+  if (options.noiseSuppression !== undefined) constraints.noiseSuppression = options.noiseSuppression
+  if (options.autoGainControl !== undefined) constraints.autoGainControl = options.autoGainControl
+
+  return Object.keys(constraints).length > 0 ? constraints : true
+}
+
+const getUserMediaAudioStream = async (options: RecorderStartOptions) => {
+  const primaryConstraints = buildAudioConstraints(options, true)
   try {
     return await navigator.mediaDevices.getUserMedia({
-      audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+      audio: primaryConstraints,
       video: false,
     })
   } catch (error) {
-    if (!deviceId || !isInvalidAudioInputDeviceError(error)) {
+    if (!options.deviceId || !isInvalidAudioInputDeviceError(error)) {
       throw error
     }
 
     console.warn("[Recorder] Configured audio input device unavailable, falling back to system default", {
-      deviceId,
+      deviceId: options.deviceId,
       error,
     })
 
     return navigator.mediaDevices.getUserMedia({
-      audio: true,
+      audio: buildAudioConstraints(options, false),
       video: false,
     })
   }
@@ -106,10 +135,10 @@ export class Recorder extends EventEmitter<{
     }
   }
 
-  async startRecording(deviceId?: string) {
+  async startRecording(options?: string | RecorderStartOptions) {
     this.stopRecording()
 
-    const stream = (this.stream = await getUserMediaAudioStream(deviceId))
+    const stream = (this.stream = await getUserMediaAudioStream(normalizeStartOptions(options)))
 
     const mediaRecorder = (this.mediaRecorder = new MediaRecorder(stream, {
       audioBitsPerSecond: 128e3,

--- a/apps/desktop/src/renderer/src/pages/onboarding.tsx
+++ b/apps/desktop/src/renderer/src/pages/onboarding.tsx
@@ -15,6 +15,7 @@ import { Config } from "@shared/types"
 import { useNavigate } from "react-router-dom"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { Recorder } from "@renderer/lib/recorder"
+import { HANDS_FREE_AUDIO_CONSTRAINTS } from "@renderer/lib/hands-free-coordinator"
 import { useMutation } from "@tanstack/react-query"
 import { KeyRecorder } from "@renderer/components/key-recorder"
 import { getAgentShortcutDisplay } from "@shared/key-utils"
@@ -146,7 +147,10 @@ export function Component() {
     setMicError(null)
     try {
       const config = await tipcClient.getConfig()
-      await recorderRef.current?.startRecording(config?.audioInputDeviceId)
+      await recorderRef.current?.startRecording({
+        deviceId: config?.audioInputDeviceId,
+        ...(config?.handsFreeSpeakerMode ? HANDS_FREE_AUDIO_CONSTRAINTS : {}),
+      })
     } catch (error: any) {
       console.error("Failed to start recording:", error)
       const errorMessage = error?.message || String(error)

--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -2,6 +2,7 @@ import { AgentProgress } from "@renderer/components/agent-progress"
 import { AgentProcessingView } from "@renderer/components/agent-processing-view"
 import { MultiAgentProgressView } from "@renderer/components/multi-agent-progress-view"
 import { Recorder } from "@renderer/lib/recorder"
+import { HANDS_FREE_AUDIO_CONSTRAINTS } from "@renderer/lib/hands-free-coordinator"
 import { playSound, setSoundOutputDevice } from "@renderer/lib/sound"
 import { cn } from "@renderer/lib/utils"
 import { useMutation, useQuery } from "@tanstack/react-query"
@@ -357,16 +358,21 @@ export function Component() {
   // ref is refreshed in the background so the synchronous visualizer UI stays accurate.
   const startRecordingWithFreshDevice = async () => {
     let deviceId = audioInputDeviceIdRef.current
+    let handsFree = configQuery.data?.handsFreeSpeakerMode ?? false
     try {
       const freshConfig = await tipcClient.getConfig()
       if (freshConfig) {
         deviceId = freshConfig.audioInputDeviceId
         audioInputDeviceIdRef.current = deviceId
+        handsFree = !!freshConfig.handsFreeSpeakerMode
       }
     } catch {
       // Best-effort: fall back to the ref value on IPC failure.
     }
-    return recorderRef.current?.startRecording(deviceId)
+    return recorderRef.current?.startRecording({
+      deviceId,
+      ...(handsFree ? HANDS_FREE_AUDIO_CONSTRAINTS : {}),
+    })
   }
 
   // Apply selected audio output device to sound effects (recording start/stop beeps)

--- a/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
@@ -205,7 +205,7 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   vi.doMock("@renderer/lib/tipc-client", () => tipcClientMock)
   vi.doMock("../lib/tipc-client", () => tipcClientMock)
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null, Search: Null }))
+  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, AlertTriangle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null, Search: Null, X: Null }))
   vi.doMock("@dotagents/shared", () => ({ __esModule: true, STT_PROVIDER_ID: {}, SUPPORTED_LANGUAGES: [] }))
   vi.doMock("@shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))
   vi.doMock("../shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -32,6 +32,7 @@ import {
 import { RemoteServerSettingsGroups } from "./settings-remote-server"
 import { useAudioDevices } from "@renderer/hooks/use-audio-devices"
 import { hasResolvedAudioInputDeviceLabel } from "@renderer/hooks/audio-input-device-utils"
+import { isLikelyFeedbackPairing } from "@renderer/lib/hands-free-coordinator"
 
 const SETTINGS_TEXT_SAVE_DEBOUNCE_MS = 400
 const MCP_MAX_ITERATIONS_MIN = 1
@@ -1006,6 +1007,54 @@ export function Component() {
               </SelectContent>
             </Select>
           </Control>
+
+          <Control
+            label={
+              <ControlLabel
+                label="Hands-free speaker mode"
+                tooltip="When listening through speakers, request browser echo cancellation/noise suppression/AGC and pause voice capture while the assistant is speaking, so its own audio is not picked back up as a new user turn."
+              />
+            }
+            className="px-3"
+          >
+            <Switch
+              checked={configQuery.data.handsFreeSpeakerMode ?? false}
+              onCheckedChange={(value) => {
+                saveConfig({ handsFreeSpeakerMode: value })
+              }}
+            />
+          </Control>
+
+          {(() => {
+            const selectedInput = audioInputDevices.find(
+              (device) => device.deviceId === configQuery.data?.audioInputDeviceId,
+            )
+            const selectedOutput = audioOutputDevices.find(
+              (device) => device.deviceId === configQuery.data?.audioOutputDeviceId,
+            )
+            const showFeedbackWarning = isLikelyFeedbackPairing({
+              inputLabel: selectedInput?.label ?? configQuery.data?.audioInputDeviceLabel,
+              outputLabel: selectedOutput?.label,
+              inputDeviceId: configQuery.data?.audioInputDeviceId,
+              outputDeviceId: configQuery.data?.audioOutputDeviceId,
+            })
+            if (!showFeedbackWarning) return null
+            return (
+              <div className="px-3">
+                <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-300">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <div className="space-y-1">
+                    <p className="font-medium">Microphone and speaker share the same device path.</p>
+                    <p>
+                      Audio output is likely to feed back into the mic. {configQuery.data?.handsFreeSpeakerMode
+                        ? "Hands-free speaker mode helps, but plugging in a headset removes feedback risk entirely."
+                        : "Enable Hands-free speaker mode above, or pick a separate headset/microphone."}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )
+          })()}
         </ControlGroup>
 
         <ControlGroup collapsible defaultCollapsed title="Speech-to-Text" forceOpen={isSearching}>

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1198,6 +1198,12 @@ export type Config = {
   audioInputDeviceLabel?: string // Last resolved microphone label (used to remap rotated IDs)
   audioOutputDeviceId?: string  // Speaker device ID (from enumerateDevices / setSinkId)
 
+  // Hands-free speaker mode: when listening through speakers, request mic input
+  // with browser echo cancellation / noise suppression / AGC and gate recording
+  // around active TTS playback so the assistant's own audio is not captured as
+  // a new user turn.
+  handsFreeSpeakerMode?: boolean
+
   // Text Input Configuration
   textInputEnabled?: boolean
   textInputShortcut?: "ctrl-t" | "ctrl-shift-t" | "alt-t" | "custom"


### PR DESCRIPTION
Closes #516.

## Summary
- Adds `handsFreeSpeakerMode` config flag and a Settings toggle next to the audio device pickers.
- `Recorder.startRecording` now accepts `echoCancellation` / `noiseSuppression` / `autoGainControl` constraints, and the existing invalid-device fallback preserves them.
- The session voice dialog applies the hands-free constraints when enabled and drops captures that overlap (or land within a tail window after) active TTS playback, using the shared `ttsPlaybackState` from the agent store rather than ad-hoc local state.
- Panel and onboarding mic capture paths pass the hands-free constraints through too.
- Settings surfaces a warning when the selected mic/output pairing is likely to feed the assistant's own audio back into the mic.

## How it works
A small `hands-free-coordinator` module encapsulates two pieces of logic that are now reused across the dialog, settings, and tests:
- `evaluateHandsFreeSubmit` — decides whether a finalized recording should be submitted, considering the live TTS playback state, any overlap with the recording window, and a conservative tail window (`HANDS_FREE_TAIL_MS = 750ms`) after playback ends.
- `isLikelyFeedbackPairing` — heuristic check for "mic and speaker share the same device path" using both default-vs-default and label-token overlap, so MacBook built-in pairings warn while headset pairings don't.

When TTS is active mid-recording the dialog re-prompts the user instead of submitting the captured audio, so the assistant's own speech doesn't become the next user turn.

## Test plan
- [x] `pnpm exec vitest run src/renderer/src/lib/recorder.test.ts` — new constraint passthrough + fallback preservation cases pass alongside the existing invalid-device coverage.
- [x] `pnpm exec vitest run src/renderer/src/lib/hands-free-coordinator.test.ts` — 13 cases covering TTS audibility, overlap, tail window, and feedback heuristic.
- [x] `pnpm exec vitest run src/renderer/src/components/session-action-dialog.voice.test.tsx` — existing unmount-safety test still passes against the updated store mock.
- [x] `pnpm exec vitest run src/renderer/src/pages/settings-general` — settings draft suite passes with the new toggle in the tree.
- [x] `pnpm exec tsc --noEmit -p tsconfig.web.json` — clean.
- [ ] Manual: enable Hands-free speaker mode, trigger an assistant response with TTS auto-play, and confirm the next recording either waits for playback to finish or is re-prompted instead of submitted.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JdhkEUXVYw8wL4sK8EFbRL)_