### PR TITLE
[codex] Speed up LLM stream rendering

### DIFF
--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -167,8 +167,69 @@ describe("emitAgentProgress snoozed propagation", () => {
     // Second update is no longer "critical", so it should be throttled.
     expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
 
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
+    vi.useRealTimers()
+  })
+
+  it("uses a shorter trailing throttle and omits repeated steps for streaming text", async () => {
+    vi.useFakeTimers()
+    mocks.isSessionSnoozed.mockReturnValue(false)
+
+    const activeThinkingStep = {
+      id: "thinking-stream-1",
+      type: "thinking" as const,
+      title: "Agent response",
+      status: "in_progress" as const,
+      timestamp: 1,
+      llmContent: "",
+    }
+
+    await emitAgentProgress({
+      sessionId: "session-fast-streaming",
+      runId: 1,
+      currentIteration: 0,
+      maxIterations: 1,
+      isComplete: false,
+      steps: [activeThinkingStep],
+    })
+
+    const firstSendCount = mocks.sendSpy.mock.calls.length
+
+    await emitAgentProgress({
+      sessionId: "session-fast-streaming",
+      runId: 1,
+      currentIteration: 0,
+      maxIterations: 1,
+      isComplete: false,
+      steps: [{
+        ...activeThinkingStep,
+        llmContent: "Hello",
+      }],
+      streamingContent: {
+        text: "Hello",
+        isStreaming: true,
+      },
+    })
+
+    expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
+
+    vi.advanceTimersByTime(49)
+    expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
+
+    vi.advanceTimersByTime(1)
+    expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
+
+    const latestUpdate = mocks.sendSpy.mock.calls.at(-1)?.[0]
+    expect(latestUpdate).toEqual(expect.objectContaining({
+      sessionId: "session-fast-streaming",
+      streamingContent: {
+        text: "Hello",
+        isStreaming: true,
+      },
+      steps: [],
+    }))
+
     vi.useRealTimers()
   })
 
@@ -200,7 +261,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     // Follow-up update should be throttled because only the first update is critical.
     expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
 
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
     vi.useRealTimers()
   })
@@ -244,7 +305,7 @@ describe("emitAgentProgress snoozed propagation", () => {
 
     // Follow-up run-scoped updates should be throttled.
     expect(mocks.sendSpy.mock.calls.length).toBe(firstRunScopedSendCount)
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstRunScopedSendCount)
     vi.useRealTimers()
   })
@@ -292,7 +353,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     })
 
     expect(mocks.sendSpy.mock.calls.length).toBe(firstSendCount)
-    vi.advanceTimersByTime(200)
+    vi.advanceTimersByTime(250)
     expect(mocks.sendSpy.mock.calls.length).toBeGreaterThan(firstSendCount)
     vi.useRealTimers()
   })

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -10,15 +10,39 @@ import { sanitizeAgentProgressUpdateForDisplay } from "@dotagents/shared"
 // Throttle interval for non-critical progress updates (ms).
 // Updates within this window are collapsed — only the latest is sent.
 const THROTTLE_INTERVAL_MS = 250
+const STREAMING_THROTTLE_INTERVAL_MS = 50
 
 // Per-session throttle state
 const sessionThrottleState = new Map<string, {
   timer: ReturnType<typeof setTimeout> | null
+  timerDueAt: number | null
   lastSendTime: number
   pendingUpdate: AgentProgressUpdate | null
   runId?: number
   sentTerminalDelegationKeys: Set<string>
 }>()
