### PR TITLE
Cancel pending hands-free auto-send when capture turn ends (closes #532)

### DIFF
--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
@@ -266,6 +266,41 @@ describe('useSpeechRecognizer', () => {
     expect(onVoiceFinalized).toHaveBeenCalledWith({ text: 'hello world', mode: 'handsfree', source: 'web' });
   });
 
+  it('cancels a pending hands-free debounce when capture is invalidated mid-debounce', async () => {
+    vi.useFakeTimers();
+    (globalThis as any).window = { SpeechRecognition: FakeSpeechRecognition };
+    const runtime = createHookRuntime();
+    const { useSpeechRecognizer } = await loadUseSpeechRecognizer(runtime);
+    const onVoiceFinalized = vi.fn();
+    const log = vi.fn();
+
+    const recognizer = runtime.render(useSpeechRecognizer, {
+      handsFree: true,
+      handsFreeDebounceMs: 500,
+      willCancel: false,
+      onVoiceFinalized,
+      log,
+    });
+    runtime.commitEffects();
+
+    await recognizer.startRecording();
+    const speechRecognition = FakeSpeechRecognition.instances[0];
+
+    speechRecognition.onresult?.({
+      resultIndex: 0,
+      results: [{ 0: { transcript: 'pending request' }, isFinal: true }],
+    });
+
+    vi.advanceTimersByTime(250);
+    recognizer.invalidateHandsFreeCapture('tts-started');
+
+    vi.advanceTimersByTime(500);
+    expect(onVoiceFinalized).not.toHaveBeenCalled();
+    const eventTypes = log.mock.calls.map(([type]) => type);
+    expect(eventTypes).toContain('finalization-cancelled');
+    expect(eventTypes).not.toContain('finalization-fired');
+  });
+
   it('does not finalize a hands-free debounce after the listening turn becomes ineligible', async () => {
     vi.useFakeTimers();
     (globalThis as any).window = { SpeechRecognition: FakeSpeechRecognition };

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
@@ -112,6 +112,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
   const nativeFinalRef = useRef('');
   const pendingHandsFreeFinalRef = useRef('');
   const handsFreeDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handsFreeCaptureGenerationRef = useRef(0);
   const sttPreviewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startingRef = useRef(false);
   const stoppingRef = useRef(false);
@@ -173,6 +174,21 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     }
     setHandsFreeDebounceEndsAt(null);
   }, []);
