### PR TITLE
Persist full execute_command stdout/stderr per session (closes #445 phase 1)

### DIFF
--- a/apps/desktop/src/main/runtime-tools.command-log.test.ts
+++ b/apps/desktop/src/main/runtime-tools.command-log.test.ts
@@ -1,0 +1,157 @@
+import os from "node:os"
+import path from "node:path"
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./mcp-service", () => ({ mcpService: { getAvailableTools: vi.fn(() => []) } }))
+vi.mock("./agent-session-tracker", () => ({
+  agentSessionTracker: { getActiveSessions: vi.fn(() => []), getSession: vi.fn(() => undefined) },
+}))
+vi.mock("./state", () => ({ agentSessionStateManager: { getSessionRunId: vi.fn(() => 1) }, toolApprovalManager: {} }))
+vi.mock("./emergency-stop", () => ({ emergencyStopAll: vi.fn() }))
+vi.mock("./acp/acp-router-tools", () => ({ executeACPRouterTool: vi.fn(), isACPRouterTool: vi.fn(() => false) }))
+vi.mock("./message-queue-service", () => ({ messageQueueService: {} }))
+vi.mock("./session-user-response-store", () => ({ appendSessionUserResponse: vi.fn() }))
+vi.mock("./conversation-service", () => ({ conversationService: { loadConversation: vi.fn().mockResolvedValue(null) } }))
+vi.mock("./context-budget", () => ({ readMoreContext: vi.fn() }))
+vi.mock("./emit-agent-progress", () => ({ emitAgentProgress: vi.fn() }))
+vi.mock("./acp-session-state", () => ({
+  getAppSessionForAcpSession: vi.fn(() => undefined),
+  getRootAppSessionForAcpSession: vi.fn(() => undefined),
+  setAcpSessionTitleOverride: vi.fn(),
+}))
+vi.mock("./skills-service", () => ({
+  skillsService: {
+    getSkill: vi.fn(() => undefined),
+    getSkills: vi.fn(() => []),
+    refreshFromDisk: vi.fn(() => []),
+    upgradeGitHubSkillToLocal: vi.fn(),
+  },
+}))
+
+let tempDataFolder: string | null = null
+
+describe("execute_command durable session command log", () => {
+  beforeEach(async () => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    tempDataFolder = await mkdtemp(path.join(os.tmpdir(), "dotagents-cmdlog-"))
+    const runtime = await import("./session-command-runtime")
+    runtime.__setSessionCommandRuntimeDataFolderForTests(tempDataFolder)
+    runtime.__resetSessionCommandRuntimeForTests()
+  })
+
+  afterEach(async () => {
+    const runtime = await import("./session-command-runtime")
+    runtime.__setSessionCommandRuntimeDataFolderForTests(null)
+    if (tempDataFolder) {
+      await rm(tempDataFolder, { recursive: true, force: true })
+      tempDataFolder = null
+    }
+  })
+
+  it("writes the full stdout, stderr, and metadata for a successful command", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool(
+      "execute_command",
+      { command: "printf 'hello\\nworld\\n'" },
+      "session-log-success",
+    )
+
+    expect(result?.isError).toBe(false)
+    const payload = JSON.parse(String(result?.content[0]?.text))
+    expect(typeof payload.commandId).toBe("string")
+    expect(payload.commandId).toMatch(/^cmd_/)
+    expect(typeof payload.fullStdoutPath).toBe("string")
+    expect(typeof payload.fullStderrPath).toBe("string")
+
+    const stdoutOnDisk = await readFile(payload.fullStdoutPath, "utf8")
+    expect(stdoutOnDisk).toBe("hello\nworld\n")
+
+    const stderrOnDisk = await readFile(payload.fullStderrPath, "utf8")
+    expect(stderrOnDisk).toBe("")
+
+    const metadataPath = payload.fullStdoutPath.replace(/\.stdout\.log$/, ".json")
+    const metadata = JSON.parse(await readFile(metadataPath, "utf8"))
+    expect(metadata).toEqual(expect.objectContaining({
+      commandId: payload.commandId,
+      command: "printf 'hello\\nworld\\n'",
+      sessionId: "session-log-success",
+      exitCode: 0,
+      stdoutBytes: Buffer.byteLength("hello\nworld\n", "utf8"),
+      stderrBytes: 0,
+    }))
+    expect(typeof metadata.startedAt).toBe("string")
+    expect(typeof metadata.endedAt).toBe("string")
+    expect(typeof metadata.durationMs).toBe("number")
+    expect(metadata.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it("persists full stdout even when the assistant-facing payload is truncated", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    // Emit > 10K characters of stdout so the assistant payload gets truncated
+    // while the durable log keeps the complete output.
+    const command = "for i in $(seq 1 12000); do printf 'line-%05d\\n' $i; done"
+    const result = await executeRuntimeTool(
+      "execute_command",
+      { command, timeout: 60000 },
+      "session-log-truncation",
+    )
+
+    expect(result?.isError).toBe(false)
+    const payload = JSON.parse(String(result?.content[0]?.text))
+    expect(payload.outputTruncated).toBe(true)
+    expect(payload.stdout.length).toBeLessThan(11000)
+    expect(typeof payload.fullStdoutPath).toBe("string")
+
+    const stdoutOnDisk = await readFile(payload.fullStdoutPath, "utf8")
+    expect(stdoutOnDisk).toContain("line-00001\n")
+    expect(stdoutOnDisk).toContain("line-12000\n")
+    expect(stdoutOnDisk.length).toBeGreaterThan(payload.stdout.length)
+  })
+
+  it("records the command log when the command exits with a non-zero status", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool(
+      "execute_command",
+      { command: "printf 'oops\\n' 1>&2 && exit 7" },
+      "session-log-failure",
+    )
+
+    expect(result?.isError).toBe(true)
+    const payload = JSON.parse(String(result?.content[0]?.text))
+    expect(payload.exitCode).toBe(7)
+    expect(typeof payload.commandId).toBe("string")
+    expect(typeof payload.fullStderrPath).toBe("string")
+
+    const stderrOnDisk = await readFile(payload.fullStderrPath, "utf8")
+    expect(stderrOnDisk).toBe("oops\n")
+
+    const metadataPath = payload.fullStderrPath.replace(/\.stderr\.log$/, ".json")
+    const metadata = JSON.parse(await readFile(metadataPath, "utf8"))
+    expect(metadata).toEqual(expect.objectContaining({
+      commandId: payload.commandId,
+      sessionId: "session-log-failure",
+      exitCode: 7,
+      stderrBytes: Buffer.byteLength("oops\n", "utf8"),
+    }))
+    expect(typeof metadata.errorMessage).toBe("string")
+  })
+
+  it("does not write a command log when no session id is supplied", async () => {
+    const { executeRuntimeTool } = await import("./runtime-tools")
+    const result = await executeRuntimeTool(
+      "execute_command",
+      { command: "echo no-session" },
+    )
+
+    expect(result?.isError).toBe(false)
+    const payload = JSON.parse(String(result?.content[0]?.text))
+    expect(payload.commandId).toBeUndefined()
+    expect(payload.fullStdoutPath).toBeUndefined()
+
+    const sessionsRoot = path.join(tempDataFolder!, "runtime", "sessions")
+    const entries = await readdir(sessionsRoot).catch(() => [])
+    expect(entries).toEqual([])
+  })
+})

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -22,6 +22,8 @@ import { exec } from "child_process"
 import { promisify } from "util"
 import path from "path"
 
