### PR TITLE
Align Langfuse trace IDs with per-run agent lifecycle

### DIFF
--- a/apps/desktop/src/main/acp-main-agent.test.ts
+++ b/apps/desktop/src/main/acp-main-agent.test.ts
@@ -427,29 +427,95 @@ describe("acp-main-agent", () => {
       profileSnapshot: { profileId: "profile-1", profileName: "Debug Agent" } as any,
     })
 
-    expect(mockCreateAgentTrace).toHaveBeenCalledWith("ui-session-1", expect.objectContaining({
-      name: "ACP Agent Session",
-      sessionId: "conversation-1",
-      input: "hello",
-      tags: ["profile:Debug Agent", "acp"],
-    }))
-    expect(mockCreateToolSpan).toHaveBeenCalledWith("ui-session-1", "acp-tool-tool-123", expect.objectContaining({
+    // The trace id must be a freshly-generated per-run UUID, NOT the long-lived
+    // DotAgents agent session id. The agent session id is now carried inside
+    // trace metadata so it can be filtered/grouped in dashboards.
+    const uuidPattern = /^[0-9a-f-]{36}$/i
+    expect(mockCreateAgentTrace).toHaveBeenCalledWith(
+      expect.stringMatching(uuidPattern),
+      expect.objectContaining({
+        name: "ACP Agent Session",
+        sessionId: "conversation-1",
+        input: "hello",
+        tags: ["profile:Debug Agent", "acp"],
+        metadata: expect.objectContaining({
+          agentName: "test-agent",
+          agentSessionId: "ui-session-1",
+          runId: 1,
+          conversationId: "conversation-1",
+          profileId: "profile-1",
+          profileName: "Debug Agent",
+        }),
+      }),
+    )
+
+    const traceId = mockCreateAgentTrace.mock.calls[0]?.[0]
+    expect(typeof traceId).toBe("string")
+    expect(traceId).toMatch(uuidPattern)
+
+    expect(mockCreateToolSpan).toHaveBeenCalledWith(traceId, "acp-tool-tool-123", expect.objectContaining({
       name: "ACP Tool: web_search",
       input: { query: "trace this" },
+      metadata: expect.objectContaining({
+        agentSessionId: "ui-session-1",
+      }),
     }))
     expect(mockEndToolSpan).toHaveBeenCalledWith("acp-tool-tool-123", expect.objectContaining({
       level: "DEFAULT",
     }))
-    expect(mockEndAgentTrace).toHaveBeenCalledWith("ui-session-1", expect.objectContaining({
+    expect(mockEndAgentTrace).toHaveBeenCalledWith(traceId, expect.objectContaining({
       output: "done",
       metadata: expect.objectContaining({
         agentName: "test-agent",
+        agentSessionId: "ui-session-1",
+        runId: 1,
         conversationId: "conversation-1",
         acpSessionId: "acp-session-1",
         success: true,
         stopReason: "complete",
       }),
     }))
+    expect(mockFlushLangfuse).toHaveBeenCalled()
+  })
+
+  it("abort with active tool span emits ERROR-level span.end", async () => {
+    mockIsTracingEnabled.mockReturnValue(true)
+    mockSendPrompt.mockImplementation(async () => {
+      // Emit a `running` tool sessionUpdate but NO corresponding `completed` update,
+      // so the span is still open when the prompt rejects.
+      sessionUpdateHandler?.({
+        sessionId: "acp-session-1",
+        toolCall: {
+          toolCallId: "tool-aborted",
+          title: "Tool: web_search",
+          status: "running",
+          rawInput: { query: "abort this" },
+        },
+        isComplete: false,
+      })
+
+      throw new Error("agent run aborted")
+    })
+
+    const { processTranscriptWithACPAgent } = await import("./acp-main-agent")
+
+    const result = await processTranscriptWithACPAgent("hello", {
+      agentName: "test-agent",
+      conversationId: "conversation-1",
+      sessionId: "ui-session-1",
+      runId: 1,
+      profileSnapshot: { profileId: "profile-1", profileName: "Debug Agent" } as any,
+    })
+
+    expect(result.success).toBe(false)
+
+    // The leftover open span should be ended at ERROR level because traceError
+    // is set on this failure path. The plan's contract: WARNING for graceful
+    // truncation (no traceError), ERROR for abnormal termination.
+    expect(mockEndToolSpan).toHaveBeenCalledWith(
+      "acp-tool-tool-aborted",
+      expect.objectContaining({ level: "ERROR" }),
+    )
     expect(mockFlushLangfuse).toHaveBeenCalled()
   })
 

--- a/apps/desktop/src/main/acp-main-agent.ts
+++ b/apps/desktop/src/main/acp-main-agent.ts
@@ -5,6 +5,7 @@
  * This allows using agents like Claude Code as the "brain" for DotAgents.
  */
 
+import { randomUUID } from "crypto"
 import {
   acpService,
   ACPContentBlock,
@@ -369,14 +370,23 @@ export async function processTranscriptWithACPAgent(
   let traceStopReason: string | undefined
   let traceAcpSessionId: string | undefined
 
+  // Generate a per-RUN Langfuse trace id (was previously reusing the DotAgents
+  // sessionId which is long-lived and shared across many runs). Langfuse
+  // sessionId stays the conversation id so the dashboard's Sessions view still
+  // groups all runs of a conversation together.
+  const langfuseTraceId = randomUUID()
+
   if (tracingEnabled) {
-    createAgentTrace(sessionId, {
+    createAgentTrace(langfuseTraceId, {
       name: "ACP Agent Session",
       sessionId: conversationId,
       input: transcript,
       metadata: {
         agentName,
         forceNewSession: forceNewSession === true,
+        agentSessionId: sessionId,
+        runId,
+        conversationId,
         profileId: profileSnapshot?.profileId,
         profileName: profileSnapshot?.profileName,
       },
@@ -522,10 +532,15 @@ export async function processTranscriptWithACPAgent(
       }
       trackedToolCalls.set(toolCallId, tracked)
       if (spanId) {
-        createToolSpan(sessionId, spanId, {
+        createToolSpan(langfuseTraceId, spanId, {
           name: `ACP Tool: ${toolCall.name}`,
           input: toolCall.arguments as Record<string, unknown>,
-          metadata: { toolName: toolCall.name, acpToolCallId: toolCallId, agentName },
+          metadata: {
+            toolName: toolCall.name,
+            acpToolCallId: toolCallId,
+            agentName,
+            agentSessionId: sessionId,
+          },
         })
       }
     } else {
@@ -995,18 +1010,24 @@ export async function processTranscriptWithACPAgent(
     if (tracingEnabled) {
       for (const tracked of trackedToolCalls.values()) {
         if (tracked.spanId && !tracked.spanEnded) {
+          // If we already recorded a trace error (abnormal termination), promote
+          // the leftover span to ERROR; otherwise keep the existing WARNING level
+          // for the "session ended before tool reported completion" case.
+          const leftoverLevel: "ERROR" | "WARNING" = traceError ? "ERROR" : "WARNING"
           endToolSpan(tracked.spanId, {
-            level: "WARNING",
+            level: leftoverLevel,
             statusMessage: traceError || "ACP session ended before tool completed",
           })
           tracked.spanEnded = true
         }
       }
 
-      endAgentTrace(sessionId, {
+      endAgentTrace(langfuseTraceId, {
         output: traceOutput,
         metadata: {
           agentName,
+          agentSessionId: sessionId,
+          runId,
           conversationId,
           acpSessionId: traceAcpSessionId,
           success: !traceError,

--- a/apps/desktop/src/main/acp/internal-agent.ts
+++ b/apps/desktop/src/main/acp/internal-agent.ts
@@ -684,7 +684,8 @@ export async function runInternalSubSession(
     // Create tool executor that respects session isolation
     const executeToolCall = async (
       toolCall: MCPToolCall,
-      toolOnProgress?: (message: string) => void
+      toolOnProgress?: (message: string) => void,
+      langfuseTraceId?: string,
     ): Promise<MCPToolResult> => {
       // Check if session should stop
       if (agentSessionStateManager.shouldStopSession(subSessionId)) {
@@ -701,7 +702,8 @@ export async function runInternalSubSession(
         toolOnProgress,
         false, // skipApprovalCheck
         subSessionId,
-        effectiveProfileSnapshot?.mcpServerConfig
+        effectiveProfileSnapshot?.mcpServerConfig,
+        langfuseTraceId,
       );
 
       // Add tool result to conversation history for UI display
@@ -973,7 +975,8 @@ export async function continueInternalSubSession(
 
     const executeToolCall = async (
       toolCall: MCPToolCall,
-      toolOnProgress?: (message: string) => void
+      toolOnProgress?: (message: string) => void,
+      langfuseTraceId?: string,
     ): Promise<MCPToolResult> => {
       if (agentSessionStateManager.shouldStopSession(subSessionId)) {
         return {
@@ -987,7 +990,8 @@ export async function continueInternalSubSession(
         toolOnProgress,
         false,
         subSessionId,
-        effectiveProfileSnapshot?.mcpServerConfig
+        effectiveProfileSnapshot?.mcpServerConfig,
+        langfuseTraceId,
       );
 
       subSession.conversationHistory.push({

--- a/apps/desktop/src/main/headless-cli.ts
+++ b/apps/desktop/src/main/headless-cli.ts
@@ -416,8 +416,8 @@ async function runAgentCLI(prompt: string): Promise<void> {
       ? mcpService.getAvailableToolsForProfile(profileSnapshot.mcpServerConfig)
       : mcpService.getAvailableTools()
 
-    const executeToolCall = async (toolCall: any, onProgress?: (message: string) => void): Promise<MCPToolResult> => {
-      return await mcpService.executeToolCall(toolCall, onProgress, false, sessionId, profileSnapshot?.mcpServerConfig)
+    const executeToolCall = async (toolCall: any, onProgress?: (message: string) => void, langfuseTraceId?: string): Promise<MCPToolResult> => {
+      return await mcpService.executeToolCall(toolCall, onProgress, false, sessionId, profileSnapshot?.mcpServerConfig, langfuseTraceId)
     }
 
     // Track last shown step to avoid duplicates

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -843,6 +843,10 @@ if (!gotSingleInstanceLock) {
           withCleanupTimeout("keyboard", () => stopListeningToKeyboardEvents()),
           withCleanupTimeout("ACP", () => acpService.shutdown()),
           withCleanupTimeout("MCP", () => mcpService.cleanup()),
+          withCleanupTimeout("langfuse", async () => {
+            const { shutdownLangfuse } = await import("./langfuse-service")
+            await shutdownLangfuse()
+          }),
         ])
 
         for (const result of cleanupResults) {

--- a/apps/desktop/src/main/langfuse-service.trace-lifecycle.test.ts
+++ b/apps/desktop/src/main/langfuse-service.trace-lifecycle.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Trace lifecycle tests for langfuse-service.
+ *
+ * These tests run in local-trace-only mode (langfuse package mocked to null),
+ * so they exercise the per-run trace id wiring, span/generation link maps,
+ * and force-close semantics without needing a real Langfuse server.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import fs from "fs"
+import os from "os"
+import path from "path"
+
+let currentConfig: Record<string, unknown> = {}
+let tempDir: string
+
+vi.mock("./config", () => ({
+  configStore: { get: () => currentConfig },
+  get dataFolder() { return tempDir },
+}))
+
+vi.mock("./debug", () => ({
+  isDebugLLM: () => false,
+  logLLM: vi.fn(),
+}))
+
+vi.mock("./langfuse-loader", () => ({
+  Langfuse: null,
+  isInstalled: false,
+}))
+
+const readTraceFile = (traceId: string): Array<Record<string, unknown>> => {
+  const tracePath = path.join(tempDir, "traces", `${traceId}.jsonl`)
+  if (!fs.existsSync(tracePath)) return []
+  const raw = fs.readFileSync(tracePath, "utf8").trim()
+  if (!raw) return []
+  return raw.split("\n").map((line) => JSON.parse(line))
+}
+
+describe("langfuse-service trace lifecycle", () => {
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-langfuse-lifecycle-"))
+    currentConfig = { localTraceLoggingEnabled: true, langfuseEnabled: false }
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it("two consecutive runs in the same conversation produce two distinct trace files", async () => {
+    const mod = await import("./langfuse-service")
+
+    // Run A
+    const traceA = "trace-run-A"
+    mod.createAgentTrace(traceA, {
+      name: "Agent Session",
+      sessionId: "conv-1",
+      metadata: { runId: 1, agentSessionId: "agent-sess-A", conversationId: "conv-1" },
+      input: "first run",
+    })
+    mod.createLLMGeneration(traceA, "gen-A", {
+      name: "LLM Call",
+      model: "test-model",
+      input: { messages: [] },
+    })
+    mod.endLLMGeneration("gen-A", { output: "first answer" })
+    mod.endAgentTrace(traceA, { output: "done A" })
+
+    // Run B in the same DotAgents session/conversation
+    const traceB = "trace-run-B"
+    mod.createAgentTrace(traceB, {
+      name: "Agent Session",
+      sessionId: "conv-1",
+      metadata: { runId: 2, agentSessionId: "agent-sess-A", conversationId: "conv-1" },
+      input: "second run",
+    })
+    mod.createLLMGeneration(traceB, "gen-B", {
+      name: "LLM Call",
+      model: "test-model",
+      input: { messages: [] },
+    })
+    mod.endLLMGeneration("gen-B", { output: "second answer" })
+    mod.endAgentTrace(traceB, { output: "done B" })
+
+    await mod.flushLangfuse()
+
+    const fileA = path.join(tempDir, "traces", `${traceA}.jsonl`)
+    const fileB = path.join(tempDir, "traces", `${traceB}.jsonl`)
+    expect(fs.existsSync(fileA)).toBe(true)
+    expect(fs.existsSync(fileB)).toBe(true)
+
+    const linesA = readTraceFile(traceA)
+    const linesB = readTraceFile(traceB)
+
+    const startEventsA = linesA.filter((line) => line.type === "trace.start")
+    const endEventsA = linesA.filter((line) => line.type === "trace.end")
+    expect(startEventsA).toHaveLength(1)
+    expect(endEventsA).toHaveLength(1)
+
+    const startEventsB = linesB.filter((line) => line.type === "trace.start")
+    const endEventsB = linesB.filter((line) => line.type === "trace.end")
+    expect(startEventsB).toHaveLength(1)
+    expect(endEventsB).toHaveLength(1)
+
+    // Both runs share the conversation as Langfuse sessionId.
+    expect((startEventsA[0].metadata as any)?.sessionId).toBe("conv-1")
+    expect((startEventsB[0].metadata as any)?.sessionId).toBe("conv-1")
+  })
+
+  it("forceCloseActiveTrace emits ERROR-level span.end and generation.end", async () => {
+    const mod = await import("./langfuse-service")
+    const traceId = "trace-X"
+
+    mod.createAgentTrace(traceId, {
+      name: "Agent Session",
+      sessionId: "conv-X",
+      input: "in",
+    })
+    mod.createToolSpan(traceId, "span-1", {
+      name: "Tool: search",
+      input: { q: "hello" },
+    })
+    mod.createLLMGeneration(traceId, "gen-1", {
+      name: "LLM Call",
+      model: "test-model",
+      input: {},
+    })
+
+    mod.forceCloseActiveTrace(traceId, { statusMessage: "aborted", level: "ERROR" })
+
+    // Calling endToolSpan again should be a no-op (no duplicate span.end line).
+    mod.endToolSpan("span-1", { output: { ok: false } })
+
+    mod.endAgentTrace(traceId, { output: "" })
+
+    await mod.flushLangfuse()
+
+    const lines = readTraceFile(traceId)
+    const spanEnds = lines.filter((l) => l.type === "span.end" && l.spanId === "span-1")
+    const genEnds = lines.filter((l) => l.type === "generation.end" && l.generationId === "gen-1")
+
+    expect(spanEnds).toHaveLength(1)
+    expect(spanEnds[0].level).toBe("ERROR")
+    expect(spanEnds[0].statusMessage).toBe("aborted")
+
+    expect(genEnds).toHaveLength(1)
+    expect(genEnds[0].level).toBe("ERROR")
+    expect(genEnds[0].statusMessage).toBe("aborted")
+  })
+
+  it("trace metadata preservation: per-run + agent-session + conversation + profile info round-trip", async () => {
+    const mod = await import("./langfuse-service")
+    const traceId = "trace-meta-test"
+
+    mod.createAgentTrace(traceId, {
+      name: "Agent",
+      sessionId: "conv-X",
+      metadata: {
+        agentSessionId: "s1",
+        runId: 5,
+        conversationId: "conv-X",
+        profileId: "p1",
+        profileName: "Profile One",
+      },
+    })
+    mod.endAgentTrace(traceId, { output: "" })
+
+    await mod.flushLangfuse()
+
+    const lines = readTraceFile(traceId)
+    const start = lines.find((l) => l.type === "trace.start")
+    expect(start).toBeDefined()
+    const metadata = start!.metadata as Record<string, unknown>
+    expect(metadata.agentSessionId).toBe("s1")
+    expect(metadata.runId).toBe(5)
+    expect(metadata.conversationId).toBe("conv-X")
+    expect(metadata.profileId).toBe("p1")
+    expect(metadata.profileName).toBe("Profile One")
+    // The Langfuse sessionId (group key) should be propagated too.
+    expect(metadata.sessionId).toBe("conv-X")
+  })
+
+  it("shutdownLangfuse force-closes active spans and generations with ERROR level", async () => {
+    const mod = await import("./langfuse-service")
+    const traceId = "trace-shutdown"
+
+    mod.createAgentTrace(traceId, {
+      name: "Agent Session",
+      sessionId: "conv-shutdown",
+      input: "in",
+    })
+    mod.createToolSpan(traceId, "span-sd", {
+      name: "Tool: search",
+      input: {},
+    })
+    mod.createLLMGeneration(traceId, "gen-sd", {
+      name: "LLM Call",
+      model: "test-model",
+      input: {},
+    })
+
+    await mod.shutdownLangfuse()
+
+    const lines = readTraceFile(traceId)
+    const spanEnd = lines.find((l) => l.type === "span.end" && l.spanId === "span-sd")
+    const genEnd = lines.find((l) => l.type === "generation.end" && l.generationId === "gen-sd")
+
+    expect(spanEnd).toBeDefined()
+    expect(spanEnd!.level).toBe("ERROR")
+    expect(spanEnd!.statusMessage).toBe("App shutdown")
+
+    expect(genEnd).toBeDefined()
+    expect(genEnd!.level).toBe("ERROR")
+    expect(genEnd!.statusMessage).toBe("App shutdown")
+  })
+})

--- a/apps/desktop/src/main/langfuse-service.ts
+++ b/apps/desktop/src/main/langfuse-service.ts
@@ -35,6 +35,13 @@ const activeTraces = new Map<string, LangfuseTraceClient>()
 const activeSpans = new Map<string, LangfuseSpanClient>()
 const activeGenerations = new Map<string, LangfuseGenerationClient>()
 
+// Reverse-link maps from span/generation id back to their owning langfuse trace id.
+// These let force-close paths (abort, reinit, shutdown) iterate the active spans
+// and generations that belong to a given trace without needing the caller to track
+// them. Entries are added on creation and removed on end.
+const spanTraceLinks = new Map<string, string>()
+const generationTraceLinks = new Map<string, string>()
+
 /**
  * Check if Langfuse package is installed and available
  */
@@ -102,17 +109,42 @@ export function getLangfuse(): LangfuseInstance | null {
 }
 
 /**
- * Reinitialize Langfuse when config changes
+ * Reinitialize Langfuse when config changes.
+ *
+ * Any active spans/generations are force-closed with ERROR level before the
+ * Langfuse instance is shut down so consumers see a clear terminal event
+ * instead of orphaned in-flight records.
  */
-export function reinitializeLangfuse(): void {
+export async function reinitializeLangfuse(): Promise<void> {
+  // Snapshot then iterate so endToolSpan/endLLMGeneration can mutate the maps.
+  for (const spanId of Array.from(activeSpans.keys())) {
+    endToolSpan(spanId, {
+      level: "ERROR",
+      statusMessage: "Langfuse reinitialized",
+    })
+  }
+  for (const generationId of Array.from(activeGenerations.keys())) {
+    endLLMGeneration(generationId, {
+      output: "",
+      level: "ERROR",
+      statusMessage: "Langfuse reinitialized",
+    })
+  }
+
   if (langfuseInstance) {
-    langfuseInstance.shutdownAsync().catch(console.error)
+    try {
+      await langfuseInstance.shutdownAsync()
+    } catch (error) {
+      console.error("[Langfuse] Failed to shut down on reinit:", error)
+    }
     langfuseInstance = null
   }
-  // Clear all active traces/spans
+  // Clear all active traces/spans and reverse links
   activeTraces.clear()
   activeSpans.clear()
   activeGenerations.clear()
+  spanTraceLinks.clear()
+  generationTraceLinks.clear()
   // Local trace logger caches the resolved path; reset so config changes apply.
   resetLocalTraceLogger()
 }
@@ -227,7 +259,13 @@ export function endAgentTrace(
 }
 
 /**
- * Create a span for a tool call
+ * Create a span for a tool call.
+ *
+ * @param traceId The per-run Langfuse trace id, NOT a DotAgents session id.
+ *   Each agent RUN has its own UUID, generated in `processTranscriptWithAgentMode`
+ *   or `processTranscriptWithACPAgent`. The DotAgents session id (long-lived
+ *   across many runs in the same UI session) lives on the trace metadata
+ *   under `agentSessionId`.
  */
 export function createToolSpan(
   traceId: string,
@@ -247,6 +285,10 @@ export function createToolSpan(
     metadata: options.metadata,
   })
 
+  // Remember the reverse link unconditionally so force-close paths work even
+  // when langfuse cloud is not configured (local-trace-only mode).
+  spanTraceLinks.set(spanId, traceId)
+
   const trace = activeTraces.get(traceId)
   if (!trace) return null
 
@@ -265,7 +307,11 @@ export function createToolSpan(
 }
 
 /**
- * End a tool span with output
+ * End a tool span with output.
+ *
+ * Idempotent: if the span has already been ended (e.g. by `forceCloseActiveTrace`
+ * during an abort), this is a no-op so callers don't have to track lifecycle
+ * state themselves.
  */
 export function endToolSpan(
   spanId: string,
@@ -276,6 +322,13 @@ export function endToolSpan(
     statusMessage?: string
   }
 ): void {
+  // If neither the langfuse span client nor the reverse trace link is around,
+  // the span has already been ended (or was never opened). Drop the event so
+  // we don't emit duplicate span.end lines after a force-close.
+  const span = activeSpans.get(spanId)
+  const hasLink = spanTraceLinks.has(spanId)
+  if (!span && !hasLink) return
+
   appendLocalTraceEvent({
     type: "span.end",
     spanId,
@@ -285,7 +338,8 @@ export function endToolSpan(
     statusMessage: options.statusMessage,
   })
 
-  const span = activeSpans.get(spanId)
+  spanTraceLinks.delete(spanId)
+
   if (!span) return
 
   try {
@@ -302,7 +356,13 @@ export function endToolSpan(
 }
 
 /**
- * Create a generation for an LLM call
+ * Create a generation for an LLM call.
+ *
+ * @param traceId The per-run Langfuse trace id, NOT a DotAgents session id.
+ *   When null, the generation is created as an orphan (no parent trace), which
+ *   is the correct behaviour for callers that have no agent run associated
+ *   (e.g. MCP sampling). When set, it must be the run-scoped UUID generated
+ *   by `processTranscriptWithAgentMode` / `processTranscriptWithACPAgent`.
  */
 export function createLLMGeneration(
   traceId: string | null,
@@ -325,6 +385,12 @@ export function createLLMGeneration(
     input: options.input,
     metadata: options.metadata,
   })
+
+  // Remember the reverse link unconditionally so force-close paths work even
+  // when langfuse cloud is not configured (local-trace-only mode).
+  if (traceId) {
+    generationTraceLinks.set(generationId, traceId)
+  }
 
   const langfuse = getLangfuse()
   if (!langfuse) return null
@@ -359,7 +425,10 @@ export function createLLMGeneration(
 }
 
 /**
- * End an LLM generation with output and usage metrics
+ * End an LLM generation with output and usage metrics.
+ *
+ * Idempotent: if the generation has already been ended (e.g. via
+ * `forceCloseActiveTrace` during an abort), this is a no-op.
  */
 export function endLLMGeneration(
   generationId: string,
@@ -375,6 +444,10 @@ export function endLLMGeneration(
     statusMessage?: string
   }
 ): void {
+  const generation = activeGenerations.get(generationId)
+  const hasLink = generationTraceLinks.has(generationId)
+  if (!generation && !hasLink) return
+
   appendLocalTraceEvent({
     type: "generation.end",
     generationId,
@@ -385,7 +458,8 @@ export function endLLMGeneration(
     statusMessage: options.statusMessage,
   })
 
-  const generation = activeGenerations.get(generationId)
+  generationTraceLinks.delete(generationId)
+
   if (!generation) return
 
   try {
@@ -399,6 +473,108 @@ export function endLLMGeneration(
     activeGenerations.delete(generationId)
   } catch (error) {
     console.error("[Langfuse] Failed to end generation:", error)
+  }
+}
+
+/**
+ * Force-close any active spans and generations attached to a trace.
+ *
+ * Used when an agent run is aborted or otherwise terminates abnormally so the
+ * trace doesn't leave dangling in-flight events. Does NOT end the trace itself
+ * — callers must still call `endAgentTrace` to finalize the trace.
+ *
+ * Subsequent normal end calls (e.g. from `mcp-service.endSpanAndReturn`) for
+ * the same span ids are no-ops, since `endToolSpan` / `endLLMGeneration` are
+ * idempotent.
+ */
+export function forceCloseActiveTrace(
+  traceId: string,
+  reason: { statusMessage: string; level?: "ERROR" | "WARNING" }
+): void {
+  const level = reason.level ?? "ERROR"
+
+  // Snapshot keys first because endToolSpan/endLLMGeneration mutate the maps.
+  const spanIds: string[] = []
+  for (const [spanId, owningTraceId] of spanTraceLinks.entries()) {
+    if (owningTraceId === traceId) spanIds.push(spanId)
+  }
+  for (const spanId of spanIds) {
+    endToolSpan(spanId, {
+      output: { error: reason.statusMessage },
+      level,
+      statusMessage: reason.statusMessage,
+    })
+  }
+
+  const generationIds: string[] = []
+  for (const [generationId, owningTraceId] of generationTraceLinks.entries()) {
+    if (owningTraceId === traceId) generationIds.push(generationId)
+  }
+  for (const generationId of generationIds) {
+    endLLMGeneration(generationId, {
+      output: "",
+      level,
+      statusMessage: reason.statusMessage,
+    })
+  }
+}
+
+/**
+ * Best-effort cleanup at app shutdown.
+ *
+ * Force-closes any active spans, generations, and traces, flushes pending
+ * local + langfuse events, then shuts down the langfuse client. Safe to call
+ * multiple times.
+ */
+export async function shutdownLangfuse(): Promise<void> {
+  for (const spanId of Array.from(activeSpans.keys())) {
+    endToolSpan(spanId, {
+      level: "ERROR",
+      statusMessage: "App shutdown",
+    })
+  }
+  // Also catch any links left over (e.g. local-trace-only mode where the
+  // langfuse activeSpans map is empty but link entries still exist).
+  for (const spanId of Array.from(spanTraceLinks.keys())) {
+    endToolSpan(spanId, {
+      level: "ERROR",
+      statusMessage: "App shutdown",
+    })
+  }
+
+  for (const generationId of Array.from(activeGenerations.keys())) {
+    endLLMGeneration(generationId, {
+      output: "",
+      level: "ERROR",
+      statusMessage: "App shutdown",
+    })
+  }
+  for (const generationId of Array.from(generationTraceLinks.keys())) {
+    endLLMGeneration(generationId, {
+      output: "",
+      level: "ERROR",
+      statusMessage: "App shutdown",
+    })
+  }
+
+  // Snapshot trace ids first because endAgentTrace mutates activeTraces.
+  const traceIds = Array.from(activeTraces.keys())
+  for (const traceId of traceIds) {
+    endAgentTrace(traceId, {
+      output: "",
+      metadata: { shutdown: true },
+    })
+  }
+
+  await flushLangfuse()
+
+  if (langfuseInstance) {
+    try {
+      await langfuseInstance.shutdownAsync()
+    } catch (error) {
+      console.error("[Langfuse] Failed to shut down:", error)
+    }
+    langfuseInstance = null
   }
 }
 

--- a/apps/desktop/src/main/llm-fetch.test.ts
+++ b/apps/desktop/src/main/llm-fetch.test.ts
@@ -1324,4 +1324,44 @@ describe('LLM Fetch with AI SDK', () => {
 
     expect(callCount).toBe(1)
   })
+
+  it('passes per-run langfuse trace id to createLLMGeneration', async () => {
+    // The fetch-side LLM call must associate its generation event with the
+    // per-RUN trace id, not the long-lived DotAgents agent session id. The
+    // session id is preserved as a separate function arg for abort-controller
+    // wiring and token-usage recording.
+    const { createLLMGeneration, isTracingEnabled } = await import('./langfuse-service')
+    const isTracingEnabledMock = vi.mocked(isTracingEnabled)
+    const createLLMGenerationMock = vi.mocked(createLLMGeneration)
+    isTracingEnabledMock.mockReturnValue(true)
+    createLLMGenerationMock.mockReturnValue(null)
+
+    const { generateText } = await import('ai')
+    const generateTextMock = vi.mocked(generateText)
+    generateTextMock.mockResolvedValue({
+      text: '{"content":"ok"}',
+      finishReason: 'stop',
+      usage: { promptTokens: 1, completionTokens: 1 },
+    } as any)
+
+    const { makeLLMCallWithFetch } = await import('./llm-fetch')
+
+    await makeLLMCallWithFetch(
+      [{ role: 'user', content: 'test' }],
+      'openai',
+      undefined,
+      'agent-sess-1',
+      undefined,
+      'trace-uuid-Q',
+    )
+
+    expect(createLLMGenerationMock).toHaveBeenCalledWith(
+      'trace-uuid-Q',
+      expect.any(String),
+      expect.any(Object),
+    )
+
+    const firstArgs = createLLMGenerationMock.mock.calls.map(call => call[0])
+    expect(firstArgs).not.toContain('agent-sess-1')
+  })
 })

--- a/apps/desktop/src/main/llm-fetch.ts
+++ b/apps/desktop/src/main/llm-fetch.ts
@@ -860,7 +860,8 @@ export async function makeLLMCallWithFetch(
   providerId?: string,
   onRetryProgress?: RetryProgressCallback,
   sessionId?: string,
-  tools?: MCPTool[]
+  tools?: MCPTool[],
+  langfuseTraceId?: string,
 ): Promise<LLMToolCallResponse> {
   const effectiveProviderId = (providerId ||
     getCurrentProviderId()) as ProviderType
@@ -883,7 +884,7 @@ export async function makeLLMCallWithFetch(
           const modelName = getCurrentChatGptWebModelName("mcp")
           const generationId = isTracingEnabled() ? randomUUID() : null
           if (generationId) {
-            createLLMGeneration(sessionId || null, generationId, {
+            createLLMGeneration(langfuseTraceId ?? null, generationId, {
               name: "LLM Call",
               model: modelName,
               modelParameters: {
@@ -1000,7 +1001,7 @@ export async function makeLLMCallWithFetch(
         // Create generation trace event if observability is enabled
         const generationId = isTracingEnabled() ? randomUUID() : null
         if (generationId) {
-          createLLMGeneration(sessionId || null, generationId, {
+          createLLMGeneration(langfuseTraceId ?? null, generationId, {
             name: "LLM Call",
             model: modelName,
             modelParameters: {
@@ -1186,7 +1187,8 @@ export async function makeLLMCallWithStreamingAndTools(
   providerId?: string,
   onRetryProgress?: RetryProgressCallback,
   sessionId?: string,
-  tools?: MCPTool[]
+  tools?: MCPTool[],
+  langfuseTraceId?: string,
 ): Promise<LLMToolCallResponse> {
   const effectiveProviderId = (providerId || getCurrentProviderId()) as ProviderType
   const transportMessages = sanitizeMessagesForLlmTransport(messages)
@@ -1205,7 +1207,7 @@ export async function makeLLMCallWithStreamingAndTools(
       if (isChatGptWebProvider(effectiveProviderId)) {
         const generationId = isTracingEnabled() ? randomUUID() : null
         if (generationId) {
-          createLLMGeneration(sessionId || null, generationId, {
+          createLLMGeneration(langfuseTraceId ?? null, generationId, {
             name: "Streaming LLM Call",
             model: modelName,
             modelParameters: {
@@ -1302,7 +1304,7 @@ export async function makeLLMCallWithStreamingAndTools(
 
       const generationId = isTracingEnabled() ? randomUUID() : null
       if (generationId) {
-        createLLMGeneration(sessionId || null, generationId, {
+        createLLMGeneration(langfuseTraceId ?? null, generationId, {
           name: "Streaming LLM Call",
           model: modelName,
           modelParameters: {
@@ -1436,7 +1438,8 @@ export async function makeTextCompletionWithFetch(
   prompt: string,
   providerId?: string,
   sessionId?: string,
-  onRetryProgress?: RetryProgressCallback
+  onRetryProgress?: RetryProgressCallback,
+  langfuseTraceId?: string,
 ): Promise<string> {
   // Use transcript provider as default since this is primarily used for transcript post-processing
   const effectiveProviderId = (providerId ||
@@ -1454,7 +1457,7 @@ export async function makeTextCompletionWithFetch(
         : getCurrentModelName(effectiveProviderId, "transcript")
 
       if (generationId) {
-        createLLMGeneration(sessionId || null, generationId, {
+        createLLMGeneration(langfuseTraceId ?? null, generationId, {
           name: "Text Completion",
           model: modelName,
           modelParameters: { provider: effectiveProviderId },
@@ -1556,7 +1559,8 @@ export async function verifyCompletionWithFetch(
   messages: Array<{ role: string; content: string }>,
   providerId?: string,
   sessionId?: string,
-  onRetryProgress?: RetryProgressCallback
+  onRetryProgress?: RetryProgressCallback,
+  langfuseTraceId?: string,
 ): Promise<CompletionVerification> {
   const effectiveProviderId = (providerId ||
     getCurrentProviderId()) as ProviderType
@@ -1593,7 +1597,7 @@ export async function verifyCompletionWithFetch(
         )
         const { system, messages: convertedMessages } = convertMessages(transportMessages)
         if (generationId) {
-          createLLMGeneration(sessionId || null, generationId, {
+          createLLMGeneration(langfuseTraceId ?? null, generationId, {
             name: "Verification Call",
             model: modelName,
             modelParameters: {

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -2102,6 +2102,8 @@ export async function processTranscriptWithAgentMode(
         verificationMessages,
         config.mcpToolsProviderId,
         currentSessionId,
+        undefined,
+        langfuseTraceId,
       ), { verificationMessages })
       if (verification?.isComplete === true) {
         verified = true

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto"
 import { configStore, conversationsFolder, globalAgentsFolder, resolveWorkspaceAgentsFolder } from "./config"
 import type {
   MCPTool,
@@ -24,6 +25,7 @@ import { DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT, getCurrentPresetName } from 
 import {
   createAgentTrace,
   endAgentTrace,
+  forceCloseActiveTrace,
   isTracingEnabled,
   flushLangfuse,
 } from "./langfuse-service"
@@ -703,7 +705,7 @@ interface ToolExecutionResult {
  */
 async function executeToolWithRetries(
   toolCall: MCPToolCall,
-  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void) => Promise<MCPToolResult>,
+  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void, langfuseTraceId?: string) => Promise<MCPToolResult>,
   currentSessionId: string,
   onToolProgress: (message: string) => void,
   maxRetries: number = 2,
@@ -811,7 +813,7 @@ async function executeToolWithRetries(
 export async function processTranscriptWithAgentMode(
   transcript: string,
   availableTools: MCPTool[],
-  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void) => Promise<MCPToolResult>,
+  executeToolCall: (toolCall: MCPToolCall, onProgress?: (message: string) => void, langfuseTraceId?: string) => Promise<MCPToolResult>,
   maxIterations: number = 10,
   previousConversationHistory?: Array<{
     role: "user" | "assistant" | "tool"
@@ -865,16 +867,24 @@ export async function processTranscriptWithAgentMode(
   // Track step summaries for dual-model mode
   const stepSummaries: import("../shared/types").AgentStepSummary[] = []
 
-  // Create an observability trace for this agent session if enabled
-  // - traceId: unique ID for this trace (our agent session ID)
-  // - sessionId: groups traces together (our conversation ID)
+  // Create an observability trace for this agent RUN if enabled.
+  //
+  // Important: trace ids are now per-RUN (one UUID per call to this function)
+  // and decoupled from the DotAgents `currentSessionId` (a long-lived agent
+  // session that may span many runs). Langfuse `sessionId` continues to be the
+  // conversation id so the dashboard's Sessions view still groups runs by
+  // conversation.
+  const langfuseTraceId = randomUUID()
   if (isTracingEnabled()) {
-    createAgentTrace(currentSessionId, {
+    createAgentTrace(langfuseTraceId, {
       name: "Agent Session",
       sessionId: currentConversationId,  // Groups all agent sessions in this conversation
       metadata: {
         maxIterations,
         hasHistory: !!previousConversationHistory?.length,
+        agentSessionId: currentSessionId,
+        runId: effectiveRunId,
+        conversationId: currentConversationId,
         profileId: effectiveProfileSnapshot?.profileId,
         profileName: effectiveProfileSnapshot?.profileName,
       },
@@ -884,6 +894,11 @@ export async function processTranscriptWithAgentMode(
         : undefined,
     })
   }
+
+  // Wrap caller-provided executeToolCall so every tool call gets the per-run
+  // trace id without each call site having to thread it through manually.
+  const tracedExecuteToolCall: typeof executeToolCall = (toolCall, onProgress) =>
+    executeToolCall(toolCall, onProgress, langfuseTraceId)
 
   // Declare variables that need to be accessible in the finally block for Langfuse tracing
   let iteration = 0
@@ -1349,7 +1364,7 @@ export async function processTranscriptWithAgentMode(
 
       const executeTitleUpdate = executeToolWithRetries(
         toolCall,
-        executeToolCall,
+        tracedExecuteToolCall,
         currentSessionId,
         onToolProgress,
         2,
@@ -1370,7 +1385,7 @@ export async function processTranscriptWithAgentMode(
     if (!cacheKey) {
       return executeToolWithRetries(
         toolCall,
-        executeToolCall,
+        tracedExecuteToolCall,
         currentSessionId,
         onToolProgress,
         2,
@@ -1411,7 +1426,7 @@ export async function processTranscriptWithAgentMode(
 
     const execution = executeToolWithRetries(
       toolCall,
-      executeToolCall,
+      tracedExecuteToolCall,
       currentSessionId,
       onToolProgress,
       2,
@@ -1953,7 +1968,7 @@ export async function processTranscriptWithAgentMode(
     // Update context info for progress display
     contextInfoRef = { estTokens: verifyEstTokens, maxTokens: verifyMaxTokens }
 
-    const response = await makeLLMCall(shrunkMessages, config, onRetryProgress, undefined, currentSessionId)
+    const response = await makeLLMCall(shrunkMessages, config, onRetryProgress, undefined, currentSessionId, undefined, langfuseTraceId)
 
     // Check for stop request if needed
     if (checkForStop && agentSessionStateManager.shouldStopSession(currentSessionId)) {
@@ -2486,7 +2501,7 @@ export async function processTranscriptWithAgentMode(
         }, { sendRendererProgress: shouldSendRendererProgress })
       }
 
-      llmResponse = await makeLLMCall(shrunkMessages, config, onRetryProgress, onStreamingUpdate, currentSessionId, activeTools)
+      llmResponse = await makeLLMCall(shrunkMessages, config, onRetryProgress, onStreamingUpdate, currentSessionId, activeTools, langfuseTraceId)
 
       // The next non-streaming progress update clears live streaming state in the renderer.
       // Avoid an extra intermediate emit that would duplicate the completed text.
@@ -3672,7 +3687,7 @@ export async function processTranscriptWithAgentMode(
 
 
         try {
-          const summaryResponse = await makeLLMCall(shrunkSummaryMessages, config, onRetryProgress, undefined, currentSessionId)
+          const summaryResponse = await makeLLMCall(shrunkSummaryMessages, config, onRetryProgress, undefined, currentSessionId, undefined, langfuseTraceId)
 
           // Check if stop was requested during summary generation
           if (agentSessionStateManager.shouldStopSession(currentSessionId)) {
@@ -3969,14 +3984,26 @@ export async function processTranscriptWithAgentMode(
       totalIterations: iteration,
     }
   } finally {
-    // End observability trace for this agent session if enabled
-    // This is in a finally block to ensure traces are closed even on unexpected exceptions
+    // End observability trace for this agent run if enabled.
+    // This is in a finally block to ensure traces are closed even on unexpected exceptions.
     if (isTracingEnabled()) {
-      endAgentTrace(currentSessionId, {
+      // If the run was aborted, force-close any in-flight tool spans / LLM
+      // generations under this trace BEFORE marking the trace finished so
+      // dashboards show clear ERROR terminal states instead of orphans.
+      if (wasAborted) {
+        forceCloseActiveTrace(langfuseTraceId, {
+          statusMessage: "Agent run aborted",
+          level: "ERROR",
+        })
+      }
+
+      endAgentTrace(langfuseTraceId, {
         output: finalContent,
         metadata: {
           totalIterations: iteration,
           wasAborted,
+          runId: effectiveRunId,
+          agentSessionId: currentSessionId,
           ...(lastContextBudgetInfo && {
             contextBudget: {
               estTokensAfter: lastContextBudgetInfo.estTokensAfter,
@@ -3986,8 +4013,9 @@ export async function processTranscriptWithAgentMode(
           }),
         },
       })
-      // Flush to ensure local trace writes and/or Langfuse events are completed
-      flushLangfuse().catch(() => {})
+      // Flush to ensure local trace writes and/or Langfuse events are completed.
+      // Await so the run truly finishes once tracing is fully flushed.
+      await flushLangfuse().catch(() => {})
     }
 
     // Clean up context budget tracking for this session
@@ -4015,6 +4043,7 @@ async function makeLLMCall(
   onStreamingUpdate?: StreamingCallback,
   sessionId?: string,
   tools?: MCPTool[],
+  langfuseTraceId?: string,
 ): Promise<LLMToolCallResponse> {
   const chatProviderId = config.mcpToolsProviderId
 
@@ -4046,9 +4075,10 @@ async function makeLLMCall(
         onRetryProgress,
         sessionId,
         tools,
+        langfuseTraceId,
       )
     } else {
-      result = await makeLLMCallWithFetch(messages, chatProviderId, onRetryProgress, sessionId, tools)
+      result = await makeLLMCallWithFetch(messages, chatProviderId, onRetryProgress, sessionId, tools, langfuseTraceId)
     }
 
     if (isDebugLLM()) {

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -2672,15 +2672,19 @@ export class MCPService {
     onProgress?: (message: string) => void,
     skipApprovalCheck: boolean = false,
     sessionId?: string,
-    profileMcpConfig?: ProfileMcpServerConfig
+    profileMcpConfig?: ProfileMcpServerConfig,
+    langfuseTraceId?: string,
   ): Promise<MCPToolResult> {
-    // Create tool span event if observability is enabled and we have a trace
-    const spanId = isTracingEnabled() && sessionId ? randomUUID() : null
-    if (spanId && sessionId) {
-      createToolSpan(sessionId, spanId, {
+    // Create tool span event only when we have a per-run langfuse trace id.
+    // The DotAgents sessionId is no longer the langfuse trace id (which is now
+    // a per-run UUID generated in processTranscriptWithAgentMode / ACP), so
+    // sessionId by itself is insufficient to link a span to a trace.
+    const spanId = isTracingEnabled() && langfuseTraceId ? randomUUID() : null
+    if (spanId && langfuseTraceId) {
+      createToolSpan(langfuseTraceId, spanId, {
         name: `Tool: ${toolCall.name}`,
         input: toolCall.arguments as Record<string, unknown>,
-        metadata: { toolName: toolCall.name },
+        metadata: { toolName: toolCall.name, agentSessionId: sessionId },
       })
     }
 

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -1331,9 +1331,11 @@ export async function runAgent(options: RunAgentOptions): Promise<{
       ? mcpService.getAvailableToolsForProfile(profileSnapshot.mcpServerConfig)
       : mcpService.getAvailableTools()
 
-    const executeToolCall = async (toolCall: any, onProgress?: (message: string) => void): Promise<MCPToolResult> => {
-      // Pass sessionId for ACP router tools progress, and profileSnapshot.mcpServerConfig for session-aware server availability
-      return await mcpService.executeToolCall(toolCall, onProgress, false, sessionId, profileSnapshot?.mcpServerConfig)
+    const executeToolCall = async (toolCall: any, onProgress?: (message: string) => void, langfuseTraceId?: string): Promise<MCPToolResult> => {
+      // Pass sessionId for ACP router tools progress, profileSnapshot.mcpServerConfig
+      // for session-aware server availability, and langfuseTraceId so the tool span
+      // is linked to the correct per-run trace.
+      return await mcpService.executeToolCall(toolCall, onProgress, false, sessionId, profileSnapshot?.mcpServerConfig, langfuseTraceId)
     }
 
     const agentResult = await processTranscriptWithAgentMode(

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -489,7 +489,7 @@ async function processWithAgentMode(
       : mcpService.getAvailableTools()
 
     // Use agent mode for iterative tool calling
-    const executeToolCall = async (toolCall: any, onProgress?: (message: string) => void): Promise<MCPToolResult> => {
+    const executeToolCall = async (toolCall: any, onProgress?: (message: string) => void, langfuseTraceId?: string): Promise<MCPToolResult> => {
       // Handle inline tool approval if enabled in config
       if (config.mcpRequireApprovalBeforeToolCall) {
         // Request approval and wait for user response via the UI
@@ -542,8 +542,10 @@ async function processWithAgentMode(
       }
 
       // Execute the tool call (approval either not required or was granted)
-      // Pass sessionId for ACP router tools progress, and profileSnapshot.mcpServerConfig for session-aware server availability
-      return await mcpService.executeToolCall(toolCall, onProgress, true, sessionId, profileSnapshot?.mcpServerConfig)
+      // Pass sessionId for ACP router tools progress, profileSnapshot.mcpServerConfig
+      // for session-aware server availability, and langfuseTraceId so the tool span
+      // is linked to the correct per-run trace.
+      return await mcpService.executeToolCall(toolCall, onProgress, true, sessionId, profileSnapshot?.mcpServerConfig, langfuseTraceId)
     }
 
     // Load previous conversation history if continuing a conversation.
@@ -3339,7 +3341,7 @@ export const router = {
 
         if (langfuseConfigChanged) {
           const { reinitializeLangfuse } = await import("./langfuse-service")
-          reinitializeLangfuse()
+          await reinitializeLangfuse()
         } else if (localTraceConfigChanged) {
           const { resetLocalTraceLogger } = await import("./local-trace-logger")
           resetLocalTraceLogger()


### PR DESCRIPTION
Closes #441.

## Summary

Stops the DotAgents `currentSessionId` from being reused as the Langfuse `traceId`. Each agent run now generates a fresh per-run UUID (`langfuseTraceId`), and `currentConversationId` becomes the Langfuse `sessionId` so continued turns in one conversation appear as multiple traces under the same Langfuse session. LLM generations and MCP tool spans attach to the per-run trace instead of the long-lived agent session. Active spans/generations are force-closed with ERROR-level events on abort, reinitialize, and shutdown. `flushLangfuse` / `shutdownAsync` are awaited at lifecycle boundaries. Local trace logging works independently of remote Langfuse enablement.

No SDK upgrade — `langfuse` stays at `^3.38.6`.

## What changed by file

- `apps/desktop/src/main/langfuse-service.ts` — added `spanTraceLinks` / `generationTraceLinks` reverse maps; new `forceCloseActiveTrace(traceId, reason)` and `shutdownLangfuse()` exports; `reinitializeLangfuse` is now `async` and awaits `shutdownAsync`; `endToolSpan` / `endLLMGeneration` are now idempotent so force-close + normal-end doesn't double-log; clarified doc comments that the first param is the per-run Langfuse trace ID, not the agent session ID.
- `apps/desktop/src/main/llm.ts` — generates `langfuseTraceId = randomUUID()` inside `processTranscriptWithAgentMode`; uses it for `createAgentTrace` / `endAgentTrace`; wraps `executeToolCall` as `tracedExecuteToolCall` so every tool call attaches to the per-run trace; threads `langfuseTraceId` through `makeLLMCall` and `verifyCompletionWithFetch`; awaits `flushLangfuse()`; calls `forceCloseActiveTrace(...)` on abort before `endAgentTrace`. Trace metadata records `agentSessionId`, `runId`, `conversationId`, `profileId`, `profileName`.
- `apps/desktop/src/main/llm-fetch.ts` — added optional `langfuseTraceId` last param to `makeLLMCallWithFetch`, `makeLLMCallWithStreamingAndTools`, `makeTextCompletionWithFetch`, `verifyCompletionWithFetch`. All six `createLLMGeneration(...)` sites now use `langfuseTraceId ?? null` instead of `sessionId || null`. Abort/token bookkeeping still uses `sessionId`.
- `apps/desktop/src/main/mcp-service.ts` — `executeToolCall` accepts optional 6th `langfuseTraceId`; a span is only opened when the trace ID is provided; span metadata records `agentSessionId` for app-level lookup.
- `apps/desktop/src/main/acp-main-agent.ts` — `processTranscriptWithACPAgent` generates a per-run `langfuseTraceId` and uses it for `createAgentTrace` / `createToolSpan` / `endAgentTrace`; metadata includes `agentSessionId`, `runId`, `conversationId`, `profileId`, `profileName`, `agentName`. Leftover open spans in the finally block are ended at `ERROR` level when the run errored, `WARNING` otherwise.
- `apps/desktop/src/main/tipc.ts` — `executeToolCall` closure accepts and forwards `langfuseTraceId`; the `reinitializeLangfuse()` settings-change handler now awaits it.
- `apps/desktop/src/main/headless-cli.ts`, `apps/desktop/src/main/remote-server.ts`, `apps/desktop/src/main/acp/internal-agent.ts` — `executeToolCall` closures accept and forward the optional `langfuseTraceId`. Non-agent direct callers of `mcpService.executeToolCall` need no change (the new param is optional).
- `apps/desktop/src/main/index.ts` — `before-quit` now schedules `shutdownLangfuse()` via `withCleanupTimeout`, so any open traces/spans/generations are force-closed and remote events are flushed before the app exits.
- `apps/desktop/src/main/langfuse-service.trace-lifecycle.test.ts` (new, 4 tests) — covers two-runs-distinct-files, `forceCloseActiveTrace` ERROR events, trace metadata preservation, and `shutdownLangfuse` force-close.
- `apps/desktop/src/main/llm-fetch.test.ts` — added test that asserts `createLLMGeneration` receives the per-run `langfuseTraceId`, not the agent `sessionId`.
- `apps/desktop/src/main/acp-main-agent.test.ts` — existing tracing test updated to expect a UUID trace ID plus the new metadata fields; new test for "abort with active tool span emits ERROR-level span.end".

## Test plan

- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/langfuse-service.test.ts src/main/langfuse-service.trace-lifecycle.test.ts` — 5/5 pass
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/llm-fetch.test.ts` — 46/46 pass (+1 new)
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/acp-main-agent.test.ts` — 20/20 pass (+1 new)
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/local-trace-logger.test.ts` — 10/10 pass
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/mcp-service.option-b.test.ts` — 5/5 pass
- [x] `pnpm --filter @dotagents/desktop run typecheck:node` — clean
- [ ] Manual: run two agent turns in the same conversation and confirm two distinct `~/Library/Application Support/app.dotagents/traces/<uuid>.jsonl` files appear, each with exactly one `trace.start` / `trace.end` pair, both carrying the same Langfuse `sessionId` and different `runId`.
- [ ] Manual: abort an in-flight tool call and confirm the local trace contains a matching `span.end` event with `level: "ERROR"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0141NpifUwWeWc6GBaCEX4Cz)_