### PR TITLE
Dedupe mobile follow-up and queued message UI (closes #527)

### DIFF
--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -3830,6 +3830,10 @@ export default function ChatScreen({ route, navigation }: any) {
   const queuedMessages = messageQueue.getQueue(currentConversationId);
   const pendingQueuedMessages = queuedMessages.filter((message) => message.status === 'pending');
   const nextQueuedMessage = !responding ? messageQueue.peek(currentConversationId) : null;
+  // The MessageQueuePanel below renders the same queued messages. Track whether
+  // it will appear so the inline "Follow-up queued" bubbles can be suppressed
+  // and avoid showing the same message in two surfaces at once (#527).
+  const messageQueuePanelVisible = messageQueueEnabled && queuedMessages.length > 0;
 
   useEffect(() => {
     if (pendingQueuedMessages.length === 0 || !shouldAutoScroll) return;
@@ -5967,7 +5971,7 @@ export default function ChatScreen({ route, navigation }: any) {
               </View>
             );
           })}
-          {pendingQueuedMessages.map((queuedMessage) => (
+          {!messageQueuePanelVisible && pendingQueuedMessages.map((queuedMessage) => (
             <View
               key={`queued-inline-${queuedMessage.id}`}
               style={[
@@ -6059,7 +6063,7 @@ export default function ChatScreen({ route, navigation }: any) {
 		          </View>
 		        )}
         {/* Message Queue Panel */}
-        {messageQueueEnabled && queuedMessages.length > 0 && (
+        {messageQueuePanelVisible && (
           <View style={{ paddingHorizontal: spacing.md, paddingTop: spacing.sm }}>
             <MessageQueuePanel
               conversationId={currentConversationId}

--- a/apps/mobile/tests/chat-queue-followup-dedup.test.js
+++ b/apps/mobile/tests/chat-queue-followup-dedup.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const source = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'screens', 'ChatScreen.tsx'),
+  'utf8'
+);
+
+test('mobile chat derives a single visibility flag for the queue panel (#527)', () => {
+  assert.match(
+    source,
+    /const messageQueuePanelVisible = messageQueueEnabled && queuedMessages\.length > 0;/,
+  );
+});
+
+test('mobile chat suppresses inline "Follow-up queued" bubbles when the queue panel is visible (#527)', () => {
+  assert.match(
+    source,
+    /\{!messageQueuePanelVisible && pendingQueuedMessages\.map\(\(queuedMessage\) => \(/,
+  );
+  assert.doesNotMatch(
+    source,
+    /^\s*\{pendingQueuedMessages\.map\(\(queuedMessage\) => \($/m,
+  );
+});
+
+test('mobile MessageQueuePanel renders behind the shared visibility flag (#527)', () => {
+  assert.match(
+    source,
+    /\{messageQueuePanelVisible && \(\s*\n\s*<View style=\{\{ paddingHorizontal: spacing\.md, paddingTop: spacing\.sm \}\}>/,
+  );
+  assert.doesNotMatch(
+    source,
+    /\{messageQueueEnabled && queuedMessages\.length > 0 && \(\s*\n\s*<View style=\{\{ paddingHorizontal: spacing\.md, paddingTop: spacing\.sm \}\}>/,
+  );
+});


### PR DESCRIPTION
## Summary
Closes #527.

Mobile chat could render the same queued message twice: once as an inline "Follow-up queued" chat bubble inside the conversation `ScrollView`, and once again in the dedicated `MessageQueuePanel` sticky at the bottom. Both surfaces drew from the same `pendingQueuedMessages` set, with no guard preventing them from rendering together.

## What changed
- **`apps/mobile/src/screens/ChatScreen.tsx`** — Derive a single `messageQueuePanelVisible = messageQueueEnabled && queuedMessages.length > 0` flag next to where queued state is computed. The inline `pendingQueuedMessages.map(...)` bubbles now render only when that flag is `false`, so they act as a fallback (e.g. when the user has disabled `messageQueueEnabled`) instead of duplicating cards. The `MessageQueuePanel` render guard now uses the same flag, keeping the two sites in sync.
- **`apps/mobile/tests/chat-queue-followup-dedup.test.js`** — New `node:test` regression covering three assertions: (1) the shared visibility flag exists, (2) the inline bubble map is gated on `!messageQueuePanelVisible`, and (3) the panel renders behind the shared flag (not the old `messageQueueEnabled && queuedMessages.length > 0` inline expression).

## Behavior
- Queue panel visible (default `messageQueueEnabled` path): only the panel shows pending/processing/failed queued messages — no inline duplicates.
- Queue panel hidden (`messageQueueEnabled === false` but residual queued messages from earlier): inline "Follow-up queued" bubbles still appear so the user can see the pending entries.
- Non-pending queue states (processing, failed) were never inlined and continue to render only in the panel.

## Test plan
- [x] `node --test tests/chat-queue-followup-dedup.test.js` (3/3 pass)
- [x] Full mobile node suite: 202/209 pass; the 7 failures are pre-existing and unrelated (header chip, agent time totals, respond_to_user content, TTS row layout, metro watchfolders, session icons) — same failures occur on `main`/before this change.
- [ ] Manual mobile smoke: queue a message while the agent is mid-turn and confirm only the panel card appears (not a duplicate inline bubble).


---
_Generated by [Claude Code](https://claude.ai/code/session_01L9arfn6sGSYZTAeWivASDf)_