### PR TITLE
Apply transcript post-processing to live dictation chunks (closes #406)

### DIFF
--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2263,7 +2263,9 @@ export const router = {
         transcript = json.text || ""
       }
 
-      transcript = await postProcessTranscriptSafely(transcript, "transcribeChunk")
+      if (transcript.trim()) {
+        transcript = await postProcessTranscriptSafely(transcript, "transcribeChunk")
+      }
 
       return { text: transcript }
     }),

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -2263,6 +2263,8 @@ export const router = {
         transcript = json.text || ""
       }
 
+      transcript = await postProcessTranscriptSafely(transcript, "transcribeChunk")
+
       return { text: transcript }
     }),
 


### PR DESCRIPTION
## Summary
- `transcribeChunk` was the only dictation entry point that returned raw STT output. `createRecording`, `createMcpRecording`, and `createTextInput` all already route their transcripts through `postProcessTranscriptSafely`. With post-processing enabled, the in-panel live preview therefore diverged from the final inserted text, which is what #406 describes as "post-processing appears broken."
- Pipe `transcribeChunk` through the same helper. The helper is a no-op when `transcriptPostProcessingEnabled` is false, so behavior is unchanged for users who haven't opted in.

## Test plan
- [ ] With `transcriptPostProcessingEnabled = true`, start dictation, watch the live preview update, and confirm the preview text now reflects the configured post-processing prompt rather than raw STT output.
- [ ] With `transcriptPostProcessingEnabled = false`, verify the preview still streams raw transcripts at the normal cadence (no extra latency).
- [ ] Confirm the final inserted text on stop is still consistent with the preview.

https://claude.ai/code/session_01AKUZ659oG3i8eFZCyoZq4j

---
_Generated by [Claude Code](https://claude.ai/code/session_01AKUZ659oG3i8eFZCyoZq4j)_