+import { startSessionCommandLog, type SessionCommandLogHandle } from "./session-command-runtime"
+
 const execAsync = promisify(exec)
 
 // Re-export from the dependency-free definitions module.
@@ -945,23 +947,46 @@ const toolHandlers: Record<string, ToolHandler> = {
       // should still work if they cannot be prepared.
     }
 
+    const execOptions: { cwd?: string; timeout?: number; maxBuffer?: number; shell?: string; env?: NodeJS.ProcessEnv } = {
+      maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
+      shell: process.platform === "win32" ? "cmd.exe" : "/bin/bash",
+      env: {
+        ...process.env,
+        ...runtimeFilesystemEnv,
+      },
+    }
+
+    execOptions.cwd = effectiveCwd
+
+    if (timeout > 0) {
+      execOptions.timeout = timeout
+    }
+
+    let commandLog: SessionCommandLogHandle | null = null
+    if (context.sessionId) {
+      try {
+        commandLog = await startSessionCommandLog({
+          sessionId: context.sessionId,
+          command: effectiveCommand,
+          cwd: effectiveCwd,
+          shell: execOptions.shell ?? "",
+          timeoutMs: timeout > 0 ? timeout : undefined,
+        })
+      } catch {
+        // Logging is best-effort; never block command execution on log failures.
+      }
+    }
+
     try {
-      const execOptions: { cwd?: string; timeout?: number; maxBuffer?: number; shell?: string; env?: NodeJS.ProcessEnv } = {
-        maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large outputs
-        shell: process.platform === "win32" ? "cmd.exe" : "/bin/bash",
-        env: {
-          ...process.env,
-          ...runtimeFilesystemEnv,
-        },
-      }
-
-      execOptions.cwd = effectiveCwd
-
-      if (timeout > 0) {
-        execOptions.timeout = timeout
-      }
-
       const { stdout, stderr } = await execAsync(effectiveCommand, execOptions)
+
+      if (commandLog) {
+        await commandLog.finalize({
+          exitCode: 0,
+          stdout: stdout || "",
+          stderr: stderr || "",
+        }).catch(() => undefined)
+      }
 
       // Truncate large outputs to prevent context bloat
       // Keep first 5K + last 5K chars so agent sees both beginning and end
@@ -995,6 +1020,11 @@ const toolHandlers: Record<string, ToolHandler> = {
               stdout: truncatedStdout,
               stderr: stderr || "",
               ...(outputTruncated ? { outputTruncated: true, hint: "Output was truncated. Use head -n/tail -n/sed -n 'X,Yp' to read specific sections." } : {}),
+              ...(commandLog ? {
+                commandId: commandLog.commandId,
+                fullStdoutPath: commandLog.stdoutPath,
+                fullStderrPath: commandLog.stderrPath,
+              } : {}),
             }, null, 2),
           },
         ],
