### PR TITLE
Add New Chat button to widescreen sidebar rail

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -266,6 +266,13 @@ function Navigation() {
     }
   }, [navigationRef]);
 
+  const handleDesktopNewChat = useCallback(() => {
+    sessionStore.createNewSession();
+    (navigationRef as any).navigate('Chat');
+    setCurrentRouteName('Chat');
+    setSelectedPrimaryNavItemId(null);
+  }, [sessionStore, navigationRef]);
+
   const navigatePrimaryShellItem = useCallback((item: AppShellPrimaryNavItem) => {
     if (!isNavigationReady.current) return;
     setSelectedPrimaryNavItemId(item.id);
@@ -281,6 +288,16 @@ function Navigation() {
           <Text style={navigationStyles.desktopShellTitle}>{APP_SHELL_PRODUCT_LABEL}</Text>
         </View>
       </View>
+
+      <TouchableOpacity
+        onPress={handleDesktopNewChat}
+        style={navigationStyles.desktopShellNewChatButton}
+        accessibilityRole="button"
+        accessibilityLabel="New chat"
+        accessibilityHint="Creates and opens a new chat."
+      >
+        <Text style={navigationStyles.desktopShellNewChatButtonText}>+ New Chat</Text>
+      </TouchableOpacity>
 
       <View style={navigationStyles.desktopShellNav}>
         {APP_SHELL_PRIMARY_NAV_ITEMS.map((item) => {
@@ -674,6 +691,19 @@ function createNavigationStyles(theme: Theme) {
       color: theme.colors.foreground,
       fontSize: 14,
       fontWeight: '700',
+    },
+    desktopShellNewChatButton: {
+      marginBottom: 10,
+      backgroundColor: theme.colors.accent,
+      borderRadius: 6,
+      paddingVertical: 8,
+      paddingHorizontal: 10,
+      alignItems: 'center',
+    },
+    desktopShellNewChatButtonText: {
+      color: theme.colors.accentForeground,
+      fontSize: 13,
+      fontWeight: '600',
     },
     desktopShellNav: {
       gap: 4,


### PR DESCRIPTION
## Summary

- Adds a `+ New Chat` button to the desktop/widescreen sidebar rail in `App.tsx`
- Button appears below the brand header and above the nav items on screens ≥ 768px
- Tapping it creates a new session and navigates directly to the Chat screen
- Styled using existing accent colors to match the active nav item style

## Test plan

- [ ] Open app on a widescreen device or browser window ≥ 768px wide
- [ ] Confirm `+ New Chat` button is visible in the left sidebar rail
- [ ] Tap the button and verify a new chat session is created and the Chat screen opens
- [ ] Verify narrow/mobile layout (< 768px) is unaffected — no button in bottom tab bar

https://claude.ai/code/session_01WmrzCxvTWjVywAsRJ2uwxe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmrzCxvTWjVywAsRJ2uwxe)_