### PR TITLE
Boost recent notes for time-sensitive recall queries (closes #497)

### DIFF
--- a/apps/desktop/src/main/knowledge-notes-service.search.test.ts
+++ b/apps/desktop/src/main/knowledge-notes-service.search.test.ts
@@ -12,7 +12,9 @@ vi.mock("electron", () => ({
 }))
 
 vi.mock("./config", () => ({
-  globalAgentsFolder: mockPaths.globalAgentsFolder,
+  get globalAgentsFolder() {
+    return mockPaths.globalAgentsFolder
+  },
   resolveWorkspaceAgentsFolder: () => null,
 }))
 
@@ -102,5 +104,67 @@ describe("KnowledgeNotesService search", () => {
         expect.objectContaining({ id: "old-auto" }),
         expect.objectContaining({ id: "new-search-only" }),
       ])
+  })
+
+  it("boosts recent notes ahead of older notes when the query is time-sensitive", async () => {
+    const now = Date.now()
+    const { KnowledgeNotesService } = await import("./knowledge-notes-service")
+    const service = new KnowledgeNotesService()
+
+    await service.saveNote({
+      id: "old-video",
+      title: "Clawdbot Moltbot Video Strategy",
+      context: "search-only",
+      createdAt: now - 120 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 120 * 24 * 60 * 60 * 1000,
+      tags: ["video", "clawdbot"],
+      body: "Older recording plan with extensive video direction notes.",
+    })
+    await service.saveNote({
+      id: "fresh-video",
+      title: "Random Note",
+      context: "search-only",
+      createdAt: now - 60 * 60 * 1000,
+      updatedAt: now - 60 * 60 * 1000,
+      tags: ["video"],
+      body: "A quick mention of video shot today.",
+    })
+
+    const baseline = await service.searchNotes("video")
+    expect(baseline[0].id).toBe("old-video")
+
+    const todayResults = await service.searchNotes("video today")
+    expect(todayResults[0]?.id).toBe("fresh-video")
+
+    const recentResults = await service.searchNotes("latest video")
+    expect(recentResults[0]?.id).toBe("fresh-video")
+  })
+
+  it("leaves ordering unchanged for non-time-sensitive queries", async () => {
+    const now = Date.now()
+    const { KnowledgeNotesService } = await import("./knowledge-notes-service")
+    const service = new KnowledgeNotesService()
+
+    await service.saveNote({
+      id: "weighty-old",
+      title: "Strategy Playbook",
+      context: "search-only",
+      createdAt: now - 200 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 200 * 24 * 60 * 60 * 1000,
+      tags: ["strategy"],
+      body: "Long-form strategy reference.",
+    })
+    await service.saveNote({
+      id: "fresh-shallow",
+      title: "Random Note",
+      context: "search-only",
+      createdAt: now - 60 * 1000,
+      updatedAt: now - 60 * 1000,
+      tags: [],
+      body: "A weaker mention of strategy in the body.",
+    })
+
+    const results = await service.searchNotes("strategy")
+    expect(results[0].id).toBe("weighty-old")
   })
 })