@@ -1002,14 +1032,28 @@ const toolHandlers: Record<string, ToolHandler> = {
       }
     } catch (error: any) {
       // exec errors include stdout/stderr in the error object
-      let stdout = error.stdout || ""
-      const stderr = error.stderr || ""
+      const fullStdout: string = error.stdout || ""
+      const stderr: string = error.stderr || ""
       const errorMessage = error.message || String(error)
       const exitCode = error.code
+      const signal = typeof error.signal === "string" ? error.signal : null
+      const timedOut = error.killed === true && error.signal === "SIGTERM" && timeout > 0
+
+      if (commandLog) {
+        await commandLog.finalize({
+          exitCode: typeof exitCode === "number" ? exitCode : null,
+          signal,
+          stdout: fullStdout,
+          stderr,
+          errorMessage,
+          timedOut,
+        }).catch(() => undefined)
+      }
 
       // Truncate large error outputs too
       const MAX_OUTPUT_CHARS = 10000
       const HALF = Math.floor(MAX_OUTPUT_CHARS / 2)
+      let stdout = fullStdout
       if (stdout.length > MAX_OUTPUT_CHARS) {
         const totalLines = stdout.split("\n").length
         const head = stdout.substring(0, HALF)
@@ -1039,6 +1083,11 @@ const toolHandlers: Record<string, ToolHandler> = {
               exitCode,
               stdout,
               stderr,
+              ...(commandLog ? {
+                commandId: commandLog.commandId,
+                fullStdoutPath: commandLog.stdoutPath,
+                fullStderrPath: commandLog.stderrPath,
+              } : {}),
             }, null, 2),
           },
         ],

