### PR TITLE
Add shortcut helper text and screenshot hint for session controls (closes #387)

### DIFF
--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -16,7 +16,7 @@ import { PredefinedPromptsMenu } from "@renderer/components/predefined-prompts-m
 import { AgentSelector } from "@renderer/components/agent-selector"
 import { useConfigQuery } from "@renderer/lib/query-client"
 import { useSavedConversationsQuery } from "@renderer/lib/queries"
-import { getAgentShortcutDisplay, getTextInputShortcutDisplay, getDictationShortcutDisplay } from "@shared/key-utils"
+import { getAgentShortcutDisplay, getTextInputShortcutDisplay, getDictationShortcutDisplay, getVoiceScreenshotShortcutDisplay } from "@shared/key-utils"
 import dayjs from "dayjs"
 import type { SessionActionDialogMode } from "@renderer/components/session-action-dialog"
 import { orderActiveSessionsByPinnedFirst } from "@renderer/lib/sidebar-sessions"
@@ -29,6 +29,7 @@ import {
 } from "@renderer/lib/session-progress-hydration"
 
 const CLEAR_INACTIVE_EVENT = "sessions:clear-inactive"
+const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac")
 
 interface LayoutContext {
   onOpenSavedConversationsDialog: () => void
@@ -301,7 +302,7 @@ const ActiveSessionTile = React.memo(function ActiveSessionTile({
   )
 })
 
-function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onSavedConversationClick, onOpenSavedConversationsDialog, textInputShortcut, voiceInputShortcut, dictationShortcut, selectedAgentId, onSelectAgent }: {
+function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onSavedConversationClick, onOpenSavedConversationsDialog, textInputShortcut, voiceInputShortcut, dictationShortcut, screenshotShortcut, selectedAgentId, onSelectAgent }: {
   onTextClick: () => void
   onVoiceClick: () => void
   onSelectPrompt: (content: string) => void
@@ -310,6 +311,7 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onSavedConversa
   textInputShortcut: string
   voiceInputShortcut: string
   dictationShortcut: string
+  screenshotShortcut: string | null
   selectedAgentId: string | null
   onSelectAgent: (id: string | null) => void
 }) {
@@ -382,6 +384,14 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onSavedConversa
               {dictationShortcut}
             </kbd>
           </div>
+          {screenshotShortcut && (
+            <div className="flex items-center gap-1.5">
+              <span>Screenshot:</span>
+              <kbd className="px-1.5 py-0.5 font-semibold bg-muted border rounded">
+                {screenshotShortcut}
+              </kbd>
+            </div>
+          )}
         </div>
       </div>
 
@@ -473,6 +483,10 @@ export function Component() {
   const textInputShortcut = getTextInputShortcutDisplay(configQuery.data?.textInputShortcut, configQuery.data?.customTextInputShortcut)
   const voiceInputShortcut = getAgentShortcutDisplay(configQuery.data?.agentShortcut || configQuery.data?.mcpToolsShortcut, configQuery.data?.customAgentShortcut || configQuery.data?.customMcpToolsShortcut)
   const dictationShortcut = getDictationShortcutDisplay(configQuery.data?.shortcut, configQuery.data?.customShortcut)
+  // Voice screenshot keybinding only fires on macOS today, so hide the hint elsewhere.
+  const screenshotShortcut = IS_MAC && configQuery.data?.voiceScreenshotShortcutEnabled !== false
+    ? getVoiceScreenshotShortcutDisplay(configQuery.data?.voiceScreenshotShortcut, configQuery.data?.customVoiceScreenshotShortcut)
+    : null
 
   const { data: sessionData, refetch: refetchSessionData } = useQuery<SessionListResponse>({
     queryKey: ["agentSessions"],
@@ -1033,6 +1047,7 @@ export function Component() {
             textInputShortcut={textInputShortcut}
             voiceInputShortcut={voiceInputShortcut}
             dictationShortcut={dictationShortcut}
+            screenshotShortcut={screenshotShortcut}
             selectedAgentId={selectedAgentId}
             onSelectAgent={setSelectedAgentId}
           />

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -359,6 +359,36 @@ export function Component() {
         : `Hold ${customRecordingShortcutDisplay} to record, release it to finish, and press any other key to cancel.`
       : "Press Ctrl+/ to start and finish recording. Press Esc to cancel."
 
+  const agentShortcut = cfg?.agentShortcut || cfg?.mcpToolsShortcut
+  const customAgentShortcutMode = cfg?.customAgentShortcutMode || "hold"
+  const effectiveAgentShortcut = getEffectiveShortcut(
+    agentShortcut,
+    cfg?.customAgentShortcut || cfg?.customMcpToolsShortcut,
+  )
+  const customAgentShortcutDisplay = effectiveAgentShortcut
+    ? formatKeyComboForDisplay(effectiveAgentShortcut)
+    : "your custom shortcut"
+  const agentShortcutHelperText = agentShortcut === "toggle-ctrl-alt"
+    ? "Press Ctrl+Alt to start agent mode, press again to send. Press Esc to cancel."
+    : agentShortcut === "ctrl-alt-slash"
+      ? "Press Ctrl+Alt+/ to start agent mode, press again to send. Press Esc to cancel."
+      : agentShortcut === "custom"
+        ? customAgentShortcutMode === "toggle"
+          ? `Press ${customAgentShortcutDisplay} to start agent mode, press again to send. Press Esc to cancel.`
+          : `Hold ${customAgentShortcutDisplay} to record an agent prompt, release to send.`
+        : "Hold Ctrl+Alt to record an agent prompt, release to send."
+
+  const toggleVoiceDictationHotkey = cfg?.toggleVoiceDictationHotkey || "fn"
+  const effectiveToggleVoiceDictationShortcut = getEffectiveShortcut(
+    toggleVoiceDictationHotkey,
+    cfg?.customToggleVoiceDictationHotkey,
+  )
+  const toggleVoiceDictationDisplay = effectiveToggleVoiceDictationShortcut
+    ? formatKeyComboForDisplay(effectiveToggleVoiceDictationShortcut)
+    : "your custom shortcut"
+  const toggleVoiceDictationHelperText =
+    `Press ${toggleVoiceDictationDisplay} to start dictation, press again to stop. Press Esc to cancel.`
+
 
   const isSearching = searchQuery.length > 0
 
@@ -698,11 +728,6 @@ export function Component() {
           defaultCollapsed
           title="Shortcuts"
           forceOpen={isSearching}
-          endDescription={
-            <div className="leading-relaxed">
-              {recordingShortcutHelperText}
-            </div>
-          }
         >
           <Control label="Recording" className="px-3">
             <div className="space-y-2">
@@ -756,6 +781,9 @@ export function Component() {
                   />
                 </>
               )}
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {recordingShortcutHelperText}
+              </p>
             </div>
           </Control>
 
@@ -817,6 +845,9 @@ export function Component() {
                       placeholder="Click to record custom toggle shortcut"
                     />
                   )}
+                  <p className="text-xs leading-relaxed text-muted-foreground">
+                    {toggleVoiceDictationHelperText}
+                  </p>
                 </>
               )}
             </div>
@@ -938,14 +969,36 @@ export function Component() {
               </Select>
 
               {(configQuery.data?.agentShortcut || configQuery.data?.mcpToolsShortcut) === "custom" && (
-                <KeyRecorder
-                  value={configQuery.data?.customAgentShortcut || configQuery.data?.customMcpToolsShortcut || ""}
-                  onChange={(keyCombo) => {
-                    saveConfig({ customAgentShortcut: keyCombo })
-                  }}
-                  placeholder="Click to record custom agent mode shortcut"
-                />
+                <>
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Mode</label>
+                    <Select
+                      value={configQuery.data?.customAgentShortcutMode || configQuery.data?.customMcpToolsShortcutMode || "hold"}
+                      onValueChange={(value: "hold" | "toggle") => {
+                        saveConfig({ customAgentShortcutMode: value })
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="hold">Hold (Press and hold to record)</SelectItem>
+                        <SelectItem value="toggle">Toggle (Press once to start, again to send)</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <KeyRecorder
+                    value={configQuery.data?.customAgentShortcut || configQuery.data?.customMcpToolsShortcut || ""}
+                    onChange={(keyCombo) => {
+                      saveConfig({ customAgentShortcut: keyCombo })
+                    }}
+                    placeholder="Click to record custom agent mode shortcut"
+                  />
+                </>
               )}
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {agentShortcutHelperText}
+              </p>
             </div>
           </Control>
         </ControlGroup>

--- a/apps/desktop/src/shared/key-utils.test.ts
+++ b/apps/desktop/src/shared/key-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   formatKeyComboForDisplay,
+  getVoiceScreenshotShortcutDisplay,
   matchesKeyCombo,
 } from "./key-utils"
 
@@ -36,5 +37,20 @@ describe("formatKeyComboForDisplay", () => {
     expect(formatKeyComboForDisplay("cmd-return")).toBe(
       `${process.platform === "darwin" ? "Cmd" : "Meta"} + Enter`,
     )
+  })
+})
+
+describe("getVoiceScreenshotShortcutDisplay", () => {
+  it("returns the built-in shortcut label by default", () => {
+    expect(getVoiceScreenshotShortcutDisplay(undefined)).toBe("Ctrl+Shift+X")
+    expect(getVoiceScreenshotShortcutDisplay("ctrl-shift-x")).toBe("Ctrl+Shift+X")
+  })
+
+  it("formats a custom shortcut when one is configured", () => {
+    expect(getVoiceScreenshotShortcutDisplay("custom", "alt-shift-s")).toBe("Shift + Alt + S")
+  })
+
+  it("falls back to the built-in label when custom mode has no shortcut yet", () => {
+    expect(getVoiceScreenshotShortcutDisplay("custom")).toBe("Ctrl+Shift+X")
   })
 })

--- a/apps/desktop/src/shared/key-utils.ts
+++ b/apps/desktop/src/shared/key-utils.ts
@@ -263,3 +263,24 @@ export function getDictationShortcutDisplay(
       return "Hold Ctrl"
   }
 }
+
+/**
+ * Get the display string for the voice screenshot shortcut.
+ * Used by both Settings UI and the empty session screen hint.
+ */
+export function getVoiceScreenshotShortcutDisplay(
+  shortcut: "ctrl-shift-x" | "custom" | undefined,
+  customShortcut?: string,
+): string {
+  switch (shortcut) {
+    case "ctrl-shift-x":
+      return "Ctrl+Shift+X"
+    case "custom":
+      if (customShortcut) {
+        return formatKeyComboForDisplay(customShortcut)
+      }
+      return "Ctrl+Shift+X"
+    default:
+      return "Ctrl+Shift+X"
+  }
+}


### PR DESCRIPTION
## Summary
Closes #387.

Improves shortcut discoverability in the desktop session UI by surfacing the active key combination directly under each control, and adds a Screenshot affordance to the empty sessions screen.

## Changes

### Settings → Shortcuts: inline helper text
- **Recording**, **Toggle Voice Dictation**, and **Agent Mode** dropdowns now render a small helper line below the control describing the active shortcut, e.g. "Hold Ctrl to record, release it to finish…", "Press Fn to start dictation, press again to stop…", "Hold Ctrl+Alt to record an agent prompt, release to send."
- The Recording helper used to live in `endDescription` at the ControlGroup level; it is now attached to its own control so each shortcut has its own contextual line.
- The custom Agent Mode shortcut gains a Hold/Toggle mode `<Select>` matching the existing Recording UX. The keyboard handler already honored `customAgentShortcutMode` (`apps/desktop/src/main/keyboard.ts:937`), but the renderer never exposed a way to set it.

### Empty sessions screen: Screenshot hint
- `sessions.tsx`'s empty-state component now renders a `Screenshot: <key>` hint alongside the existing Text / Voice / Dictation hints when the voice screenshot shortcut is enabled. The hint is gated to macOS because the keyboard handler at `apps/desktop/src/main/keyboard.ts:873` only registers the screenshot binding under `process.platform === "darwin"`.

### Shared helper
- New `getVoiceScreenshotShortcutDisplay` in `apps/desktop/src/shared/key-utils.ts`, mirroring `getAgentShortcutDisplay` / `getDictationShortcutDisplay`, plus unit tests in `key-utils.test.ts`.

## Test plan
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/shared/key-utils.test.ts src/renderer/src/pages/sessions.in-app-actions.test.ts src/renderer/src/pages/settings-general.langfuse-draft.test.tsx` — 37 passing
- [x] `pnpm --filter @dotagents/desktop typecheck:web` — no new errors (one pre-existing `uuid` module-resolution error in `acp/internal-agent.ts` is unrelated to this change)
- [ ] Manual: open Settings → Shortcuts and verify the helper line under each dropdown updates when the shortcut is changed, including custom hold/toggle for Agent Mode
- [ ] Manual on macOS: close all active sessions, confirm the empty state shows the Screenshot key hint
- [ ] Manual on Windows/Linux: confirm the Screenshot hint is hidden

---
_Generated by [Claude Code](https://claude.ai/code/session_0177yNJxc9juwgGHgBNCBnWb)_