### PR TITLE
Default mobile config to unpaired instead of OpenAI (closes #490)

### DIFF
--- a/apps/mobile/src/screens/ConnectionSettingsScreen.tsx
+++ b/apps/mobile/src/screens/ConnectionSettingsScreen.tsx
@@ -15,8 +15,6 @@ import {
 } from '../lib/accessibility';
 import { resolveQrScannerActivation } from './connection-settings-qr';
 
-const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-
 function parseQRCode(data: string): { baseUrl?: string; apiKey?: string; model?: string } | null {
   try {
     const parsed = Linking.parse(data);
@@ -74,29 +72,18 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
     // Clear any previous error
     setConnectionError(null);
 
-    // Default to OpenAI URL if baseUrl is empty
-    if (!normalizedDraft.baseUrl) {
-      normalizedDraft.baseUrl = DEFAULT_OPENAI_BASE_URL;
-    }
-
-    const hasCustomUrl = normalizedDraft.baseUrl && normalizedDraft.baseUrl.replace(/\/+$/, '') !== DEFAULT_OPENAI_BASE_URL;
     const hasApiKey = normalizedDraft.apiKey && normalizedDraft.apiKey.length > 0;
 
     // On first-time setup, do not silently save a disconnected default config.
     if (!isConnected && !hasApiKey) {
-      setConnectionError('Enter an API key or scan a DotAgents QR code before saving');
+      setConnectionError('Scan a DotAgents QR code or enter a base URL and API key before saving');
       return;
     }
 
-    // Require API key when using a custom server URL
-    if (hasCustomUrl && !hasApiKey) {
-      setConnectionError('API Key is required when using a custom server URL');
-      return;
-    }
-
-    // Validate: if API key is set, base URL must also be set
+    // Require a base URL whenever an API key is provided — we no longer fall
+    // back to a hidden OpenAI default for the mobile companion app.
     if (hasApiKey && !normalizedDraft.baseUrl) {
-      setConnectionError('Base URL is required when an API key is provided');
+      setConnectionError('Scan a DotAgents QR code or enter a base URL before saving');
       return;
     }
 
@@ -206,7 +193,7 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
   };
 
   const resetBaseUrl = () => {
-    setDraft(prev => ({ ...prev, baseUrl: DEFAULT_OPENAI_BASE_URL }));
+    setDraft(prev => ({ ...prev, baseUrl: '' }));
   };
 
   // Connection status indicator
@@ -284,20 +271,20 @@ export default function ConnectionSettingsScreen({ navigation, route }: any) {
             onPress={resetBaseUrl}
             style={styles.inlineActionButton}
             accessibilityRole="button"
-            accessibilityLabel={createButtonAccessibilityLabel('Reset base URL to default')}
-            accessibilityHint="Restores the default OpenAI-compatible base URL"
+            accessibilityLabel={createButtonAccessibilityLabel('Clear base URL')}
+            accessibilityHint="Clears the base URL so you can re-pair via QR code"
           >
-            <Text style={styles.resetText}>Reset to default</Text>
+            <Text style={styles.resetText}>Clear</Text>
           </TouchableOpacity>
         </View>
         <TextInput
           style={styles.input}
           value={draft.baseUrl}
           onChangeText={(t) => setDraft({ ...draft, baseUrl: t })}
-          placeholder='https://api.openai.com/v1'
+          placeholder='Scan a QR code or enter a custom URL'
           placeholderTextColor={theme.colors.mutedForeground}
           accessibilityLabel={createTextInputAccessibilityLabel('Base URL')}
-          accessibilityHint="Enter the base URL for your OpenAI-compatible server"
+          accessibilityHint="Enter the base URL of your DotAgents remote server or another OpenAI-compatible endpoint"
           autoCapitalize='none'
         />
 

--- a/apps/mobile/src/store/config.test.ts
+++ b/apps/mobile/src/store/config.test.ts
@@ -16,7 +16,35 @@ import {
   normalizeStoredConfig,
 } from './config';
 
+describe('DEFAULT_APP_CONFIG', () => {
+  it('leaves baseUrl empty so fresh installs do not falsely look paired to OpenAI', () => {
+    expect(DEFAULT_APP_CONFIG.baseUrl).toBe('');
+    expect(DEFAULT_APP_CONFIG.apiKey).toBe('');
+  });
+});
+
 describe('normalizeStoredConfig', () => {
+  it('preserves an explicitly stored OpenAI base URL for legacy users', () => {
+    const normalized = normalizeStoredConfig({
+      apiKey: 'sk-legacy',
+      baseUrl: 'https://api.openai.com/v1/',
+      model: 'gpt-4.1-mini',
+    });
+
+    expect(normalized.baseUrl).toBe('https://api.openai.com/v1');
+    expect(normalized.apiKey).toBe('sk-legacy');
+  });
+
+  it('keeps an empty baseUrl empty rather than backfilling it from the defaults', () => {
+    const normalized = normalizeStoredConfig({
+      apiKey: '',
+      baseUrl: '',
+      model: 'gpt-4.1-mini',
+    });
+
+    expect(normalized.baseUrl).toBe('');
+  });
+
   it('backfills the handsfree defaults for older configs', () => {
     const normalized = normalizeStoredConfig({
       apiKey: 'test',

--- a/apps/mobile/src/store/config.ts
+++ b/apps/mobile/src/store/config.ts
@@ -4,7 +4,9 @@ import { normalizeApiBaseUrl } from '@dotagents/shared';
 
 export type AppConfig = {
   apiKey: string;
-  baseUrl: string; // OpenAI-compatible API base URL e.g., https://api.openai.com/v1
+  // OpenAI-compatible API base URL. Empty until paired with a DotAgents
+  // desktop remote server (or a custom OpenAI-compatible URL is entered).
+  baseUrl: string;
   model: string; // model name required by /v1/chat/completions
   handsFree?: boolean; // hands-free voice mode toggle (optional for backward compatibility)
   handsFreeMessageDebounceMs?: number; // silence window before auto-sending a hands-free message
@@ -57,7 +59,7 @@ function normalizeHandsFreeMessageDebounceMs(value?: number) {
 
 export const DEFAULT_APP_CONFIG: AppConfig = {
   apiKey: '',
-  baseUrl: 'https://api.openai.com/v1',
+  baseUrl: '',
   model: 'gpt-4.1-mini',
   handsFree: false,
   handsFreeMessageDebounceMs: DEFAULT_HANDS_FREE_MESSAGE_DEBOUNCE_MS,

--- a/apps/mobile/tests/connection-settings-validation.test.js
+++ b/apps/mobile/tests/connection-settings-validation.test.js
@@ -10,13 +10,27 @@ const screenSource = fs.readFileSync(
 
 test('blocks first-time save when no API key is provided', () => {
   assert.match(screenSource, /if \(!isConnected && !hasApiKey\) \{/);
-  assert.match(screenSource, /Enter an API key or scan a DotAgents QR code before saving/);
-});
-
-test('keeps the custom URL validation after the no-key guard', () => {
   assert.match(
     screenSource,
-    /if \(!isConnected && !hasApiKey\) \{[\s\S]*?return;[\s\S]*?if \(hasCustomUrl && !hasApiKey\) \{/
+    /Scan a DotAgents QR code or enter a base URL and API key before saving/
+  );
+});
+
+test('no longer silently defaults a missing base URL to OpenAI on save', () => {
+  // Issue #490: the mobile companion should not invent an OpenAI base URL on
+  // the user's behalf — pairing with the DotAgents desktop is the primary path.
+  assert.doesNotMatch(screenSource, /DEFAULT_OPENAI_BASE_URL/);
+  assert.doesNotMatch(screenSource, /api\.openai\.com\/v1/);
+});
+
+test('requires a base URL whenever an API key is provided', () => {
+  assert.match(
+    screenSource,
+    /if \(!isConnected && !hasApiKey\) \{[\s\S]*?return;[\s\S]*?if \(hasApiKey && !normalizedDraft\.baseUrl\) \{/
+  );
+  assert.match(
+    screenSource,
+    /Scan a DotAgents QR code or enter a base URL before saving/
   );
 });
 
@@ -26,8 +40,8 @@ test('exposes the API key visibility toggle as a button with a larger touch targ
 });
 
 test('exposes the reset action as an accessible button with a descriptive label', () => {
-  assert.match(screenSource, /createButtonAccessibilityLabel\('Reset base URL to default'\)/);
-  assert.match(screenSource, /Restores the default OpenAI-compatible base URL/);
+  assert.match(screenSource, /createButtonAccessibilityLabel\('Clear base URL'\)/);
+  assert.match(screenSource, /Clears the base URL so you can re-pair via QR code/);
 });
 
 test('surfaces a clear error when QR scanning cannot get camera permission', () => {


### PR DESCRIPTION
## Summary

Closes #490. Mobile/Expo web previously seeded `baseUrl` with `https://api.openai.com/v1`, so fresh installs looked pre-configured against OpenAI even though no API key was present — the disconnected gate still rendered `https://api.openai.com/v1` underneath the "Connect DotAgents to get started" empty state. With QR pairing being the primary mobile path, defaulting to an unconfigured state is more honest and unblocks local web verification flows like the one in #408.

## Changes

- `apps/mobile/src/store/config.ts`: `DEFAULT_APP_CONFIG.baseUrl` is now `''` instead of the OpenAI URL.
- `apps/mobile/src/screens/ConnectionSettingsScreen.tsx`:
  - Removed the `DEFAULT_OPENAI_BASE_URL` constant and the silent OpenAI fallback in `onSave`.
  - "Reset to default" → "Clear" (re-enables the QR pairing placeholder).
  - Placeholder text now reads `Scan a QR code or enter a custom URL`.
  - Save validation now requires a base URL whenever an API key is provided, with messaging that nudges users toward QR pairing.
- `apps/mobile/src/store/config.test.ts`: covers the new empty default and verifies stored legacy OpenAI URLs are preserved.
- `apps/mobile/tests/connection-settings-validation.test.js`: updated to match the new copy and to assert the screen no longer references `api.openai.com/v1`.

Legacy users who had explicitly saved the OpenAI URL keep it via `normalizeStoredConfig` (covered by a new test).

## Test plan

- [x] `pnpm --filter @dotagents/mobile run test:vitest` — 14 files, 133 tests pass.
- [x] `pnpm --filter @dotagents/mobile run test:node` — 7/7 connection-settings node tests pass; overall pass/fail matches baseline `main` (197 pass / 11 pre-existing failures unrelated to this change).
- [ ] Manually launch Expo web on a clean profile and confirm the disconnected state no longer shows `https://api.openai.com/v1` under the empty state.
- [ ] Scan a DotAgents QR code from desktop and confirm save still works end-to-end.

https://claude.ai/code/session_019qjX8gAihsFPnrQvKwz6Wc

---
_Generated by [Claude Code](https://claude.ai/code/session_019qjX8gAihsFPnrQvKwz6Wc)_