--- a/apps/desktop/src/main/session-command-runtime.ts
+++ b/apps/desktop/src/main/session-command-runtime.ts
@@ -1,0 +1,180 @@
+/**
+ * Session Command Runtime — durable per-session command logging.
+ *
+ * Records every `execute_command` invocation with full stdout/stderr and
+ * metadata to disk, scoped per session. Assistant-facing tool results stay
+ * bounded for context safety; this service is the source of truth for the
+ * complete transcript.
+ *
+ * See issue #445 for the full design. This module implements Phase 1
+ * (mandatory logging) without persistent PTY or live streaming.
+ */
+
+import { promises as fs } from "fs"
+import path from "path"
+
+import { logApp } from "./debug"
+
+export interface SessionCommandLogStartParams {
+  sessionId: string
+  command: string
+  cwd: string
+  shell: string
+  timeoutMs?: number
+}
+
+export interface SessionCommandLogFinishParams {
+  exitCode: number | null
+  signal?: string | null
+  stdout: string
+  stderr: string
+  errorMessage?: string
+  timedOut?: boolean
+}
+
+export interface SessionCommandLogHandle {
+  sessionId: string
+  commandId: string
+  metadataPath: string
+  stdoutPath: string
+  stderrPath: string
+  finalize(params: SessionCommandLogFinishParams): Promise<void>
+}
+
+export interface SessionCommandLogMetadata {
+  sessionId: string
+  commandId: string
+  command: string
+  cwd: string
+  shell: string
+  timeoutMs?: number
+  startedAt: string
+  endedAt?: string
+  durationMs?: number
+  exitCode?: number | null
+  signal?: string | null
+  timedOut?: boolean
+  errorMessage?: string
+  stdoutPath: string
+  stderrPath: string
+  stdoutBytes?: number
+  stderrBytes?: number
+}
+
+function sanitizePathSegment(value: string): string {
+  return value
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    || "session"
+}
+
+let dataFolderOverride: string | null = null
+
+async function getSessionCommandsDir(sessionId: string): Promise<string> {
+  const root = dataFolderOverride ?? (await import("./config")).dataFolder
+  return path.join(root, "runtime", "sessions", sanitizePathSegment(sessionId), "commands")
+}
+
+let commandCounter = 0
+
+function generateCommandId(): string {
+  commandCounter += 1
+  const time = Date.now().toString(36)
+  const counter = commandCounter.toString(36).padStart(4, "0")
+  const noise = Math.random().toString(36).slice(2, 8)
+  return `cmd_${time}_${counter}_${noise}`
+}
+
+async function writeFileSafe(filePath: string, contents: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, contents, "utf8")
+}
+
+export async function startSessionCommandLog(params: SessionCommandLogStartParams): Promise<SessionCommandLogHandle> {
+  const { sessionId, command, cwd, shell, timeoutMs } = params
+  const commandId = generateCommandId()
+  const dir = await getSessionCommandsDir(sessionId)
+  const metadataPath = path.join(dir, `${commandId}.json`)
+  const stdoutPath = path.join(dir, `${commandId}.stdout.log`)
+  const stderrPath = path.join(dir, `${commandId}.stderr.log`)
+  const startedAt = new Date().toISOString()
+  const startMs = Date.now()
+
+  const initialMetadata: SessionCommandLogMetadata = {
+    sessionId,
+    commandId,
+    command,
+    cwd,
+    shell,
+    timeoutMs,
+    startedAt,
+    stdoutPath,
+    stderrPath,
+  }
+
+  try {
+    await writeFileSafe(metadataPath, JSON.stringify(initialMetadata, null, 2))
+  } catch (error) {
+    logApp("[session-command-runtime] failed to write initial metadata", {
+      sessionId,
+      commandId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  return {
+    sessionId,
+    commandId,
+    metadataPath,
+    stdoutPath,
+    stderrPath,
+    async finalize(finish: SessionCommandLogFinishParams) {
+      const endedAt = new Date().toISOString()
+      const durationMs = Date.now() - startMs
+      const stdoutBytes = Buffer.byteLength(finish.stdout, "utf8")
+      const stderrBytes = Buffer.byteLength(finish.stderr, "utf8")
+
+      try {
+        await writeFileSafe(stdoutPath, finish.stdout)
+        await writeFileSafe(stderrPath, finish.stderr)
+      } catch (error) {
+        logApp("[session-command-runtime] failed to write command logs", {
+          sessionId,
+          commandId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+
+      const finalMetadata: SessionCommandLogMetadata = {
+        ...initialMetadata,
+        endedAt,
+        durationMs,
+        exitCode: finish.exitCode,
+        signal: finish.signal ?? null,
+        timedOut: finish.timedOut,
+        errorMessage: finish.errorMessage,
+        stdoutBytes,
+        stderrBytes,
+      }
+
+      try {
+        await writeFileSafe(metadataPath, JSON.stringify(finalMetadata, null, 2))
+      } catch (error) {
+        logApp("[session-command-runtime] failed to finalize metadata", {
+          sessionId,
+          commandId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    },
+  }
+}
+
+export function __setSessionCommandRuntimeDataFolderForTests(folder: string | null): void {
+  dataFolderOverride = folder
+}
+
+export function __resetSessionCommandRuntimeForTests(): void {
+  commandCounter = 0
+}


### PR DESCRIPTION
## Summary
Implements Phase 1 of #445: every `execute_command` invocation now writes a complete, durable per-command transcript to disk, so users can recover the full output even when the assistant-facing payload is truncated. No UI yet — that comes in later phases of the issue.

- Adds `apps/desktop/src/main/session-command-runtime.ts` — a small main-process service that, given a session id, allocates a `commandId` and writes `{commandId}.json`, `{commandId}.stdout.log`, and `{commandId}.stderr.log` under `runtime/sessions/<sessionId>/commands/` (sharing the existing per-session runtime directory layout). Metadata records `command`, `cwd`, `shell`, `timeoutMs`, `startedAt`/`endedAt`, `durationMs`, `exitCode`, `signal`, `timedOut`, `errorMessage`, and stdout/stderr byte counts.
- Wires `execute_command` in `runtime-tools.ts` to start a log before exec and finalize it on both the success and failure paths. Existing policy/normalization/truncation behavior is unchanged; logging is best-effort and never blocks the command. The assistant-facing JSON now also includes `commandId`, `fullStdoutPath`, and `fullStderrPath` so future UI / tools can navigate from a tool result to the complete output.
- Preserves the existing pre-finalize behavior on the failure path: the original `error.code` is still surfaced verbatim in the assistant payload (so callers that depend on string codes like `ETIMEDOUT` aren't affected), while the on-disk metadata stores a numeric `exitCode` plus separate `signal` / `timedOut` fields.

## Scope
This is intentionally Phase 1 of the issue's phased rollout (mandatory logging only). Streaming exec via `spawn`, the per-session terminal panel, and the `node-pty`/ConPTY runtime are left for follow-up PRs.

## Test plan
- [x] `pnpm --filter @dotagents/desktop test:run src/main/runtime-tools` — all 5 runtime-tools test files pass (20/20), including 4 new tests covering: successful command logging, persistence of full stdout when the assistant payload is truncated, non-zero exit logging, and the no-session case (no log written).
- [ ] Manual: invoke `execute_command` with a real session, verify `~/.../runtime/sessions/<id>/commands/` contains the expected `.json` / `.stdout.log` / `.stderr.log` files, and confirm the assistant JSON includes the new `commandId`/`fullStdoutPath`/`fullStderrPath` keys.

Closes (phase 1 of) #445.

https://claude.ai/code/session_014nuG969i9bCApTAPWY7NeS

---
_Generated by [Claude Code](https://claude.ai/code/session_014nuG969i9bCApTAPWY7NeS)_