+
+function isStreamingTextUpdate(update: AgentProgressUpdate): boolean {
+  return update.streamingContent?.isStreaming === true && !update.isComplete && update.userResponse === undefined
+}
+
+function getThrottleInterval(update: AgentProgressUpdate): number {
+  return isStreamingTextUpdate(update) ? STREAMING_THROTTLE_INTERVAL_MS : THROTTLE_INTERVAL_MS
+}
+
+function getRendererProgressUpdate(update: AgentProgressUpdate): AgentProgressUpdate {
+  if (!isStreamingTextUpdate(update) || (update.steps?.length ?? 0) === 0) {
+    return update
+  }
+
+  // The renderer already has the active steps from the previous progress update.
+  // Streaming ticks only need to advance the visible text; preserving steps in
+  // the store avoids rebuilding the whole timeline for every token batch.
+  return {
+    ...update,
+    steps: [],
+  }
+}
 
 function getDelegationIdentity(step: AgentProgressUpdate["steps"][number]): string | undefined {
   if (step.delegation?.runId) return `run:${step.delegation.runId}`
@@ -178,6 +202,7 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
     if (!state) {
       state = {
         timer: null,
+        timerDueAt: null,
         lastSendTime: 0,
         pendingUpdate: null,
         runId: incomingRunId,
@@ -193,6 +218,7 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
       isFirstUpdateForSession = true
       state = {
         timer: null,
+        timerDueAt: null,
         lastSendTime: 0,
         pendingUpdate: null,
         runId: incomingRunId,
@@ -211,15 +237,17 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
     if (state?.timer) {
       clearTimeout(state.timer)
       state.timer = null
+      state.timerDueAt = null
       state.pendingUpdate = null
     }
 
     // Send immediately
-    sendToWindows(displayUpdate)
+    sendToWindows(getRendererProgressUpdate(displayUpdate))
 
     // Update throttle state
     sessionThrottleState.set(sessionId, {
       timer: null,
+      timerDueAt: null,
       lastSendTime: Date.now(),
       pendingUpdate: null,
       runId: typeof incomingRunId === "number" ? incomingRunId : state?.runId,
@@ -237,6 +265,7 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
   if (!state) {
     state = {
       timer: null,
+      timerDueAt: null,
       lastSendTime: 0,
       pendingUpdate: null,
       runId: typeof incomingRunId === "number" ? incomingRunId : undefined,
@@ -247,22 +276,30 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
 
   const now = Date.now()
   const elapsed = now - state.lastSendTime
+  const throttleInterval = getThrottleInterval(displayUpdate)
+  const rendererUpdate = getRendererProgressUpdate(displayUpdate)
 
-  if (elapsed >= THROTTLE_INTERVAL_MS) {
+  if (elapsed >= throttleInterval) {
     // Enough time has passed — send immediately
     if (state.timer) {
       clearTimeout(state.timer)
       state.timer = null
+      state.timerDueAt = null
     }
     state.pendingUpdate = null
     state.lastSendTime = now
     state.sentTerminalDelegationKeys = mergeTerminalDelegationKeys(state.sentTerminalDelegationKeys, displayUpdate)
-    sendToWindows(displayUpdate)
+    sendToWindows(rendererUpdate)
   } else {
     // Within throttle window — store as pending and schedule a trailing send
-    state.pendingUpdate = displayUpdate
-    if (!state.timer) {
-      const remaining = THROTTLE_INTERVAL_MS - elapsed
+    state.pendingUpdate = rendererUpdate
+    const remaining = throttleInterval - elapsed
+    const timerDueAt = now + remaining
+    if (!state.timer || state.timerDueAt === null || timerDueAt < state.timerDueAt) {
+      if (state.timer) {
+        clearTimeout(state.timer)
+      }
+      state.timerDueAt = timerDueAt
       state.timer = setTimeout(() => {
         const s = sessionThrottleState.get(sessionId)
         if (s?.pendingUpdate) {
@@ -270,6 +307,7 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
           if (typeof pendingRunId === "number" && typeof s.runId === "number" && pendingRunId < s.runId) {
             s.pendingUpdate = null
             s.timer = null
+            s.timerDueAt = null
             return
           }
           if (
@@ -279,6 +317,7 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
           ) {
             s.pendingUpdate = null
             s.timer = null
+            s.timerDueAt = null
             sessionThrottleState.delete(sessionId)
             return
           }
@@ -287,7 +326,10 @@ export async function emitAgentProgress(update: AgentProgressUpdate): Promise<vo
           sendToWindows(s.pendingUpdate)
           s.pendingUpdate = null
         }
-        if (s) s.timer = null
+        if (s) {
+          s.timer = null
+          s.timerDueAt = null
+        }
       }, remaining)
     }
   }

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -2448,7 +2448,7 @@ export async function processTranscriptWithAgentMode(
       let lastStreamEmitTime = 0
       let lastRendererStreamEmitTime = 0
       const STREAM_EMIT_THROTTLE_MS = 50
-      const RENDERER_STREAM_EMIT_THROTTLE_MS = 250
+      const RENDERER_STREAM_EMIT_THROTTLE_MS = STREAM_EMIT_THROTTLE_MS
       const streamingProgressSteps = progressSteps.length <= 3
         ? progressSteps
         : progressSteps.slice(-3)


### PR DESCRIPTION
## Summary

- Reduce live LLM streaming progress updates from 250ms to 50ms so text appears closer to token arrival.
- Keep normal non-critical progress updates on the existing 250ms throttle.
- Send focused renderer payloads for streaming text by omitting repeated step data, letting the renderer preserve the existing timeline while only updating `streamingContent`.
- Add focused coverage for the streaming throttle behavior and update existing timer expectations to match the production throttle.

## Root Cause

The desktop path had two 250ms gates for live response text: the LLM streaming callback only allowed renderer updates every 250ms, and the progress emitter also throttled non-critical IPC updates at 250ms. Streaming updates also carried repeated step payloads, causing extra renderer timeline work on every live text tick.

## Validation

- `pnpm --filter @dotagents/desktop exec vitest run src/main/emit-agent-progress.snoozed.test.ts src/renderer/src/stores/agent-store.test.ts src/renderer/src/components/agent-progress.response-history.test.ts`
- `pnpm --filter @dotagents/desktop run typecheck`
- `git diff --check`

Note: `pnpm --filter @dotagents/desktop run --if-present lint` could not run because `eslint` is not installed on PATH in this checkout.