### PR TITLE
[codex] Add floating panel progress opt-out

### DIFF
--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -4,10 +4,13 @@ const mocks = vi.hoisted(() => ({
   sendSpy: vi.fn(),
   showPanelWindow: vi.fn(),
   resizePanelForAgentMode: vi.fn(),
+  closeAgentModeAndHidePanelWindow: vi.fn(),
   isSessionSnoozed: vi.fn(),
   getSession: vi.fn(),
   shouldStopSession: vi.fn(() => false),
   getSessionRunId: vi.fn(() => undefined),
+  appState: { isRecording: false, isTextInputActive: false },
+  config: { floatingPanelAutoShow: true, floatingPanelAgentProgressEnabled: true, hidePanelWhenMainFocused: true },
   mainWindow: { isVisible: vi.fn(() => true), isFocused: vi.fn(() => false), webContents: { id: "main" } },
   panelWindow: { isVisible: vi.fn(() => false), webContents: { id: "panel" } },
 }))
@@ -20,11 +23,13 @@ vi.mock("./window", () => ({
   WINDOWS: { get: (id: string) => (id === "main" ? mocks.mainWindow : id === "panel" ? mocks.panelWindow : null) },
   showPanelWindow: mocks.showPanelWindow,
   resizePanelForAgentMode: mocks.resizePanelForAgentMode,
+  closeAgentModeAndHidePanelWindow: mocks.closeAgentModeAndHidePanelWindow,
 }))
 
 vi.mock("./state", () => ({
   isPanelAutoShowSuppressed: vi.fn(() => false),
   agentSessionStateManager: { shouldStopSession: mocks.shouldStopSession, getSessionRunId: mocks.getSessionRunId },
+  state: mocks.appState,
 }))
 
 vi.mock("./agent-session-tracker", () => ({
@@ -32,7 +37,7 @@ vi.mock("./agent-session-tracker", () => ({
 }))
 
 vi.mock("./config", () => ({
-  configStore: { get: () => ({ floatingPanelAutoShow: true, hidePanelWhenMainFocused: true }) },
+  configStore: { get: () => mocks.config },
 }))
 
 vi.mock("@dotagents/shared", () => ({
@@ -46,10 +51,16 @@ describe("emitAgentProgress snoozed propagation", () => {
     mocks.sendSpy.mockClear()
     mocks.showPanelWindow.mockClear()
     mocks.resizePanelForAgentMode.mockClear()
+    mocks.closeAgentModeAndHidePanelWindow.mockClear()
     mocks.isSessionSnoozed.mockReset()
     mocks.getSession.mockReset()
     mocks.shouldStopSession.mockClear()
     mocks.getSessionRunId.mockClear()
+    mocks.appState.isRecording = false
+    mocks.appState.isTextInputActive = false
+    mocks.config.floatingPanelAutoShow = true
+    mocks.config.floatingPanelAgentProgressEnabled = true
+    mocks.config.hidePanelWhenMainFocused = true
   })
 
   it("backfills isSnoozed from the session tracker when callers omit it", async () => {
@@ -90,6 +101,32 @@ describe("emitAgentProgress snoozed propagation", () => {
     expect(mocks.sendSpy).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "session-tile-visible", isSnoozed: false }))
     expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
     expect(mocks.showPanelWindow).not.toHaveBeenCalled()
+  })
+
+  it("keeps agent progress out of the panel when panel progress is disabled", async () => {
+    mocks.config.floatingPanelAgentProgressEnabled = false
+    mocks.isSessionSnoozed.mockReturnValue(false)
+
+    await emitAgentProgress({ sessionId: "session-panel-disabled", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
+
+    expect(mocks.sendSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.sendSpy).toHaveBeenCalledWith(expect.objectContaining({ sessionId: "session-panel-disabled" }))
+    expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
+    expect(mocks.showPanelWindow).not.toHaveBeenCalled()
+    expect(mocks.closeAgentModeAndHidePanelWindow).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not close an active waveform recording when panel progress is disabled", async () => {
+    mocks.config.floatingPanelAgentProgressEnabled = false
+    mocks.appState.isRecording = true
+    mocks.isSessionSnoozed.mockReturnValue(false)
+
+    await emitAgentProgress({ sessionId: "session-panel-disabled-recording", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
+
+    expect(mocks.sendSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
+    expect(mocks.showPanelWindow).not.toHaveBeenCalled()
+    expect(mocks.closeAgentModeAndHidePanelWindow).not.toHaveBeenCalled()
   })
 
   it("sends terminal delegation updates immediately instead of leaving them behind the throttle", async () => {
@@ -167,7 +204,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     // Second update is no longer "critical", so it should be throttled.
     expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
 
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
     vi.useRealTimers()
   })
@@ -200,7 +237,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     // Follow-up update should be throttled because only the first update is critical.
     expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
 
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
     vi.useRealTimers()
   })
@@ -244,7 +281,7 @@ describe("emitAgentProgress snoozed propagation", () => {
 
     // Follow-up run-scoped updates should be throttled.
     expect(mocks.sendSpy.mock.calls.length).toBe(firstRunScopedSendCount)
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstRunScopedSendCount)
     vi.useRealTimers()
   })
@@ -292,7 +329,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     })
 
     expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
     vi.useRealTimers()
   })

--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -114,6 +114,8 @@ describe("emitAgentProgress snoozed propagation", () => {
     expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
     expect(mocks.showPanelWindow).not.toHaveBeenCalled()
     expect(mocks.closeAgentModeAndHidePanelWindow).toHaveBeenCalledTimes(1)
+    // Must preserve shouldStopAgent so a trailing update can't undo an emergency stop.
+    expect(mocks.closeAgentModeAndHidePanelWindow).toHaveBeenCalledWith({ preserveAgentStopState: true })
   })
 
   it("does not close an active waveform recording when panel progress is disabled", async () => {

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -94,7 +94,9 @@ function sendToWindows(update: AgentProgressUpdate): void {
 
   if (!floatingPanelAgentProgressEnabled) {
     if (update.sessionId && !appState.isRecording && !appState.isTextInputActive) {
-      closeAgentModeAndHidePanelWindow()
+      // Preserve shouldStopAgent: this fires on every progress update, so a
+      // trailing update after an emergency stop must not re-enable the agent.
+      closeAgentModeAndHidePanelWindow({ preserveAgentStopState: true })
     }
     return
   }

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -1,8 +1,8 @@
 import { getRendererHandlers } from "@egoist/tipc/main"
-import { WINDOWS, showPanelWindow, resizePanelForAgentMode } from "./window"
+import { WINDOWS, showPanelWindow, resizePanelForAgentMode, closeAgentModeAndHidePanelWindow } from "./window"
 import { RendererHandlers } from "./renderer-handlers"
 import { AgentProgressUpdate } from "../shared/types"
-import { isPanelAutoShowSuppressed, agentSessionStateManager } from "./state"
+import { isPanelAutoShowSuppressed, agentSessionStateManager, state as appState } from "./state"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { configStore } from "./config"
 import { sanitizeAgentProgressUpdateForDisplay } from "@dotagents/shared"
@@ -87,9 +87,17 @@ function sendToWindows(update: AgentProgressUpdate): void {
 
   // Handle auto-show logic for panel window
   const config = configStore.get()
+  const floatingPanelAgentProgressEnabled = config.floatingPanelAgentProgressEnabled !== false
   const floatingPanelAutoShowEnabled = config.floatingPanelAutoShow !== false
   const hidePanelWhenMainFocused = config.hidePanelWhenMainFocused !== false
   const isMainFocused = main?.isFocused() ?? false
+
+  if (!floatingPanelAgentProgressEnabled) {
+    if (update.sessionId && !appState.isRecording && !appState.isTextInputActive) {
+      closeAgentModeAndHidePanelWindow()
+    }
+    return
+  }
 
   if (!panel.isVisible() && update.sessionId) {
     const isSnoozed = agentSessionTracker.isSessionSnoozed(update.sessionId)

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3148,7 +3148,9 @@ export const router = {
         const prevPanelProgressEnabled = (prev as any)?.floatingPanelAgentProgressEnabled !== false
         const nextPanelProgressEnabled = (merged as any)?.floatingPanelAgentProgressEnabled !== false
         if (prevPanelProgressEnabled && !nextPanelProgressEnabled && !state.isRecording && !state.isTextInputActive) {
-          closeAgentModeAndHidePanelWindow()
+          // Toggling a display preference must not touch agent execution control,
+          // so preserve shouldStopAgent (don't undo a prior emergency stop).
+          closeAgentModeAndHidePanelWindow({ preserveAgentStopState: true })
         }
       } catch (_e) {
         // panel cleanup is best-effort only

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -3145,6 +3145,16 @@ export const router = {
       configStore.save(merged)
 
       try {
+        const prevPanelProgressEnabled = (prev as any)?.floatingPanelAgentProgressEnabled !== false
+        const nextPanelProgressEnabled = (merged as any)?.floatingPanelAgentProgressEnabled !== false
+        if (prevPanelProgressEnabled && !nextPanelProgressEnabled && !state.isRecording && !state.isTextInputActive) {
+          closeAgentModeAndHidePanelWindow()
+        }
+      } catch (_e) {
+        // panel cleanup is best-effort only
+      }
+
+      try {
         const { globalAgentsFolder, resolveWorkspaceAgentsFolder } = await import("./config")
         const { getAgentsLayerPaths } = await import("./agents-files/modular-config")
         const { cleanupInvalidMcpServerReferencesInLayers } = await import("./agent-profile-mcp-cleanup")

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -1322,12 +1322,19 @@ export const stopTextInputAndHidePanelWindow = () => {
   }
 }
 
-export const closeAgentModeAndHidePanelWindow = () => {
+export const closeAgentModeAndHidePanelWindow = (options?: { preserveAgentStopState?: boolean }) => {
   const win = WINDOWS.get("panel")
   if (win) {
     // Update agent state
     state.isAgentModeActive = false
-    state.shouldStopAgent = false
+    // Normally a panel close clears the stop flag (it's a user-initiated "done"
+    // action). When invoked automatically — e.g. to keep agent progress out of
+    // the panel because the display preference is off — preserve shouldStopAgent
+    // so a late/in-flight update can't undo an emergency stop's intentional block
+    // on trailing progress (see emergency-stop.ts).
+    if (!options?.preserveAgentStopState) {
+      state.shouldStopAgent = false
+    }
     state.agentIterationCount = 0
 
     // Hide the panel immediately to avoid flash when mode changes

--- a/apps/desktop/src/renderer/src/pages/panel.recording-layout.test.ts
+++ b/apps/desktop/src/renderer/src/pages/panel.recording-layout.test.ts
@@ -208,7 +208,7 @@ describe("panel recording layout", () => {
     expect(panelSource).toContain('lastRequestedModeRef.current = "textInput"')
     expect(panelSource).toContain('lastRequestedModeRef.current = "normal"')
     expect(mainWindowSource).toContain('export const stopTextInputAndHidePanelWindow = () => {')
-    expect(mainWindowSource).toContain('export const closeAgentModeAndHidePanelWindow = () => {')
+    expect(mainWindowSource).toContain('export const closeAgentModeAndHidePanelWindow = (options?: { preserveAgentStopState?: boolean }) => {')
     expect(mainWindowSource).toContain('export function hideFloatingPanelWindow()')
     expect(mainWindowSource).toContain('setPanelMode("normal")')
     expect(tipcSource).toContain('state.isTextInputActive = false')

--- a/apps/desktop/src/renderer/src/pages/panel.recording-layout.test.ts
+++ b/apps/desktop/src/renderer/src/pages/panel.recording-layout.test.ts
@@ -75,10 +75,11 @@ describe("panel recording layout", () => {
       panelSource.indexOf("// Note: We don't need to hide text input")
     )
 
-    expect(panelSource).toContain("const shouldShowProgressPanel = anyVisibleSessions && !recording")
+    expect(panelSource).toContain("const showAgentProgressInPanel = configQuery.data?.floatingPanelAgentProgressEnabled !== false")
+    expect(panelSource).toContain("const shouldShowProgressPanel = showAgentProgressInPanel && anyVisibleSessions && !recording")
     expect(modeSwitchSection).toContain("if (recording) {")
     expect(modeSwitchSection).toContain('targetMode = "normal"')
-    expect(modeSwitchSection).toContain("} else if (anyActiveNonSnoozed) {")
+    expect(modeSwitchSection).toContain("} else if (showAgentProgressInPanel && anyActiveNonSnoozed) {")
     expect(modeSwitchSection).toContain("} else if (shouldShowProgressPanel) {")
     expect(modeSwitchSection).toContain('targetMode = "agent"')
     expect(modeSwitchSection).not.toContain("recorderRef.current?.stopRecording()")

--- a/apps/desktop/src/renderer/src/pages/panel.tsx
+++ b/apps/desktop/src/renderer/src/pages/panel.tsx
@@ -286,6 +286,14 @@ export function Component() {
     return result
   }
 
+  const configQuery = useConfigQuery()
+  const isDragEnabled = (configQuery.data as any)?.panelDragEnabled ?? true
+  const showAgentProgressInPanel = configQuery.data?.floatingPanelAgentProgressEnabled !== false
+  // Disable transcription preview for Parakeet since live chunk PCM conversion is expensive.
+  const isPreviewEnabled =
+    (configQuery.data?.transcriptionPreviewEnabled ?? false) &&
+    configQuery.data?.sttProviderId !== "parakeet"
+
   const activeSessionCount = Array.from(agentProgressById?.values() ?? [])
     .filter(progress => progress && !progress.isSnoozed && !progress.isComplete).length
 
@@ -299,14 +307,7 @@ export function Component() {
   // Any non-snoozed session (including completed) should show the overlay
   // Also show overlay if there's a focused session (user explicitly selected it, even if snoozed)
   const anyVisibleSessions = visibleSessionCount > 0 || (focusedSessionId && agentProgressById?.has(focusedSessionId))
-  const shouldShowProgressPanel = anyVisibleSessions && !recording
-
-  const configQuery = useConfigQuery()
-  const isDragEnabled = (configQuery.data as any)?.panelDragEnabled ?? true
-  // Disable transcription preview for Parakeet since live chunk PCM conversion is expensive.
-  const isPreviewEnabled =
-    (configQuery.data?.transcriptionPreviewEnabled ?? false) &&
-    configQuery.data?.sttProviderId !== "parakeet"
+  const shouldShowProgressPanel = showAgentProgressInPanel && anyVisibleSessions && !recording
 
   useEffect(() => {
     const updateNativePanelSize = (size: unknown) => {
@@ -1122,7 +1123,7 @@ export function Component() {
     let targetMode: "agent" | "normal" | null = null
     if (recording) {
       targetMode = "normal"
-    } else if (anyActiveNonSnoozed) {
+    } else if (showAgentProgressInPanel && anyActiveNonSnoozed) {
       targetMode = "agent"
     } else if (shouldShowProgressPanel) {
       targetMode = "agent"
@@ -1142,7 +1143,7 @@ export function Component() {
     return () => {
       if (tid) clearTimeout(tid)
     }
-  }, [anyActiveNonSnoozed, recording, shouldShowProgressPanel, textInputMutation.isPending, mcpTextInputMutation.isPending, showTextInput])
+  }, [anyActiveNonSnoozed, recording, shouldShowProgressPanel, showAgentProgressInPanel, textInputMutation.isPending, mcpTextInputMutation.isPending, showTextInput])
 
   // Note: We don't need to hide text input when agentProgress changes because:
   // 1. handleTextSubmit already hides it immediately on submit (line 375)
@@ -1215,7 +1216,7 @@ export function Component() {
 
 	  // Track latest state values in a ref to avoid race conditions with auto-close timeout
 	  const autoCloseStateRef = useRef({
-	    anyVisibleSessions,
+	    showsAgentOverlay: shouldShowProgressPanel,
 	    showTextInput,
 	    recording,
 	    isTextSubmissionPending: textInputMutation.isPending || mcpTextInputMutation.isPending
@@ -1224,18 +1225,18 @@ export function Component() {
 	  // Keep ref in sync with latest state
 	  useEffect(() => {
 	    autoCloseStateRef.current = {
-	      anyVisibleSessions,
+	      showsAgentOverlay: shouldShowProgressPanel,
 	      showTextInput,
 	      recording,
 	      isTextSubmissionPending: textInputMutation.isPending || mcpTextInputMutation.isPending
 	    }
-	  }, [anyVisibleSessions, showTextInput, recording, textInputMutation.isPending, mcpTextInputMutation.isPending])
+	  }, [shouldShowProgressPanel, showTextInput, recording, textInputMutation.isPending, mcpTextInputMutation.isPending])
 
 	  // Auto-close the panel when there's nothing to show
 	  useEffect(() => {
 	    // Keep panel open if a text submission is still pending (to avoid flicker)
 	    const isTextSubmissionPending = textInputMutation.isPending || mcpTextInputMutation.isPending
-	    const showsAgentOverlay = anyVisibleSessions
+	    const showsAgentOverlay = shouldShowProgressPanel
 
 	    const shouldAutoClose =
 	      !showsAgentOverlay &&
@@ -1249,7 +1250,7 @@ export function Component() {
 	        // State may have changed during the 200ms delay
 	        const latestState = autoCloseStateRef.current
 	        const stillShouldClose =
-	          !latestState.anyVisibleSessions &&
+	          !latestState.showsAgentOverlay &&
 	          !latestState.showTextInput &&
 	          !latestState.recording &&
 	          !latestState.isTextSubmissionPending
@@ -1263,7 +1264,7 @@ export function Component() {
 
       return undefined as void
 
-	  }, [anyVisibleSessions, showTextInput, recording, textInputMutation.isPending, mcpTextInputMutation.isPending])
+	  }, [shouldShowProgressPanel, showTextInput, recording, textInputMutation.isPending, mcpTextInputMutation.isPending])
 
   // Use appropriate minimum height based on current mode
   const hasPreviewVisible = recording && isPreviewEnabled && previewText.length > 0
@@ -1357,7 +1358,7 @@ export function Component() {
             isProcessing={
               textInputMutation.isPending || mcpTextInputMutation.isPending
             }
-            agentProgress={agentProgress}
+            agentProgress={showAgentProgressInPanel ? agentProgress : null}
             continueConversationTitle={continueConversationTitle}
           />
         ) : (

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -1316,6 +1316,26 @@ export function Component() {
             </div>
           </Control>
 
+          <Control label={<ControlLabel label="Agent Progress in Floating Panel" tooltip="When enabled, agent progress can appear in the floating panel. When disabled, agent progress stays in the main app; the voice waveform still uses the floating panel." />} className="px-3">
+            <div className="space-y-2">
+              <div className="flex justify-start sm:justify-end">
+                <Switch
+                  checked={configQuery.data?.floatingPanelAgentProgressEnabled !== false}
+                  onCheckedChange={(value) => {
+                    saveConfig({
+                      floatingPanelAgentProgressEnabled: value,
+                    })
+                  }}
+                />
+              </div>
+              {configQuery.data?.floatingPanelAgentProgressEnabled === false && (
+                <div className="text-xs text-muted-foreground sm:text-right">
+                  Agent progress stays in the main app. Voice waveform recording still uses the floating panel.
+                </div>
+              )}
+            </div>
+          </Control>
+
           <Control label={<ControlLabel label="Hide Panel When Main App Focused" tooltip="When enabled, the floating panel automatically hides when the main DotAgents window is focused. The panel reappears when the main window loses focus." />} className="px-3">
             <Switch
               checked={configQuery.data?.hidePanelWhenMainFocused !== false}

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1322,6 +1322,11 @@ export type Config = {
   // Users can still manually access the panel via hotkeys, tray menu, or UI
   floatingPanelAutoShow?: boolean
 
+  // Floating Panel Agent Progress Configuration
+  // When false, agent progress will not render in the floating panel.
+  // Voice waveform recording can still use the floating panel.
+  floatingPanelAgentProgressEnabled?: boolean
+
   // Hide Floating Panel When Main App is Focused
   // When true (default), the floating panel will automatically hide when the main DotAgents window is focused
   // The panel will reappear when the main window loses focus (if auto-show conditions are met)

--- a/packages/core/src/agents-files/modular-config.ts
+++ b/packages/core/src/agents-files/modular-config.ts
@@ -156,6 +156,7 @@ const LAYOUT_KEYS = new Set<string>([
   "panelWaveformSize",
   "panelProgressSize",
   "floatingPanelAutoShow",
+  "floatingPanelAgentProgressEnabled",
   "hidePanelWhenMainFocused",
 ])
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -237,6 +237,8 @@ const getConfig = (): LoadedConfig => {
     panelProgressSize: undefined,
     // Floating panel auto-show - when true, panel auto-shows during agent sessions
     floatingPanelAutoShow: true,
+    // Floating panel agent progress - when false, agent progress stays out of the panel
+    floatingPanelAgentProgressEnabled: true,
     // Hide floating panel when main app is focused (default: enabled)
     hidePanelWhenMainFocused: true,
     // Theme preference defaults


### PR DESCRIPTION
## Summary

Adds a separate setting to disable agent progress in the floating panel while preserving the floating panel for waveform recording.

## Changes

- Adds `floatingPanelAgentProgressEnabled` config support with a default of `true`.
- Adds an **Agent Progress in Floating Panel** toggle under Settings > Panel Position.
- Gates panel-mode rendering and main-process progress delivery so disabled agent progress stays in the main app.
- Closes the agent progress panel when the setting is turned off, while avoiding interruption of active waveform recording or text input.
- Adds focused regression coverage for disabled panel progress and waveform preservation.

## Validation

- `pnpm --filter @dotagents/desktop exec vitest run src/main/emit-agent-progress.snoozed.test.ts src/renderer/src/pages/panel.recording-layout.test.ts`
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/pages/settings-general.langfuse-draft.test.tsx src/renderer/src/pages/settings-general-main-agent-options.test.ts`
- `pnpm --filter @dotagents/desktop typecheck`
- `pnpm --filter @dotagents/core typecheck`
- `git diff --check`