### PR TITLE
[codex] Fix desktop focus jumps during agent progress

### DIFF
--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -56,6 +56,9 @@ describe("emitAgentProgress snoozed propagation", () => {
     mocks.getSession.mockReset()
     mocks.shouldStopSession.mockClear()
     mocks.getSessionRunId.mockClear()
+    mocks.mainWindow.isVisible.mockReturnValue(true)
+    mocks.mainWindow.isFocused.mockReturnValue(false)
+    mocks.panelWindow.isVisible.mockReturnValue(false)
     mocks.appState.isRecording = false
     mocks.appState.isTextInputActive = false
     mocks.appState.isAgentModeActive = false
@@ -106,7 +109,7 @@ describe("emitAgentProgress snoozed propagation", () => {
 
   it("keeps agent progress out of the panel when panel progress is disabled", async () => {
     mocks.config.floatingPanelAgentProgressEnabled = false
-    mocks.appState.isAgentModeActive = true
+    mocks.panelWindow.isVisible.mockReturnValue(true)
     mocks.isSessionSnoozed.mockReturnValue(false)
 
     await emitAgentProgress({ sessionId: "session-panel-disabled", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
@@ -120,8 +123,9 @@ describe("emitAgentProgress snoozed propagation", () => {
     expect(mocks.closeAgentModeAndHidePanelWindow).toHaveBeenCalledWith({ preserveAgentStopState: true })
   })
 
-  it("does not repeatedly clear the hidden panel when panel progress is disabled", async () => {
+  it("does not clear the hidden panel when panel progress is disabled", async () => {
     mocks.config.floatingPanelAgentProgressEnabled = false
+    mocks.appState.isAgentModeActive = true
     mocks.isSessionSnoozed.mockReturnValue(false)
 
     await emitAgentProgress({ sessionId: "session-panel-disabled-hidden", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })

--- a/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
+++ b/apps/desktop/src/main/emit-agent-progress.snoozed.test.ts
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
   getSession: vi.fn(),
   shouldStopSession: vi.fn(() => false),
   getSessionRunId: vi.fn(() => undefined),
-  appState: { isRecording: false, isTextInputActive: false },
+  appState: { isRecording: false, isTextInputActive: false, isAgentModeActive: false },
   config: { floatingPanelAutoShow: true, floatingPanelAgentProgressEnabled: true, hidePanelWhenMainFocused: true },
   mainWindow: { isVisible: vi.fn(() => true), isFocused: vi.fn(() => false), webContents: { id: "main" } },
   panelWindow: { isVisible: vi.fn(() => false), webContents: { id: "panel" } },
@@ -58,6 +58,7 @@ describe("emitAgentProgress snoozed propagation", () => {
     mocks.getSessionRunId.mockClear()
     mocks.appState.isRecording = false
     mocks.appState.isTextInputActive = false
+    mocks.appState.isAgentModeActive = false
     mocks.config.floatingPanelAutoShow = true
     mocks.config.floatingPanelAgentProgressEnabled = true
     mocks.config.hidePanelWhenMainFocused = true
@@ -105,6 +106,7 @@ describe("emitAgentProgress snoozed propagation", () => {
 
   it("keeps agent progress out of the panel when panel progress is disabled", async () => {
     mocks.config.floatingPanelAgentProgressEnabled = false
+    mocks.appState.isAgentModeActive = true
     mocks.isSessionSnoozed.mockReturnValue(false)
 
     await emitAgentProgress({ sessionId: "session-panel-disabled", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
@@ -116,6 +118,18 @@ describe("emitAgentProgress snoozed propagation", () => {
     expect(mocks.closeAgentModeAndHidePanelWindow).toHaveBeenCalledTimes(1)
     // Must preserve shouldStopAgent so a trailing update can't undo an emergency stop.
     expect(mocks.closeAgentModeAndHidePanelWindow).toHaveBeenCalledWith({ preserveAgentStopState: true })
+  })
+
+  it("does not repeatedly clear the hidden panel when panel progress is disabled", async () => {
+    mocks.config.floatingPanelAgentProgressEnabled = false
+    mocks.isSessionSnoozed.mockReturnValue(false)
+
+    await emitAgentProgress({ sessionId: "session-panel-disabled-hidden", currentIteration: 0, maxIterations: 1, steps: [], isComplete: false })
+
+    expect(mocks.sendSpy).toHaveBeenCalledTimes(1)
+    expect(mocks.resizePanelForAgentMode).not.toHaveBeenCalled()
+    expect(mocks.showPanelWindow).not.toHaveBeenCalled()
+    expect(mocks.closeAgentModeAndHidePanelWindow).not.toHaveBeenCalled()
   })
 
   it("does not close an active waveform recording when panel progress is disabled", async () => {

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -93,7 +93,13 @@ function sendToWindows(update: AgentProgressUpdate): void {
   const isMainFocused = main?.isFocused() ?? false
 
   if (!floatingPanelAgentProgressEnabled) {
-    if (update.sessionId && !appState.isRecording && !appState.isTextInputActive) {
+    const shouldClosePanelAgentMode =
+      update.sessionId &&
+      !appState.isRecording &&
+      !appState.isTextInputActive &&
+      (panel.isVisible() || appState.isAgentModeActive)
+
+    if (shouldClosePanelAgentMode) {
       // Preserve shouldStopAgent: this fires on every progress update, so a
       // trailing update after an emergency stop must not re-enable the agent.
       closeAgentModeAndHidePanelWindow({ preserveAgentStopState: true })

--- a/apps/desktop/src/main/emit-agent-progress.ts
+++ b/apps/desktop/src/main/emit-agent-progress.ts
@@ -97,7 +97,7 @@ function sendToWindows(update: AgentProgressUpdate): void {
       update.sessionId &&
       !appState.isRecording &&
       !appState.isTextInputActive &&
-      (panel.isVisible() || appState.isAgentModeActive)
+      panel.isVisible()
 
     if (shouldClosePanelAgentMode) {
       // Preserve shouldStopAgent: this fires on every progress update, so a

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -12,7 +12,11 @@ import {
   setAppQuitting,
   WINDOWS,
 } from "./window"
-import { listenToKeyboardEvents, stopListeningToKeyboardEvents } from "./keyboard"
+import {
+  getFocusedAppInfo,
+  listenToKeyboardEvents,
+  stopListeningToKeyboardEvents,
+} from "./keyboard"
 import { registerIpcMain } from "@egoist/tipc/main"
 import { router } from "./tipc"
 import { state } from "./state"
@@ -59,6 +63,56 @@ import {
   buildHubBundleInstallUrl,
   resolveStartupMainWindowDecision,
 } from "./startup-routing"
+
+function getBrowserWindowDebugId(window: Electron.BrowserWindow): string {
+  if (WINDOWS.get("main") === window) return "main"
+  if (WINDOWS.get("panel") === window) return "panel"
+  if (WINDOWS.get("setup") === window) return "setup"
+  return "unknown"
+}
+
+function serializeUnknownError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      stack: error.stack,
+    }
+  }
+
+  return { message: String(error) }
+}
+
+function logFrontmostAppSnapshotForBlur(
+  window: Electron.BrowserWindow,
+  delayMs = 0,
+) {
+  const logSnapshot = () => {
+    void getFocusedAppInfo()
+      .then((focusedApp) => {
+        logApp("[app.browser-window-blur] Frontmost app snapshot", {
+          delayMs,
+          windowId: getBrowserWindowDebugId(window),
+          focusedApp,
+          snapshot: getWindowFocusDebugSnapshot(),
+        })
+      })
+      .catch((error) => {
+        logApp("[app.browser-window-blur] Failed to capture frontmost app snapshot", {
+          delayMs,
+          windowId: getBrowserWindowDebugId(window),
+          error: serializeUnknownError(error),
+          snapshot: getWindowFocusDebugSnapshot(),
+        })
+      })
+  }
+
+  if (delayMs > 0) {
+    setTimeout(logSnapshot, delayMs)
+    return
+  }
+
+  logSnapshot()
+}
 
 // Check for --qr flag (headless mode with QR code)
 const isQRMode = process.argv.includes("--qr")
@@ -789,6 +843,22 @@ if (!gotSingleInstanceLock) {
 
     app.on("did-become-active", function () {
       handleAppActivation("app.did-become-active")
+    })
+
+    app.on("browser-window-focus", function (_event, window) {
+      logApp("[app.browser-window-focus] Window focused", {
+        windowId: getBrowserWindowDebugId(window),
+        snapshot: getWindowFocusDebugSnapshot(),
+      })
+    })
+
+    app.on("browser-window-blur", function (_event, window) {
+      logApp("[app.browser-window-blur] Window blurred", {
+        windowId: getBrowserWindowDebugId(window),
+        snapshot: getWindowFocusDebugSnapshot(),
+      })
+      logFrontmostAppSnapshotForBlur(window)
+      logFrontmostAppSnapshotForBlur(window, 75)
     })
 
     // Track if we're already cleaning up to prevent re-entry

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -1249,6 +1249,24 @@ export async function processTranscriptWithAgentMode(
 
   // Helper function to add a message to conversation history AND save it incrementally
   // This ensures all messages are both in memory and persisted to disk
+  const normalizePromptEcho = (content: string | undefined) =>
+    (content ?? "").replace(/\s+/g, " ").trim()
+
+  const isAssistantPromptEchoInActiveTurn = (content: string) => {
+    const normalizedContent = normalizePromptEcho(content)
+    if (!normalizedContent) return false
+    if (normalizedContent !== normalizePromptEcho(transcript)) return false
+
+    return conversationHistory
+      .slice(currentPromptIndex + 1)
+      .some((entry) =>
+        entry.role === "assistant" ||
+        entry.role === "tool" ||
+        (entry.toolCalls?.length ?? 0) > 0 ||
+        (entry.toolResults?.length ?? 0) > 0,
+      )
+  }
+
   const addMessage = (
     role: "user" | "assistant" | "tool",
     content: string,
@@ -1257,6 +1275,16 @@ export async function processTranscriptWithAgentMode(
     timestamp?: number,
     options?: { skipModelReplay?: boolean; displayContent?: string },
   ) => {
+    if (role === "assistant" && isAssistantPromptEchoInActiveTurn(content)) {
+      logLLM("[addMessage] Suppressed assistant prompt echo in active turn", {
+        sessionId: currentSessionId,
+        conversationId: currentConversationId,
+        contentLength: content.length,
+        hasToolCalls: (toolCalls?.length ?? 0) > 0,
+      })
+      return
+    }
+
     // Add to in-memory history
     const message: typeof conversationHistory[0] = {
       role,

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -19,6 +19,7 @@ import {
   emergencyStopAgentMode,
   showPanelWindowAndShowTextInput,
   showPanelWindowAndStartMcpRecording,
+  getWindowFocusDebugSnapshot,
   WAVEFORM_MIN_HEIGHT,
   TEXT_INPUT_MIN_WIDTH,
   TEXT_INPUT_MIN_HEIGHT,
@@ -2384,6 +2385,13 @@ export const router = {
         messageLength: input.text.length,
         queueEnabled,
       })
+      logApp("[createMcpTextInput] Submit lifecycle snapshot", {
+        conversationId: input.conversationId ?? null,
+        sessionId: input.sessionId ?? null,
+        fromTile: input.fromTile ?? false,
+        queueEnabled,
+        snapshot: getWindowFocusDebugSnapshot(),
+      })
 
       // Panel suppression is separate from snoozing. Tile-originated sessions
       // can stay foreground/audible while still avoiding floating-panel popups.
@@ -2534,6 +2542,14 @@ export const router = {
       // Fire-and-forget: Start agent processing without blocking
       // This allows multiple sessions to run concurrently
       // Pass existingSessionId to reuse the session if found
+      logApp("[createMcpTextInput] Starting agent processing", {
+        conversationId,
+        existingSessionId: existingSessionId ?? null,
+        sessionId: input.sessionId ?? null,
+        fromTile: input.fromTile ?? false,
+        launchState: serializeAgentLaunchState(launchState),
+        snapshot: getWindowFocusDebugSnapshot(),
+      })
       processWithAgentMode(agentInputText, conversationId, existingSessionId, launchState)
         .then((finalResponse) => {
           // Save to history after completion

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -51,6 +51,7 @@ function getWindowStateForDebug(win: BrowserWindow | undefined) {
 
 export function getWindowFocusDebugSnapshot() {
   return {
+    appHidden: safeWindowFlag(() => app.isHidden(), false),
     focusedWindow: getWindowIdForDebug(BrowserWindow.getFocusedWindow()),
     main: getWindowStateForDebug(WINDOWS.get("main")),
     panel: getWindowStateForDebug(WINDOWS.get("panel")),

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -722,6 +722,10 @@ function normalizeAssistantResponseForDedupe(content: string | undefined): strin
   return (content ?? "").replace(/\s+/g, " ").trim()
 }
 
+function normalizePromptEchoForDedupe(content: string | undefined): string {
+  return (content ?? "").replace(/\s+/g, " ").trim()
+}
+
 function shouldAutoPlayTTSForVariant(
   _variant: "default" | "overlay" | "tile",
   isSnoozed: boolean,
@@ -3980,10 +3984,46 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         startIndex > 0 ? conversationHistory.slice(startIndex) : conversationHistory
 
       const isCompletionNudge = (content: string) => content.trim() === INTERNAL_COMPLETION_NUDGE_TEXT
+      const shouldHideAssistantPromptEcho = (entry: typeof historyForSession[number], localIndex: number) => {
+        if (entry.role !== "assistant") return false
+        if ((entry.toolCalls?.length ?? 0) > 0 || (entry.toolResults?.length ?? 0) > 0) return false
+
+        const assistantContent = normalizePromptEchoForDedupe(entry.displayContent ?? entry.content)
+        if (!assistantContent) return false
+
+        let previousUserContent: string | undefined
+        for (let i = localIndex - 1; i >= 0; i--) {
+          const previousEntry = historyForSession[i]
+          if (previousEntry.role === "user" && !isCompletionNudge(previousEntry.content)) {
+            previousUserContent = previousEntry.content
+            break
+          }
+        }
+        if (normalizePromptEchoForDedupe(previousUserContent) !== assistantContent) return false
+
+        for (let i = localIndex + 1; i < historyForSession.length; i++) {
+          const nextEntry = historyForSession[i]
+          if (nextEntry.role === "user" && !isCompletionNudge(nextEntry.content)) return false
+          if (
+            nextEntry.role === "tool" ||
+            (nextEntry.role === "assistant" &&
+              (
+                normalizePromptEchoForDedupe(nextEntry.displayContent ?? nextEntry.content).length > 0 ||
+                (nextEntry.toolCalls?.length ?? 0) > 0 ||
+                (nextEntry.toolResults?.length ?? 0) > 0
+              ))
+          ) {
+            return true
+          }
+        }
+
+        return false
+      }
 
       historyForSession
         .forEach((entry, localIndex) => {
           if (entry.role === "user" && isCompletionNudge(entry.content)) return
+          if (shouldHideAssistantPromptEcho(entry, localIndex)) return
           nextMessages.push({
             role: entry.role,
             content: entry.displayContent ?? entry.content,


### PR DESCRIPTION
## Summary
- stop repeatedly clearing/closing the hidden floating panel when panel progress is disabled
- add focus/blur lifecycle diagnostics for the main Electron window
- suppress and hide assistant messages that exactly echo the user prompt when real assistant/tool activity follows

## Root Cause
When `floatingPanelAgentProgressEnabled` was false, every active agent progress update called `closeAgentModeAndHidePanelWindow()`, even after the panel was already hidden and inactive. That repeatedly sent `clearAgentProgress` to the hidden panel and correlated with native main-window focus loss.

The prompt echo issue was a separate model/persistence artifact where exact user prompt echoes could be saved/rendered as assistant messages before later real activity arrived.

## Validation
- `pnpm --filter @dotagents/desktop typecheck:web`
- `pnpm --filter @dotagents/desktop test:run src/main/emit-agent-progress.snoozed.test.ts`

## Notes
- `pnpm --filter @dotagents/desktop typecheck:node` still fails on preexisting unrelated `src/main/runtime-tools.ts` `session` possibly undefined errors around line 795.
- The new frontmost-app blur diagnostic currently reveals that the bundled `dotagents-rs` in this dev build does not support `get-focus`, so those logs now include the real failure instead of `{}`.