+
+  const invalidateHandsFreeCapture = useCallback((reason?: string) => {
+    const hadPending = !!handsFreeDebounceRef.current || !!pendingHandsFreeFinalRef.current;
+    handsFreeCaptureGenerationRef.current += 1;
+    clearHandsFreeDebounce();
+    pendingHandsFreeFinalRef.current = '';
+    webFinalRef.current = '';
+    nativeFinalRef.current = '';
+    if (hadPending) {
+      log?.('finalization-cancelled', 'Hands-free transcript capture invalidated.', {
+        reason: reason ?? 'unspecified',
+        generation: handsFreeCaptureGenerationRef.current,
+      });
+    }
+  }, [clearHandsFreeDebounce, log]);
 
   const isHandsFreeTranscriptSuppressed = useCallback(() => (
     handsFree && shouldSuppressHandsFreeTranscriptRef.current?.() === true
@@ -467,16 +483,32 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
 
     clearHandsFreeDebounce();
     const debounceMs = Math.max(0, handsFreeDebounceMs);
+    const scheduledGeneration = handsFreeCaptureGenerationRef.current;
     setHandsFreeDebounceEndsAt(Date.now() + debounceMs);
     log?.('finalization-scheduled', 'Hands-free transcript debounce scheduled.', {
       source,
       debounceMs,
+      generation: scheduledGeneration,
       text: truncateDebugText(finalText),
       textLength: finalText.length,
     });
     handsFreeDebounceRef.current = setTimeout(() => {
       handsFreeDebounceRef.current = null;
       setHandsFreeDebounceEndsAt(null);
+      if (handsFreeCaptureGenerationRef.current !== scheduledGeneration) {
+        pendingHandsFreeFinalRef.current = '';
+        if (source === 'web') {
+          webFinalRef.current = '';
+        } else {
+          nativeFinalRef.current = '';
+        }
+        log?.('finalization-cancelled', 'Hands-free transcript debounce fired after capture invalidation.', {
+          source,
+          scheduledGeneration,
+          currentGeneration: handsFreeCaptureGenerationRef.current,
+        });
+        return;
+      }
       finalizePendingHandsFree(source);
     }, debounceMs);
     return true;
@@ -1305,5 +1337,6 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     handlePushToTalkPressIn,
     handlePushToTalkPressOut,
     setSttPreviewWithExpiry,
+    invalidateHandsFreeCapture,
   } as const;
 }

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -2453,6 +2453,7 @@ export default function ChatScreen({ route, navigation }: any) {
     stopRecognitionOnly,
     handlePushToTalkPressIn,
     handlePushToTalkPressOut,
+    invalidateHandsFreeCapture,
   } = useSpeechRecognizer({
     enabled: foregroundSpeechRecognizerEnabled,
     handsFree,
@@ -2513,9 +2514,11 @@ export default function ChatScreen({ route, navigation }: any) {
     clearAndroidHandsFreePartialTimer();
     androidHandsFreePendingPartialRef.current = '';
     setSttPreviewWithExpiry('');
+    invalidateHandsFreeCapture(`phase-${handsFreeController.state.phase}`);
   }, [
     clearAndroidHandsFreePartialTimer,
     handsFreeController.state.phase,
+    invalidateHandsFreeCapture,
     isHandsFreeFinalizationEligibleNow,
     setSttPreviewWithExpiry,
   ]);
@@ -2888,6 +2891,7 @@ export default function ChatScreen({ route, navigation }: any) {
       markGlobalTtsPlaybackSpeaking(playbackId);
       if (!handsFree || handsFreeSpeechStarted) return;
       handsFreeSpeechStarted = true;
+      invalidateHandsFreeCapture('tts-started');
       handsFreeController.onSpeechStarted();
       voiceLog('tts-started', message ?? `Assistant speech started (${reason}).`, extra);
     };
@@ -3062,7 +3066,7 @@ export default function ChatScreen({ route, navigation }: any) {
       return false;
     }
 		return true;
-			  }, [androidBackgroundHandsFree, androidHandsFreeServiceAvailable, config.apiKey, config.baseUrl, config.ttsPitch, config.ttsRate, config.ttsVoiceId, effectiveEdgeTtsRate, effectiveEdgeTtsVoice, effectiveTtsProvider, handsFree, handsFreeController, playHandsFreeCue, sessionStore, stableHandsFreeForeground, voiceLog]);
+			  }, [androidBackgroundHandsFree, androidHandsFreeServiceAvailable, config.apiKey, config.baseUrl, config.ttsPitch, config.ttsRate, config.ttsVoiceId, effectiveEdgeTtsRate, effectiveEdgeTtsVoice, effectiveTtsProvider, handsFree, handsFreeController, invalidateHandsFreeCapture, playHandsFreeCue, sessionStore, stableHandsFreeForeground, voiceLog]);
 
 	  const syncResponseHistoryRefs = useCallback((events: AgentUserResponseEvent[]) => {
 	    respondToUserHistoryRef.current = events;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -123,6 +123,7 @@ export type HandsFreeDebugEventType =
   | 'transcript-ignored'
   | 'finalization-scheduled'
   | 'finalization-fired'
+  | 'finalization-cancelled'
   | 'handsfree-control'
   | 'runtime-state'
   | 'tts-started'


### PR DESCRIPTION
## Summary

Fixes #532: in mobile hands-free mode, a transcript could finalize and dispatch a send while the controller was already in `processing`, then immediately collide with the next assistant TTS turn (phase → `speaking`). Root cause: the transcript debounce timer scheduled during `listening` was not invalidated when the capture turn ended, so it could fire on a stale phase.

This change adds a monotonic capture-generation guard in line with the suggested solution in the issue.

### Changes

- **`apps/mobile/src/lib/voice/useSpeechRecognizer.ts`**
  - New `handsFreeCaptureGenerationRef` counter.
  - New `invalidateHandsFreeCapture(reason?)` API: bumps the generation, clears the debounce timer, drops any captured/pending final transcript, and emits `finalization-cancelled` debug logs when there was pending state.
  - `scheduleHandsFreeFinalization` snapshots the current generation and the debounce `setTimeout` re-checks it on fire; if the generation no longer matches, it logs `finalization-cancelled` and returns without finalizing.
  - Hook exposes `invalidateHandsFreeCapture` to callers.

- **`apps/mobile/src/screens/ChatScreen.tsx`**
  - Destructures `invalidateHandsFreeCapture` from the recognizer.
  - `markAssistantSpeechStarted` invalidates capture (`reason: 'tts-started'`) before transitioning the controller to `speaking`, so any pending transcript debounce is dropped the moment TTS begins (remote, Android service, or Expo).
  - The existing `isHandsFreeFinalizationEligibleNow` effect also invalidates capture (`reason: 'phase-<next>'`) whenever the phase leaves `listening`/`waking`, ensuring transitions to `processing`, `speaking`, `paused`, `sleeping`, or `error` cancel an in-flight debounce.

- **`packages/shared/src/types.ts`**
  - Adds `finalization-cancelled` to `HandsFreeDebugEventType`.

- **`apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts`**
  - Adds a vitest case verifying that invalidating capture mid-debounce prevents `onVoiceFinalized` from firing and logs `finalization-cancelled` instead of `finalization-fired`.

### Test plan

- [x] `pnpm --filter @dotagents/mobile test:vitest` → 131 passing
- [x] `pnpm --filter @dotagents/mobile exec tsc --noEmit` → clean
- [x] `pnpm --filter @dotagents/shared typecheck` → clean
- [ ] Manual: mobile hands-free turn where TTS starts during the silence debounce → no auto-send fires; `finalization-cancelled` appears in voice debug log
- [ ] Manual: rapid follow-up turns where phase oscillates `processing → listening → processing` cleanly debounce-cancel between rounds


---
_Generated by [Claude Code](https://claude.ai/code/session_01VThjshNSGgeVAd8aY3sTut)_