### PR TITLE
Keep Android hands-free audio routing session-scoped

### DIFF
--- a/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeAudioRouter.kt
+++ b/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeAudioRouter.kt
@@ -15,13 +15,15 @@ object HandsFreeAudioRouter {
 
   @Synchronized
   fun acquire(context: Context, reason: String): Bundle {
-    requesters.add(normalizeReason(reason))
+    val normalizedReason = normalizeReason(reason)
+    requesters.add(normalizedReason)
     val audioManager = context.getSystemService(AudioManager::class.java)
     val target = preferredCommunicationHeadset(audioManager)
 
     if (target == null) {
-      Log.i(TAG, "audio-route acquire reason=$reason target=none requesters=${requesters.joinToString(",")}")
-      return routeBundle(audioManager, false)
+      val route = routeBundle(audioManager, false)
+      Log.i(TAG, "audio-route acquire reason=$normalizedReason target=none ${routeSummary(route)}")
+      return route
     }
 
     if (previousMode == null) {
@@ -44,24 +46,24 @@ object HandsFreeAudioRouter {
       }
       routingApplied = routingApplied || applied
     } catch (error: Throwable) {
-      Log.w(TAG, "audio-route acquire failed reason=$reason target=${audioDeviceTypeName(target.type)}", error)
+      Log.w(TAG, "audio-route acquire failed reason=$normalizedReason target=${audioDeviceTypeName(target.type)}", error)
     }
 
-    Log.i(
-      TAG,
-      "audio-route acquire reason=$reason target=${audioDeviceTypeName(target.type)} applied=$applied requesters=${requesters.joinToString(",")}"
-    )
-    return routeBundle(audioManager, applied)
+    val route = routeBundle(audioManager, applied)
+    Log.i(TAG, "audio-route acquire reason=$normalizedReason target=${audioDeviceTypeName(target.type)} ${routeSummary(route)}")
+    return route
   }
 
   @Synchronized
   fun release(context: Context, reason: String): Bundle {
-    requesters.remove(normalizeReason(reason))
+    val normalizedReason = normalizeReason(reason)
+    requesters.remove(normalizedReason)
     val audioManager = context.getSystemService(AudioManager::class.java)
 
     if (requesters.isNotEmpty()) {
-      Log.i(TAG, "audio-route release reason=$reason deferred requesters=${requesters.joinToString(",")}")
-      return routeBundle(audioManager, false)
+      val route = routeBundle(audioManager, false)
+      Log.i(TAG, "audio-route release reason=$normalizedReason deferred ${routeSummary(route)}")
+      return route
     }
 
     try {
@@ -77,19 +79,27 @@ object HandsFreeAudioRouter {
       }
       previousMode?.let { audioManager.mode = it }
     } catch (error: Throwable) {
-      Log.w(TAG, "audio-route release failed reason=$reason", error)
+      Log.w(TAG, "audio-route release failed reason=$normalizedReason", error)
     } finally {
       previousMode = null
       routingApplied = false
     }
 
-    Log.i(TAG, "audio-route release reason=$reason requesters=none")
-    return routeBundle(audioManager, false)
+    val route = routeBundle(audioManager, false)
+    Log.i(TAG, "audio-route release reason=$normalizedReason ${routeSummary(route)}")
+    return route
   }
 
   @Synchronized
   fun currentRoute(context: Context): Bundle {
     return routeBundle(context.getSystemService(AudioManager::class.java), false)
+  }
+
+  @Synchronized
+  fun logCurrentRoute(context: Context, reason: String): Bundle {
+    val route = currentRoute(context)
+    Log.i(TAG, "audio-route snapshot reason=${normalizeReason(reason)} ${routeSummary(route)}")
+    return route
   }
 
   private fun preferredCommunicationHeadset(audioManager: AudioManager): AudioDeviceInfo? {
@@ -146,6 +156,10 @@ object HandsFreeAudioRouter {
 
   private fun normalizeReason(reason: String): String {
     return reason.ifBlank { "unknown" }
+  }
+
+  private fun routeSummary(route: Bundle): String {
+    return "hasHeadset=${route.getBoolean("hasHeadset")} mode=${route.getString("mode")} communicationDevice=${route.getString("communicationDevice")} route=${route.getString("route")} routingRequested=${route.getBoolean("routingRequested")} routingActive=${route.getBoolean("routingActive")} routeApplied=${route.getBoolean("routeApplied")} requesters=${route.getString("requesters") ?: "-"} inputTypes=${route.getString("inputTypes")} outputTypes=${route.getString("outputTypes")}"
   }
 
   private fun isCommunicationHeadset(type: Int): Boolean {

--- a/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
+++ b/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
@@ -41,6 +41,7 @@ class HandsFreeVoiceService : Service() {
   private var activeTtsRestoreListeningAfterDone = false
   private var activeTtsAllowBargeIn = false
   private var ttsSpeaking = false
+  private var consecutiveRecognizerErrors = 0
 
   private val restartRunnable = Runnable {
     if (captureEnabled && (activeTtsUtteranceId == null || activeTtsAllowBargeIn)) {
@@ -657,6 +658,7 @@ class HandsFreeVoiceService : Service() {
   private fun createRecognitionListener(): RecognitionListener {
     return object : RecognitionListener {
       override fun onReadyForSpeech(params: Bundle?) {
+        consecutiveRecognizerErrors = 0
         HandsFreeVoiceEvents.emit("ready-for-speech")
       }
 
@@ -694,11 +696,20 @@ class HandsFreeVoiceService : Service() {
         if (error == SpeechRecognizer.ERROR_RECOGNIZER_BUSY || error == SpeechRecognizer.ERROR_CLIENT) {
           destroyRecognizer()
         }
-        scheduleRestart(if (message == "no-speech") 1500L else 1000L)
+        consecutiveRecognizerErrors += 1
+        val restartDelay = when {
+          message == "no-speech" -> 1500L
+          message == "server-disconnected" -> 2500L
+          consecutiveRecognizerErrors >= 3 -> 3000L
+          else -> 1000L
+        }
+        Log.i(TAG, "recognizer recoverable error message=$message consecutive=$consecutiveRecognizerErrors restartDelayMs=$restartDelay")
+        scheduleRestart(restartDelay)
       }
 
       override fun onResults(results: Bundle?) {
         listening = false
+        consecutiveRecognizerErrors = 0
         emitBestResult(results, callback = "results", isFinal = true)
         if (captureEnabled) {
           scheduleRestart(300L)
@@ -827,6 +838,7 @@ class HandsFreeVoiceService : Service() {
       SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "recognizer-busy"
       SpeechRecognizer.ERROR_SERVER -> "server"
       SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "no-speech"
+      11 -> "server-disconnected"
       else -> String.format(Locale.US, "speech-error-%d", error)
     }
   }

--- a/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
+++ b/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
@@ -134,6 +134,9 @@ class HandsFreeVoiceService : Service() {
       }
 
       captureEnabled = enabled
+      if (captureEnabled) {
+        consecutiveRecognizerErrors = 0
+      }
       Log.i(TAG, "service capture changed enabled=$captureEnabled listening=$listening")
       HandsFreeVoiceEvents.emit("capture-state") {
         it.putBoolean("listeningEnabled", captureEnabled)
@@ -725,6 +728,17 @@ class HandsFreeVoiceService : Service() {
           destroyRecognizer()
         }
         consecutiveRecognizerErrors += 1
+        if (message == "server-disconnected" && consecutiveRecognizerErrors >= 5) {
+          Log.w(TAG, "recognizer server-disconnected retry limit reached; disabling service capture consecutive=$consecutiveRecognizerErrors")
+          captureEnabled = false
+          mainHandler.removeCallbacks(restartRunnable)
+          stopListening(suppressEvent = true)
+          HandsFreeAudioRouter.release(this@HandsFreeVoiceService, CAPTURE_ROUTE_REQUESTER)
+          HandsFreeVoiceEvents.emit("capture-state") {
+            it.putBoolean("listeningEnabled", captureEnabled)
+          }
+          return
+        }
         val restartDelay = when {
           message == "no-speech" -> 1500L
           message == "server-disconnected" -> 2500L

--- a/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
+++ b/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
@@ -93,6 +93,7 @@ class HandsFreeVoiceService : Service() {
           return START_NOT_STICKY
         }
         startForegroundWithNotification()
+        HandsFreeAudioRouter.acquire(this, SESSION_ROUTE_REQUESTER)
         HandsFreeVoiceEvents.emit("service-started") {
           it.putString("language", language)
           it.putBoolean("listeningEnabled", captureEnabled)
@@ -113,7 +114,8 @@ class HandsFreeVoiceService : Service() {
     stopListening(suppressEvent = true)
     stopTtsOnMain(emitStopped = false)
     shutdownTextToSpeech()
-    HandsFreeAudioRouter.release(this, ROUTE_REQUESTER)
+    HandsFreeAudioRouter.release(this, CAPTURE_ROUTE_REQUESTER)
+    HandsFreeAudioRouter.release(this, SESSION_ROUTE_REQUESTER)
     destroyRecognizer()
     running = false
     if (activeService === this) {
@@ -141,7 +143,7 @@ class HandsFreeVoiceService : Service() {
       } else {
         mainHandler.removeCallbacks(restartRunnable)
         stopListening()
-        HandsFreeAudioRouter.release(this@HandsFreeVoiceService, ROUTE_REQUESTER)
+        HandsFreeAudioRouter.release(this@HandsFreeVoiceService, CAPTURE_ROUTE_REQUESTER)
       }
     }
   }
@@ -240,7 +242,7 @@ class HandsFreeVoiceService : Service() {
     }
 
     val recognizer = ensureRecognizer()
-    HandsFreeAudioRouter.acquire(this, ROUTE_REQUESTER)
+    HandsFreeAudioRouter.acquire(this, CAPTURE_ROUTE_REQUESTER)
     val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
       putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
       putExtra(RecognizerIntent.EXTRA_LANGUAGE, language)
@@ -376,7 +378,8 @@ class HandsFreeVoiceService : Service() {
 
     mainHandler.removeCallbacks(restartRunnable)
     stopListening()
-    HandsFreeAudioRouter.release(this, ROUTE_REQUESTER)
+    HandsFreeAudioRouter.release(this, CAPTURE_ROUTE_REQUESTER)
+    HandsFreeAudioRouter.logCurrentRoute(this, "tts-prepare")
 
     if (captureEnabled) {
       captureEnabled = false
@@ -478,8 +481,9 @@ class HandsFreeVoiceService : Service() {
 
       Log.i(
         TAG,
-        "tts dispatching utteranceId=${request.utteranceId} textLength=${request.text.length} language=${request.language} rate=${request.rate} pitch=${request.pitch} voice=${request.voice ?: "default"} audioRoute=${HandsFreeAudioRouter.currentRoute(this)}",
+        "tts dispatching utteranceId=${request.utteranceId} textLength=${request.text.length} language=${request.language} rate=${request.rate} pitch=${request.pitch} voice=${request.voice ?: "default"}",
       )
+      HandsFreeAudioRouter.logCurrentRoute(this, "tts-dispatch")
 
       val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
         engine.speak(request.text, TextToSpeech.QUEUE_FLUSH, null, request.utteranceId)
@@ -571,8 +575,9 @@ class HandsFreeVoiceService : Service() {
 
     Log.i(
       TAG,
-      "tts completed utteranceId=$utteranceId eventType=$eventType restoreListening=$shouldRestoreListening message=${message ?: "-"} errorCode=${errorCode ?: "-"} audioRoute=${HandsFreeAudioRouter.currentRoute(this)}",
+      "tts completed utteranceId=$utteranceId eventType=$eventType restoreListening=$shouldRestoreListening message=${message ?: "-"} errorCode=${errorCode ?: "-"}",
     )
+    HandsFreeAudioRouter.logCurrentRoute(this, "tts-complete-$eventType")
     HandsFreeVoiceEvents.emit(eventType) {
       it.putString("utteranceId", utteranceId)
       message?.let { value -> it.putString("message", value) }
@@ -844,7 +849,8 @@ class HandsFreeVoiceService : Service() {
     private const val LONG_SESSION_TIMEOUT_MS = 600000
     private const val NOTIFICATION_CHANNEL_ID = "dotagents_handsfree_voice"
     private const val NOTIFICATION_ID = 4701
-    private const val ROUTE_REQUESTER = "service"
+    private const val SESSION_ROUTE_REQUESTER = "service-session"
+    private const val CAPTURE_ROUTE_REQUESTER = "service-capture"
     private const val MIN_TTS_RATE = 0.1f
     private const val MAX_TTS_RATE = 3.0f
     private const val MIN_TTS_PITCH = 0.1f

--- a/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
+++ b/apps/mobile/android/app/src/main/java/com/aj47/dotagents/HandsFreeVoiceService.kt
@@ -464,16 +464,17 @@ class HandsFreeVoiceService : Service() {
         Log.w(TAG, "tts language unsupported language=${request.language} result=$languageResult")
       }
 
-      request.voice?.let { voiceName ->
+      request.voice?.let { requestedVoice ->
         val selectedVoice = try {
-          engine.voices?.firstOrNull { it.name == voiceName }
+          selectTtsVoice(engine.voices, requestedVoice)
         } catch (_: Throwable) {
           null
         }
         if (selectedVoice != null) {
           engine.voice = selectedVoice
+          Log.i(TAG, "tts voice selected requested=$requestedVoice selected=${selectedVoice.name} locale=${selectedVoice.locale}")
         } else {
-          Log.w(TAG, "tts voice unavailable voice=$voiceName")
+          Log.w(TAG, "tts voice unavailable requested=$requestedVoice available=${availableTtsVoiceSummary(engine)}")
         }
       }
 
@@ -549,6 +550,33 @@ class HandsFreeVoiceService : Service() {
           }
         }
       }
+    }
+  }
+
+  private fun selectTtsVoice(voices: Set<android.speech.tts.Voice>?, requestedVoice: String): android.speech.tts.Voice? {
+    if (voices.isNullOrEmpty()) return null
+    val normalizedRequested = normalizeTtsVoiceId(requestedVoice)
+    return voices.firstOrNull { it.name == requestedVoice }
+      ?: voices.firstOrNull { normalizeTtsVoiceId(it.name) == normalizedRequested }
+      ?: voices.firstOrNull { requestedVoice.endsWith(it.name) }
+      ?: voices.firstOrNull { it.name.endsWith(normalizedRequested) }
+  }
+
+  private fun normalizeTtsVoiceId(value: String): String {
+    return value.substringAfterLast(':')
+      .substringAfterLast('/')
+      .trim()
+      .lowercase(Locale.US)
+  }
+
+  private fun availableTtsVoiceSummary(engine: TextToSpeech): String {
+    return try {
+      engine.voices
+        ?.take(12)
+        ?.joinToString("|") { voice -> "${voice.name}:${voice.locale}" }
+        ?: "unavailable"
+    } catch (_: Throwable) {
+      "unreadable"
     }
   }
 

--- a/apps/mobile/src/lib/remoteTts.ts
+++ b/apps/mobile/src/lib/remoteTts.ts
@@ -346,6 +346,8 @@ function startNativePlayback(
   };
   let hasStartedPlaying = false;
   let hasLoggedFirstStatus = false;
+  let startedAtMs: number | null = null;
+  let transientStopRetries = 0;
 
   const finalize = (reason: 'done' | 'error' | 'stopped') => {
     logRemoteTts(reason === 'error' ? 'warn' : 'info', 'native playback finalize', {
@@ -381,6 +383,7 @@ function startNativePlayback(
       if (status.playing) {
         if (!hasStartedPlaying) {
           hasStartedPlaying = true;
+          startedAtMs = Date.now();
           logRemoteTts('info', 'native playback started', summarizePlaybackStatus(status));
           options.onStart?.();
         }
@@ -391,11 +394,32 @@ function startNativePlayback(
         return;
       }
       if (hasStartedPlaying && !status.playing && !status.isBuffering) {
-        playback.stopped = true;
         const reachedEnd = status.duration > 0 && status.currentTime >= Math.max(0, status.duration - 0.25);
+        const elapsedSinceStartMs = startedAtMs ? Date.now() - startedAtMs : null;
+        const stoppedAtStart = status.currentTime <= 0.25 && !reachedEnd;
+        if (
+          stoppedAtStart
+          && transientStopRetries < 2
+          && (elapsedSinceStartMs === null || elapsedSinceStartMs < 1500)
+        ) {
+          transientStopRetries += 1;
+          logRemoteTts('info', 'native playback transient stop ignored', {
+            ...summarizePlaybackStatus(status),
+            elapsedSinceStartMs,
+            retry: transientStopRetries,
+          });
+          try {
+            player.play();
+          } catch (error) {
+            logRemoteTts('warn', 'native playback transient resume failed', summarizeRemoteTtsError(error));
+          }
+          return;
+        }
+        playback.stopped = true;
         logRemoteTts('info', 'native playback stopped status', {
           ...summarizePlaybackStatus(status),
           reachedEnd,
+          elapsedSinceStartMs,
         });
         finalize(reachedEnd ? 'done' : 'stopped');
       }
@@ -429,6 +453,11 @@ function stopCurrentRemotePlayback(notifyStopped: boolean): void {
   currentPlayback = null;
   const shouldNotifyStopped = notifyStopped && !playback.stopped;
   playback.stopped = true;
+  logRemoteTts('info', 'stop current playback', {
+    kind: playback.kind,
+    notifyStopped,
+    shouldNotifyStopped,
+  });
 
   if (playback.kind === 'web') {
     try { playback.audio.pause(); } catch {}

--- a/apps/mobile/src/lib/remoteTts.ts
+++ b/apps/mobile/src/lib/remoteTts.ts
@@ -63,6 +63,23 @@ function summarizePlaybackStatus(status: unknown): Record<string, unknown> {
   };
 }
 
+function safePlayerNumber(read: () => number): number | undefined {
+  try {
+    const value = read();
+    return Number.isFinite(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function safePlayerBoolean(read: () => boolean): boolean | undefined {
+  try {
+    return read();
+  } catch {
+    return undefined;
+  }
+}
+
 export type RemoteSpeakOptions = {
   /** Paired desktop remote-server base URL including /v1. From AppConfig.baseUrl. */
   baseUrl: string;
@@ -94,6 +111,10 @@ type NativePlayback = {
   stopped: boolean;
   onStopped?: () => void;
 };
+
+const NATIVE_PLAYBACK_STARTUP_STALL_MS = 1800;
+const NATIVE_PLAYBACK_STARTUP_FAIL_MS = 4200;
+const NATIVE_PLAYBACK_ZERO_PROGRESS_STOP_RETRY_MS = 3600;
 
 let currentPlayback: WebPlayback | NativePlayback | null = null;
 let audioModeConfigured = false;
@@ -345,15 +366,32 @@ function startNativePlayback(
     onStopped: options.onStopped,
   };
   let hasStartedPlaying = false;
+  let hasAdvancedPlayback = false;
   let hasLoggedFirstStatus = false;
   let startedAtMs: number | null = null;
   let transientStopRetries = 0;
+  let startupReplayAttempts = 0;
+  let startupStallTimer: ReturnType<typeof setTimeout> | null = null;
+  let startupFailTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearStartupTimers = () => {
+    if (startupStallTimer) {
+      clearTimeout(startupStallTimer);
+      startupStallTimer = null;
+    }
+    if (startupFailTimer) {
+      clearTimeout(startupFailTimer);
+      startupFailTimer = null;
+    }
+  };
 
   const finalize = (reason: 'done' | 'error' | 'stopped') => {
+    clearStartupTimers();
     logRemoteTts(reason === 'error' ? 'warn' : 'info', 'native playback finalize', {
       reason,
       filename,
       started: hasStartedPlaying,
+      advanced: hasAdvancedPlayback,
     });
     try { playback.subscription?.remove(); } catch {}
     try { player.remove(); } catch {}
@@ -364,6 +402,48 @@ function startNativePlayback(
     if (reason === 'done') options.onDone?.();
     else if (reason === 'error') options.onError?.();
     else options.onStopped?.();
+  };
+
+  const scheduleStartupWatchdog = () => {
+    if (startupStallTimer || startupFailTimer) return;
+    startupStallTimer = setTimeout(() => {
+      startupStallTimer = null;
+      if (playback.stopped || hasAdvancedPlayback) return;
+      const currentTime = safePlayerNumber(() => player.currentTime);
+      const playing = safePlayerBoolean(() => player.playing);
+      startupReplayAttempts += 1;
+      logRemoteTts('warn', 'native playback startup stalled', {
+        filename,
+        playing,
+        currentTime,
+        attempt: startupReplayAttempts,
+        elapsedSinceStartMs: startedAtMs ? Date.now() - startedAtMs : null,
+      });
+      try {
+        void player.seekTo(0);
+      } catch (error) {
+        logRemoteTts('warn', 'native playback startup seek failed', summarizeRemoteTtsError(error));
+      }
+      try {
+        player.play();
+      } catch (error) {
+        logRemoteTts('warn', 'native playback startup replay failed', summarizeRemoteTtsError(error));
+      }
+    }, NATIVE_PLAYBACK_STARTUP_STALL_MS);
+
+    startupFailTimer = setTimeout(() => {
+      startupFailTimer = null;
+      if (playback.stopped || hasAdvancedPlayback) return;
+      logRemoteTts('warn', 'native playback startup failed to advance', {
+        filename,
+        playing: safePlayerBoolean(() => player.playing),
+        currentTime: safePlayerNumber(() => player.currentTime),
+        duration: safePlayerNumber(() => player.duration),
+        elapsedSinceStartMs: startedAtMs ? Date.now() - startedAtMs : null,
+      });
+      playback.stopped = true;
+      finalize('error');
+    }, NATIVE_PLAYBACK_STARTUP_FAIL_MS);
   };
 
   try {
@@ -386,6 +466,12 @@ function startNativePlayback(
           startedAtMs = Date.now();
           logRemoteTts('info', 'native playback started', summarizePlaybackStatus(status));
           options.onStart?.();
+          scheduleStartupWatchdog();
+        }
+        if (!hasAdvancedPlayback && status.currentTime > 0.25) {
+          hasAdvancedPlayback = true;
+          clearStartupTimers();
+          logRemoteTts('info', 'native playback advanced', summarizePlaybackStatus(status));
         }
       }
       if (status.didJustFinish) {
@@ -397,6 +483,10 @@ function startNativePlayback(
         const reachedEnd = status.duration > 0 && status.currentTime >= Math.max(0, status.duration - 0.25);
         const elapsedSinceStartMs = startedAtMs ? Date.now() - startedAtMs : null;
         const stoppedAtStart = status.currentTime <= 0.25 && !reachedEnd;
+        const stillWithinStartupRetryWindow =
+          !hasAdvancedPlayback
+          && stoppedAtStart
+          && (elapsedSinceStartMs === null || elapsedSinceStartMs < NATIVE_PLAYBACK_ZERO_PROGRESS_STOP_RETRY_MS);
         if (
           stoppedAtStart
           && transientStopRetries < 2
@@ -412,6 +502,20 @@ function startNativePlayback(
             player.play();
           } catch (error) {
             logRemoteTts('warn', 'native playback transient resume failed', summarizeRemoteTtsError(error));
+          }
+          return;
+        }
+        if (stillWithinStartupRetryWindow) {
+          startupReplayAttempts += 1;
+          logRemoteTts('warn', 'native playback zero-progress stop ignored while startup watchdog is active', {
+            ...summarizePlaybackStatus(status),
+            elapsedSinceStartMs,
+            attempt: startupReplayAttempts,
+          });
+          try {
+            player.play();
+          } catch (error) {
+            logRemoteTts('warn', 'native playback zero-progress resume failed', summarizeRemoteTtsError(error));
           }
           return;
         }

--- a/apps/mobile/src/lib/voice/useHandsFreeController.test.ts
+++ b/apps/mobile/src/lib/voice/useHandsFreeController.test.ts
@@ -253,6 +253,39 @@ describe('resolveHandsFreeUtterance', () => {
     expect(result.nextState.phase).toBe('processing');
   });
 
+  it('sends long dictation that starts with a stop command word', () => {
+    const result = resolveHandsFreeUtterance({
+      state: { ...createInitialHandsFreeState(), phase: 'listening', awakeSince: 100 },
+      transcript: 'stop okay I think we need to plan my reintroduction into the game',
+      wakePhrase: 'hey dot agents',
+      sleepPhrase: 'go to sleep',
+      now: 275,
+    });
+
+    expect(result.action).toEqual({
+      type: 'send',
+      text: 'okay i think we need to plan my reintroduction into the game',
+    });
+    expect(result.matchedCommand).toBeNull();
+    expect(result.nextState.phase).toBe('processing');
+  });
+
+  it('keeps short stop phrases as commands', () => {
+    const result = resolveHandsFreeUtterance({
+      state: { ...createInitialHandsFreeState(), phase: 'listening', awakeSince: 100 },
+      transcript: 'stop talking',
+      wakePhrase: 'hey dot agents',
+      sleepPhrase: 'go to sleep',
+      now: 276,
+    });
+
+    expect(result.action.type).toBe('command');
+    if (result.action.type === 'command') {
+      expect(result.action.command).toBe('stop-tts');
+    }
+    expect(result.matchedCommand).toBe('stop-tts');
+  });
+
   it('emits a stop-tts command while the assistant is speaking', () => {
     const result = resolveHandsFreeUtterance({
       state: { ...createInitialHandsFreeState(), phase: 'speaking', awakeSince: 100, resumePhase: 'listening' },

--- a/apps/mobile/src/lib/voice/useHandsFreeController.ts
+++ b/apps/mobile/src/lib/voice/useHandsFreeController.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   matchVoiceCommand,
+  PARAMETERIZED_VOICE_COMMANDS,
   type HandsFreePhase,
   type HandsFreeResumePhase,
   type VoiceCommandDefinition,
@@ -46,6 +47,7 @@ type HandsFreeControllerOptions = {
 };
 
 const DEFAULT_REPEATED_ERROR_THRESHOLD = 3;
+const COMMAND_REMAINDER_SEND_WORD_THRESHOLD = 4;
 const BENIGN_RECOGNIZER_ERRORS = new Set(['no-speech', 'aborted']);
 const BENIGN_RECOGNIZER_ERROR_PATTERNS = [
   /server\s+disconnected/i,
@@ -147,11 +149,28 @@ function buildCommandAction(
   match: ReturnType<typeof matchVoiceCommand>,
 ): HandsFreeUtteranceAction {
   if (!match) return { type: 'none' };
+  const remainderWordCount = match.remainder ? match.remainder.split(/\s+/).filter(Boolean).length : 0;
+  if (
+    match.remainder
+    && !PARAMETERIZED_VOICE_COMMANDS.has(match.command)
+    && remainderWordCount >= COMMAND_REMAINDER_SEND_WORD_THRESHOLD
+  ) {
+    return { type: 'send', text: match.remainder };
+  }
   return {
     type: 'command',
     command: match.command,
     label: match.label,
     remainder: match.remainder,
+  };
+}
+
+function buildCommandResolution(match: NonNullable<ReturnType<typeof matchVoiceCommand>>) {
+  const action = buildCommandAction(match);
+  return {
+    action,
+    convertedToSend: action.type === 'send',
+    matchedCommand: action.type === 'command' ? match.command : null,
   };
 }
 
@@ -197,18 +216,21 @@ export function resolveHandsFreeUtterance({
       if (allowDirectSpeechWhileSleeping) {
         const commandMatch = matchVoiceCommand(normalizedTranscript, voiceCommands);
         if (commandMatch) {
+          const commandResolution = buildCommandResolution(commandMatch);
           return {
             nextState: {
               ...state,
+              phase: commandResolution.convertedToSend ? 'processing' : state.phase,
+              resumePhase: commandResolution.convertedToSend ? 'listening' : state.resumePhase,
               awakeSince: state.awakeSince ?? now,
               lastTranscript: normalizedTranscript,
               lastError: null,
               recognizerErrorCount: 0,
             },
-            action: buildCommandAction(commandMatch),
+            action: commandResolution.action,
             matchedWake: false,
             matchedSleep: false,
-            matchedCommand: commandMatch.command,
+            matchedCommand: commandResolution.matchedCommand,
           };
         }
         return {
@@ -240,20 +262,21 @@ export function resolveHandsFreeUtterance({
     if (wakeMatch.remainder) {
       const commandMatch = matchVoiceCommand(wakeMatch.remainder, voiceCommands);
       if (commandMatch) {
+        const commandResolution = buildCommandResolution(commandMatch);
         return {
-          nextState: {
-            ...state,
-            phase: 'listening',
-            resumePhase: null,
-            awakeSince: state.awakeSince ?? now,
-            lastTranscript: wakeMatch.remainder,
+            nextState: {
+              ...state,
+              phase: commandResolution.convertedToSend ? 'processing' : 'listening',
+              resumePhase: commandResolution.convertedToSend ? 'listening' : null,
+              awakeSince: state.awakeSince ?? now,
+              lastTranscript: wakeMatch.remainder,
             lastError: null,
             recognizerErrorCount: 0,
           },
-          action: buildCommandAction(commandMatch),
+          action: commandResolution.action,
           matchedWake: true,
           matchedSleep: false,
-          matchedCommand: commandMatch.command,
+          matchedCommand: commandResolution.matchedCommand,
         };
       }
       return {
@@ -306,19 +329,21 @@ export function resolveHandsFreeUtterance({
 
     const commandMatch = matchVoiceCommand(normalizedTranscript, voiceCommands);
     if (commandMatch) {
+      const commandResolution = buildCommandResolution(commandMatch);
       return {
         nextState: {
           ...state,
-          phase: 'listening',
+          phase: commandResolution.convertedToSend ? 'processing' : 'listening',
+          resumePhase: commandResolution.convertedToSend ? 'listening' : state.resumePhase,
           awakeSince: state.awakeSince ?? now,
           lastTranscript: normalizedTranscript,
           lastError: null,
           recognizerErrorCount: 0,
         },
-        action: buildCommandAction(commandMatch),
+        action: commandResolution.action,
         matchedWake: false,
         matchedSleep: false,
-        matchedCommand: commandMatch.command,
+        matchedCommand: commandResolution.matchedCommand,
       };
     }
 
@@ -356,15 +381,18 @@ export function resolveHandsFreeUtterance({
 
     const commandMatch = matchVoiceCommand(normalizedTranscript, voiceCommands);
     if (commandMatch) {
+      const commandResolution = buildCommandResolution(commandMatch);
       return {
         nextState: {
           ...state,
+          phase: commandResolution.convertedToSend ? 'processing' : state.phase,
+          resumePhase: commandResolution.convertedToSend ? 'listening' : state.resumePhase,
           lastTranscript: normalizedTranscript,
         },
-        action: buildCommandAction(commandMatch),
+        action: commandResolution.action,
         matchedWake: false,
         matchedSleep: false,
-        matchedCommand: commandMatch.command,
+        matchedCommand: commandResolution.matchedCommand,
       };
     }
 
@@ -411,15 +439,16 @@ export function resolveHandsFreeUtterance({
 
     const commandMatch = matchVoiceCommand(normalizedTranscript, voiceCommands);
     if (commandMatch) {
+      const commandResolution = buildCommandResolution(commandMatch);
       return {
         nextState: {
           ...state,
           lastTranscript: normalizedTranscript,
         },
-        action: buildCommandAction(commandMatch),
+        action: commandResolution.action,
         matchedWake: false,
         matchedSleep: false,
-        matchedCommand: commandMatch.command,
+        matchedCommand: commandResolution.matchedCommand,
       };
     }
 
@@ -429,15 +458,16 @@ export function resolveHandsFreeUtterance({
         ? matchVoiceCommand(wakeMatch.remainder, voiceCommands)
         : null;
       if (remainderCommand) {
+        const commandResolution = buildCommandResolution(remainderCommand);
         return {
           nextState: {
             ...state,
             lastTranscript: wakeMatch.remainder,
           },
-          action: buildCommandAction(remainderCommand),
+          action: commandResolution.action,
           matchedWake: true,
           matchedSleep: false,
-          matchedCommand: remainderCommand.command,
+          matchedCommand: commandResolution.matchedCommand,
         };
       }
       return {

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
@@ -563,6 +563,55 @@ describe('useSpeechRecognizer', () => {
     });
   });
 
+  it('finalizes configured native hands-free control phrases immediately', async () => {
+    vi.useFakeTimers();
+    const runtime = createHookRuntime();
+    const speechRecognitionModule = {
+      getPermissionsAsync: vi.fn().mockResolvedValue({ granted: true }),
+      requestPermissionsAsync: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    };
+    const { useSpeechRecognizer } = await loadUseSpeechRecognizer(runtime, {
+      platform: 'android',
+      eventEmitterClass: FakeNativeSpeechEventEmitter,
+      speechRecognitionModule,
+    });
+    const onVoiceFinalized = vi.fn();
+    const log = vi.fn();
+
+    const recognizer = runtime.render(useSpeechRecognizer, {
+      handsFree: true,
+      handsFreeDebounceMs: 5_000,
+      willCancel: false,
+      onVoiceFinalized,
+      shouldImmediatelyFinalizeHandsFreeTranscript: ({ text }) => text === 'hey bro',
+      log,
+    });
+    runtime.commitEffects();
+
+    await recognizer.startRecording();
+    const eventEmitter = FakeNativeSpeechEventEmitter.instances[0];
+    eventEmitter.emit('result', {
+      isFinal: false,
+      results: [{ transcript: 'hey bro' }],
+    });
+
+    expect(onVoiceFinalized).toHaveBeenCalledWith({
+      text: 'hey bro',
+      mode: 'handsfree',
+      source: 'native',
+    });
+    expect(log.mock.calls.find(([, summary]) => summary === 'Hands-free transcript finalized immediately.')?.[2]).toMatchObject({
+      source: 'native',
+      isFinal: false,
+      text: 'hey bro',
+    });
+
+    vi.advanceTimersByTime(5_000);
+    expect(onVoiceFinalized).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps a pending native hands-free final when the recognizer is auto-disarmed before debounce fires', async () => {
     vi.useFakeTimers();
     const runtime = createHookRuntime();

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.test.ts
@@ -113,6 +113,10 @@ class FakeNativeSpeechEventEmitter {
   emit(eventName: string, event: any) {
     this.listeners.get(eventName)?.forEach((listener) => listener(event));
   }
+
+  listenerCount(eventName: string) {
+    return this.listeners.get(eventName)?.size ?? 0;
+  }
 }
 
 async function loadUseSpeechRecognizer(
@@ -600,6 +604,49 @@ describe('useSpeechRecognizer', () => {
       mode: 'handsfree',
       source: 'native',
     });
+  });
+
+  it('removes native speech listeners when foreground recognition is disarmed', async () => {
+    vi.useFakeTimers();
+    const runtime = createHookRuntime();
+    const speechRecognitionModule = {
+      getPermissionsAsync: vi.fn().mockResolvedValue({ granted: true }),
+      requestPermissionsAsync: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+    };
+    const { useSpeechRecognizer } = await loadUseSpeechRecognizer(runtime, {
+      platform: 'android',
+      eventEmitterClass: FakeNativeSpeechEventEmitter,
+      speechRecognitionModule,
+    });
+    const onVoiceFinalized = vi.fn();
+    const log = vi.fn();
+
+    const recognizer = runtime.render(useSpeechRecognizer, {
+      handsFree: true,
+      handsFreeDebounceMs: 500,
+      willCancel: false,
+      onVoiceFinalized,
+      log,
+    });
+    runtime.commitEffects();
+
+    await recognizer.startRecording();
+    const eventEmitter = FakeNativeSpeechEventEmitter.instances[0];
+    expect(eventEmitter.listenerCount('result')).toBe(1);
+
+    await recognizer.stopRecognitionOnly();
+    expect(eventEmitter.listenerCount('result')).toBe(0);
+
+    eventEmitter.emit('result', {
+      isFinal: true,
+      results: [{ transcript: 'hey bro' }],
+    });
+    vi.advanceTimersByTime(500);
+
+    expect(onVoiceFinalized).not.toHaveBeenCalled();
+    expect(log.mock.calls.map(([, summary]) => summary)).not.toContain('Native speech recognizer produced a result.');
   });
 
   it('clears the STT preview immediately without leaving an expiry timer active', async () => {

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
@@ -381,6 +381,9 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
       }
     } finally {
       await setForegroundAndroidHandsFreeAudioRouting(false);
+      if (Platform.OS !== 'web') {
+        cleanupNativeSubs();
+      }
       setListeningValue(false);
       if (!shouldPreservePendingHandsFreeFinal) {
         setLiveTranscriptValue('');
@@ -392,7 +395,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
       webPressInSeenRef.current = false;
       log?.('recognizer-stop', 'Speech recognizer stopped.');
     }
-  }, [clearHandsFreeDebounce, handsFree, isHandsFreeTranscriptSuppressed, log, setForegroundAndroidHandsFreeAudioRouting, setListeningValue, setLiveTranscriptValue]);
+  }, [cleanupNativeSubs, clearHandsFreeDebounce, handsFree, isHandsFreeTranscriptSuppressed, log, setForegroundAndroidHandsFreeAudioRouting, setListeningValue, setLiveTranscriptValue]);
 
   useEffect(() => {
     if (enabled || !listeningRef.current) {
@@ -400,6 +403,13 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     }
     void stopRecognitionOnly();
   }, [enabled, stopRecognitionOnly]);
+
+  useEffect(() => {
+    if (enabled || Platform.OS === 'web') {
+      return;
+    }
+    cleanupNativeSubs();
+  }, [cleanupNativeSubs, enabled]);
 
   const finalizePendingHandsFree = useCallback((source: 'native' | 'web') => {
     if (!enabledRef.current) {

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
@@ -25,6 +25,12 @@ type SuppressedHandsFreeTranscriptPayload = {
   isFinal?: boolean;
 };
 
+type HandsFreeTranscriptPayload = {
+  text: string;
+  source: 'native' | 'web';
+  isFinal?: boolean;
+};
+
 type DeferredPushToTalkFinal = {
   gestureId: number;
   text: string;
@@ -41,6 +47,7 @@ type UseSpeechRecognizerOptions = {
   onPermissionDenied?: () => void;
   shouldSuppressHandsFreeTranscript?: () => boolean;
   shouldFinalizeHandsFreeTranscript?: () => boolean;
+  shouldImmediatelyFinalizeHandsFreeTranscript?: (payload: HandsFreeTranscriptPayload) => boolean;
   onSuppressedHandsFreeTranscript?: (payload: SuppressedHandsFreeTranscriptPayload) => boolean;
   log?: VoiceDebugLog;
   /** Preferred microphone device ID (web only). When set, getUserMedia is called
@@ -94,6 +101,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     onPermissionDenied,
     shouldSuppressHandsFreeTranscript,
     shouldFinalizeHandsFreeTranscript,
+    shouldImmediatelyFinalizeHandsFreeTranscript,
     onSuppressedHandsFreeTranscript,
     log,
     audioInputDeviceId,
@@ -131,10 +139,12 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
   const suppressFinalizeRef = useRef(false);
   const shouldSuppressHandsFreeTranscriptRef = useRef(shouldSuppressHandsFreeTranscript);
   const shouldFinalizeHandsFreeTranscriptRef = useRef(shouldFinalizeHandsFreeTranscript);
+  const shouldImmediatelyFinalizeHandsFreeTranscriptRef = useRef(shouldImmediatelyFinalizeHandsFreeTranscript);
   const onSuppressedHandsFreeTranscriptRef = useRef(onSuppressedHandsFreeTranscript);
   const enabledRef = useRef(enabled);
   shouldSuppressHandsFreeTranscriptRef.current = shouldSuppressHandsFreeTranscript;
   shouldFinalizeHandsFreeTranscriptRef.current = shouldFinalizeHandsFreeTranscript;
+  shouldImmediatelyFinalizeHandsFreeTranscriptRef.current = shouldImmediatelyFinalizeHandsFreeTranscript;
   onSuppressedHandsFreeTranscriptRef.current = onSuppressedHandsFreeTranscript;
   enabledRef.current = enabled;
 
@@ -468,6 +478,66 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     return true;
   }, [clearSuppressedHandsFreeTranscript, emitFinalized, isHandsFreeFinalizationEligible, isHandsFreeTranscriptSuppressed, log, setLiveTranscriptValue, stopRecognitionOnly]);
 
+  const maybeFinalizeHandsFreeImmediately = useCallback((source: 'native' | 'web', text: string, isFinal?: boolean) => {
+    if (!handsFree || !enabledRef.current) {
+      return false;
+    }
+
+    const finalText = normalizeVoiceText(text);
+    if (!finalText) {
+      return false;
+    }
+
+    if (isHandsFreeTranscriptSuppressed()) {
+      clearSuppressedHandsFreeTranscript(source, finalText, isFinal);
+      return true;
+    }
+
+    if (!isHandsFreeFinalizationEligible()) {
+      return false;
+    }
+
+    const shouldFinalizeImmediately = shouldImmediatelyFinalizeHandsFreeTranscriptRef.current?.({
+      text: finalText,
+      source,
+      isFinal,
+    }) === true;
+    if (!shouldFinalizeImmediately) {
+      return false;
+    }
+
+    clearHandsFreeDebounce();
+    pendingHandsFreeFinalRef.current = '';
+    if (source === 'web') {
+      webFinalRef.current = '';
+    } else {
+      nativeFinalRef.current = '';
+    }
+    setLiveTranscriptValue(finalText);
+    setSttPreviewWithExpiry(finalText);
+    setHandsFreeDebounceEndsAt(null);
+    log?.('finalization-fired', 'Hands-free transcript finalized immediately.', {
+      source,
+      isFinal: !!isFinal,
+      text: truncateDebugText(finalText),
+      textLength: finalText.length,
+    });
+    void stopRecognitionOnly();
+    emitFinalized(finalText, source);
+    return true;
+  }, [
+    clearHandsFreeDebounce,
+    clearSuppressedHandsFreeTranscript,
+    emitFinalized,
+    handsFree,
+    isHandsFreeFinalizationEligible,
+    isHandsFreeTranscriptSuppressed,
+    log,
+    setLiveTranscriptValue,
+    setSttPreviewWithExpiry,
+    stopRecognitionOnly,
+  ]);
+
   const scheduleHandsFreeFinalization = useCallback((source: 'native' | 'web', text: string) => {
     if (!enabledRef.current) {
       return false;
@@ -685,6 +755,17 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
         clearSuppressedHandsFreeTranscript('web', rawResultText, !!finalText);
         return;
       }
+      if (
+        handsFree
+        && rawResultText
+        && maybeFinalizeHandsFreeImmediately(
+          'web',
+          mergeVoiceText(pendingHandsFreeFinalRef.current, rawResultText),
+          !!finalText,
+        )
+      ) {
+        return;
+      }
 
       if (finalText) {
         if (handsFree) {
@@ -824,6 +905,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     handsFree,
     isHandsFreeTranscriptSuppressed,
     log,
+    maybeFinalizeHandsFreeImmediately,
     onRecognizerError,
     restartWebHandsFreeRecognition,
     scheduleHandsFreeFinalization,
@@ -936,6 +1018,17 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
               });
               if (handsFree && text && isHandsFreeTranscriptSuppressed()) {
                 clearSuppressedHandsFreeTranscript('native', text, !!nativeEvent?.isFinal);
+                return;
+              }
+              if (
+                handsFree
+                && text
+                && maybeFinalizeHandsFreeImmediately(
+                  'native',
+                  mergeVoiceText(pendingHandsFreeFinalRef.current, text),
+                  !!nativeEvent?.isFinal,
+                )
+              ) {
                 return;
               }
               if (nativeEvent?.isFinal && text) {
@@ -1191,6 +1284,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
     handsFreeDebounceMs,
     isHandsFreeTranscriptSuppressed,
     log,
+    maybeFinalizeHandsFreeImmediately,
     onPermissionDenied,
     onRecognizerError,
     restartNativeHandsFreeRecognition,

--- a/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
+++ b/apps/mobile/src/lib/voice/useSpeechRecognizer.ts
@@ -116,6 +116,7 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
   const sttPreviewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startingRef = useRef(false);
   const stoppingRef = useRef(false);
+  const foregroundAndroidRoutingRequestedRef = useRef(false);
   const userReleasedButtonRef = useRef(false);
   const webPressInSeenRef = useRef(false);
   const lastGrantTimeRef = useRef(0);
@@ -223,18 +224,29 @@ export function useSpeechRecognizer(options: UseSpeechRecognizerOptions) {
   }, [clearHandsFreeDebounce, log, setLiveTranscriptValue, setSttPreviewWithExpiry]);
 
   const setForegroundAndroidHandsFreeAudioRouting = useCallback(async (enabled: boolean) => {
-    if (Platform.OS !== 'android' || !handsFree) {
+    if (Platform.OS !== 'android') {
+      return;
+    }
+    if (enabled && !handsFree) {
+      return;
+    }
+    if (!enabled && !foregroundAndroidRoutingRequestedRef.current) {
       return;
     }
 
     try {
       const route = await setAndroidHandsFreeAudioRoutingEnabled(enabled, 'foreground');
+      foregroundAndroidRoutingRequestedRef.current = enabled;
       log?.('runtime-state', 'Android handsfree audio routing updated.', {
         enabled,
+        hasHeadset: route?.hasHeadset,
+        mode: route?.mode,
         route: route?.route,
         communicationDevice: route?.communicationDevice,
+        routingRequested: route?.routingRequested,
         routingActive: route?.routingActive,
         routeApplied: route?.routeApplied,
+        requesters: route?.requesters,
       });
     } catch (error) {
       log?.('recognizer-error', 'Android handsfree audio routing update failed.', {

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -104,6 +104,7 @@ import { useStableForeground } from '../lib/voice/useStableForeground';
 import {
   getAndroidHandsFreeAudioRoute,
   isAndroidHandsFreeServiceAvailable,
+  setAndroidHandsFreeAudioRoutingEnabled,
   setAndroidHandsFreeListeningEnabled,
   speakAndroidHandsFreeTts,
   startAndroidHandsFreeService,
@@ -1000,7 +1001,7 @@ export default function ChatScreen({ route, navigation }: any) {
     && !stableHandsFreeForeground;
   const shouldUseAndroidHandsFreeServiceTts =
     Platform.OS === 'android'
-    && androidBackgroundHandsFree;
+    && shouldRunAndroidHandsFreeService;
   const shouldUseAndroidHandsFreeServiceTtsRef = useRef(shouldUseAndroidHandsFreeServiceTts);
   shouldUseAndroidHandsFreeServiceTtsRef.current = shouldUseAndroidHandsFreeServiceTts;
   const allowHandsFreeDirectSpeechWhileSleeping = Platform.OS === 'android' && androidHandsFreeServiceAvailable
@@ -1503,6 +1504,49 @@ export default function ChatScreen({ route, navigation }: any) {
       clearVoiceDebug();
     }
   }, [clearVoiceDebug, handsFreeDebugEnabled]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'android' || !androidHandsFreeServiceAvailable || !handsFree) {
+      return;
+    }
+
+    let released = false;
+    void setAndroidHandsFreeAudioRoutingEnabled(true, 'session').then((route) => {
+      voiceLog('runtime-state', 'Android handsfree session audio routing acquired.', {
+        hasHeadset: route?.hasHeadset,
+        mode: route?.mode,
+        communicationDevice: route?.communicationDevice,
+        routingRequested: route?.routingRequested,
+        routingActive: route?.routingActive,
+        requesters: route?.requesters,
+      });
+    }).catch((error) => {
+      voiceLog('recognizer-error', 'Android handsfree session audio routing acquire failed.', {
+        message: (error as any)?.message || String(error),
+      });
+    });
+
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      void setAndroidHandsFreeAudioRoutingEnabled(false, 'session').then((route) => {
+        voiceLog('runtime-state', 'Android handsfree session audio routing released.', {
+          hasHeadset: route?.hasHeadset,
+          mode: route?.mode,
+          communicationDevice: route?.communicationDevice,
+          routingRequested: route?.routingRequested,
+          routingActive: route?.routingActive,
+          requesters: route?.requesters,
+        });
+      }).catch((error) => {
+        voiceLog('recognizer-error', 'Android handsfree session audio routing release failed.', {
+          message: (error as any)?.message || String(error),
+        });
+      });
+    };
+  }, [androidHandsFreeServiceAvailable, handsFree, voiceLog]);
 
   useEffect(() => {
     if (Platform.OS === 'web' || !handsFree || !isAppActive || !isFocused) {
@@ -3236,9 +3280,10 @@ export default function ChatScreen({ route, navigation }: any) {
       intendedSpeakingIndexRef.current = null;
       return;
     }
+    const useAndroidServiceTts = shouldUseAndroidHandsFreeServiceTtsRef.current;
     const playbackId = beginGlobalTtsPlayback({
       source: 'message',
-      status: effectiveTtsProvider === 'edge' && config.baseUrl && config.apiKey ? 'loading' : 'speaking',
+      status: (effectiveTtsProvider === 'edge' && config.baseUrl && config.apiKey) || useAndroidServiceTts ? 'loading' : 'speaking',
       sessionId: sessionStore.currentSessionId,
       sessionTitle: sessionStore.getCurrentSession()?.title ?? 'Chat',
       messageIndex: index,
@@ -3249,6 +3294,59 @@ export default function ChatScreen({ route, navigation }: any) {
 	      voiceLog('tts-started', 'Assistant speech started from message playback.');
 	    }
     setSpeakingMessageIndex(index);
+    if (useAndroidServiceTts) {
+      const utteranceId = createAndroidHandsFreeTtsUtteranceId();
+      let settled = false;
+      let clearNativeTtsTimeout: (() => void) | null = null;
+      const settle = (eventType: AndroidHandsFreeTtsSettleType | 'not-started' | 'promise-error', message?: string) => {
+        if (settled) return;
+        settled = true;
+        androidHandsFreeTtsHandlersRef.current.delete(utteranceId);
+        clearNativeTtsTimeout?.();
+        clearNativeTtsTimeout = null;
+        intendedSpeakingIndexRef.current = null;
+        completeGlobalTtsPlayback(playbackId);
+        if (handsFree) {
+          handsFreeController.onSpeechFinished();
+          voiceLog('tts-stopped', `Android service TTS settled from message playback (${eventType}).`, {
+            utteranceId,
+            message,
+          });
+        }
+        setSpeakingMessageIndex(null);
+      };
+
+      androidHandsFreeTtsHandlersRef.current.set(utteranceId, {
+        onStarted: () => {
+          markGlobalTtsPlaybackSpeaking(playbackId);
+        },
+        onSettled: (type, message) => {
+          settle(type, message);
+        },
+      });
+      const timeout = setTimeout(() => {
+        settle('not-started', 'watchdog');
+      }, estimateNativeTtsWatchdogMs(processedText, config.ttsRate ?? 1.0));
+      clearNativeTtsTimeout = () => clearTimeout(timeout);
+
+      void speakAndroidHandsFreeTts({
+        utteranceId,
+        text: processedText,
+        language: 'en-US',
+        rate: config.ttsRate ?? 1.0,
+        pitch: config.ttsPitch ?? 1.0,
+        voice: config.ttsVoiceId,
+        restoreListeningAfterDone: true,
+        allowBargeIn: true,
+      }).then((startedUtteranceId) => {
+        if (!startedUtteranceId) {
+          settle('not-started');
+        }
+      }).catch((error) => {
+        settle('promise-error', (error as any)?.message || String(error));
+      });
+      return;
+    }
     if (effectiveTtsProvider === 'edge' && config.baseUrl && config.apiKey) {
       // Edge TTS routes through the paired desktop's /v1/tts/speak.
       void speakRemoteTts(processedText, {

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -114,7 +114,7 @@ import {
   isExpectedHandsFreeRecognizerStopError,
   useHandsFreeController,
 } from '../lib/voice/useHandsFreeController';
-import { normalizeVoicePhrase } from '../lib/voice/phraseMatcher';
+import { matchWakePhrase, normalizeVoicePhrase } from '../lib/voice/phraseMatcher';
 import { findAgentSessionMatch } from '../lib/voice/agentSessionMatch';
 import {
   playHandsFreeAudioCue,
@@ -1992,6 +1992,19 @@ export default function ChatScreen({ route, navigation }: any) {
     || handsFreePhaseRef.current === 'waking'
     || handsFreePhaseRef.current === 'listening'
   ), []);
+  const shouldImmediatelyFinalizeHandsFreeTranscript = useCallback(({
+    text,
+  }: {
+    text: string;
+    source: 'native' | 'web';
+    isFinal?: boolean;
+  }) => {
+    if (!handsFreeRef.current || handsFreePhaseRef.current !== 'sleeping') {
+      return false;
+    }
+    const wakeMatch = matchWakePhrase(text, handsFreeWakePhrase);
+    return wakeMatch.matched && !wakeMatch.remainder;
+  }, [handsFreeWakePhrase]);
 
   const playHandsFreeCue = useCallback((cue: HandsFreeAudioCue) => {
     if (!handsFreeRef.current) {
@@ -2820,6 +2833,7 @@ export default function ChatScreen({ route, navigation }: any) {
     onVoiceFinalized: handleVoiceFinalized,
     shouldSuppressHandsFreeTranscript: isHandsFreeTranscriptSuppressedNow,
     shouldFinalizeHandsFreeTranscript: isHandsFreeFinalizationEligibleNow,
+    shouldImmediatelyFinalizeHandsFreeTranscript,
     onSuppressedHandsFreeTranscript: ({ text, source }) => handleHandsFreeTtsBargeInCommand(text, source),
     onRecognizerError: handleRecognizerError,
     onPermissionDenied: () => {

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, useMemo, useCallback, type SetStateAction } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState, useMemo, useCallback, type ComponentProps, type SetStateAction } from 'react';
 import {
   View,
   Text,
@@ -34,7 +34,7 @@ import {
 	useConfigContext,
 	saveConfig,
 } from '../store/config';
-import { useSessionContext } from '../store/sessions';
+import { canRefreshServerGeneratedSessionTitle, useSessionContext } from '../store/sessions';
 import { useMessageQueueContext } from '../store/message-queue';
 import { MessageQueuePanel } from '../ui/MessageQueuePanel';
 import { ensureNativeTtsAudioMode, speakRemoteTts } from '../lib/remoteTts';
@@ -90,8 +90,6 @@ import {
   createButtonAccessibilityLabel,
   createChatComposerAccessibilityHint,
   createExpandCollapseAccessibilityLabel,
-  createMicControlAccessibilityHint,
-  createMicControlAccessibilityLabel,
   createMinimumTouchTargetStyle,
   createSwitchAccessibilityLabel,
   createTextInputAccessibilityLabel,
@@ -162,6 +160,10 @@ const HANDS_FREE_SESSION_READY_CUE_MIN_INTERVAL_MS = 1_500;
 const HANDS_FREE_PREVIEW_SUBMITTED_PROCESSING_CUE_SUPPRESSION_MS = 900;
 const HANDS_FREE_SUBMITTED_CUE_ANDROID_DELAY_MS = 120;
 const SERVER_GENERATED_TITLE_REFRESH_DELAYS_MS = [1_500, 5_000, 12_000, 25_000] as const;
+type ServerGeneratedTitleRefreshJob = {
+  cancelled: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+};
 const HANDS_FREE_PHASE_AUDIO_CUES: Record<HandsFreePhase, HandsFreeAudioCue> = {
   sleeping: 'sleeping',
   waking: 'listening',
@@ -177,6 +179,206 @@ const NATIVE_TTS_MIN_WATCHDOG_MS = 4_000;
 const NATIVE_TTS_MAX_WATCHDOG_MS = 90_000;
 const NATIVE_TTS_STARTUP_TIMEOUT_MS = 8_000;
 const NATIVE_TTS_ESTIMATED_WORDS_PER_MINUTE = 150;
+
+type IoniconName = ComponentProps<typeof Ionicons>['name'];
+type HandsFreeDisplayPhase = HandsFreePhase | 'off';
+type MicControlTone = 'idle' | 'active' | 'danger';
+type MicControlIndicator = {
+  key: string;
+  icon: IoniconName;
+  label: string;
+  active?: boolean;
+  warning?: boolean;
+};
+type MicControlVisual = {
+  icon: IoniconName;
+  label: string;
+  status: string;
+  tone: MicControlTone;
+  busy: boolean;
+  indicators: MicControlIndicator[];
+  accessibilityLabel: string;
+  accessibilityHint: string;
+};
+
+function compactVoiceStatus(message: string | null | undefined, fallback: string): string {
+  const normalized = message?.trim();
+  if (!normalized) return fallback;
+  return normalized.length > 72 ? `${normalized.slice(0, 69)}...` : normalized;
+}
+
+function createMicStateIndicator(effectiveMicListening: boolean): MicControlIndicator {
+  return {
+    key: 'mic',
+    icon: effectiveMicListening ? 'mic' : 'mic-off-outline',
+    label: effectiveMicListening ? 'Mic armed' : 'Mic idle',
+    active: effectiveMicListening,
+  };
+}
+
+function createMicControlVisual({
+  handsFree,
+  displayPhase,
+  effectiveMicListening,
+  hasPendingHandsFreeSend,
+  handsFreeCountdownSeconds,
+  willCancel,
+  wakePhrase,
+  lastError,
+}: {
+  handsFree: boolean;
+  displayPhase: HandsFreeDisplayPhase;
+  effectiveMicListening: boolean;
+  hasPendingHandsFreeSend: boolean;
+  handsFreeCountdownSeconds: number;
+  willCancel: boolean;
+  wakePhrase: string;
+  lastError: string | null;
+}): MicControlVisual {
+  if (!handsFree) {
+    const listeningLabel = willCancel ? 'Release to edit' : 'Release to send';
+    return {
+      icon: effectiveMicListening ? 'mic' : 'mic-outline',
+      label: effectiveMicListening ? 'Listening' : 'Hold',
+      status: effectiveMicListening
+        ? (willCancel ? 'Release to edit before sending.' : 'Release to send.')
+        : 'Hold to speak. Release to send.',
+      tone: effectiveMicListening ? 'active' : 'idle',
+      busy: effectiveMicListening,
+      indicators: effectiveMicListening
+        ? [{
+            key: 'mode',
+            icon: willCancel ? 'create-outline' : 'send-outline',
+            label: listeningLabel,
+            active: true,
+          }]
+        : [{
+            key: 'mode',
+            icon: 'mic-outline',
+            label: 'Push to talk',
+          }],
+      accessibilityLabel: effectiveMicListening ? 'Voice input listening' : 'Voice input hold to talk',
+      accessibilityHint: effectiveMicListening
+        ? (willCancel ? 'Release to edit dictated text before sending.' : 'Release to send your dictated message.')
+        : 'Press and hold to dictate your message.',
+    };
+  }
+
+  const micIndicator = createMicStateIndicator(effectiveMicListening);
+  const countdownIndicator: MicControlIndicator | null = hasPendingHandsFreeSend
+    ? {
+        key: 'countdown',
+        icon: 'time-outline',
+        label: `${handsFreeCountdownSeconds}s`,
+        active: true,
+      }
+    : null;
+  const trimmedWakePhrase = wakePhrase.trim();
+
+  switch (displayPhase) {
+    case 'sleeping':
+      return {
+        icon: 'moon-outline',
+        label: 'Wake',
+        status: trimmedWakePhrase
+          ? `Sleeping. Tap Wake or say "${trimmedWakePhrase}".`
+          : 'Sleeping. Tap Wake to listen.',
+        tone: 'idle',
+        busy: false,
+        indicators: [micIndicator, { key: 'sleep', icon: 'moon-outline', label: 'Sleeping' }],
+        accessibilityLabel: 'Hands-free sleeping',
+        accessibilityHint: 'Double tap to wake hands-free listening.',
+      };
+    case 'waking':
+      return {
+        icon: 'radio-outline',
+        label: 'Waking',
+        status: 'Starting listener.',
+        tone: 'active',
+        busy: true,
+        indicators: [micIndicator, { key: 'wake', icon: 'radio-outline', label: 'Wake heard', active: true }],
+        accessibilityLabel: 'Hands-free waking',
+        accessibilityHint: 'Hands-free is starting. Double tap to pause.',
+      };
+    case 'listening':
+      return {
+        icon: 'ear-outline',
+        label: 'Listening',
+        status: hasPendingHandsFreeSend
+          ? `Auto-sending in ${handsFreeCountdownSeconds}s. Tap to pause.`
+          : 'Listening for your request.',
+        tone: 'active',
+        busy: true,
+        indicators: [
+          micIndicator,
+          { key: 'send-mode', icon: 'send-outline', label: 'Auto-send', active: true },
+          ...(countdownIndicator ? [countdownIndicator] : []),
+        ],
+        accessibilityLabel: hasPendingHandsFreeSend
+          ? `Hands-free listening, sending in ${handsFreeCountdownSeconds} seconds`
+          : 'Hands-free listening',
+        accessibilityHint: hasPendingHandsFreeSend
+          ? 'Double tap to pause hands-free before the automatic send.'
+          : 'Double tap to pause hands-free listening.',
+      };
+    case 'processing':
+      return {
+        icon: 'sync-outline',
+        label: 'Processing',
+        status: 'Agent is working. Mic stays ready for stop commands.',
+        tone: 'active',
+        busy: true,
+        indicators: [micIndicator, { key: 'agent', icon: 'sync-outline', label: 'Agent working', active: true }],
+        accessibilityLabel: 'Hands-free processing',
+        accessibilityHint: 'Double tap to pause hands-free.',
+      };
+    case 'speaking':
+      return {
+        icon: 'volume-high-outline',
+        label: 'Speaking',
+        status: 'TTS playing. Say stop to interrupt.',
+        tone: 'active',
+        busy: true,
+        indicators: [micIndicator, { key: 'tts', icon: 'volume-high-outline', label: 'TTS playing', active: true }],
+        accessibilityLabel: 'Hands-free speaking',
+        accessibilityHint: 'Say stop to interrupt text to speech, or double tap to pause hands-free.',
+      };
+    case 'paused':
+      return {
+        icon: 'pause-outline',
+        label: 'Resume',
+        status: 'Hands-free paused. Tap to resume.',
+        tone: 'idle',
+        busy: false,
+        indicators: [micIndicator, { key: 'paused', icon: 'pause-outline', label: 'Paused' }],
+        accessibilityLabel: 'Hands-free paused',
+        accessibilityHint: 'Double tap to resume hands-free listening.',
+      };
+    case 'error':
+      return {
+        icon: 'warning-outline',
+        label: 'Retry voice',
+        status: compactVoiceStatus(lastError, 'Voice error. Tap to retry.'),
+        tone: 'danger',
+        busy: false,
+        indicators: [micIndicator, { key: 'error', icon: 'warning-outline', label: 'Needs retry', warning: true }],
+        accessibilityLabel: 'Hands-free voice error',
+        accessibilityHint: 'Double tap to retry hands-free listening.',
+      };
+    case 'off':
+    default:
+      return {
+        icon: 'mic-outline',
+        label: 'Hold',
+        status: 'Hold to speak. Release to send.',
+        tone: 'idle',
+        busy: false,
+        indicators: [{ key: 'mode', icon: 'mic-outline', label: 'Push to talk' }],
+        accessibilityLabel: 'Voice input hold to talk',
+        accessibilityHint: 'Press and hold to dictate your message.',
+      };
+  }
+}
 
 function isHandsFreeDebugForcedInDev(): boolean {
   if (!__DEV__ || Platform.OS !== 'web') return false;
@@ -1123,6 +1325,21 @@ export default function ChatScreen({ route, navigation }: any) {
   useEffect(() => {
     currentSessionIdRef.current = sessionStore.currentSessionId;
   }, [sessionStore.currentSessionId]);
+  const sessionListRef = useRef(sessionStore.sessions);
+  useEffect(() => {
+    sessionListRef.current = sessionStore.sessions;
+  }, [sessionStore.sessions]);
+  const serverGeneratedTitleRefreshJobsRef = useRef<Map<string, ServerGeneratedTitleRefreshJob>>(new Map());
+
+  useEffect(() => () => {
+    for (const job of serverGeneratedTitleRefreshJobsRef.current.values()) {
+      job.cancelled = true;
+      if (job.timer) {
+        clearTimeout(job.timer);
+      }
+    }
+    serverGeneratedTitleRefreshJobsRef.current.clear();
+  }, []);
 
   // Get or create a connection for the current session using the connection manager
   // This preserves connections when switching between sessions (fixes #608)
@@ -1426,6 +1643,7 @@ export default function ChatScreen({ route, navigation }: any) {
   const lastHandsFreeAudioCuePhaseRef = useRef<HandsFreePhase | null>(null);
   const lastHandsFreeSessionReadyCueAtRef = useRef(0);
   const lastHandsFreePreviewSubmittedCueAtRef = useRef(0);
+  const lastForegroundHandsFreeAutoStartAtRef = useRef(0);
   useEffect(() => { messagesRef.current = messages; }, [messages]);
 	// Stable ref to the latest send() to avoid stale closures in speech callbacks
 	const sendRef = useRef<(text: string, options?: { fromComposer?: boolean; source?: 'handsfree' }) => Promise<void>>(async () => {});
@@ -1657,22 +1875,15 @@ export default function ChatScreen({ route, navigation }: any) {
     || isAssistantAudioSpeaking;
   const shouldKeepHandsFreeMicArmed = handsFreeController.shouldKeepRecognizerActive;
   const isAgentRunningInHeader = conversationState === 'running' || responding;
-  const headerHandsFreePhase: HandsFreePhase | 'off' = handsFree
-    ? (isAssistantAudioLoading ? 'processing' : handsFreeController.state.phase)
+  const handsFreeDisplayPhase: HandsFreeDisplayPhase = handsFree
+    ? (
+        isAssistantAudioLoading
+          ? 'processing'
+          : isAssistantAudioSpeaking
+            ? 'speaking'
+            : handsFreeController.state.phase
+      )
     : 'off';
-  const headerHandsFreeIcon = ({
-    off: 'mic-off-outline',
-    sleeping: 'moon-outline',
-    waking: 'radio-outline',
-    listening: 'ear-outline',
-    processing: 'sync-outline',
-    speaking: 'volume-high-outline',
-    paused: 'pause-outline',
-    error: 'warning-outline',
-  } as const)[headerHandsFreePhase];
-  const headerHandsFreeLabel = headerHandsFreePhase === 'off'
-    ? 'Hands-free off'
-    : `Hands-free ${headerHandsFreePhase}`;
 
   useLayoutEffect(() => {
     navigation?.setOptions?.({
@@ -1704,29 +1915,6 @@ export default function ChatScreen({ route, navigation }: any) {
           >
             <Text style={{ fontSize: 20, color: theme.colors.foreground }}>←</Text>
           </TouchableOpacity>
-          <TouchableOpacity
-            onPress={openChatMenu}
-            accessibilityRole="button"
-            accessibilityLabel={headerHandsFreeLabel}
-            accessibilityHint="Opens the voice menu for hands-free status and controls."
-            style={[
-              styles.headerVoiceStatusButton,
-              handsFree && styles.headerVoiceStatusButtonActive,
-              headerHandsFreePhase === 'error' && styles.headerVoiceStatusButtonError,
-            ]}
-          >
-            <Ionicons
-              name={headerHandsFreeIcon}
-              size={18}
-              color={
-                headerHandsFreePhase === 'error'
-                  ? theme.colors.danger
-                  : handsFree
-                    ? theme.colors.primary
-                    : theme.colors.mutedForeground
-              }
-            />
-          </TouchableOpacity>
         </View>
       ),
       headerRight: () => (
@@ -1747,14 +1935,9 @@ export default function ChatScreen({ route, navigation }: any) {
     currentSession?.title,
     globalTtsPlayback,
     handleOpenGlobalTtsSession,
-    handsFree,
-    headerHandsFreeIcon,
-    headerHandsFreeLabel,
-    headerHandsFreePhase,
     navigation,
     openChatMenu,
     styles,
-    theme.colors.danger,
     theme.colors.foreground,
   ]);
 
@@ -1875,15 +2058,71 @@ export default function ChatScreen({ route, navigation }: any) {
       return;
     }
 
-    SERVER_GENERATED_TITLE_REFRESH_DELAYS_MS.forEach((delayMs, index) => {
-      setTimeout(() => {
+    const refreshKey = `${sessionId}:${serverConversationId}`;
+    const existingJob = serverGeneratedTitleRefreshJobsRef.current.get(refreshKey);
+    if (existingJob) {
+      existingJob.cancelled = true;
+      if (existingJob.timer) {
+        clearTimeout(existingJob.timer);
+      }
+      serverGeneratedTitleRefreshJobsRef.current.delete(refreshKey);
+    }
+
+    const getTargetSession = () => (
+      sessionListRef.current.find(session => session.id === sessionId)
+    );
+    const shouldContinue = () => (
+      canRefreshServerGeneratedSessionTitle(getTargetSession(), serverConversationId)
+    );
+    if (!shouldContinue()) {
+      return;
+    }
+
+    const job: ServerGeneratedTitleRefreshJob = { cancelled: false, timer: null };
+    serverGeneratedTitleRefreshJobsRef.current.set(refreshKey, job);
+    let attemptIndex = 0;
+
+    const finish = () => {
+      job.cancelled = true;
+      if (job.timer) {
+        clearTimeout(job.timer);
+        job.timer = null;
+      }
+      if (serverGeneratedTitleRefreshJobsRef.current.get(refreshKey) === job) {
+        serverGeneratedTitleRefreshJobsRef.current.delete(refreshKey);
+      }
+    };
+
+    const scheduleNextAttempt = () => {
+      if (job.cancelled) return;
+      if (!shouldContinue()) {
+        finish();
+        return;
+      }
+
+      const delayMs = SERVER_GENERATED_TITLE_REFRESH_DELAYS_MS[attemptIndex];
+      if (delayMs === undefined) {
+        finish();
+        return;
+      }
+
+      const attempt = attemptIndex + 1;
+      attemptIndex += 1;
+      job.timer = setTimeout(() => {
+        job.timer = null;
         void (async () => {
+          if (job.cancelled) return;
+          if (!shouldContinue()) {
+            finish();
+            return;
+          }
+
           try {
             console.info('[ChatScreen] Refreshing server-generated conversation title.', {
               source,
               sessionId,
               serverConversationId,
-              attempt: index + 1,
+              attempt,
               delayMs,
             });
             const fullConversation = await settingsClient.getConversation(serverConversationId);
@@ -1898,19 +2137,30 @@ export default function ChatScreen({ route, navigation }: any) {
               sessionId,
               serverConversationId,
               title: fullConversation.title,
+              titleSource: fullConversation.titleSource,
               applied,
             });
+
+            if (applied || !shouldContinue()) {
+              finish();
+              return;
+            }
           } catch (error: any) {
             console.warn('[ChatScreen] Failed to refresh server-generated conversation title:', {
               source,
               sessionId,
               serverConversationId,
+              attempt,
               message: error?.message || String(error),
             });
           }
+
+          scheduleNextAttempt();
         })();
       }, delayMs);
-    });
+    };
+
+    scheduleNextAttempt();
   }, [sessionStore, settingsClient]);
 
   const ensureServerConversationForExistingFollowUp = useCallback(async (
@@ -2894,6 +3144,11 @@ export default function ChatScreen({ route, navigation }: any) {
     }
 
     if (shouldKeepHandsFreeMicArmed && !listening) {
+      const now = Date.now();
+      if (now - lastForegroundHandsFreeAutoStartAtRef.current < 1500) {
+        return;
+      }
+      lastForegroundHandsFreeAutoStartAtRef.current = now;
       void startRecording();
       return;
     }
@@ -3014,6 +3269,67 @@ export default function ChatScreen({ route, navigation }: any) {
 			}
 		};
 
+    const startExpoSpeechPlayback = (playbackReason: string): boolean => {
+      let nativeSpeechStarted = false;
+	      console.info('[DotAgentsTTS] expo speech playback requested', {
+	        reason: playbackReason,
+	        fallbackFor: playbackReason === reason ? undefined : reason,
+	        textLength: processedText.length,
+	        rate: config.ttsRate ?? 1.0,
+	        pitch: config.ttsPitch ?? 1.0,
+	        voiceConfigured: !!config.ttsVoiceId,
+	      });
+		  const speechOptions: Speech.SpeechOptions = {
+			  language: 'en-US',
+			  rate: config.ttsRate ?? 1.0,
+			  pitch: config.ttsPitch ?? 1.0,
+        onStart: () => {
+          nativeSpeechStarted = true;
+	        console.info('[DotAgentsTTS] expo speech playback started', { reason: playbackReason });
+          markAssistantSpeechStarted();
+        },
+				onDone: () => {
+					console.info('[DotAgentsTTS] expo speech playback done', { reason: playbackReason });
+					settle();
+				},
+				onError: () => {
+					console.warn('[DotAgentsTTS] expo speech playback error callback', { reason: playbackReason });
+					settle();
+				},
+				onStopped: () => {
+					console.info('[DotAgentsTTS] expo speech playback stopped callback', { reason: playbackReason });
+					settle();
+				},
+		  };
+		  if (config.ttsVoiceId) {
+			  speechOptions.voice = config.ttsVoiceId;
+		  }
+		  try {
+		    void (async () => {
+		      try {
+		        await ensureNativeTtsAudioMode();
+		        if (settled) return;
+		        Speech.speak(processedText, speechOptions);
+		      } catch {
+		        settle();
+		      }
+		    })();
+        clearSpeechWatchdog = startNativeTtsSettlementWatchdog(
+          processedText,
+          config.ttsRate ?? 1.0,
+          () => nativeSpeechStarted,
+          settle,
+          (watchdogReason) => {
+            voiceLog('tts-stopped', `Assistant speech watchdog settled (${playbackReason}, ${watchdogReason}).`);
+          },
+        );
+      } catch {
+        settle();
+        return false;
+      }
+		  return true;
+    };
+
 		if (!useAndroidServiceTts && effectiveTtsProvider === 'edge' && config.baseUrl && config.apiKey) {
 			// Edge TTS routes through the paired desktop's /v1/tts/speak.
 				console.info('[DotAgentsTTS] remote edge playback requested', {
@@ -3038,7 +3354,9 @@ export default function ChatScreen({ route, navigation }: any) {
 					},
 					onError: () => {
 						console.warn('[DotAgentsTTS] remote edge playback error callback', { reason });
-						settle();
+            if (settled) return;
+            voiceLog('tts-stopped', `Remote TTS failed; falling back to native speech (${reason}).`);
+            startExpoSpeechPlayback(`${reason} native fallback`);
 					},
 					onStopped: () => {
 						console.info('[DotAgentsTTS] remote edge playback stopped callback', { reason });
@@ -3115,63 +3433,7 @@ export default function ChatScreen({ route, navigation }: any) {
       return true;
     }
 
-    let nativeSpeechStarted = false;
-	    console.info('[DotAgentsTTS] expo speech playback requested', {
-	      reason,
-	      textLength: processedText.length,
-	      rate: config.ttsRate ?? 1.0,
-	      pitch: config.ttsPitch ?? 1.0,
-	      voiceConfigured: !!config.ttsVoiceId,
-	    });
-		const speechOptions: Speech.SpeechOptions = {
-			language: 'en-US',
-			rate: config.ttsRate ?? 1.0,
-			pitch: config.ttsPitch ?? 1.0,
-      onStart: () => {
-        nativeSpeechStarted = true;
-	        console.info('[DotAgentsTTS] expo speech playback started', { reason });
-        markAssistantSpeechStarted();
-      },
-				onDone: () => {
-					console.info('[DotAgentsTTS] expo speech playback done', { reason });
-					settle();
-				},
-				onError: () => {
-					console.warn('[DotAgentsTTS] expo speech playback error callback', { reason });
-					settle();
-				},
-				onStopped: () => {
-					console.info('[DotAgentsTTS] expo speech playback stopped callback', { reason });
-					settle();
-				},
-		};
-		if (config.ttsVoiceId) {
-			speechOptions.voice = config.ttsVoiceId;
-		}
-		try {
-		  void (async () => {
-		    try {
-		      await ensureNativeTtsAudioMode();
-		      if (settled) return;
-		      Speech.speak(processedText, speechOptions);
-		    } catch {
-		      settle();
-		    }
-		  })();
-      clearSpeechWatchdog = startNativeTtsSettlementWatchdog(
-        processedText,
-        config.ttsRate ?? 1.0,
-        () => nativeSpeechStarted,
-        settle,
-        (watchdogReason) => {
-          voiceLog('tts-stopped', `Assistant speech watchdog settled (${reason}, ${watchdogReason}).`);
-        },
-      );
-    } catch {
-      settle();
-      return false;
-    }
-		return true;
+    return startExpoSpeechPlayback(reason);
 			  }, [androidBackgroundHandsFree, androidHandsFreeServiceAvailable, config.apiKey, config.baseUrl, config.ttsPitch, config.ttsRate, config.ttsVoiceId, effectiveEdgeTtsRate, effectiveEdgeTtsVoice, effectiveTtsProvider, handsFree, handsFreeController, invalidateHandsFreeCapture, playHandsFreeCue, sessionStore, stableHandsFreeForeground, voiceLog]);
 
 	  const syncResponseHistoryRefs = useCallback((events: AgentUserResponseEvent[]) => {
@@ -3324,6 +3586,13 @@ export default function ChatScreen({ route, navigation }: any) {
       messageIndex: index,
       text: processedText,
     });
+    const isCurrentMessagePlayback = () => getGlobalTtsPlayback()?.id === playbackId;
+    const clearStaleMessagePlaybackState = () => {
+      if (intendedSpeakingIndexRef.current === index) {
+        intendedSpeakingIndexRef.current = null;
+      }
+      setSpeakingMessageIndex((current) => (current === index ? null : current));
+    };
 	    if (handsFree) {
 	      handsFreeController.onSpeechStarted();
 	      voiceLog('tts-started', 'Assistant speech started from message playback.');
@@ -3339,6 +3608,10 @@ export default function ChatScreen({ route, navigation }: any) {
         androidHandsFreeTtsHandlersRef.current.delete(utteranceId);
         clearNativeTtsTimeout?.();
         clearNativeTtsTimeout = null;
+        if (!isCurrentMessagePlayback()) {
+          clearStaleMessagePlaybackState();
+          return;
+        }
         intendedSpeakingIndexRef.current = null;
         completeGlobalTtsPlayback(playbackId);
         if (handsFree) {
@@ -3353,6 +3626,7 @@ export default function ChatScreen({ route, navigation }: any) {
 
       androidHandsFreeTtsHandlersRef.current.set(utteranceId, {
         onStarted: () => {
+          if (!isCurrentMessagePlayback()) return;
           markGlobalTtsPlaybackSpeaking(playbackId);
         },
         onSettled: (type, message) => {
@@ -3391,6 +3665,10 @@ export default function ChatScreen({ route, navigation }: any) {
         voice: effectiveEdgeTtsVoice,
         rate: effectiveEdgeTtsRate,
         onDone: () => {
+          if (!isCurrentMessagePlayback()) {
+            clearStaleMessagePlaybackState();
+            return;
+          }
           intendedSpeakingIndexRef.current = null;
           completeGlobalTtsPlayback(playbackId);
           if (handsFree) {
@@ -3400,6 +3678,10 @@ export default function ChatScreen({ route, navigation }: any) {
           setSpeakingMessageIndex(null);
         },
         onError: () => {
+          if (!isCurrentMessagePlayback()) {
+            clearStaleMessagePlaybackState();
+            return;
+          }
           intendedSpeakingIndexRef.current = null;
           completeGlobalTtsPlayback(playbackId);
           if (handsFree) {
@@ -3409,6 +3691,10 @@ export default function ChatScreen({ route, navigation }: any) {
           setSpeakingMessageIndex(null);
         },
         onStopped: () => {
+          if (!isCurrentMessagePlayback()) {
+            clearStaleMessagePlaybackState();
+            return;
+          }
           if (intendedSpeakingIndexRef.current === null || intendedSpeakingIndexRef.current === index) {
             intendedSpeakingIndexRef.current = null;
             completeGlobalTtsPlayback(playbackId);
@@ -3421,6 +3707,7 @@ export default function ChatScreen({ route, navigation }: any) {
         },
       }).then((started) => {
         if (started) {
+          if (!isCurrentMessagePlayback()) return;
           markGlobalTtsPlaybackSpeaking(playbackId);
         }
       });
@@ -3434,10 +3721,15 @@ export default function ChatScreen({ route, navigation }: any) {
       rate: config.ttsRate ?? 1.0,
       pitch: config.ttsPitch ?? 1.0,
       onStart: () => {
+        if (!isCurrentMessagePlayback()) return;
         nativeSpeechStarted = true;
         markGlobalTtsPlaybackSpeaking(playbackId);
       },
       onDone: () => {
+        if (!isCurrentMessagePlayback()) {
+          clearStaleMessagePlaybackState();
+          return;
+        }
         clearSpeechWatchdog?.();
         clearSpeechWatchdog = null;
         intendedSpeakingIndexRef.current = null;
@@ -3449,6 +3741,10 @@ export default function ChatScreen({ route, navigation }: any) {
         setSpeakingMessageIndex(null);
       },
       onError: () => {
+        if (!isCurrentMessagePlayback()) {
+          clearStaleMessagePlaybackState();
+          return;
+        }
         clearSpeechWatchdog?.();
         clearSpeechWatchdog = null;
         intendedSpeakingIndexRef.current = null;
@@ -3460,6 +3756,10 @@ export default function ChatScreen({ route, navigation }: any) {
         setSpeakingMessageIndex(null);
       },
       onStopped: () => {
+        if (!isCurrentMessagePlayback()) {
+          clearStaleMessagePlaybackState();
+          return;
+        }
         // Only clear if this callback is for the current intended message,
         // not a stale callback from a previously stopped utterance
         if (intendedSpeakingIndexRef.current === null || intendedSpeakingIndexRef.current === index) {
@@ -5427,19 +5727,14 @@ export default function ChatScreen({ route, navigation }: any) {
 	const effectiveMicListening = handsFree
 		? (androidBackgroundHandsFree ? shouldKeepHandsFreeMicArmed : listening)
 		: listening;
-	const composerAccessibilityHint = createChatComposerAccessibilityHint({
-	  handsFree,
-	  listening: effectiveMicListening,
-	  isWeb: isWebPlatform,
-	});
-	const micControlAccessibilityHint = createMicControlAccessibilityHint({
-	  handsFree,
-	  listening: effectiveMicListening,
-	  willCancel,
-	});
-	const voiceInputLiveRegionAnnouncement = createVoiceInputLiveRegionAnnouncement({
-	  listening: effectiveMicListening,
-	  handsFree,
+		const composerAccessibilityHint = createChatComposerAccessibilityHint({
+		  handsFree,
+		  listening: effectiveMicListening,
+		  isWeb: isWebPlatform,
+		});
+		const voiceInputLiveRegionAnnouncement = createVoiceInputLiveRegionAnnouncement({
+		  listening: effectiveMicListening,
+		  handsFree,
 	  willCancel,
 	  liveTranscript,
 		  sttPreview,
@@ -5718,13 +6013,23 @@ export default function ChatScreen({ route, navigation }: any) {
 			: 'Tap mic to wake handsfree or type a message')
 		: (listening ? 'Listening…' : 'Type or hold mic');
 
-	const micButtonLabel = handsFree
-			? (handsFreeController.state.phase === 'sleeping'
-				? 'Wake'
-				: handsFreeController.state.phase === 'paused'
-					? 'Resume'
-					: 'Stop Listening')
-		: (listening ? '...' : 'Hold');
+  const micControlVisual = createMicControlVisual({
+    handsFree,
+    displayPhase: handsFreeDisplayPhase,
+    effectiveMicListening,
+    hasPendingHandsFreeSend,
+    handsFreeCountdownSeconds,
+    willCancel,
+    wakePhrase: handsFreeWakePhrase,
+    lastError: handsFreeController.state.lastError,
+  });
+  const micControlActive = micControlVisual.tone === 'active';
+  const micControlDanger = micControlVisual.tone === 'danger';
+  const micControlForeground = micControlActive
+    ? theme.colors.primaryForeground
+    : micControlDanger
+      ? theme.colors.danger
+      : theme.colors.mutedForeground;
   const isMessageQueuePaused = handsFree && handsFreeController.state.phase === 'paused';
 
   const firstVisibleMessageIndex = Math.max(0, messages.length - visibleMessageCount);
@@ -6821,17 +7126,27 @@ export default function ChatScreen({ route, navigation }: any) {
 	                {voiceInputLiveRegionAnnouncement}
 	              </Text>
 	            )}
-		            <TouchableOpacity
-	              style={[styles.sendButton, !composerHasContent && styles.sendButtonDisabled]}
+            <TouchableOpacity
+	              style={[styles.sendButton, !composerHasContent && !hasPendingHandsFreeSend && styles.sendButtonDisabled]}
 	              onPress={sendComposerInput}
 	              activeOpacity={0.7}
 	              disabled={!composerHasContent}
               accessibilityRole="button"
-              accessibilityLabel={createButtonAccessibilityLabel('Send message')}
-	              accessibilityHint="Sends your typed text and any attached images to the selected agent."
+              accessibilityLabel={createButtonAccessibilityLabel(
+                hasPendingHandsFreeSend
+                  ? `Handsfree sending in ${handsFreeCountdownSeconds} seconds`
+                  : 'Send message',
+              )}
+	              accessibilityHint={hasPendingHandsFreeSend
+                  ? 'Shows the remaining handsfree auto-send countdown.'
+                  : 'Sends your typed text and any attached images to the selected agent.'}
               accessibilityState={{ disabled: !composerHasContent }}
 	            >
-              <Ionicons name="send-outline" size={18} color={theme.colors.primaryForeground} />
+              {hasPendingHandsFreeSend ? (
+                <Text style={styles.sendButtonCountdownText}>{handsFreeCountdownSeconds}s</Text>
+              ) : (
+                <Ionicons name="send-outline" size={18} color={theme.colors.primaryForeground} />
+              )}
             </TouchableOpacity>
           </View>
           {/* Large mic button - ~20% of screen height */}
@@ -6842,30 +7157,87 @@ export default function ChatScreen({ route, navigation }: any) {
             <Pressable
               style={[
                 styles.mic,
-                effectiveMicListening && styles.micOn,
+                micControlActive && styles.micOn,
+                micControlDanger && styles.micDanger,
                 // @ts-ignore - Web-only CSS to disable long-press selection/callouts
                 Platform.OS === 'web' && { userSelect: 'none', WebkitUserSelect: 'none', WebkitTouchCallout: 'none', touchAction: 'manipulation' },
               ]}
               accessibilityRole="button"
-              accessibilityLabel={createMicControlAccessibilityLabel()}
-              accessibilityHint={micControlAccessibilityHint}
-              accessibilityState={{ busy: effectiveMicListening }}
-              aria-busy={effectiveMicListening}
+              accessibilityLabel={micControlVisual.accessibilityLabel}
+              accessibilityHint={micControlVisual.accessibilityHint}
+              accessibilityState={{ busy: micControlVisual.busy }}
+              aria-busy={micControlVisual.busy}
               onLongPress={undefined}
-	              onPressIn={handsFree && isWebPlatform ? handleHandsFreePrimaryControl : (!handsFree ? handlePushToTalkPressIn : undefined)}
-	              onPressOut={!handsFree ? handlePushToTalkPressOut : undefined}
-	              onPress={handsFree && !isWebPlatform ? handleHandsFreePrimaryControl : undefined}
+              onPressIn={handsFree && isWebPlatform ? handleHandsFreePrimaryControl : (!handsFree ? handlePushToTalkPressIn : undefined)}
+              onPressOut={!handsFree ? handlePushToTalkPressOut : undefined}
+              onPress={handsFree && !isWebPlatform ? handleHandsFreePrimaryControl : undefined}
             >
               <View style={styles.micContent}>
                 <View style={styles.micTitleRow}>
                   <Ionicons
-                    name={effectiveMicListening ? 'mic' : 'mic-outline'}
+                    name={micControlVisual.icon}
                     size={20}
-                    color={effectiveMicListening ? theme.colors.primaryForeground : theme.colors.mutedForeground}
+                    color={micControlForeground}
                   />
-                  <Text style={[styles.micLabel, effectiveMicListening && styles.micLabelOn]} selectable={false}>
-		                {micButtonLabel}
+                  <Text
+                    style={[
+                      styles.micLabel,
+                      micControlActive && styles.micLabelOn,
+                      micControlDanger && styles.micLabelDanger,
+                    ]}
+                    selectable={false}
+                  >
+                    {micControlVisual.label}
                   </Text>
+                </View>
+                <Text
+                  style={[
+                    styles.micStatusText,
+                    micControlActive && styles.micStatusTextOn,
+                    micControlDanger && styles.micStatusTextDanger,
+                  ]}
+                  numberOfLines={2}
+                  selectable={false}
+                >
+                  {micControlVisual.status}
+                </Text>
+                <View style={styles.micIndicatorRow}>
+                  {micControlVisual.indicators.map((indicator) => {
+                    const indicatorWarning = micControlDanger || indicator.warning;
+                    const indicatorEmphasized = micControlActive || indicator.active;
+                    const indicatorColor = micControlActive
+                      ? theme.colors.primaryForeground
+                      : indicatorWarning
+                        ? theme.colors.danger
+                        : indicator.active
+                          ? theme.colors.primary
+                          : theme.colors.mutedForeground;
+                    return (
+                      <View
+                        key={indicator.key}
+                        style={[
+                          styles.micIndicatorPill,
+                          micControlActive && styles.micIndicatorPillOn,
+                          indicator.active && !micControlActive && styles.micIndicatorPillActive,
+                          indicatorWarning && !micControlActive && styles.micIndicatorPillWarning,
+                        ]}
+                      >
+                        <Ionicons name={indicator.icon} size={12} color={indicatorColor} />
+                        <Text
+                          style={[
+                            styles.micIndicatorText,
+                            indicatorEmphasized && styles.micIndicatorTextActive,
+                            micControlActive && styles.micIndicatorTextOn,
+                            indicatorWarning && !micControlActive && styles.micIndicatorTextWarning,
+                          ]}
+                          numberOfLines={1}
+                          selectable={false}
+                        >
+                          {indicator.label}
+                        </Text>
+                      </View>
+                    );
+                  })}
                 </View>
               </View>
             </Pressable>
@@ -7192,23 +7564,6 @@ function createStyles(theme: Theme, screenHeight: number, isDark: boolean) {
     },
     headerActionButton,
     headerEdgeActionButton,
-    headerVoiceStatusButton: {
-      ...createMinimumTouchTargetStyle({ horizontalPadding: 10, verticalPadding: 8 }),
-      borderRadius: radius.lg,
-      borderWidth: 1,
-      borderColor: theme.colors.border,
-      backgroundColor: theme.colors.background,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    headerVoiceStatusButtonActive: {
-      borderColor: theme.colors.primary,
-      backgroundColor: theme.colors.primary + '18',
-    },
-    headerVoiceStatusButtonError: {
-      borderColor: theme.colors.danger,
-      backgroundColor: hexToRgba(theme.colors.danger, 0.12),
-    },
     loadOlderContainer: {
       alignItems: 'center',
       paddingVertical: spacing.xs,
@@ -7778,14 +8133,13 @@ function createStyles(theme: Theme, screenHeight: number, isDark: boolean) {
     },
     mic: {
       width: '100%' as any,
-      minHeight: 64,
-      flexDirection: 'row',
+      minHeight: 94,
       borderRadius: radius.lg,
       borderWidth: 1.5,
       borderColor: theme.colors.border,
       backgroundColor: theme.colors.card,
-      alignItems: 'center',
-      justifyContent: 'space-between',
+      alignItems: 'stretch',
+      justifyContent: 'center',
       gap: spacing.sm,
       paddingHorizontal: spacing.md,
       paddingVertical: spacing.sm,
@@ -7794,7 +8148,7 @@ function createStyles(theme: Theme, screenHeight: number, isDark: boolean) {
       flex: 1,
       minWidth: 0,
       alignItems: 'center',
-      gap: 2,
+      gap: 6,
     },
     micTitleRow: {
       flexDirection: 'row',
@@ -7806,16 +8160,78 @@ function createStyles(theme: Theme, screenHeight: number, isDark: boolean) {
       backgroundColor: theme.colors.primary,
       borderColor: theme.colors.primary,
     },
-    micText: {
-      fontSize: 20,
+    micDanger: {
+      backgroundColor: hexToRgba(theme.colors.danger, 0.12),
+      borderColor: theme.colors.danger,
     },
     micLabel: {
-      fontSize: 15,
+      fontSize: 16,
       color: theme.colors.mutedForeground,
-      fontWeight: '600',
+      fontWeight: '700',
     },
     micLabelOn: {
       color: theme.colors.primaryForeground,
+    },
+    micLabelDanger: {
+      color: theme.colors.danger,
+    },
+    micStatusText: {
+      color: theme.colors.mutedForeground,
+      fontSize: 12,
+      lineHeight: 16,
+      fontWeight: '500',
+      textAlign: 'center',
+    },
+    micStatusTextOn: {
+      color: hexToRgba(theme.colors.primaryForeground, 0.84),
+    },
+    micStatusTextDanger: {
+      color: theme.colors.danger,
+    },
+    micIndicatorRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexWrap: 'wrap',
+      gap: 6,
+    },
+    micIndicatorPill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      borderRadius: radius.full,
+      borderWidth: 1,
+      borderColor: theme.colors.border,
+      backgroundColor: theme.colors.background,
+      paddingHorizontal: 8,
+      paddingVertical: 3,
+      maxWidth: '100%' as any,
+    },
+    micIndicatorPillActive: {
+      borderColor: hexToRgba(theme.colors.primary, 0.45),
+      backgroundColor: hexToRgba(theme.colors.primary, 0.12),
+    },
+    micIndicatorPillOn: {
+      borderColor: hexToRgba(theme.colors.primaryForeground, 0.34),
+      backgroundColor: hexToRgba(theme.colors.primaryForeground, 0.14),
+    },
+    micIndicatorPillWarning: {
+      borderColor: hexToRgba(theme.colors.danger, 0.45),
+      backgroundColor: hexToRgba(theme.colors.danger, 0.1),
+    },
+    micIndicatorText: {
+      color: theme.colors.mutedForeground,
+      fontSize: 11,
+      fontWeight: '600',
+    },
+    micIndicatorTextActive: {
+      color: theme.colors.primary,
+    },
+    micIndicatorTextOn: {
+      color: theme.colors.primaryForeground,
+    },
+    micIndicatorTextWarning: {
+      color: theme.colors.danger,
     },
     ttsToggle: {
 	      width: 44,
@@ -7853,6 +8269,12 @@ function createStyles(theme: Theme, screenHeight: number, isDark: boolean) {
       color: theme.colors.primaryForeground,
       fontWeight: '600',
       fontSize: 13,
+    },
+    sendButtonCountdownText: {
+      color: theme.colors.primaryForeground,
+      fontWeight: '700',
+      fontSize: 13,
+      fontVariant: ['tabular-nums'],
     },
     debugInfo: {
       backgroundColor: theme.colors.muted,

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -413,6 +413,8 @@ type AndroidHandsFreeTtsHandler = {
   onSettled: (type: AndroidHandsFreeTtsSettleType, message?: string) => void;
 };
 
+const STALE_HANDS_FREE_TTS_RECOVERY_MS = 15000;
+
 const createAndroidHandsFreeTtsUtteranceId = () =>
   `handsfree-tts-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
@@ -1761,14 +1763,46 @@ export default function ChatScreen({ route, navigation }: any) {
     && isAssistantAudioPendingOrSpeaking;
   const shouldSuppressHandsFreeTranscriptRef = useRef(shouldSuppressHandsFreeTranscript);
   shouldSuppressHandsFreeTranscriptRef.current = shouldSuppressHandsFreeTranscript;
-  const isHandsFreeTranscriptSuppressedNow = useCallback(() => (
-    handsFreeRef.current
-    && (
+  const recoverStaleHandsFreeTtsIfNeeded = useCallback((reason: string) => {
+    if (!handsFreeRef.current) return false;
+    const playback = getGlobalTtsPlayback();
+    const phase = handsFreePhaseRef.current;
+    const playbackAgeMs = playback ? Date.now() - playback.startedAt : null;
+    const stalePlayback =
+      !!playback
+      && playback.status === 'speaking'
+      && playbackAgeMs !== null
+      && playbackAgeMs > STALE_HANDS_FREE_TTS_RECOVERY_MS;
+    const staleControllerSpeech = phase === 'speaking' && !playback;
+    if (!stalePlayback && !staleControllerSpeech) {
+      return false;
+    }
+
+    stopGlobalTtsPlayback();
+    if (phase === 'speaking') {
+      handsFreeController.onSpeechFinished();
+    }
+    voiceLog('tts-stopped', 'Recovered stale handsfree TTS state.', {
+      reason,
+      phase,
+      playbackStatus: playback?.status,
+      playbackAgeMs,
+      playbackSource: playback?.source,
+      textPreview: playback?.textPreview,
+    });
+    return true;
+  }, [handsFreeController.onSpeechFinished, voiceLog]);
+  const isHandsFreeTranscriptSuppressedNow = useCallback(() => {
+    if (!handsFreeRef.current) return false;
+    if (recoverStaleHandsFreeTtsIfNeeded('transcript-suppression-check')) {
+      return false;
+    }
+    return (
       shouldSuppressHandsFreeTranscriptRef.current
       || !!getGlobalTtsPlayback()
       || handsFreePhaseRef.current === 'speaking'
-    )
-  ), []);
+    );
+  }, [recoverStaleHandsFreeTtsIfNeeded]);
   const isHandsFreeFinalizationEligibleNow = useCallback(() => (
     !handsFreeRef.current
     || handsFreePhaseRef.current === 'waking'

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -141,6 +141,7 @@ const MESSAGE_COPY_FEEDBACK_RESET_MS = 2_000;
 const HANDS_FREE_DEBUG_STORAGE_KEY = 'dotagents:handsfree-debug';
 const ANDROID_HANDS_FREE_DUPLICATE_SUPPRESSION_MS = 3_000;
 const HANDS_FREE_FINALIZED_DUPLICATE_SUPPRESSION_MS = 3_000;
+const HANDS_FREE_ACCEPTED_CONTROL_PREVIEW_SUPPRESSION_MS = 3_000;
 const ANDROID_HANDS_FREE_FOREGROUND_HANDOFF_DELAY_MS = 1_500;
 const HANDS_FREE_KEEP_AWAKE_TAG = 'dotagents-handsfree';
 const HANDS_FREE_TTS_BARGE_IN_DUPLICATE_SUPPRESSION_MS = 1_200;
@@ -1653,6 +1654,7 @@ export default function ChatScreen({ route, navigation }: any) {
   const androidHandsFreeLastSentRef = useRef<{ text: string; timestamp: number } | null>(null);
   const handsFreeLastFinalizedRef = useRef<{ text: string; timestamp: number } | null>(null);
   const voicePreviewComposerTextRef = useRef('');
+  const acceptedHandsFreeControlPreviewRef = useRef<{ text: string; timestamp: number } | null>(null);
 		  const [input, setInput] = useState('');
 	  const [pendingImages, setPendingImages] = useState<PendingImageAttachment[]>([]);
 	  const inputRef = useRef<TextInput>(null);
@@ -1992,19 +1994,64 @@ export default function ChatScreen({ route, navigation }: any) {
     || handsFreePhaseRef.current === 'waking'
     || handsFreePhaseRef.current === 'listening'
   ), []);
-  const shouldImmediatelyFinalizeHandsFreeTranscript = useCallback(({
-    text,
-  }: {
-    text: string;
-    source: 'native' | 'web';
-    isFinal?: boolean;
-  }) => {
+  const isExactSleepingWakeTranscript = useCallback((text: string) => {
     if (!handsFreeRef.current || handsFreePhaseRef.current !== 'sleeping') {
       return false;
     }
     const wakeMatch = matchWakePhrase(text, handsFreeWakePhrase);
     return wakeMatch.matched && !wakeMatch.remainder;
   }, [handsFreeWakePhrase]);
+  const shouldImmediatelyFinalizeHandsFreeTranscript = useCallback(({
+    text,
+  }: {
+    text: string;
+    source: 'native' | 'web';
+    isFinal?: boolean;
+  }) => isExactSleepingWakeTranscript(text), [isExactSleepingWakeTranscript]);
+
+  const clearAcceptedHandsFreeControlPreview = useCallback((acceptedText: string) => {
+    const normalizedAcceptedText = normalizeVoiceText(acceptedText);
+    const previousPreviewText = voicePreviewComposerTextRef.current;
+    const normalizedPreviousPreviewText = normalizeVoiceText(previousPreviewText);
+    const textToRemove = normalizedPreviousPreviewText || normalizedAcceptedText;
+
+    if (normalizedAcceptedText) {
+      acceptedHandsFreeControlPreviewRef.current = {
+        text: normalizedAcceptedText,
+        timestamp: Date.now(),
+      };
+    }
+
+    voicePreviewComposerTextRef.current = '';
+    setSttPreviewWithExpiry('');
+    setInput((current) => {
+      const normalizedCurrent = normalizeVoiceText(current);
+
+      if (!normalizedCurrent) {
+        return current;
+      }
+
+      if (
+        normalizedCurrent === normalizedAcceptedText
+        || (normalizedPreviousPreviewText && normalizedCurrent === normalizedPreviousPreviewText)
+      ) {
+        return '';
+      }
+
+      if (textToRemove && current.endsWith(textToRemove)) {
+        return current.slice(0, -textToRemove.length).trimEnd();
+      }
+
+      if (previousPreviewText && current.endsWith(previousPreviewText)) {
+        return current.slice(0, -previousPreviewText.length).trimEnd();
+      }
+
+      return current;
+    });
+    voiceLog('runtime-state', 'Accepted handsfree wake phrase cleared from composer preview.', {
+      textLength: normalizedAcceptedText.length,
+    });
+  }, [voiceLog]);
 
   const playHandsFreeCue = useCallback((cue: HandsFreeAudioCue) => {
     if (!handsFreeRef.current) {
@@ -2563,9 +2610,11 @@ export default function ChatScreen({ route, navigation }: any) {
 
     if (mode === 'handsfree') {
       if (handsFreeRef.current) {
+        const acceptedWakeControlText = isExactSleepingWakeTranscript(finalText);
+        const phaseBeforeFinalTranscript = handsFreePhaseRef.current;
         const action = handsFreeController.handleFinalTranscript(finalText);
         console.info(
-          `[DotAgentsHandsFreeJS] controller action=${action.type} phaseBefore=${handsFreePhaseRef.current} textLength=${finalText.length}`,
+          `[DotAgentsHandsFreeJS] controller action=${action.type} phaseBefore=${phaseBeforeFinalTranscript} textLength=${finalText.length}`,
         );
         if (action.type === 'send') {
           voicePreviewComposerTextRef.current = '';
@@ -2577,6 +2626,8 @@ export default function ChatScreen({ route, navigation }: any) {
           setInput('');
           setSttPreviewWithExpiry('');
           handleHandsFreeVoiceCommand(action.command, action.label, action.remainder);
+        } else if (acceptedWakeControlText) {
+          clearAcceptedHandsFreeControlPreview(finalText);
         }
         return;
       }
@@ -2584,6 +2635,7 @@ export default function ChatScreen({ route, navigation }: any) {
 
     void sendRef.current(finalText);
   }, [
+    clearAcceptedHandsFreeControlPreview,
     handleHandsFreeTtsBargeInCommand,
     handleHandsFreeVoiceCommand,
     handsFreeController.handleFinalTranscript,
@@ -2591,6 +2643,7 @@ export default function ChatScreen({ route, navigation }: any) {
     hasLiveAgentTurn,
     isHandsFreeFinalizationEligibleNow,
     isHandsFreeTranscriptSuppressedNow,
+    isExactSleepingWakeTranscript,
     voiceLog,
   ]);
 
@@ -2849,8 +2902,22 @@ export default function ChatScreen({ route, navigation }: any) {
     if (!handsFree || !previewText) {
       if (!previewText) {
         voicePreviewComposerTextRef.current = '';
+        acceptedHandsFreeControlPreviewRef.current = null;
       }
       return;
+    }
+
+    const acceptedControlPreview = acceptedHandsFreeControlPreviewRef.current;
+    if (acceptedControlPreview) {
+      const acceptedControlPreviewExpired =
+        Date.now() - acceptedControlPreview.timestamp > HANDS_FREE_ACCEPTED_CONTROL_PREVIEW_SUPPRESSION_MS;
+
+      if (acceptedControlPreviewExpired || acceptedControlPreview.text !== previewText) {
+        acceptedHandsFreeControlPreviewRef.current = null;
+      } else {
+        voicePreviewComposerTextRef.current = '';
+        return;
+      }
     }
 
     setInput((current) => {

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -1988,6 +1988,7 @@ export default function ChatScreen({ route, navigation }: any) {
   }, [recoverStaleHandsFreeTtsIfNeeded]);
   const isHandsFreeFinalizationEligibleNow = useCallback(() => (
     !handsFreeRef.current
+    || handsFreePhaseRef.current === 'sleeping'
     || handsFreePhaseRef.current === 'waking'
     || handsFreePhaseRef.current === 'listening'
   ), []);

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -2571,7 +2571,7 @@ export default function ChatScreen({ route, navigation }: any) {
   }, [handsFree, liveTranscript, sttPreview]);
 
   const androidHandsFreeServiceListeningEnabled =
-    androidBackgroundHandsFree && shouldKeepHandsFreeMicArmed;
+    androidBackgroundHandsFree && shouldKeepHandsFreeMicArmed && !listening;
 
   useEffect(() => {
     if (!shouldSuppressHandsFreeTranscript) return;
@@ -2839,7 +2839,7 @@ export default function ChatScreen({ route, navigation }: any) {
       return;
     }
     if (!handsFreeRuntimeActive && listening) {
-      void stopRecognitionOnly();
+      void stopRecognitionOnly({ preservePendingHandsFreeFinal: true });
     }
   }, [androidBackgroundHandsFree, handsFree, handsFreeRuntimeActive, listening, stopRecognitionOnly]);
 

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -1001,7 +1001,8 @@ export default function ChatScreen({ route, navigation }: any) {
     && !stableHandsFreeForeground;
   const shouldUseAndroidHandsFreeServiceTts =
     Platform.OS === 'android'
-    && shouldRunAndroidHandsFreeService;
+    && shouldRunAndroidHandsFreeService
+    && effectiveTtsProvider === 'native';
   const shouldUseAndroidHandsFreeServiceTtsRef = useRef(shouldUseAndroidHandsFreeServiceTts);
   shouldUseAndroidHandsFreeServiceTtsRef.current = shouldUseAndroidHandsFreeServiceTts;
   const allowHandsFreeDirectSpeechWhileSleeping = Platform.OS === 'android' && androidHandsFreeServiceAvailable

--- a/apps/mobile/src/store/sessions.storage.test.ts
+++ b/apps/mobile/src/store/sessions.storage.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Session } from '../types/session';
-import { compactSessionsForStorageQuota, discardLocalEmptyDraftSessions, shouldApplyServerGeneratedSessionTitle } from './sessions';
+import {
+  canRefreshServerGeneratedSessionTitle,
+  compactSessionsForStorageQuota,
+  discardLocalEmptyDraftSessions,
+  shouldApplyServerGeneratedSessionTitle,
+} from './sessions';
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
   default: {
@@ -182,6 +187,28 @@ describe('shouldApplyServerGeneratedSessionTitle', () => {
     ).toBe(false);
   });
 
+  it('requires explicit non-fallback server provenance before replacing a local fallback', () => {
+    const session: Session = {
+      id: 'session-1',
+      title: 'what did we do today',
+      titleSource: 'local_generated',
+      createdAt: 100,
+      updatedAt: 200,
+      serverConversationId: 'conv-1',
+      messages: [
+        { id: 'm1', role: 'user', content: 'what did we do today', timestamp: 100 },
+      ],
+    };
+
+    expect(
+      shouldApplyServerGeneratedSessionTitle(
+        session,
+        'conv-1',
+        'Hands-Free Debugging Recap',
+      ),
+    ).toBe(false);
+  });
+
   it('does not infer fallback provenance from matching title text', () => {
     const session: Session = {
       id: 'session-1',
@@ -202,5 +229,29 @@ describe('shouldApplyServerGeneratedSessionTitle', () => {
         'server_generated',
       ),
     ).toBe(false);
+  });
+});
+
+describe('canRefreshServerGeneratedSessionTitle', () => {
+  it('only refreshes titles for sessions still using a fallback title source', () => {
+    const fallbackSession: Session = {
+      id: 'session-1',
+      title: 'first user message',
+      titleSource: 'local_generated',
+      createdAt: 100,
+      updatedAt: 200,
+      serverConversationId: 'conv-1',
+      messages: [],
+    };
+
+    const settledSession: Session = {
+      ...fallbackSession,
+      title: 'Server Title',
+      titleSource: 'server_generated',
+    };
+
+    expect(canRefreshServerGeneratedSessionTitle(fallbackSession, 'conv-1')).toBe(true);
+    expect(canRefreshServerGeneratedSessionTitle(settledSession, 'conv-1')).toBe(false);
+    expect(canRefreshServerGeneratedSessionTitle(fallbackSession, 'conv-other')).toBe(false);
   });
 });

--- a/apps/mobile/src/store/sessions.ts
+++ b/apps/mobile/src/store/sessions.ts
@@ -186,28 +186,6 @@ function normalizeLoadedSession(session: Session): Session {
   return { ...session, titleSource: session.title === 'New Chat' ? 'default' : 'manual' };
 }
 
-function getServerGeneratedTitleSkipReason(session: Session, title: string, titleSource?: TitleSource): string {
-  if (normalizeSessionTitleText(session.title) === normalizeSessionTitleText(title)) {
-    if (isSessionFallbackTitle(session) && titleSource && !isFallbackTitleSource(titleSource)) {
-      return 'same-title-source-upgrade';
-    }
-    return 'same-title';
-  }
-  if (getSessionTitleSource(session) === 'manual') {
-    return 'local-title-manual';
-  }
-  if (!isSessionFallbackTitle(session)) {
-    return 'local-title-not-fallback';
-  }
-  if (titleSource && isFallbackTitleSource(titleSource)) {
-    return 'server-title-source-is-fallback';
-  }
-  if (!titleSource) {
-    return 'server-title-source-missing';
-  }
-  return 'not-applicable';
-}
-
 export function shouldApplyServerGeneratedSessionTitle(session: Session, serverConversationId: string, title: string, titleSource?: TitleSource): boolean {
   const normalizedTitle = normalizeSessionTitleText(title);
   const normalizedTitleSource = isTitleSource(titleSource) ? titleSource : undefined;
@@ -222,6 +200,12 @@ export function shouldApplyServerGeneratedSessionTitle(session: Session, serverC
     && isSessionFallbackTitle(session)
     && !!normalizedTitleSource
     && !isFallbackTitleSource(normalizedTitleSource);
+}
+
+export function canRefreshServerGeneratedSessionTitle(session: Session | undefined, serverConversationId: string): boolean {
+  return !!session
+    && session.serverConversationId === serverConversationId
+    && isSessionFallbackTitle(session);
 }
 
 export function useSessions(): SessionStore {
@@ -722,20 +706,13 @@ export function useSessions(): SessionStore {
 
   const setServerGeneratedTitleForSession = useCallback(async (sessionId: string, serverConversationId: string, title: string, titleSource?: TitleSource): Promise<boolean> => {
     const normalizedTitle = normalizeSessionTitleText(title);
-    const normalizedTitleSource = isTitleSource(titleSource) ? titleSource : 'server_generated';
+    const normalizedTitleSource = isTitleSource(titleSource) ? titleSource : undefined;
     const currentSessions = sessionsRef.current;
     const currentSession = currentSessions.find(session => session.id === sessionId);
     if (!currentSession || currentSession.serverConversationId !== serverConversationId) {
       return false;
     }
     if (!shouldApplyServerGeneratedSessionTitle(currentSession, serverConversationId, normalizedTitle, normalizedTitleSource)) {
-      console.info('[sessions] Skipped server-generated title update.', {
-        sessionId,
-        serverConversationId,
-        localTitle: currentSession.title,
-        serverTitle: normalizedTitle,
-        reason: getServerGeneratedTitleSkipReason(currentSession, normalizedTitle, normalizedTitleSource),
-      });
       return false;
     }
 


### PR DESCRIPTION
## Summary
- keep Android headset hands-free routing acquired for the hands-free session instead of only foreground recognizer lifecycles
- keep the background hands-free service route held across TTS/listening transitions while releasing only capture-scoped ownership
- route Android hands-free replay/message TTS through the hands-free service when that service is active
- expand route diagnostics for adb/logcat with hasHeadset, mode, communicationDevice, routingRequested, routingActive, requesters, inputs, and outputs

Fixes #538

## Verification
- pnpm --dir apps/mobile exec tsc --noEmit
- pnpm --filter @dotagents/mobile test:vitest -- src/lib/voice/useSpeechRecognizer.test.ts src/lib/voice/useHandsFreeController.test.ts
- ./gradlew :app:compileDebugKotlin (from apps/mobile/android)

## Android test logs
Use this while testing with a headset connected:

```sh
adb logcat -s DotAgentsHandsFree ReactNativeJS
```

Expected route snapshots should keep `mode=in-communication` and `routingRequested=true` while hands-free remains enabled, including during TTS replay/playback.