--- a/apps/desktop/src/main/knowledge-notes-service.ts
+++ b/apps/desktop/src/main/knowledge-notes-service.ts
@@ -66,6 +66,42 @@ const VALID_ENTRY_TYPE_VALUES = new Set<KnowledgeNoteEntryType>(["note", "entry"
 const LEGACY_NOTE_META_PREFIX = "<!-- dotagents-memory-meta:"
 const DAY_MS = 24 * 60 * 60 * 1000
 
+const TIME_SENSITIVE_QUERY_PATTERN_SOURCES: string[] = [
+  "today(?:'s)?",
+  "tonight",
+  "(?:right )?now",
+  "current(?:ly)?",
+  "latest",
+  "recent(?:ly)?",
+  "yesterday",
+  "this (?:morning|afternoon|evening|week|month)",
+  "what (?:were we|was i|are we|am i) (?:working|doing) on",
+]
+const TIME_SENSITIVE_QUERY_REGEX = new RegExp(
+  `\\b(?:${TIME_SENSITIVE_QUERY_PATTERN_SOURCES.join("|")})\\b`,
+  "gi",
+)
+
+function isTimeSensitiveQuery(query: string | undefined): boolean {
+  if (!query) return false
+  TIME_SENSITIVE_QUERY_REGEX.lastIndex = 0
+  return TIME_SENSITIVE_QUERY_REGEX.test(query)
+}
+
+function stripTimeSensitiveMarkers(query: string): string {
+  return query.replace(TIME_SENSITIVE_QUERY_REGEX, " ").replace(/\s+/g, " ").trim()
+}
+
+function recencyBoostMultiplier(updatedAtMs: number, nowMs: number): number {
+  const ageDays = Math.max(0, nowMs - updatedAtMs) / DAY_MS
+  if (ageDays <= 2) return 1.6
+  if (ageDays <= 7) return 1.3
+  if (ageDays <= 30) return 1.1
+  if (ageDays <= 90) return 1.0
+  if (ageDays <= 365) return 0.85
+  return 0.7
+}
+
 type SearchIndexEntry = {
   note: KnowledgeNote
   title: string
@@ -585,12 +621,18 @@ export class KnowledgeNotesService {
   } = {}): Promise<KnowledgeNote[]> {
     await this.initialize()
     const scores = new Map<string, number>()
+    const timeSensitive = isTimeSensitiveQuery(query)
+    const scoringQuery = timeSensitive ? (stripTimeSensitiveMarkers(query) || query) : query
+    const nowMs = Date.now()
     const matches = this.searchIndex
       .filter((entry) => {
         if (filter.context && entry.note.context !== filter.context) return false
         if (!matchesDateFilter(entry.note, filter.dateFilter)) return false
-        const score = scoreSearchEntry(entry, query)
+        let score = scoreSearchEntry(entry, scoringQuery)
         if (score <= 0) return false
+        if (timeSensitive) {
+          score *= recencyBoostMultiplier(getNoteTimestamp(entry.note, "updated"), nowMs)
+        }
         scores.set(entry.note.id, score)
         return true
       })


### PR DESCRIPTION
## Summary
Closes #497.

PR #509 added source-date annotations to recalled working notes but explicitly deferred the search-result ranking work the issue asked for ("rank recent conversations/notes higher for time-sensitive queries"). This PR closes that gap.

When the user query carries time-sensitive intent (`today`, `tonight`, `(right) now`, `current(ly)`, `latest`, `recent(ly)`, `yesterday`, `this morning/afternoon/evening/week/month`, or phrases like "what were we working on"), `KnowledgeNotesService.searchNotes`:

1. **Strips the time marker from the query** before scoring. Without stripping, the existing 75%-token-match scorer rejected matches whose notes didn't literally contain the word "today" — a hidden bug where time-sensitive queries could return nothing. The marker is metadata about *intent*, not a token to match against note text.
2. **Applies a recency multiplier** to each note's relevance score based on `updatedAt`:
   - ≤ 2d → 1.6×
   - ≤ 7d → 1.3×
   - ≤ 30d → 1.1×
   - ≤ 90d → 1.0×
   - ≤ 365d → 0.85×
   - older → 0.7×

The multiplier is calibrated so recent notes can outrank older but lexically similar ones, while strong-matching older notes still win when relevance dominates. Non-time-sensitive queries are unaffected.

The system-prompt staleness guidance from #509 still does the user-visible "ask before answering from stale context" guardrail — this PR is purely about which notes get retrieved in the first place.

## Files
- `apps/desktop/src/main/knowledge-notes-service.ts` — adds `TIME_SENSITIVE_QUERY_REGEX`, `isTimeSensitiveQuery`, `stripTimeSensitiveMarkers`, `recencyBoostMultiplier`; wires them into `searchNotes`.
- `apps/desktop/src/main/knowledge-notes-service.search.test.ts` — new test covers (a) baseline relevance ordering preserved, (b) time-sensitive query flips ordering toward the recent note, (c) non-time-sensitive query unchanged. Also fixes a latent mock issue where `globalAgentsFolder` was captured at factory time so subsequent `beforeEach` temp dirs leaked into later tests.

## Test plan
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/knowledge-notes-service.search.test.ts` — 4/4 pass.
- [x] `pnpm --filter @dotagents/desktop exec vitest run src/main/system-prompts.test.ts` — 17/17 pass (no regression in the #509 surface).
- [x] `pnpm --filter @dotagents/desktop run typecheck:node` — clean.
- [ ] Manual: with several `search-only` knowledge notes of varying age, query `"<topic> today"` from the recall tool and confirm a recent note ranks above an older lexically-matching note; query the same `<topic>` without a time marker and confirm baseline relevance ordering is preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_0172eyg52jrGp42cegqrPi2o)_