### PR TITLE
Implement goal-driven repeat tasks

### DIFF
--- a/apps/desktop/resources/bundled-skills/dotagents-config-admin/SKILL.md
+++ b/apps/desktop/resources/bundled-skills/dotagents-config-admin/SKILL.md
@@ -30,6 +30,8 @@ Use `~/.agents/` by default. When `DOTAGENTS_WORKSPACE_DIR` is explicitly set, t
 - `~/.agents/agents/<id>/config.json` — nested per-agent config
 - `~/.agents/skills/<id>/skill.md` — skill definition and instructions
 - `~/.agents/tasks/<id>/task.md` — repeat task definition
+- `~/.agents/goals/<id>/goal.md` — structured goal definition
+- `~/.agents/decisions/<id>/decision.md` — structured decision queue item
 - `~/.agents/knowledge/<slug>/<slug>.md` — durable knowledge note
 
 ## Layering rules
@@ -37,7 +39,7 @@ Use `~/.agents/` by default. When `DOTAGENTS_WORKSPACE_DIR` is explicitly set, t
 - `~/.agents/` is the default layer for user-wide defaults
 - Use `${DOTAGENTS_WORKSPACE_DIR}/.agents/` for workspace-specific behavior only when `DOTAGENTS_WORKSPACE_DIR` is explicitly set
 - Config merge is shallow by key
-- Agents, skills, tasks, and knowledge notes merge by ID
+- Agents, skills, tasks, goals, decisions, and knowledge notes merge by ID
 - When a workspace file intentionally overrides a global file, edit the workspace copy
 
 ## Edit workflow
@@ -79,6 +81,14 @@ Edit `skills/<id>/skill.md`. Keep the frontmatter valid and update the markdown 
 ### Change a repeat task
 
 Edit `tasks/<id>/task.md`. Frontmatter defines the task metadata; the markdown body is the task prompt.
+
+### Change or create a goal
+
+Prefer the structured runtime tools `create_goal`, `update_goal`, and `list_goals` when available. If editing files directly, use `goals/<id>/goal.md`, not `knowledge/`. Goal frontmatter uses `kind: goal`, `id`, `title`, `description`, `level`, `priority`, `status`, `successCriteria`, `abandonIf`, timestamps, and provenance fields; the markdown body is long-form goal context.
+
+### Change or create a decision
+
+Prefer the structured runtime tools `create_decision`, `answer_decision`, and `list_decisions` when available. If editing files directly, use `decisions/<id>/decision.md`, not `knowledge/`. Create decisions only for irreversible, path-changing, or >3 effort-hour revert choices.
 
 ### Change durable knowledge
 

--- a/apps/desktop/src/main/agents-files/decisions.ts
+++ b/apps/desktop/src/main/agents-files/decisions.ts
@@ -1,0 +1,26 @@
+import {
+  DECISION_CANONICAL_FILENAME,
+  getDecisionsDir,
+  getDecisionsBackupDir,
+  decisionIdToDirPath,
+  decisionIdToFilePath,
+  stringifyDecisionMarkdown,
+  parseDecisionMarkdown,
+  loadDecisionsLayer,
+  writeDecisionFile,
+  deleteDecisionFiles,
+} from "../../../../../packages/core/src/agents-files/decisions"
+
+export {
+  DECISION_CANONICAL_FILENAME,
+  getDecisionsDir,
+  getDecisionsBackupDir,
+  decisionIdToDirPath,
+  decisionIdToFilePath,
+  stringifyDecisionMarkdown,
+  parseDecisionMarkdown,
+  loadDecisionsLayer,
+  writeDecisionFile,
+  deleteDecisionFiles,
+}
+export type { DecisionOrigin, LoadedDecisionsLayer } from "../../../../../packages/core/src/agents-files/decisions"

--- a/apps/desktop/src/main/agents-files/goals.ts
+++ b/apps/desktop/src/main/agents-files/goals.ts
@@ -1,0 +1,26 @@
+import {
+  GOAL_CANONICAL_FILENAME,
+  getGoalsDir,
+  getGoalsBackupDir,
+  goalIdToDirPath,
+  goalIdToFilePath,
+  stringifyGoalMarkdown,
+  parseGoalMarkdown,
+  loadGoalsLayer,
+  writeGoalFile,
+  deleteGoalFiles,
+} from "../../../../../packages/core/src/agents-files/goals"
+
+export {
+  GOAL_CANONICAL_FILENAME,
+  getGoalsDir,
+  getGoalsBackupDir,
+  goalIdToDirPath,
+  goalIdToFilePath,
+  stringifyGoalMarkdown,
+  parseGoalMarkdown,
+  loadGoalsLayer,
+  writeGoalFile,
+  deleteGoalFiles,
+}
+export type { GoalOrigin, LoadedGoalsLayer } from "../../../../../packages/core/src/agents-files/goals"

--- a/apps/desktop/src/main/decision-service.ts
+++ b/apps/desktop/src/main/decision-service.ts
@@ -1,0 +1,295 @@
+import type {
+  Decision,
+  DecisionCreateRequest,
+  DecisionRespondRequest,
+  DecisionStatus,
+  DecisionUpdateRequest,
+} from "@dotagents/shared"
+import { globalAgentsFolder, resolveWorkspaceAgentsFolder } from "./config"
+import { logApp } from "./debug"
+import { getAgentsLayerPaths, type AgentsLayerPaths } from "./agents-files/modular-config"
+import {
+  deleteDecisionFiles,
+  loadDecisionsLayer,
+  writeDecisionFile,
+  type DecisionOrigin,
+} from "./agents-files/decisions"
+import { goalService } from "./goal-service"
+import { goalProgressService } from "./goal-progress-service"
+
+type LayerName = "global" | "workspace"
+type ServiceDecisionOrigin = DecisionOrigin & { layer: LayerName }
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80)
+}
+
+function buildDecisionId(question: string): string {
+  return `d_${slugify(question) || Date.now().toString(36)}`
+}
+
+function shouldAskDecision(input: DecisionCreateRequest): boolean {
+  return Boolean(input.irreversible || input.pathChanging || (input.revertEffortHours ?? 0) > 3)
+}
+
+function normalizeDecision(input: DecisionCreateRequest | Decision, existing?: Decision): Decision {
+  const now = Date.now()
+  const id = (input.id ?? existing?.id ?? buildDecisionId(input.question)).trim()
+  const createdAt = existing?.createdAt ?? ("createdAt" in input && typeof input.createdAt === "number" ? input.createdAt : now)
+  const status = input.status ?? existing?.status ?? "pending"
+  const history = "history" in input && Array.isArray(input.history)
+    ? input.history
+    : existing?.history ?? [{ at: now, type: "created", by: "agent" as const }]
+
+  return {
+    id,
+    type: input.type ?? existing?.type ?? "yn",
+    status,
+    question: (input.question ?? existing?.question ?? id).trim() || id,
+    recommendation: input.recommendation ?? existing?.recommendation,
+    why: input.why ?? existing?.why,
+    risk: input.risk ?? existing?.risk,
+    goalId: input.goalId ?? existing?.goalId,
+    taskId: input.taskId ?? existing?.taskId,
+    createdAt,
+    updatedAt: now,
+    answeredAt: "answeredAt" in input ? input.answeredAt : existing?.answeredAt,
+    expiresAt: input.expiresAt ?? existing?.expiresAt,
+    defaultAction: input.defaultAction ?? existing?.defaultAction,
+    answer: "answer" in input ? input.answer : existing?.answer,
+    answerSource: "answerSource" in input ? input.answerSource : existing?.answerSource,
+    urgent: input.urgent ?? existing?.urgent ?? false,
+    revertEffortHours: input.revertEffortHours ?? existing?.revertEffortHours ?? 0,
+    pathChanging: input.pathChanging ?? existing?.pathChanging ?? false,
+    irreversible: input.irreversible ?? existing?.irreversible ?? false,
+    history,
+    body: input.body ?? existing?.body ?? "",
+  }
+}
+
+export class DecisionService {
+  private decisions: Decision[] = []
+  private originById = new Map<string, ServiceDecisionOrigin>()
+  private initialized = false
+
+  private getLayers(): { globalLayer: AgentsLayerPaths; workspaceLayer: AgentsLayerPaths | null } {
+    const globalLayer = getAgentsLayerPaths(globalAgentsFolder)
+    const workspaceAgentsFolder = resolveWorkspaceAgentsFolder()
+    const workspaceLayer = workspaceAgentsFolder ? getAgentsLayerPaths(workspaceAgentsFolder) : null
+    return { globalLayer, workspaceLayer }
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    const { globalLayer, workspaceLayer } = this.getLayers()
+    const globalLoaded = loadDecisionsLayer(globalLayer)
+    const workspaceLoaded = workspaceLayer ? loadDecisionsLayer(workspaceLayer) : null
+
+    const mergedById = new Map<string, Decision>()
+    const originById = new Map<string, ServiceDecisionOrigin>()
+
+    for (const decision of globalLoaded.decisions) {
+      const origin = globalLoaded.originById.get(decision.id)
+      mergedById.set(decision.id, decision)
+      if (origin) originById.set(decision.id, { ...origin, layer: "global" })
+    }
+
+    if (workspaceLoaded) {
+      for (const decision of workspaceLoaded.decisions) {
+        const origin = workspaceLoaded.originById.get(decision.id)
+        mergedById.set(decision.id, decision)
+        if (origin) originById.set(decision.id, { ...origin, layer: "workspace" })
+      }
+    }
+
+    this.decisions = Array.from(mergedById.values())
+    this.originById = originById
+  }
+
+  private async persist(decision: Decision): Promise<Decision> {
+    const { globalLayer, workspaceLayer } = this.getLayers()
+    const origin = this.originById.get(decision.id)
+    const targetLayerName = origin?.layer ?? "global"
+    const targetLayer = targetLayerName === "workspace" && workspaceLayer ? workspaceLayer : globalLayer
+    writeDecisionFile(targetLayer, decision, { maxBackups: 10 })
+
+    const index = this.decisions.findIndex((item) => item.id === decision.id)
+    if (index >= 0) this.decisions[index] = decision
+    else this.decisions.push(decision)
+    this.originById.set(decision.id, { layer: targetLayerName, filePath: origin?.filePath ?? "" })
+    return decision
+  }
+
+  private async autoResolveExpired(): Promise<void> {
+    const now = Date.now()
+    const expired = this.decisions.filter((decision) =>
+      decision.status === "pending" &&
+      typeof decision.expiresAt === "number" &&
+      decision.expiresAt <= now &&
+      Boolean(decision.defaultAction),
+    )
+
+    for (const decision of expired) {
+      await this.persist({
+        ...decision,
+        status: "auto_resolved",
+        answer: decision.defaultAction ?? null,
+        answerSource: "timeout",
+        answeredAt: now,
+        updatedAt: now,
+        history: [...decision.history, { at: now, type: "auto_resolved", by: "timeout", note: decision.defaultAction }],
+      })
+      goalProgressService.appendEvent({
+        type: "decision_answered",
+        actor: "system",
+        goalId: decision.goalId,
+        decisionId: decision.id,
+        title: `Auto-resolved decision: ${decision.question}`,
+        summary: decision.defaultAction ?? undefined,
+        source: "timeout",
+      })
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+    await this.loadFromDisk()
+    await this.autoResolveExpired()
+    this.initialized = true
+  }
+
+  async reload(): Promise<void> {
+    await this.loadFromDisk()
+    await this.autoResolveExpired()
+    this.initialized = true
+  }
+
+  async listDecisions(status: "pending" | "history" | "all" = "all"): Promise<Decision[]> {
+    await this.initialize()
+    await this.loadFromDisk()
+    await this.autoResolveExpired()
+
+    const goalPriorityById = new Map((await goalService.listGoals()).map((goal) => [goal.id, goal.priority]))
+    const filtered = this.decisions.filter((decision) => {
+      if (status === "pending") return decision.status === "pending"
+      if (status === "history") return decision.status !== "pending"
+      return true
+    })
+
+    return [...filtered].sort((a, b) => {
+      if (status !== "pending") return b.updatedAt - a.updatedAt
+      if (a.urgent !== b.urgent) return a.urgent ? -1 : 1
+      const priorityDiff = (goalPriorityById.get(a.goalId ?? "") ?? 99) - (goalPriorityById.get(b.goalId ?? "") ?? 99)
+      if (priorityDiff !== 0) return priorityDiff
+      return a.createdAt - b.createdAt
+    })
+  }
+
+  async getDecision(id: string): Promise<Decision | null> {
+    await this.initialize()
+    await this.loadFromDisk()
+    await this.autoResolveExpired()
+    return this.decisions.find((decision) => decision.id === id) ?? null
+  }
+
+  async saveDecision(input: DecisionCreateRequest | Decision): Promise<Decision> {
+    await this.initialize()
+    if (!("status" in input) && !shouldAskDecision(input)) {
+      throw new Error("Decision does not meet ask threshold: irreversible, path-changing, or >3 effort-hours to revert.")
+    }
+    const existing = input.id ? this.decisions.find((decision) => decision.id === input.id) : undefined
+    const normalized = normalizeDecision(input, existing)
+    const saved = await this.persist(normalized)
+    if (!existing) {
+      goalProgressService.appendEvent({
+        type: "decision_created",
+        actor: "agent",
+        goalId: saved.goalId,
+        decisionId: saved.id,
+        title: `Decision needed: ${saved.question}`,
+        summary: saved.recommendation,
+        source: saved.taskId,
+        metadata: {
+          urgent: saved.urgent,
+          irreversible: saved.irreversible,
+          pathChanging: saved.pathChanging,
+          revertEffortHours: saved.revertEffortHours,
+        },
+      })
+    }
+    logApp(`[DecisionService] Saved decision ${saved.id}`)
+    return saved
+  }
+
+  async updateDecision(id: string, updates: DecisionUpdateRequest): Promise<Decision | null> {
+    const existing = await this.getDecision(id)
+    if (!existing) return null
+    return this.saveDecision({ ...existing, ...updates, id })
+  }
+
+  async respondToDecision(id: string, response: DecisionRespondRequest): Promise<Decision | null> {
+    const existing = await this.getDecision(id)
+    if (!existing) return null
+    const now = Date.now()
+    const decision = await this.persist({
+      ...existing,
+      status: "answered",
+      answer: response.answer,
+      answerSource: response.answerSource ?? "aj",
+      answeredAt: now,
+      updatedAt: now,
+      history: [...existing.history, { at: now, type: "answered", by: response.answerSource ?? "aj", note: response.answer }],
+    })
+    goalProgressService.appendEvent({
+      type: "decision_answered",
+      actor: response.answerSource === "agent" ? "agent" : "aj",
+      goalId: decision.goalId,
+      decisionId: decision.id,
+      title: `Answered decision: ${decision.question}`,
+      summary: response.answer,
+      source: response.answerSource ?? "aj",
+    })
+    return decision
+  }
+
+  async setStatus(id: string, status: Extract<DecisionStatus, "deferred" | "canceled">, note?: string): Promise<Decision | null> {
+    const existing = await this.getDecision(id)
+    if (!existing) return null
+    const now = Date.now()
+    const decision = await this.persist({
+      ...existing,
+      status,
+      updatedAt: now,
+      history: [...existing.history, { at: now, type: status, by: "aj", note }],
+    })
+    goalProgressService.appendEvent({
+      type: status === "deferred" ? "decision_deferred" : "decision_canceled",
+      actor: "aj",
+      goalId: decision.goalId,
+      decisionId: decision.id,
+      title: `${status === "deferred" ? "Deferred" : "Canceled"} decision: ${decision.question}`,
+      summary: note,
+      source: "aj",
+    })
+    return decision
+  }
+
+  async deleteDecision(id: string): Promise<boolean> {
+    await this.initialize()
+    const index = this.decisions.findIndex((decision) => decision.id === id)
+    if (index < 0) return false
+    const { globalLayer, workspaceLayer } = this.getLayers()
+    const origin = this.originById.get(id)
+    const layer = origin?.layer === "workspace" && workspaceLayer ? workspaceLayer : globalLayer
+    deleteDecisionFiles(layer, id)
+    this.decisions.splice(index, 1)
+    this.originById.delete(id)
+    return true
+  }
+}
+
+export const decisionService = new DecisionService()

--- a/apps/desktop/src/main/goal-progress-service.ts
+++ b/apps/desktop/src/main/goal-progress-service.ts
@@ -1,0 +1,103 @@
+import fs from "fs"
+import path from "path"
+import type { GoalProgressActor, GoalProgressEvent, GoalProgressEventType } from "@dotagents/shared"
+import { globalAgentsFolder } from "./config"
+import { logApp } from "./debug"
+
+export interface GoalProgressEventInput {
+  type: GoalProgressEventType
+  actor: GoalProgressActor
+  goalId?: string
+  parentGoalId?: string
+  decisionId?: string
+  loopId?: string
+  sessionId?: string
+  conversationId?: string
+  title: string
+  summary?: string
+  source?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface GoalProgressEventListOptions {
+  goalId?: string
+  parentGoalId?: string
+  limit?: number
+}
+
+function createEventId(now: number): string {
+  const suffix = Math.random().toString(36).slice(2, 10)
+  return `gpe_${now}_${suffix}`
+}
+
+function getEventsDir(): string {
+  return path.join(globalAgentsFolder, "goal-events")
+}
+
+function getEventsPath(): string {
+  return path.join(getEventsDir(), "events.jsonl")
+}
+
+export class GoalProgressService {
+  appendEvent(input: GoalProgressEventInput): GoalProgressEvent {
+    const now = Date.now()
+    const event: GoalProgressEvent = {
+      id: createEventId(now),
+      at: now,
+      ...input,
+    }
+
+    try {
+      fs.mkdirSync(getEventsDir(), { recursive: true })
+      fs.appendFileSync(getEventsPath(), `${JSON.stringify(event)}\n`, "utf8")
+    } catch (error) {
+      logApp("[GoalProgressService] Failed to append goal progress event", error)
+    }
+
+    return event
+  }
+
+  listEvents(options: GoalProgressEventListOptions = {}): GoalProgressEvent[] {
+    const filePath = getEventsPath()
+    if (!fs.existsSync(filePath)) return []
+
+    let lines: string[]
+    try {
+      lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/u).filter(Boolean)
+    } catch (error) {
+      logApp("[GoalProgressService] Failed to read goal progress events", error)
+      return []
+    }
+
+    const events: GoalProgressEvent[] = []
+    for (const line of lines) {
+      try {
+        const event = JSON.parse(line) as GoalProgressEvent
+        if (options.goalId && event.goalId !== options.goalId && event.parentGoalId !== options.goalId) continue
+        if (options.parentGoalId && event.parentGoalId !== options.parentGoalId) continue
+        events.push(event)
+      } catch {
+        // Ignore malformed historical lines; the log remains append-only.
+      }
+    }
+
+    const limit = Math.max(1, Math.min(500, Math.floor(options.limit ?? 100)))
+    return events.sort((a, b) => b.at - a.at).slice(0, limit)
+  }
+
+  countEvents(): number {
+    const filePath = getEventsPath()
+    if (!fs.existsSync(filePath)) return 0
+    try {
+      return fs.readFileSync(filePath, "utf8").split(/\r?\n/u).filter(Boolean).length
+    } catch {
+      return 0
+    }
+  }
+
+  hasEventForGoal(type: GoalProgressEvent["type"], goalId: string): boolean {
+    return this.listEvents({ goalId, limit: 500 }).some((event) => event.type === type && event.goalId === goalId)
+  }
+}
+
+export const goalProgressService = new GoalProgressService()

--- a/apps/desktop/src/main/goal-service.ts
+++ b/apps/desktop/src/main/goal-service.ts
@@ -1,0 +1,311 @@
+import type { Goal, GoalCreateRequest, GoalUpdateRequest } from "@dotagents/shared"
+import { globalAgentsFolder, resolveWorkspaceAgentsFolder } from "./config"
+import { logApp } from "./debug"
+import { getAgentsLayerPaths, type AgentsLayerPaths } from "./agents-files/modular-config"
+import {
+  deleteGoalFiles,
+  loadGoalsLayer,
+  writeGoalFile,
+  type GoalOrigin,
+} from "./agents-files/goals"
+import { goalProgressService } from "./goal-progress-service"
+
+type LayerName = "global" | "workspace"
+type ServiceGoalOrigin = GoalOrigin & { layer: LayerName }
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 80)
+}
+
+function buildGoalId(title: string): string {
+  return `g_${slugify(title) || Date.now().toString(36)}`
+}
+
+function isValidAgentGoal(goal: Goal): boolean {
+  if (goal.createdBy !== "agent") return true
+  if (!goal.successCriteria || !goal.abandonIf || !goal.provenance) return false
+  return goal.level === "goal" || Boolean(goal.parentId)
+}
+
+function sameStringArray(a?: string[], b?: string[]): boolean {
+  const left = a ?? []
+  const right = b ?? []
+  if (left.length !== right.length) return false
+  return left.every((value, index) => value === right[index])
+}
+
+function hasMeaningfulGoalUpdate(existing: Goal, next: Goal): boolean {
+  return (
+    existing.title !== next.title ||
+    existing.description !== next.description ||
+    existing.level !== next.level ||
+    existing.priority !== next.priority ||
+    existing.parentId !== next.parentId ||
+    existing.successCriteria !== next.successCriteria ||
+    existing.signalToWatch !== next.signalToWatch ||
+    existing.abandonIf !== next.abandonIf ||
+    existing.createdBy !== next.createdBy ||
+    existing.createdFrom !== next.createdFrom ||
+    existing.provenance !== next.provenance ||
+    existing.notes !== next.notes ||
+    existing.body !== next.body ||
+    !sameStringArray(existing.linkedTaskIds, next.linkedTaskIds)
+  )
+}
+
+function normalizeGoal(input: GoalCreateRequest | Goal, existing?: Goal): Goal {
+  const now = Date.now()
+  const id = (input.id ?? existing?.id ?? buildGoalId(input.title)).trim()
+  const createdAt = existing?.createdAt ?? ("createdAt" in input && typeof input.createdAt === "number" ? input.createdAt : now)
+  const createdBy = input.createdBy ?? existing?.createdBy ?? "aj"
+  const priority = typeof input.priority === "number" && Number.isFinite(input.priority)
+    ? input.priority
+    : existing?.priority ?? 3
+
+  return {
+    id,
+    title: (input.title ?? existing?.title ?? id).trim() || id,
+    description: (input.description ?? existing?.description ?? "").trim(),
+    level: input.level ?? existing?.level ?? "goal",
+    priority: Math.max(1, Math.min(5, Math.round(priority))),
+    status: input.status ?? existing?.status ?? "active",
+    parentId: input.parentId ?? existing?.parentId,
+    successCriteria: input.successCriteria ?? existing?.successCriteria,
+    signalToWatch: input.signalToWatch ?? existing?.signalToWatch,
+    abandonIf: input.abandonIf ?? existing?.abandonIf,
+    createdAt,
+    updatedAt: now,
+    lastTouchedAt: "lastTouchedAt" in input && typeof input.lastTouchedAt === "number"
+      ? input.lastTouchedAt
+      : existing?.lastTouchedAt,
+    createdBy,
+    createdFrom: input.createdFrom ?? existing?.createdFrom ?? "manual",
+    provenance: input.provenance ?? existing?.provenance,
+    linkedTaskIds: input.linkedTaskIds ?? existing?.linkedTaskIds ?? [],
+    notes: input.notes ?? existing?.notes,
+    body: input.body ?? existing?.body ?? "",
+  }
+}
+
+export class GoalService {
+  private goals: Goal[] = []
+  private originById = new Map<string, ServiceGoalOrigin>()
+  private initialized = false
+
+  private getLayers(): { globalLayer: AgentsLayerPaths; workspaceLayer: AgentsLayerPaths | null } {
+    const globalLayer = getAgentsLayerPaths(globalAgentsFolder)
+    const workspaceAgentsFolder = resolveWorkspaceAgentsFolder()
+    const workspaceLayer = workspaceAgentsFolder ? getAgentsLayerPaths(workspaceAgentsFolder) : null
+    return { globalLayer, workspaceLayer }
+  }
+
+  private async loadFromDisk(): Promise<void> {
+    const { globalLayer, workspaceLayer } = this.getLayers()
+    const globalLoaded = loadGoalsLayer(globalLayer)
+    const workspaceLoaded = workspaceLayer ? loadGoalsLayer(workspaceLayer) : null
+
+    const mergedById = new Map<string, Goal>()
+    const originById = new Map<string, ServiceGoalOrigin>()
+
+    for (const goal of globalLoaded.goals) {
+      const origin = globalLoaded.originById.get(goal.id)
+      mergedById.set(goal.id, goal)
+      if (origin) originById.set(goal.id, { ...origin, layer: "global" })
+    }
+
+    if (workspaceLoaded) {
+      for (const goal of workspaceLoaded.goals) {
+        const origin = workspaceLoaded.originById.get(goal.id)
+        mergedById.set(goal.id, goal)
+        if (origin) originById.set(goal.id, { ...origin, layer: "workspace" })
+      }
+    }
+
+    this.goals = Array.from(mergedById.values())
+    this.originById = originById
+    for (const goal of this.goals) {
+      if (goal.createdFrom !== "loop_daily_planning") continue
+      if (!goalProgressService.hasEventForGoal("goal_created", goal.id)) {
+        goalProgressService.appendEvent({
+          type: "goal_created",
+          actor: goal.createdBy === "agent" ? "agent" : "aj",
+          goalId: goal.id,
+          parentGoalId: goal.parentId,
+          title: `Created goal: ${goal.title}`,
+          summary: goal.description || goal.successCriteria,
+          source: goal.createdFrom,
+          metadata: {
+            level: goal.level,
+            priority: goal.priority,
+            status: goal.status,
+            backfilled: true,
+          },
+        })
+      }
+      if (goal.level === "today" && goal.parentId && !goalProgressService.hasEventForGoal("focus_selected", goal.id)) {
+        goalProgressService.appendEvent({
+          type: "focus_selected",
+          actor: goal.createdBy === "agent" ? "agent" : "aj",
+          goalId: goal.id,
+          parentGoalId: goal.parentId,
+          title: `Selected today's focus: ${goal.title}`,
+          summary: goal.successCriteria,
+          source: goal.createdFrom,
+          metadata: { backfilled: true },
+        })
+      }
+    }
+  }
+
+  async initialize(): Promise<void> {
+    if (this.initialized) return
+    await this.loadFromDisk()
+    this.initialized = true
+  }
+
+  async reload(): Promise<void> {
+    await this.loadFromDisk()
+    this.initialized = true
+  }
+
+  async listGoals(): Promise<Goal[]> {
+    await this.initialize()
+    await this.loadFromDisk()
+    return [...this.goals].sort((a, b) => a.priority - b.priority || b.updatedAt - a.updatedAt)
+  }
+
+  async listLoopVisibleGoals(): Promise<Goal[]> {
+    const goals = await this.listGoals()
+    return goals.filter((goal) => goal.status === "active" && Boolean(goal.successCriteria))
+  }
+
+  async getGoal(id: string): Promise<Goal | null> {
+    await this.initialize()
+    await this.loadFromDisk()
+    return this.goals.find((goal) => goal.id === id) ?? null
+  }
+
+  async saveGoal(input: GoalCreateRequest | Goal): Promise<Goal> {
+    await this.initialize()
+    const existing = input.id ? this.goals.find((goal) => goal.id === input.id) : undefined
+    const normalized = normalizeGoal(input, existing)
+
+    if (!isValidAgentGoal(normalized)) {
+      throw new Error("Agent-created goals require successCriteria, abandonIf, provenance, and parentId unless top-level.")
+    }
+
+    const { globalLayer, workspaceLayer } = this.getLayers()
+    const origin = this.originById.get(normalized.id)
+    const targetLayerName = origin?.layer ?? "global"
+    const targetLayer = targetLayerName === "workspace" && workspaceLayer ? workspaceLayer : globalLayer
+
+    writeGoalFile(targetLayer, normalized, { maxBackups: 10 })
+
+    const index = this.goals.findIndex((goal) => goal.id === normalized.id)
+    if (index >= 0) this.goals[index] = normalized
+    else this.goals.push(normalized)
+    this.originById.set(normalized.id, { layer: targetLayerName, filePath: origin?.filePath ?? "" })
+    const actor = normalized.createdBy === "agent" ? "agent" : "aj"
+    const eventSource = normalized.createdFrom
+    if (!existing) {
+      goalProgressService.appendEvent({
+        type: "goal_created",
+        actor,
+        goalId: normalized.id,
+        parentGoalId: normalized.parentId,
+        title: `Created goal: ${normalized.title}`,
+        summary: normalized.description || normalized.successCriteria,
+        source: eventSource,
+        metadata: {
+          level: normalized.level,
+          priority: normalized.priority,
+          status: normalized.status,
+        },
+      })
+      if (normalized.level === "today" && normalized.parentId) {
+        goalProgressService.appendEvent({
+          type: "focus_selected",
+          actor,
+          goalId: normalized.id,
+          parentGoalId: normalized.parentId,
+          title: `Selected today's focus: ${normalized.title}`,
+          summary: normalized.successCriteria,
+          source: eventSource,
+        })
+      }
+    } else if (existing.status !== normalized.status) {
+      goalProgressService.appendEvent({
+        type: "goal_status_changed",
+        actor,
+        goalId: normalized.id,
+        parentGoalId: normalized.parentId,
+        title: `Changed status: ${normalized.title}`,
+        summary: `${existing.status} -> ${normalized.status}`,
+        source: eventSource,
+        metadata: { from: existing.status, to: normalized.status },
+      })
+    } else if (hasMeaningfulGoalUpdate(existing, normalized)) {
+      goalProgressService.appendEvent({
+        type: "goal_updated",
+        actor,
+        goalId: normalized.id,
+        parentGoalId: normalized.parentId,
+        title: `Updated goal: ${normalized.title}`,
+        summary: normalized.successCriteria,
+        source: eventSource,
+      })
+    }
+    logApp(`[GoalService] Saved goal ${normalized.id}`)
+    return normalized
+  }
+
+  async updateGoal(id: string, updates: GoalUpdateRequest): Promise<Goal | null> {
+    const existing = await this.getGoal(id)
+    if (!existing) return null
+    return this.saveGoal({ ...existing, ...updates, id })
+  }
+
+  async touchGoal(id: string): Promise<Goal | null> {
+    const goal = await this.updateGoal(id, { lastTouchedAt: Date.now() })
+    if (goal) {
+      goalProgressService.appendEvent({
+        type: "goal_touched",
+        actor: "aj",
+        goalId: goal.id,
+        parentGoalId: goal.parentId,
+        title: `Touched goal: ${goal.title}`,
+      })
+    }
+    return goal
+  }
+
+  async deleteGoal(id: string): Promise<boolean> {
+    await this.initialize()
+    const index = this.goals.findIndex((goal) => goal.id === id)
+    if (index < 0) return false
+    const deletedGoal = this.goals[index]
+
+    const { globalLayer, workspaceLayer } = this.getLayers()
+    const origin = this.originById.get(id)
+    const layer = origin?.layer === "workspace" && workspaceLayer ? workspaceLayer : globalLayer
+    deleteGoalFiles(layer, id)
+    this.goals.splice(index, 1)
+    this.originById.delete(id)
+    goalProgressService.appendEvent({
+      type: "goal_deleted",
+      actor: "aj",
+      goalId: id,
+      parentGoalId: deletedGoal.parentId,
+      title: `Deleted goal: ${deletedGoal.title}`,
+    })
+    logApp(`[GoalService] Deleted goal ${id}`)
+    return true
+  }
+}
+
+export const goalService = new GoalService()

--- a/apps/desktop/src/main/loop-service.ts
+++ b/apps/desktop/src/main/loop-service.ts
@@ -23,10 +23,12 @@ import { getAgentsLayerPaths } from "./agents-files/modular-config"
 import {
   getTasksDir,
   loadTasksLayer,
+  taskIdToFilePath,
   writeTaskFile,
   writeAllTaskFiles,
   deleteTaskFiles,
 } from "./agents-files/tasks"
+import { goalProgressService } from "./goal-progress-service"
 
 export interface LoopStatus {
   id: string
@@ -51,6 +53,49 @@ export interface LoopExecutionResult {
 
 export function isContinuousLoop(loop: Pick<LoopConfig, "runContinuously">): boolean {
   return loop.runContinuously === true
+}
+
+function isGoalSupervisorLoop(loop: Pick<LoopConfig, "loopType" | "outputType" | "runContinuously">): boolean {
+  return isContinuousLoop(loop) && (loop.loopType === "daily_planning" || loop.outputType === "goals")
+}
+
+const DAILY_GOAL_PLANNING_LOOP_ID = "daily-goal-planning"
+const GOAL_SUPERVISOR_DEFAULT_INTERVAL_MINUTES = 15
+
+const DAILY_GOAL_PLANNING_PROMPT = `# 24/7 Goal Agent
+
+You are running the DotAgents 24/7 goal supervisor.
+
+Use the structured runtime tools when available:
+
+1. Call list_goals with loopVisibleOnly=true.
+2. Call list_decisions with status="pending".
+3. Select 1-3 active goals that should become today's focus.
+4. If a concrete today-level focus goal is missing, call create_goal with:
+   - level: "today"
+   - createdBy is handled by the tool as agent
+   - parentId pointing at the parent goal/week goal
+   - successCriteria, abandonIf, and provenance
+5. Create at most one pending decision with create_decision only if blocked by a call that is irreversible, path-changing, or would take more than 3 effort-hours to revert.
+6. If the next action is reversible, act or record context instead of asking.
+
+Do not create vague goals. Do not change user-set priorities. End with a concise summary of the current focus, progress observed, and any decision created.`
+
+function buildDailyGoalPlanningLoop(): LoopConfig {
+  return {
+    id: DAILY_GOAL_PLANNING_LOOP_ID,
+    name: "24/7 Goal Agent",
+    prompt: DAILY_GOAL_PLANNING_PROMPT,
+    intervalMinutes: GOAL_SUPERVISOR_DEFAULT_INTERVAL_MINUTES,
+    enabled: false,
+    runOnStartup: false,
+    runContinuously: true,
+    continueInSession: true,
+    loopType: "daily_planning",
+    linkedGoalIds: [],
+    outputType: "goals",
+    tokenBudgetPerRun: 4000,
+  }
 }
 
 class LoopService {
@@ -95,6 +140,7 @@ class LoopService {
       for (const t of globalResult.tasks) mergedById.set(t.id, t)
       for (const t of workspaceTasks) mergedById.set(t.id, t) // workspace wins
       this.loops = Array.from(mergedById.values())
+      this.ensureDailyGoalPlanningTemplate()
       logApp(`[LoopService] Loaded ${this.loops.length} task(s) from .agents/tasks/`)
       return
     }
@@ -105,6 +151,7 @@ class LoopService {
       this.loops = [...legacyLoops]
       try {
         writeAllTaskFiles(globalLayer, legacyLoops, { onlyIfMissing: true, maxBackups: 10 })
+        this.ensureDailyGoalPlanningTemplate()
         logApp(`[LoopService] Migrated ${legacyLoops.length} task(s) from config.json to .agents/tasks/`)
       } catch (error) {
         logApp("[LoopService] Error migrating tasks to modular files:", error)
@@ -113,6 +160,26 @@ class LoopService {
     }
 
     this.loops = []
+    this.ensureDailyGoalPlanningTemplate()
+  }
+
+  private ensureDailyGoalPlanningTemplate(): void {
+    if (this.loops.some((loop) => loop.id === DAILY_GOAL_PLANNING_LOOP_ID)) return
+
+    const globalLayer = getAgentsLayerPaths(globalAgentsFolder)
+    const template = buildDailyGoalPlanningLoop()
+
+    try {
+      const filePath = taskIdToFilePath(globalLayer, DAILY_GOAL_PLANNING_LOOP_ID)
+      if (!fs.existsSync(filePath)) {
+        writeTaskFile(globalLayer, template, { maxBackups: 10 })
+      }
+      this.loops.push(template)
+      this.syncToConfigJson()
+      logApp("[LoopService] Seeded 24/7 Goal Agent repeat-task template")
+    } catch (error) {
+      logApp("[LoopService] Failed to seed 24/7 Goal Agent template:", error)
+    }
   }
 
   /** Persist a single task to the global .agents/tasks/ layer. */
@@ -407,6 +474,7 @@ class LoopService {
     this.clearScheduledTimer(loopId)
 
     logApp(`[LoopService] Executing loop "${loop.name}" (${loopId})`)
+    const goalEventCountBeforeRun = goalProgressService.countEvents()
     let conversationId: string | undefined
     let sessionId: string | undefined
 
@@ -500,6 +568,18 @@ class LoopService {
         logApp(`[LoopService] Created session ${sessionId} for loop "${loop.name}" (snoozed=${startSnoozed})`)
       }
 
+      if (loop.loopType === "daily_planning" || loop.outputType === "goals") {
+        goalProgressService.appendEvent({
+          type: "planner_run_started",
+          actor: "agent",
+          loopId,
+          sessionId,
+          conversationId,
+          title: `Started goal agent check: ${loop.name}`,
+          source: loop.id,
+        })
+      }
+
       if (loop.continueInSession) {
         const latest = this.getLoop(loopId)
         if (latest && latest.lastSessionId !== sessionId) {
@@ -510,6 +590,22 @@ class LoopService {
       // Reuse the main agent execution flow.
       const { runAgentLoopSession } = await import("./tipc")
       await runAgentLoopSession(loop.prompt, conversationId, sessionId, startSnoozed, loop.maxIterations)
+      if (loop.loopType === "daily_planning" || loop.outputType === "goals") {
+        const eventCountAfterRun = goalProgressService.countEvents()
+        const madeGoalProgress = eventCountAfterRun > goalEventCountBeforeRun + 1
+        goalProgressService.appendEvent({
+          type: madeGoalProgress ? "planner_run_completed" : "planner_run_noop",
+          actor: "agent",
+          loopId,
+          sessionId,
+          conversationId,
+          title: madeGoalProgress ? `Goal agent recorded progress: ${loop.name}` : `Goal agent checked goals: ${loop.name}`,
+          summary: madeGoalProgress
+            ? "The goal agent recorded goal progress during this check."
+            : "No new goal, decision, or status change was needed.",
+          source: loop.id,
+        })
+      }
 
       // When `speakOnTrigger` is set, unsnooze the now-completed session and
       // show the panel so the renderer's TTS auto-play gate fires for the
@@ -586,6 +682,13 @@ class LoopService {
   }
 
   private getNextDelayMs(loop: LoopConfig, now: number = Date.now()): number {
+    if (isGoalSupervisorLoop(loop)) {
+      const intervalMinutes = Number.isFinite(loop.intervalMinutes) && loop.intervalMinutes > 0
+        ? loop.intervalMinutes
+        : GOAL_SUPERVISOR_DEFAULT_INTERVAL_MINUTES
+      return Math.max(60_000, intervalMinutes * 60_000)
+    }
+
     if (isContinuousLoop(loop)) {
       return 0
     }

--- a/apps/desktop/src/main/mcp-service.option-b.test.ts
+++ b/apps/desktop/src/main/mcp-service.option-b.test.ts
@@ -8,6 +8,12 @@ const mockSaveCurrentMcpStateToProfile = vi.fn()
 const mockExecuteRuntimeTool = vi.fn(async (name: string) => ({ content: [{ type: "text", text: `ran ${name}` }], isError: false }))
 
 const runtimeTools = [
+  { name: "list_goals", description: "goals", inputSchema: {} },
+  { name: "create_goal", description: "goals", inputSchema: {} },
+  { name: "update_goal", description: "goals", inputSchema: {} },
+  { name: "list_decisions", description: "decisions", inputSchema: {} },
+  { name: "create_decision", description: "decisions", inputSchema: {} },
+  { name: "answer_decision", description: "decisions", inputSchema: {} },
   { name: "mark_work_complete", description: "essential", inputSchema: {} },
   { name: "execute_command", description: "command", inputSchema: {} },
   { name: "read_more_context", description: "context", inputSchema: {} },
@@ -26,7 +32,19 @@ vi.mock("./mcp-sampling", () => ({ requestSampling: vi.fn(), cancelAllSamplingRe
 vi.mock("./langfuse-service", () => ({ isTracingEnabled: vi.fn(() => false), createToolSpan: vi.fn(), endToolSpan: vi.fn(), getAgentTrace: vi.fn(() => null) }))
 vi.mock("./agent-profile-service", () => ({ agentProfileService: { getCurrentProfile: () => ({ id: "profile_1", toolConfig: { enabledRuntimeTools: currentProfileEnabledRuntimeTools } }), saveCurrentMcpStateToProfile: mockSaveCurrentMcpStateToProfile } }))
 vi.mock("./runtime-tools", () => ({ runtimeTools, isRuntimeTool: (n: string) => runtimeTools.some((tool) => tool.name === n), executeRuntimeTool: mockExecuteRuntimeTool }))
-vi.mock("./runtime-tool-definitions", () => ({ DEFAULT_AGENT_RUNTIME_TOOL_NAMES: ["execute_command", "read_more_context", "mark_work_complete"] }))
+vi.mock("./runtime-tool-definitions", () => ({
+  DEFAULT_AGENT_RUNTIME_TOOL_NAMES: [
+    "execute_command",
+    "read_more_context",
+    "mark_work_complete",
+    "list_goals",
+    "create_goal",
+    "update_goal",
+    "list_decisions",
+    "create_decision",
+    "answer_decision",
+  ],
+}))
 
 const flushPromises = async (): Promise<void> => {
   await Promise.resolve(); await Promise.resolve()
@@ -76,11 +94,18 @@ describe("MCPService Option B (runtime tool allowlist)", () => {
     mcpService.applyProfileMcpConfig(undefined, undefined, false, undefined, ["execute_command"])
 
     expect(mcpService.getAvailableTools().map((t) => t.name)).toEqual([
+      "list_goals",
+      "create_goal",
+      "update_goal",
+      "list_decisions",
+      "create_decision",
+      "answer_decision",
       "mark_work_complete",
       "execute_command",
     ])
 
     const detailed = mcpService.getDetailedToolList()
+    expect(detailed.find((t) => t.name === "create_goal")?.enabled).toBe(true)
     expect(detailed.find((t) => t.name === "mark_work_complete")?.enabled).toBe(true)
     expect(detailed.find((t) => t.name === "execute_command")?.enabled).toBe(true)
     expect(detailed.find((t) => t.name === "respond_to_user")?.enabled).toBe(false)
@@ -101,10 +126,16 @@ describe("MCPService Option B (runtime tool allowlist)", () => {
     expect(mockSaveCurrentMcpStateToProfile).toHaveBeenCalledTimes(1)
     const enabledRuntimeTools = mockSaveCurrentMcpStateToProfile.mock.calls[0][4] as string[]
     expect(enabledRuntimeTools.slice().sort()).toEqual([
+      "answer_decision",
+      "create_decision",
+      "create_goal",
       "execute_command",
+      "list_decisions",
+      "list_goals",
       "mark_work_complete",
       "read_more_context",
       "respond_to_user",
+      "update_goal",
     ])
   })
 

--- a/apps/desktop/src/main/mcp-service.ts
+++ b/apps/desktop/src/main/mcp-service.ts
@@ -43,6 +43,14 @@ import { agentProfileService } from "./agent-profile-service"
 import { app, dialog } from "electron"
 import { runtimeTools, executeRuntimeTool, isRuntimeTool } from "./runtime-tools"
 import { DEFAULT_AGENT_RUNTIME_TOOL_NAMES } from "./runtime-tool-definitions"
+import {
+  ANSWER_DECISION_TOOL,
+  CREATE_DECISION_TOOL,
+  CREATE_GOAL_TOOL,
+  LIST_DECISIONS_TOOL,
+  LIST_GOALS_TOOL,
+  UPDATE_GOAL_TOOL,
+} from "../shared/runtime-tool-names"
 import { randomUUID } from "crypto"
 import {
   createToolSpan,
@@ -81,7 +89,15 @@ const RUNTIME_BUILTIN_TOOL_SOURCE_LABEL = "DotAgents Runtime Tools"
  */
 const DOTAGENTS_USER_AGENT = `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 DotAgents/${app.getVersion()}`
 
-const ESSENTIAL_RUNTIME_TOOL_NAMES = new Set<string>(["mark_work_complete"])
+const ESSENTIAL_RUNTIME_TOOL_NAMES = new Set<string>([
+  "mark_work_complete",
+  LIST_GOALS_TOOL,
+  CREATE_GOAL_TOOL,
+  UPDATE_GOAL_TOOL,
+  LIST_DECISIONS_TOOL,
+  CREATE_DECISION_TOOL,
+  ANSWER_DECISION_TOOL,
+])
 
 function isEssentialRuntimeTool(toolName: string): boolean {
   return ESSENTIAL_RUNTIME_TOOL_NAMES.has(toolName)

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -52,6 +52,9 @@ import { emergencyStopAll } from "./emergency-stop"
 import { sendMessageNotification, isPushEnabled, clearBadgeCount } from "./push-notification-service"
 import { skillsService } from "./skills-service"
 import { knowledgeNotesService } from "./knowledge-notes-service"
+import { goalService } from "./goal-service"
+import { decisionService } from "./decision-service"
+import { goalProgressService } from "./goal-progress-service"
 import { sanitizeAgentProfileConnection, VALID_AGENT_PROFILE_CONNECTION_TYPES } from "./agent-profile-connection-sanitize"
 import { isRuntimeTool } from "./runtime-tools"
 import { agentProfileService, createSessionSnapshotFromProfile, toolConfigToMcpServerConfig } from "./agent-profile-service"
@@ -113,6 +116,11 @@ import type {
   OperatorWhatsAppIntegrationSummary,
   RemoteSttTranscriptionRequest,
   RemoteSttTranscriptionResponse,
+  GoalCreateRequest,
+  GoalUpdateRequest,
+  DecisionCreateRequest,
+  DecisionUpdateRequest,
+  DecisionRespondRequest,
 } from "@dotagents/shared"
 import type { RendererHandlers } from "./renderer-handlers"
 import { INJECTED_RUNTIME_TOOL_TRANSPORT_NAME, RESERVED_RUNTIME_TOOL_SERVER_NAMES } from "../shared/runtime-tool-names"
@@ -7502,8 +7510,177 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       isRunning: status?.isRunning ?? false,
       nextRunAt: status?.nextRunAt,
       schedule: loop.schedule,
+      loopType: loop.loopType,
+      linkedGoalIds: loop.linkedGoalIds,
+      outputType: loop.outputType,
+      tokenBudgetPerRun: loop.tokenBudgetPerRun,
     }
   }
+
+  // GET /v1/goals - List goals
+  fastify.get("/v1/goals", async (_req, reply) => {
+    try {
+      return reply.send({ goals: await goalService.listGoals() })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to get goals", error)
+      return reply.code(500).send({ error: error?.message || "Failed to get goals" })
+    }
+  })
+
+  // POST /v1/goals - Create a goal
+  fastify.post("/v1/goals", async (req, reply) => {
+    try {
+      const goal = await goalService.saveGoal(req.body as GoalCreateRequest)
+      return reply.code(201).send({ goal })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to create goal", error)
+      return reply.code(400).send({ error: error?.message || "Failed to create goal" })
+    }
+  })
+
+  // GET /v1/goals/:id - Get a goal
+  fastify.get("/v1/goals/:id", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const goal = await goalService.getGoal(id)
+      if (!goal) return reply.code(404).send({ error: "Goal not found" })
+      return reply.send({ goal })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to get goal", error)
+      return reply.code(500).send({ error: error?.message || "Failed to get goal" })
+    }
+  })
+
+  // PATCH /v1/goals/:id - Update a goal
+  fastify.patch("/v1/goals/:id", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const goal = await goalService.updateGoal(id, req.body as GoalUpdateRequest)
+      if (!goal) return reply.code(404).send({ error: "Goal not found" })
+      return reply.send({ success: true, goal })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to update goal", error)
+      return reply.code(400).send({ error: error?.message || "Failed to update goal" })
+    }
+  })
+
+  // DELETE /v1/goals/:id - Delete a goal
+  fastify.delete("/v1/goals/:id", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const success = await goalService.deleteGoal(id)
+      if (!success) return reply.code(404).send({ error: "Goal not found" })
+      return reply.send({ success: true, id })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to delete goal", error)
+      return reply.code(500).send({ error: error?.message || "Failed to delete goal" })
+    }
+  })
+
+  // GET /v1/goal-events - List goal progress events
+  fastify.get("/v1/goal-events", async (req, reply) => {
+    try {
+      const query = req.query as { goalId?: string; parentGoalId?: string; limit?: string }
+      const limit = query.limit ? Number(query.limit) : undefined
+      return reply.send({
+        events: goalProgressService.listEvents({
+          goalId: query.goalId,
+          parentGoalId: query.parentGoalId,
+          limit: Number.isFinite(limit) ? limit : undefined,
+        }),
+      })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to get goal progress events", error)
+      return reply.code(500).send({ error: error?.message || "Failed to get goal progress events" })
+    }
+  })
+
+  // GET /v1/decisions - List decisions
+  fastify.get("/v1/decisions", async (req, reply) => {
+    try {
+      const query = req.query as { status?: "pending" | "history" | "all" }
+      const status = ["pending", "history", "all"].includes(query.status ?? "") ? query.status : "all"
+      return reply.send({ decisions: await decisionService.listDecisions(status ?? "all") })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to get decisions", error)
+      return reply.code(500).send({ error: error?.message || "Failed to get decisions" })
+    }
+  })
+
+  // POST /v1/decisions - Create a decision
+  fastify.post("/v1/decisions", async (req, reply) => {
+    try {
+      const decision = await decisionService.saveDecision(req.body as DecisionCreateRequest)
+      return reply.code(201).send({ decision })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to create decision", error)
+      return reply.code(400).send({ error: error?.message || "Failed to create decision" })
+    }
+  })
+
+  // GET /v1/decisions/:id - Get a decision
+  fastify.get("/v1/decisions/:id", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const decision = await decisionService.getDecision(id)
+      if (!decision) return reply.code(404).send({ error: "Decision not found" })
+      return reply.send({ decision })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to get decision", error)
+      return reply.code(500).send({ error: error?.message || "Failed to get decision" })
+    }
+  })
+
+  // PATCH /v1/decisions/:id - Update a decision
+  fastify.patch("/v1/decisions/:id", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const decision = await decisionService.updateDecision(id, req.body as DecisionUpdateRequest)
+      if (!decision) return reply.code(404).send({ error: "Decision not found" })
+      return reply.send({ success: true, decision })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to update decision", error)
+      return reply.code(400).send({ error: error?.message || "Failed to update decision" })
+    }
+  })
+
+  fastify.post("/v1/decisions/:id/respond", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const decision = await decisionService.respondToDecision(id, req.body as DecisionRespondRequest)
+      if (!decision) return reply.code(404).send({ error: "Decision not found" })
+      return reply.send({ success: true, decision })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to respond to decision", error)
+      return reply.code(400).send({ error: error?.message || "Failed to respond to decision" })
+    }
+  })
+
+  fastify.post("/v1/decisions/:id/defer", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const body = req.body as { note?: string }
+      const decision = await decisionService.setStatus(id, "deferred", body?.note)
+      if (!decision) return reply.code(404).send({ error: "Decision not found" })
+      return reply.send({ success: true, decision })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to defer decision", error)
+      return reply.code(400).send({ error: error?.message || "Failed to defer decision" })
+    }
+  })
+
+  fastify.post("/v1/decisions/:id/cancel", async (req, reply) => {
+    try {
+      const { id } = req.params as { id: string }
+      const body = req.body as { note?: string }
+      const decision = await decisionService.setStatus(id, "canceled", body?.note)
+      if (!decision) return reply.code(404).send({ error: "Decision not found" })
+      return reply.send({ success: true, decision })
+    } catch (error: any) {
+      diagnosticsService.logError("remote-server", "Failed to cancel decision", error)
+      return reply.code(400).send({ error: error?.message || "Failed to cancel decision" })
+    }
+  })
 
   // GET /v1/loops - List all repeat tasks
   fastify.get("/v1/loops", async (_req, reply) => {
@@ -7535,6 +7712,10 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
             isRunning: status?.isRunning ?? false,
             nextRunAt: status?.nextRunAt,
             schedule: l.schedule,
+            loopType: l.loopType,
+            linkedGoalIds: l.linkedGoalIds,
+            outputType: l.outputType,
+            tokenBudgetPerRun: l.tokenBudgetPerRun,
           }
         }),
       })

--- a/apps/desktop/src/main/runtime-tool-definitions.ts
+++ b/apps/desktop/src/main/runtime-tool-definitions.ts
@@ -35,6 +35,109 @@ export const runtimeToolDefinitions: RuntimeToolDefinition[] = [
   // runtime tools for execution purposes (see isRuntimeTool in runtime-tools.ts).
   ...acpRouterToolDefinitions,
   {
+    name: "list_goals",
+    description: "List DotAgents goals. Use this before planning repeat-task work so you can choose active goals with success criteria.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        loopVisibleOnly: {
+          type: "boolean",
+          description: "When true, only return active goals that have success criteria and are visible to loops.",
+        },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "create_goal",
+    description: "Create a structured DotAgents goal. Agent-created non-top-level goals require parentId, successCriteria, abandonIf, and provenance.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        description: { type: "string" },
+        level: { type: "string", enum: ["goal", "week", "today"] },
+        priority: { type: "number" },
+        parentId: { type: "string" },
+        successCriteria: { type: "string" },
+        signalToWatch: { type: "string" },
+        abandonIf: { type: "string" },
+        provenance: { type: "string" },
+        body: { type: "string" },
+      },
+      required: ["title", "successCriteria", "abandonIf", "provenance"],
+    },
+  },
+  {
+    name: "update_goal",
+    description: "Update a structured DotAgents goal by id. Use for status, priority, focus, and context updates.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        title: { type: "string" },
+        description: { type: "string" },
+        level: { type: "string", enum: ["goal", "week", "today"] },
+        priority: { type: "number" },
+        status: { type: "string", enum: ["active", "paused", "done", "abandoned"] },
+        parentId: { type: "string" },
+        successCriteria: { type: "string" },
+        signalToWatch: { type: "string" },
+        abandonIf: { type: "string" },
+        provenance: { type: "string" },
+        body: { type: "string" },
+      },
+      required: ["id"],
+    },
+  },
+  {
+    name: "list_decisions",
+    description: "List DotAgents decisions. Use status='pending' to inspect the in-app decision queue.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        status: { type: "string", enum: ["pending", "history", "all"] },
+      },
+      required: [],
+    },
+  },
+  {
+    name: "create_decision",
+    description: "Create an in-app decision only when the action is irreversible, path-changing, or would take more than 3 effort-hours to revert.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        question: { type: "string" },
+        type: { type: "string", enum: ["yn", "ab", "ranked", "edit", "defer"] },
+        recommendation: { type: "string" },
+        why: { type: "string" },
+        risk: { type: "string" },
+        goalId: { type: "string" },
+        taskId: { type: "string" },
+        expiresAt: { type: "number" },
+        defaultAction: { type: "string" },
+        urgent: { type: "boolean" },
+        revertEffortHours: { type: "number" },
+        pathChanging: { type: "boolean" },
+        irreversible: { type: "boolean" },
+        body: { type: "string" },
+      },
+      required: ["question"],
+    },
+  },
+  {
+    name: "answer_decision",
+    description: "Answer a pending DotAgents decision by id. Use this only when the answer is already known from user input or safe defaults.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        answer: { type: "string" },
+      },
+      required: ["id", "answer"],
+    },
+  },
+  {
     name: "respond_to_user",
     description:
       "Send a response through DotAgents' explicit delivery channel. Normal assistant text is valid for ordinary chat and simple final answers; use this tool when you specifically need voice/TTS or messaging-channel delivery semantics, or when sending images/videos. Provide at least one of: non-empty text, one/more images, or one/more videos.",

--- a/apps/desktop/src/main/runtime-tools.ts
+++ b/apps/desktop/src/main/runtime-tools.ts
@@ -17,6 +17,9 @@ import { conversationService } from "./conversation-service"
 import { readMoreContext } from "./context-budget"
 import { getRootAppSessionForAcpSession, setAcpSessionTitleOverride } from "./acp-session-state"
 import { emitAgentProgress } from "./emit-agent-progress"
+import { goalService } from "./goal-service"
+import { decisionService } from "./decision-service"
+import type { DecisionCreateRequest, GoalCreateRequest, GoalUpdateRequest } from "@dotagents/shared"
 import { promises as fs } from "fs"
 import { exec } from "child_process"
 import { promisify } from "util"
@@ -419,6 +422,134 @@ type ToolHandler = (
 ) => Promise<MCPToolResult>
 
 const toolHandlers: Record<string, ToolHandler> = {
+  list_goals: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+    const loopVisibleOnly = args.loopVisibleOnly === true
+    const goals = loopVisibleOnly
+      ? await goalService.listLoopVisibleGoals()
+      : await goalService.listGoals()
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: true, goals }) }],
+      isError: false,
+    }
+  },
+
+  create_goal: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+    const title = typeof args.title === "string" ? args.title.trim() : ""
+    if (!title) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "title is required" }) }],
+        isError: true,
+      }
+    }
+
+    const goal = await goalService.saveGoal({
+      title,
+      description: typeof args.description === "string" ? args.description : "",
+      level: args.level === "week" || args.level === "today" || args.level === "goal" ? args.level : "today",
+      priority: typeof args.priority === "number" ? args.priority : 3,
+      parentId: typeof args.parentId === "string" && args.parentId.trim() ? args.parentId.trim() : undefined,
+      successCriteria: typeof args.successCriteria === "string" ? args.successCriteria : undefined,
+      signalToWatch: typeof args.signalToWatch === "string" ? args.signalToWatch : undefined,
+      abandonIf: typeof args.abandonIf === "string" ? args.abandonIf : undefined,
+      createdBy: "agent",
+      createdFrom: "loop_daily_planning",
+      provenance: typeof args.provenance === "string" ? args.provenance : undefined,
+      linkedTaskIds: [],
+      body: typeof args.body === "string" ? args.body : "",
+    } satisfies GoalCreateRequest)
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: true, goal }) }],
+      isError: false,
+    }
+  },
+
+  update_goal: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+    const id = typeof args.id === "string" ? args.id.trim() : ""
+    if (!id) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "id is required" }) }],
+        isError: true,
+      }
+    }
+
+    const updates: GoalUpdateRequest = {}
+    if (typeof args.title === "string") updates.title = args.title
+    if (typeof args.description === "string") updates.description = args.description
+    if (args.level === "goal" || args.level === "week" || args.level === "today") updates.level = args.level
+    if (typeof args.priority === "number") updates.priority = args.priority
+    if (args.status === "active" || args.status === "paused" || args.status === "done" || args.status === "abandoned") updates.status = args.status
+    if (typeof args.parentId === "string") updates.parentId = args.parentId
+    if (typeof args.successCriteria === "string") updates.successCriteria = args.successCriteria
+    if (typeof args.signalToWatch === "string") updates.signalToWatch = args.signalToWatch
+    if (typeof args.abandonIf === "string") updates.abandonIf = args.abandonIf
+    if (typeof args.provenance === "string") updates.provenance = args.provenance
+    if (typeof args.body === "string") updates.body = args.body
+
+    const goal = await goalService.updateGoal(id, updates)
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: Boolean(goal), goal, error: goal ? undefined : "Goal not found" }) }],
+      isError: !goal,
+    }
+  },
+
+  list_decisions: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+    const status = args.status === "pending" || args.status === "history" || args.status === "all" ? args.status : "all"
+    const decisions = await decisionService.listDecisions(status)
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: true, decisions }) }],
+      isError: false,
+    }
+  },
+
+  create_decision: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+    const question = typeof args.question === "string" ? args.question.trim() : ""
+    if (!question) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "question is required" }) }],
+        isError: true,
+      }
+    }
+
+    const decision = await decisionService.saveDecision({
+      question,
+      type: args.type === "ab" || args.type === "ranked" || args.type === "edit" || args.type === "defer" || args.type === "yn" ? args.type : "yn",
+      recommendation: typeof args.recommendation === "string" ? args.recommendation : undefined,
+      why: typeof args.why === "string" ? args.why : undefined,
+      risk: typeof args.risk === "string" ? args.risk : undefined,
+      goalId: typeof args.goalId === "string" ? args.goalId : undefined,
+      taskId: typeof args.taskId === "string" ? args.taskId : undefined,
+      expiresAt: typeof args.expiresAt === "number" ? args.expiresAt : undefined,
+      defaultAction: typeof args.defaultAction === "string" ? args.defaultAction : undefined,
+      urgent: args.urgent === true,
+      revertEffortHours: typeof args.revertEffortHours === "number" ? args.revertEffortHours : 0,
+      pathChanging: args.pathChanging === true,
+      irreversible: args.irreversible === true,
+      body: typeof args.body === "string" ? args.body : "",
+    } satisfies DecisionCreateRequest)
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: true, decision }) }],
+      isError: false,
+    }
+  },
+
+  answer_decision: async (args: Record<string, unknown>): Promise<MCPToolResult> => {
+    const id = typeof args.id === "string" ? args.id.trim() : ""
+    const answer = typeof args.answer === "string" ? args.answer.trim() : ""
+    if (!id || !answer) {
+      return {
+        content: [{ type: "text", text: JSON.stringify({ success: false, error: "id and answer are required" }) }],
+        isError: true,
+      }
+    }
+    const decision = await decisionService.respondToDecision(id, { answer, answerSource: "agent" })
+    return {
+      content: [{ type: "text", text: JSON.stringify({ success: Boolean(decision), decision, error: decision ? undefined : "Decision not found" }) }],
+      isError: !decision,
+    }
+  },
+
   respond_to_user: async (args: Record<string, unknown>, context: BuiltinToolContext): Promise<MCPToolResult> => {
     if (!context.sessionId) {
       return {
@@ -788,7 +919,7 @@ const toolHandlers: Record<string, ToolHandler> = {
       })
     }
 
-    if (mappedAppSessionId) {
+    if (mappedAppSessionId && session) {
       setAcpSessionTitleOverride(context.sessionId, updatedConversation.title)
       const parentSessionId = mappedAppSessionId
       const runId = agentSessionStateManager.getSessionRunId(trackedSessionId)

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -98,9 +98,19 @@ import { getAppSessionForAcpSession } from "./acp-session-state"
 import { fetchModelsDevData, getModelFromModelsDevByProviderId, findBestModelMatch, refreshModelsDevCache } from "./models-dev-service"
 import * as parakeetStt from "./parakeet-stt"
 import { loopService } from "./loop-service"
+import { goalService } from "./goal-service"
+import { decisionService } from "./decision-service"
+import { goalProgressService } from "./goal-progress-service"
 import { clearSessionUserResponse } from "./session-user-response-store"
 import { isMissingApiKeyErrorMessage } from "@dotagents/shared"
 import { hasRepeatTaskTitlePrefix } from "../shared/repeat-tasks"
+import type {
+  DecisionCreateRequest,
+  DecisionRespondRequest,
+  DecisionUpdateRequest,
+  GoalCreateRequest,
+  GoalUpdateRequest,
+} from "@dotagents/shared"
 
 function describeAgentSessionId(sessionId?: string | null): "missing" | "pending" | "subsession" | "session" | "unknown" {
   if (!sessionId) return "missing"
@@ -5800,6 +5810,98 @@ export const router = {
         sort: input.sort,
         limit: input.limit,
       })
+    }),
+
+  // Goals handlers
+  getGoals: t.procedure.action(async () => {
+    return goalService.listGoals()
+  }),
+
+  getGoal: t.procedure
+    .input<{ id: string }>()
+    .action(async ({ input }) => {
+      return goalService.getGoal(input.id)
+    }),
+
+  saveGoal: t.procedure
+    .input<{ goal: GoalCreateRequest }>()
+    .action(async ({ input }) => {
+      const goal = await goalService.saveGoal(input.goal)
+      return { success: true, goal }
+    }),
+
+  updateGoal: t.procedure
+    .input<{ id: string; updates: GoalUpdateRequest }>()
+    .action(async ({ input }) => {
+      const goal = await goalService.updateGoal(input.id, input.updates)
+      return { success: Boolean(goal), goal }
+    }),
+
+  deleteGoal: t.procedure
+    .input<{ id: string }>()
+    .action(async ({ input }) => {
+      return { success: await goalService.deleteGoal(input.id), id: input.id }
+    }),
+
+  touchGoal: t.procedure
+    .input<{ id: string }>()
+    .action(async ({ input }) => {
+      const goal = await goalService.touchGoal(input.id)
+      return { success: Boolean(goal), goal }
+    }),
+
+  getGoalProgressEvents: t.procedure
+    .input<{ goalId?: string; parentGoalId?: string; limit?: number } | undefined>()
+    .action(async ({ input }) => {
+      return goalProgressService.listEvents(input ?? {})
+    }),
+
+  // Decisions handlers
+  getDecisions: t.procedure
+    .input<{ status?: "pending" | "history" | "all" }>()
+    .action(async ({ input }) => {
+      return decisionService.listDecisions(input.status ?? "all")
+    }),
+
+  getDecision: t.procedure
+    .input<{ id: string }>()
+    .action(async ({ input }) => {
+      return decisionService.getDecision(input.id)
+    }),
+
+  saveDecision: t.procedure
+    .input<{ decision: DecisionCreateRequest }>()
+    .action(async ({ input }) => {
+      const decision = await decisionService.saveDecision(input.decision)
+      return { success: true, decision }
+    }),
+
+  updateDecision: t.procedure
+    .input<{ id: string; updates: DecisionUpdateRequest }>()
+    .action(async ({ input }) => {
+      const decision = await decisionService.updateDecision(input.id, input.updates)
+      return { success: Boolean(decision), decision }
+    }),
+
+  respondToDecision: t.procedure
+    .input<{ id: string; response: DecisionRespondRequest }>()
+    .action(async ({ input }) => {
+      const decision = await decisionService.respondToDecision(input.id, input.response)
+      return { success: Boolean(decision), decision }
+    }),
+
+  deferDecision: t.procedure
+    .input<{ id: string; note?: string }>()
+    .action(async ({ input }) => {
+      const decision = await decisionService.setStatus(input.id, "deferred", input.note)
+      return { success: Boolean(decision), decision }
+    }),
+
+  cancelDecision: t.procedure
+    .input<{ id: string; note?: string }>()
+    .action(async ({ input }) => {
+      const decision = await decisionService.setStatus(input.id, "canceled", input.note)
+      return { success: Boolean(decision), decision }
     }),
 
   // Summarization service handlers

--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -329,11 +329,6 @@ export const Component = () => {
       icon: Plug2,
     },
     {
-      text: "Knowledge",
-      href: "/knowledge",
-      icon: "i-mingcute-book-2-line",
-    },
-    {
       text: "Agents",
       href: "/settings/agents",
       icon: "i-mingcute-group-line",
@@ -366,6 +361,24 @@ export const Component = () => {
       text: "Repeat Tasks",
       href: "/settings/repeat-tasks",
       icon: "i-mingcute-refresh-3-line",
+    },
+  ]
+
+  const productNavLinks: NavLinkItem[] = [
+    {
+      text: "Goals",
+      href: "/goals",
+      icon: "i-mingcute-target-line",
+    },
+    {
+      text: "Decisions",
+      href: "/decisions",
+      icon: "i-mingcute-question-line",
+    },
+    {
+      text: "Knowledge",
+      href: "/knowledge",
+      icon: "i-mingcute-book-2-line",
     },
   ]
 
@@ -762,7 +775,7 @@ export const Component = () => {
 
               {/* Settings Section - collapsed quick navigation */}
               <div className="mt-2 grid gap-1">
-                {settingsNavLinks.map((link) => {
+                {[...productNavLinks, ...settingsNavLinks].map((link) => {
                   const isActive = isNavLinkActive(link.href)
                   const icon = typeof link.icon === "string"
                     ? <span className={cn(link.icon, "h-4 w-4")}></span>
@@ -812,6 +825,16 @@ export const Component = () => {
                 onClearInactiveSessions={isSessionsActive ? clearInactiveSessions : undefined}
                 inactiveSessionCount={0}
               />
+
+              <div className="shrink-0 px-2">
+                <div className="flex w-full items-center gap-1 rounded px-1.5 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  <span className="i-mingcute-compass-line h-3 w-3 shrink-0"></span>
+                  <span className="select-none">Workspace</span>
+                </div>
+                <div className="mt-1 grid gap-0.5 text-xs">
+                  {productNavLinks.map(renderNavLink)}
+                </div>
+              </div>
 
               {/* Settings Section - Collapsible, collapsed by default */}
               <div className="shrink-0 px-2">

--- a/apps/desktop/src/renderer/src/pages/decisions.tsx
+++ b/apps/desktop/src/renderer/src/pages/decisions.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import type { Decision, Goal } from "@dotagents/shared"
+import { Badge } from "@renderer/components/ui/badge"
+import { Button } from "@renderer/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@renderer/components/ui/card"
+import { Input } from "@renderer/components/ui/input"
+import { Textarea } from "@renderer/components/ui/textarea"
+import { tipcClient } from "@renderer/lib/tipc-client"
+
+type Tab = "pending" | "history"
+
+function formatTime(timestamp?: number | null): string {
+  if (!timestamp) return "None"
+  return new Date(timestamp).toLocaleString()
+}
+
+function DecisionCard({
+  decision,
+  goal,
+  onAnswer,
+  onDefer,
+  onCancel,
+}: {
+  decision: Decision
+  goal?: Goal
+  onAnswer: (decision: Decision, answer: string) => void
+  onDefer: (decision: Decision) => void
+  onCancel: (decision: Decision) => void
+}) {
+  const [customAnswer, setCustomAnswer] = useState("")
+  const isPending = decision.status === "pending"
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-lg">{decision.question}</CardTitle>
+            <CardDescription className="mt-1">
+              {goal ? `Goal: ${goal.title}` : decision.goalId ? `Goal: ${decision.goalId}` : "No linked goal"}
+            </CardDescription>
+          </div>
+          <div className="flex shrink-0 gap-1">
+            {decision.urgent && <Badge className="bg-red-500/15 text-red-700 dark:text-red-300">urgent</Badge>}
+            <Badge variant="outline">{decision.type}</Badge>
+            <Badge variant="secondary">{decision.status}</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        <div className="grid gap-2 text-muted-foreground">
+          {decision.recommendation && <div><span className="font-medium text-foreground">Recommendation:</span> {decision.recommendation}</div>}
+          {decision.why && <div><span className="font-medium text-foreground">Why:</span> {decision.why}</div>}
+          {decision.risk && <div><span className="font-medium text-foreground">Risk:</span> {decision.risk}</div>}
+          <div><span className="font-medium text-foreground">Default:</span> {decision.defaultAction || "None"} · expires {formatTime(decision.expiresAt)}</div>
+          <div>
+            <span className="font-medium text-foreground">Ask threshold:</span>{" "}
+            {decision.irreversible ? "irreversible" : decision.pathChanging ? "path-changing" : `${decision.revertEffortHours}h revert effort`}
+          </div>
+          {decision.body && <Textarea readOnly value={decision.body} rows={3} />}
+        </div>
+
+        {isPending ? (
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              {decision.recommendation && (
+                <Button onClick={() => onAnswer(decision, decision.recommendation ?? "")}>Accept recommendation</Button>
+              )}
+              <Button variant="outline" onClick={() => onAnswer(decision, "yes")}>Yes</Button>
+              <Button variant="outline" onClick={() => onAnswer(decision, "no")}>No</Button>
+              <Button variant="outline" onClick={() => onDefer(decision)}>Defer</Button>
+              <Button variant="ghost" onClick={() => onCancel(decision)}>Cancel</Button>
+            </div>
+            <div className="flex gap-2">
+              <Input
+                value={customAnswer}
+                onChange={(event) => setCustomAnswer(event.target.value)}
+                placeholder="Custom answer"
+              />
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  if (!customAnswer.trim()) return
+                  onAnswer(decision, customAnswer.trim())
+                  setCustomAnswer("")
+                }}
+              >
+                Submit
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-md bg-muted/50 p-3 text-muted-foreground">
+            Answer: <span className="font-medium text-foreground">{decision.answer || "None"}</span> · {formatTime(decision.answeredAt)}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export function DecisionsPage() {
+  const [tab, setTab] = useState<Tab>("pending")
+  const queryClient = useQueryClient()
+
+  const decisionsQuery = useQuery<Decision[]>({
+    queryKey: ["decisions", tab],
+    queryFn: () => tipcClient.getDecisions({ status: tab }) as Promise<Decision[]>,
+  })
+
+  const goalsQuery = useQuery<Goal[]>({
+    queryKey: ["goals"],
+    queryFn: () => tipcClient.getGoals() as Promise<Goal[]>,
+  })
+
+  const goalsById = useMemo(
+    () => new Map((goalsQuery.data ?? []).map((goal) => [goal.id, goal] as const)),
+    [goalsQuery.data],
+  )
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["decisions"] })
+    queryClient.invalidateQueries({ queryKey: ["goals"] })
+  }
+
+  const answerDecision = async (decision: Decision, answer: string) => {
+    try {
+      await tipcClient.respondToDecision({ id: decision.id, response: { answer, answerSource: "aj" } })
+      invalidate()
+      toast.success("Decision answered")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to answer decision")
+    }
+  }
+
+  const setDecisionAside = async (decision: Decision, action: "defer" | "cancel") => {
+    try {
+      if (action === "defer") await tipcClient.deferDecision({ id: decision.id })
+      else await tipcClient.cancelDecision({ id: decision.id })
+      invalidate()
+      toast.success(action === "defer" ? "Decision deferred" : "Decision canceled")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to update decision")
+    }
+  }
+
+  const decisions = decisionsQuery.data ?? []
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-6">
+      <div className="flex flex-col gap-2">
+        <div className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">Decision Queue</div>
+        <h1 className="text-3xl font-semibold tracking-tight">Decisions</h1>
+        <p className="max-w-2xl text-sm text-muted-foreground">
+          Agents should only ask here for irreversible, path-changing, or expensive-to-revert calls.
+        </p>
+      </div>
+
+      <div className="flex gap-2">
+        <Button variant={tab === "pending" ? "default" : "outline"} onClick={() => setTab("pending")}>Pending</Button>
+        <Button variant={tab === "history" ? "default" : "outline"} onClick={() => setTab("history")}>History</Button>
+      </div>
+
+      {decisions.length === 0 ? (
+        <Card><CardContent className="py-8 text-sm text-muted-foreground">No {tab} decisions.</CardContent></Card>
+      ) : (
+        <div className="grid gap-4">
+          {decisions.map((decision) => (
+            <DecisionCard
+              key={decision.id}
+              decision={decision}
+              goal={decision.goalId ? goalsById.get(decision.goalId) : undefined}
+              onAnswer={(item, answer) => void answerDecision(item, answer)}
+              onDefer={(item) => void setDecisionAside(item, "defer")}
+              onCancel={(item) => void setDecisionAside(item, "cancel")}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const Component = DecisionsPage

--- a/apps/desktop/src/renderer/src/pages/goals.tsx
+++ b/apps/desktop/src/renderer/src/pages/goals.tsx
@@ -1,0 +1,981 @@
+import { useEffect, useMemo, useState } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { toast } from "sonner"
+import { Activity, Bot, CheckCircle2, CircleAlert, ExternalLink, History, ListChecks, PauseCircle, Play, Radio, Square } from "lucide-react"
+import type { Goal, GoalCreateRequest, GoalLevel, GoalStatus, Decision, GoalProgressEvent } from "@dotagents/shared"
+import type { AgentProgressUpdate, LoopConfig } from "@shared/types"
+import { Badge } from "@renderer/components/ui/badge"
+import { Button } from "@renderer/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@renderer/components/ui/card"
+import { Input } from "@renderer/components/ui/input"
+import { Label } from "@renderer/components/ui/label"
+import { Textarea } from "@renderer/components/ui/textarea"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select"
+import { tipcClient, rendererHandlers } from "@renderer/lib/tipc-client"
+import { cn } from "@renderer/lib/utils"
+import { useAgentStore } from "@renderer/stores"
+
+type GoalForm = {
+  title: string
+  description: string
+  level: GoalLevel
+  priority: string
+  parentId: string
+  successCriteria: string
+  abandonIf: string
+  body: string
+}
+
+interface AgentSessionRecord {
+  id: string
+  conversationId?: string
+  conversationTitle?: string
+  status: "active" | "completed" | "error" | "stopped"
+  startTime?: number
+  endTime?: number
+  currentIteration?: number
+  maxIterations?: number
+  lastActivity?: string
+  errorMessage?: string
+  isSnoozed?: boolean
+  isRepeatTask?: boolean
+}
+
+interface SessionListResponse {
+  activeSessions: AgentSessionRecord[]
+  recentCompletedSessions?: AgentSessionRecord[]
+  recentSessions?: AgentSessionRecord[]
+}
+
+interface LoopStatus {
+  id: string
+  name: string
+  enabled: boolean
+  isRunning: boolean
+  lastRunAt?: number
+  nextRunAt?: number
+  intervalMinutes: number
+  schedule?: LoopConfig["schedule"]
+}
+
+const emptyForm: GoalForm = {
+  title: "",
+  description: "",
+  level: "goal",
+  priority: "3",
+  parentId: "",
+  successCriteria: "",
+  abandonIf: "",
+  body: "",
+}
+
+const LEVEL_LABELS: Record<GoalLevel, string> = {
+  goal: "Big Goals",
+  week: "This Week",
+  today: "Today's Focus",
+}
+
+function priorityLabel(priority: number): string {
+  return `P${priority}`
+}
+
+function statusTone(status: GoalStatus): string {
+  if (status === "active") return "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+  if (status === "paused") return "bg-amber-500/15 text-amber-700 dark:text-amber-300"
+  if (status === "done") return "bg-blue-500/15 text-blue-700 dark:text-blue-300"
+  return "bg-muted text-muted-foreground"
+}
+
+function formatRelativeTime(timestamp?: number): string {
+  if (!timestamp) return "Never"
+  const diffMs = Date.now() - timestamp
+  const absMs = Math.abs(diffMs)
+  const suffix = diffMs >= 0 ? "ago" : "from now"
+  const minute = 60_000
+  const hour = 60 * minute
+  const day = 24 * hour
+
+  if (absMs < minute) return diffMs >= 0 ? "just now" : "in under 1m"
+  if (absMs < hour) return `${Math.round(absMs / minute)}m ${suffix}`
+  if (absMs < day) return `${Math.round(absMs / hour)}h ${suffix}`
+  return `${Math.round(absMs / day)}d ${suffix}`
+}
+
+function getLatestProgressText(progress?: AgentProgressUpdate): string {
+  const latestStep = progress?.steps.at(-1)
+  if (latestStep?.description) return latestStep.description
+  if (latestStep?.title) return latestStep.title
+  if (progress?.streamingContent?.text) return progress.streamingContent.text
+  if (progress?.userResponse) return progress.userResponse
+  return "Waiting for the next update."
+}
+
+function getSessionTimestamp(session: AgentSessionRecord, progress?: AgentProgressUpdate): number {
+  const latestStepTimestamp = progress?.steps.at(-1)?.timestamp
+  const latestMessageTimestamp = progress?.conversationHistory?.at(-1)?.timestamp
+  return Math.max(
+    latestStepTimestamp ?? 0,
+    latestMessageTimestamp ?? 0,
+    session.endTime ?? 0,
+    session.startTime ?? 0,
+  )
+}
+
+function sessionStatusTone(session: AgentSessionRecord, progress?: AgentProgressUpdate): string {
+  if (progress?.pendingToolApproval) return "border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+  if (session.status === "error" || session.status === "stopped") return "border-red-500/50 bg-red-500/10 text-red-700 dark:text-red-300"
+  if (progress?.isComplete || session.status === "completed") return "border-emerald-500/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+  if (session.isSnoozed || progress?.isSnoozed) return "border-muted-foreground/30 bg-muted text-muted-foreground"
+  return "border-blue-500/50 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+}
+
+function SessionCard({
+  session,
+  progress,
+  matchedGoal,
+  onFocus,
+  onStop,
+}: {
+  session: AgentSessionRecord
+  progress?: AgentProgressUpdate
+  matchedGoal?: Goal
+  onFocus: (session: AgentSessionRecord) => void
+  onStop: (session: AgentSessionRecord) => void
+}) {
+  const latestTimestamp = getSessionTimestamp(session, progress)
+  const isActive = session.status === "active" && !progress?.isComplete
+
+  return (
+    <div className="rounded-2xl border border-border/70 bg-background/80 p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <Bot className="h-4 w-4 text-blue-500" />
+            <div className="truncate text-sm font-semibold">
+              {progress?.conversationTitle || session.conversationTitle || "Agent session"}
+            </div>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {matchedGoal ? `Goal: ${matchedGoal.title}` : session.isRepeatTask ? "Repeat task run" : "Manual session"}
+          </div>
+        </div>
+        <Badge variant="outline" className={sessionStatusTone(session, progress)}>
+          {progress?.pendingToolApproval ? "needs input" : progress?.isComplete ? "complete" : session.isSnoozed ? "background" : session.status}
+        </Badge>
+      </div>
+      <div className="mt-3 line-clamp-2 text-sm text-muted-foreground">{getLatestProgressText(progress)}</div>
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+        <div className="text-xs text-muted-foreground">
+          Updated {formatRelativeTime(latestTimestamp)}
+          {progress?.currentIteration ? ` · Iteration ${progress.currentIteration}/${progress.maxIterations}` : ""}
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" onClick={() => onFocus(session)}>
+            <ExternalLink className="mr-1 h-3.5 w-3.5" />
+            Open
+          </Button>
+          {isActive && (
+            <Button size="sm" variant="outline" onClick={() => onStop(session)}>
+              <Square className="mr-1 h-3.5 w-3.5" />
+              Stop
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function GoalLoopPanel({
+  loop,
+  status,
+  isBusy,
+  latestEvent,
+  liveSessionCount,
+  onArm,
+  onPause,
+  onCheckNow,
+}: {
+  loop?: LoopConfig
+  status?: LoopStatus
+  isBusy: boolean
+  latestEvent?: GoalProgressEvent
+  liveSessionCount: number
+  onArm: () => void
+  onPause: () => void
+  onCheckNow: () => void
+}) {
+  const isArmed = Boolean(status?.enabled)
+  const isOnline = isArmed && loop?.runContinuously === true
+  const statusLabel = status?.isRunning ? "checking now" : isOnline ? "online 24/7" : isArmed ? "scheduled only" : "paused"
+  const wakeLabel = status?.isRunning
+    ? "Running now"
+    : isOnline
+      ? "Continuous"
+      : status?.nextRunAt
+      ? formatRelativeTime(status.nextRunAt)
+      : isArmed
+        ? "Timer pending"
+        : "Not armed"
+  const cadenceLabel = isOnline
+    ? `Always on · sweep every ${loop?.intervalMinutes ?? 15}m`
+    : loop?.schedule?.type === "daily"
+    ? `Daily ${loop.schedule.times.join(", ")}`
+    : `${loop?.intervalMinutes ?? 1440}m cadence`
+
+  return (
+    <Card className="overflow-hidden border-emerald-500/25 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.18),transparent_34%),linear-gradient(135deg,rgba(15,23,42,0.96),rgba(15,23,42,0.84)_42%,rgba(8,47,73,0.82))] text-white shadow-xl">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.22em] text-emerald-200">
+              <Radio className="h-3.5 w-3.5" />
+              Goal agent
+            </div>
+            <CardTitle className="mt-2 text-2xl">24/7 supervisor</CardTitle>
+            <CardDescription className="text-slate-300">
+              Stays online, watches goal state, records evidence, and launches bounded checks without burning tokens in a tight no-op loop.
+            </CardDescription>
+          </div>
+          <Badge
+            variant="outline"
+            className={cn(
+              "shrink-0 border-white/20 bg-white/10 text-white",
+              status?.isRunning && "border-blue-300 bg-blue-400/20 text-blue-100",
+              isOnline && !status?.isRunning && "border-emerald-300 bg-emerald-400/20 text-emerald-100",
+            )}
+          >
+            <span className={cn("mr-2 h-2 w-2 rounded-full", status?.isRunning ? "animate-pulse bg-blue-200" : isOnline ? "animate-pulse bg-emerald-200" : isArmed ? "bg-amber-200" : "bg-slate-400")} />
+            {statusLabel}
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-2xl border border-white/10 bg-white/10 p-4 text-sm text-slate-200">
+          {isOnline ? (
+            <span>
+              The goal agent is online 24/7. <span className="font-semibold text-white">0 live sessions</span> means standby between bounded checks, not off.
+            </span>
+          ) : isArmed ? (
+            <span>
+              The goal agent is only on a daily schedule right now. Switch it to 24/7 mode to keep the supervisor online.
+            </span>
+          ) : (
+            <span>
+              The goal agent is paused. Start 24/7 mode to bring the supervisor online and run an immediate check.
+            </span>
+          )}
+        </div>
+        <div className="grid gap-3 text-sm sm:grid-cols-4">
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Supervisor</div>
+            <div className="mt-1 font-medium">{isOnline ? "Online" : isArmed ? "Scheduled" : "Paused"}</div>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Current run</div>
+            <div className="mt-1 font-medium">{status?.isRunning ? "Live" : liveSessionCount > 0 ? `${liveSessionCount} live` : isOnline ? "Standby" : "Idle"}</div>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Next check</div>
+            <div className="mt-1 font-medium">{wakeLabel}</div>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Last evidence</div>
+            <div className="mt-1 truncate font-medium">{latestEvent ? formatRelativeTime(latestEvent.at) : "None yet"}</div>
+          </div>
+        </div>
+        <div className="grid gap-3 text-sm sm:grid-cols-3">
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Last run</div>
+            <div className="mt-1 font-medium">{formatRelativeTime(status?.lastRunAt)}</div>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Cadence</div>
+            <div className="mt-1 font-medium">{cadenceLabel}</div>
+          </div>
+          <div className="rounded-xl border border-white/10 bg-white/10 p-3">
+            <div className="text-xs uppercase tracking-wide text-slate-400">Conversation</div>
+            <div className="mt-1 font-medium">{loop?.continueInSession ? "Reused memory" : "New each run"}</div>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {isOnline ? (
+            <Button className="bg-white text-slate-950 hover:bg-slate-100" onClick={onCheckNow} disabled={!loop || isBusy || status?.isRunning}>
+              <Play className="mr-2 h-4 w-4" />
+              Check now
+            </Button>
+          ) : (
+            <Button className="bg-emerald-300 text-slate-950 hover:bg-emerald-200" onClick={onArm} disabled={!loop || isBusy || status?.isRunning}>
+              <Radio className="mr-2 h-4 w-4" />
+              Start 24/7 goal agent
+            </Button>
+          )}
+          {!isOnline && (
+            <Button variant="outline" className="border-white/20 bg-white/5 text-white hover:bg-white/10 hover:text-white" onClick={onCheckNow} disabled={!loop || isBusy || status?.isRunning}>
+              <Play className="mr-2 h-4 w-4" />
+              Run one check
+            </Button>
+          )}
+          {isArmed && (
+            <Button variant="outline" className="border-white/20 bg-white/5 text-white hover:bg-white/10 hover:text-white" onClick={onPause} disabled={!loop || isBusy}>
+              <PauseCircle className="mr-2 h-4 w-4" />
+              Pause supervisor
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+function getEventTone(type: GoalProgressEvent["type"]): string {
+  if (type === "planner_run_noop") return "border-muted-foreground/30 bg-muted text-muted-foreground"
+  if (type.includes("decision")) return "border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+  if (type === "goal_status_changed" || type === "criterion_completed") return "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+  return "border-blue-500/40 bg-blue-500/10 text-blue-700 dark:text-blue-300"
+}
+
+function formatEventType(type: GoalProgressEvent["type"]): string {
+  return type.replace(/^planner_run_/u, "goal agent ").replace(/^goal_/u, "goal ").replace(/^decision_/u, "decision ").replace(/_/gu, " ")
+}
+
+function formatEventTitle(event: GoalProgressEvent): string {
+  return event.title
+    .replace(/^Started planner:/u, "Started goal agent check:")
+    .replace(/^Planner completed:/u, "Goal agent recorded progress:")
+    .replace(/^Planner checked goals:/u, "Goal agent checked goals:")
+}
+
+function getEventSignature(event: GoalProgressEvent): string {
+  return [
+    event.type,
+    event.goalId ?? "",
+    event.parentGoalId ?? "",
+    event.title,
+    event.summary ?? "",
+  ].join("|")
+}
+
+function compactGoalProgressEvents(events: GoalProgressEvent[]): GoalProgressEvent[] {
+  const focusSelectedAtByGoalId = new Map<string, number>()
+  for (const event of events) {
+    if (event.type === "focus_selected" && event.goalId) {
+      const current = focusSelectedAtByGoalId.get(event.goalId) ?? 0
+      focusSelectedAtByGoalId.set(event.goalId, Math.max(current, event.at))
+    }
+  }
+
+  const lastSeenBySignature = new Map<string, number>()
+  const compacted: GoalProgressEvent[] = []
+  for (const event of events) {
+    if (event.type === "planner_run_noop") continue
+
+    const focusSelectedAt = event.goalId ? focusSelectedAtByGoalId.get(event.goalId) : undefined
+    if (
+      event.type === "goal_updated" &&
+      event.source === "loop_daily_planning" &&
+      focusSelectedAt &&
+      Math.abs(event.at - focusSelectedAt) < 10 * 60_000
+    ) {
+      continue
+    }
+
+    const signature = getEventSignature(event)
+    const lastSeenAt = lastSeenBySignature.get(signature)
+    if (lastSeenAt && Math.abs(lastSeenAt - event.at) < 10 * 60_000) continue
+
+    lastSeenBySignature.set(signature, event.at)
+    compacted.push(event)
+  }
+
+  return compacted
+}
+
+function ProgressLedger({
+  events,
+  goalsById,
+}: {
+  events: GoalProgressEvent[]
+  goalsById: Map<string, Goal>
+}) {
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <CardTitle>Progress ledger</CardTitle>
+            <CardDescription>Meaningful changes recorded by goals, decisions, and planner runs.</CardDescription>
+          </div>
+          <History className="h-5 w-5 text-muted-foreground" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {events.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+            No goal progress events recorded yet.
+          </div>
+        ) : (
+          events.slice(0, 8).map((event) => {
+            const goal = event.goalId ? goalsById.get(event.goalId) : undefined
+            return (
+              <div key={event.id} className="rounded-lg border border-border/70 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{formatEventTitle(event)}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {goal?.title ?? event.goalId ?? "Goal agent"} · {formatRelativeTime(event.at)}
+                    </div>
+                  </div>
+                  <Badge variant="outline" className={getEventTone(event.type)}>
+                    {formatEventType(event.type)}
+                  </Badge>
+                </div>
+                {event.summary && <div className="mt-2 line-clamp-2 text-sm text-muted-foreground">{event.summary}</div>}
+              </div>
+            )
+          })
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function GoalCard({
+  goal,
+  pendingDecisionCount,
+  onStatus,
+  onPriority,
+}: {
+  goal: Goal
+  pendingDecisionCount: number
+  onStatus: (goal: Goal, status: GoalStatus) => void
+  onPriority: (goal: Goal, priority: number) => void
+}) {
+  return (
+    <Card className="border-border/70">
+      <CardHeader className="space-y-2 pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="truncate text-base">{goal.title}</CardTitle>
+            <CardDescription className="mt-1 line-clamp-2">{goal.description || "No description yet."}</CardDescription>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Badge className={statusTone(goal.status)} variant="secondary">{goal.status}</Badge>
+            <Badge variant="outline">{priorityLabel(goal.priority)}</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <div className="grid gap-2 text-muted-foreground">
+          <div><span className="font-medium text-foreground">Success:</span> {goal.successCriteria || "Hidden from loops until defined."}</div>
+          {goal.abandonIf && <div><span className="font-medium text-foreground">Abandon if:</span> {goal.abandonIf}</div>}
+          {pendingDecisionCount > 0 && (
+            <div className="font-medium text-amber-700 dark:text-amber-300">
+              {pendingDecisionCount} pending decision{pendingDecisionCount === 1 ? "" : "s"} blocking this goal
+            </div>
+          )}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {goal.status !== "paused" && <Button size="sm" variant="outline" onClick={() => onStatus(goal, "paused")}>Pause</Button>}
+          {goal.status !== "active" && <Button size="sm" variant="outline" onClick={() => onStatus(goal, "active")}>Activate</Button>}
+          {goal.status !== "done" && <Button size="sm" variant="outline" onClick={() => onStatus(goal, "done")}>Done</Button>}
+          {goal.status !== "abandoned" && <Button size="sm" variant="outline" onClick={() => onStatus(goal, "abandoned")}>Abandon</Button>}
+          {[1, 2, 3, 4, 5].map((priority) => (
+            <Button
+              key={priority}
+              size="sm"
+              variant={goal.priority === priority ? "default" : "ghost"}
+              onClick={() => onPriority(goal, priority)}
+            >
+              P{priority}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function GoalsPage() {
+  const queryClient = useQueryClient()
+  const [form, setForm] = useState<GoalForm>(emptyForm)
+  const [loopBusy, setLoopBusy] = useState(false)
+  const agentProgressById = useAgentStore((state) => state.agentProgressById)
+  const focusedSessionId = useAgentStore((state) => state.focusedSessionId)
+  const setFocusedSessionId = useAgentStore((state) => state.setFocusedSessionId)
+
+  const goalsQuery = useQuery<Goal[]>({
+    queryKey: ["goals"],
+    queryFn: () => tipcClient.getGoals() as Promise<Goal[]>,
+  })
+
+  const pendingDecisionsQuery = useQuery<Decision[]>({
+    queryKey: ["decisions", "pending"],
+    queryFn: () => tipcClient.getDecisions({ status: "pending" }) as Promise<Decision[]>,
+  })
+
+  const sessionsQuery = useQuery<SessionListResponse>({
+    queryKey: ["agentSessions"],
+    queryFn: () => tipcClient.getAgentSessions() as Promise<SessionListResponse>,
+    refetchInterval: 5_000,
+    refetchOnWindowFocus: true,
+  })
+
+  const loopsQuery = useQuery<LoopConfig[]>({
+    queryKey: ["loops"],
+    queryFn: () => tipcClient.getLoops() as Promise<LoopConfig[]>,
+  })
+
+  const loopStatusesQuery = useQuery<LoopStatus[]>({
+    queryKey: ["loopStatuses"],
+    queryFn: () => tipcClient.getLoopStatuses() as Promise<LoopStatus[]>,
+    refetchInterval: 5_000,
+  })
+
+  const goalEventsQuery = useQuery<GoalProgressEvent[]>({
+    queryKey: ["goalProgressEvents"],
+    queryFn: () => tipcClient.getGoalProgressEvents({ limit: 100 }) as Promise<GoalProgressEvent[]>,
+    refetchInterval: 10_000,
+  })
+
+  useEffect(() => {
+    const unlisten = rendererHandlers.agentSessionsUpdated.listen(() => {
+      queryClient.invalidateQueries({ queryKey: ["agentSessions"] })
+      queryClient.invalidateQueries({ queryKey: ["loopStatuses"] })
+      queryClient.invalidateQueries({ queryKey: ["goalProgressEvents"] })
+    })
+    return unlisten
+  }, [queryClient])
+
+  const goals = goalsQuery.data ?? []
+  const pendingDecisions = pendingDecisionsQuery.data ?? []
+  const loops = loopsQuery.data ?? []
+  const loopStatuses = loopStatusesQuery.data ?? []
+  const goalEvents = goalEventsQuery.data ?? []
+  const dashboardGoalEvents = useMemo(() => compactGoalProgressEvents(goalEvents), [goalEvents])
+  const activeGoals = goals.filter((goal) => goal.status === "active")
+  const blockedGoalIds = new Set(pendingDecisions.map((decision) => decision.goalId).filter(Boolean))
+  const dailyGoalLoop = loops.find((loop) => loop.id === "daily-goal-planning" || loop.loopType === "daily_planning")
+  const dailyGoalLoopStatus = dailyGoalLoop ? loopStatuses.find((status) => status.id === dailyGoalLoop.id) : undefined
+  const goalsById = useMemo(() => new Map(goals.map((goal) => [goal.id, goal] as const)), [goals])
+  const latestMeaningfulEvent = dashboardGoalEvents[0]
+
+  const groupedGoals = useMemo(() => {
+    const groups: Record<GoalLevel, Goal[]> = { goal: [], week: [], today: [] }
+    for (const goal of goals) groups[goal.level].push(goal)
+    for (const level of Object.keys(groups) as GoalLevel[]) {
+      groups[level].sort((a, b) => a.priority - b.priority || b.updatedAt - a.updatedAt)
+    }
+    return groups
+  }, [goals])
+
+  const pendingCountByGoalId = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const decision of pendingDecisions) {
+      if (!decision.goalId) continue
+      counts.set(decision.goalId, (counts.get(decision.goalId) ?? 0) + 1)
+    }
+    return counts
+  }, [pendingDecisions])
+
+  const liveSessions = useMemo(() => {
+    const merged = new Map<string, AgentSessionRecord>()
+    for (const session of sessionsQuery.data?.activeSessions ?? []) {
+      merged.set(session.id, session)
+    }
+    for (const [sessionId, progress] of agentProgressById.entries()) {
+      if (progress.isComplete) continue
+      const existing = merged.get(sessionId)
+      merged.set(sessionId, {
+        id: sessionId,
+        conversationId: progress.conversationId ?? existing?.conversationId,
+        conversationTitle: progress.conversationTitle ?? existing?.conversationTitle,
+        status: existing?.status ?? "active",
+        startTime: existing?.startTime ?? progress.conversationHistory?.[0]?.timestamp ?? Date.now(),
+        currentIteration: progress.currentIteration,
+        maxIterations: progress.maxIterations,
+        isSnoozed: progress.isSnoozed ?? existing?.isSnoozed,
+        isRepeatTask: existing?.isRepeatTask,
+      })
+    }
+    return Array.from(merged.values()).sort((a, b) => {
+      return getSessionTimestamp(b, agentProgressById.get(b.id)) - getSessionTimestamp(a, agentProgressById.get(a.id))
+    })
+  }, [agentProgressById, sessionsQuery.data?.activeSessions])
+
+  const goalBySessionId = useMemo(() => {
+    const matched = new Map<string, Goal>()
+    for (const session of liveSessions) {
+      const title = `${session.conversationTitle ?? ""} ${agentProgressById.get(session.id)?.conversationTitle ?? ""}`.toLowerCase()
+      const goal = goals.find((item) => title.includes(item.title.toLowerCase()) || title.includes(item.id.toLowerCase()))
+      if (goal) matched.set(session.id, goal)
+    }
+    return matched
+  }, [agentProgressById, goals, liveSessions])
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["goals"] })
+    queryClient.invalidateQueries({ queryKey: ["decisions"] })
+    queryClient.invalidateQueries({ queryKey: ["goalProgressEvents"] })
+  }
+
+  const handleCreate = async () => {
+    const title = form.title.trim()
+    if (!title) {
+      toast.error("Goal title is required")
+      return
+    }
+
+    const goal: GoalCreateRequest = {
+      title,
+      description: form.description.trim(),
+      level: form.level,
+      priority: Number(form.priority) || 3,
+      status: "active",
+      parentId: form.parentId.trim() || undefined,
+      successCriteria: form.successCriteria.trim() || undefined,
+      abandonIf: form.abandonIf.trim() || undefined,
+      body: form.body.trim(),
+      createdBy: "aj",
+      createdFrom: "manual",
+      linkedTaskIds: [],
+    }
+
+    try {
+      await tipcClient.saveGoal({ goal })
+      setForm(emptyForm)
+      invalidate()
+      toast.success("Goal created")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to create goal")
+    }
+  }
+
+  const updateGoal = async (goal: Goal, updates: Partial<Goal>) => {
+    await tipcClient.updateGoal({ id: goal.id, updates })
+    invalidate()
+  }
+
+  const runDailyGoalLoop = async () => {
+    if (!dailyGoalLoop) {
+      toast.error("Goal agent task is not installed")
+      return
+    }
+
+    setLoopBusy(true)
+    try {
+      const result = await tipcClient.triggerLoop({ loopId: dailyGoalLoop.id })
+      if (result && !result.success) {
+        toast.error("Could not start the goal agent check right now")
+        return
+      }
+      toast.success("Goal agent check started")
+      queryClient.invalidateQueries({ queryKey: ["agentSessions"] })
+      queryClient.invalidateQueries({ queryKey: ["loopStatuses"] })
+      queryClient.invalidateQueries({ queryKey: ["goalProgressEvents"] })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to start goal agent check")
+    } finally {
+      setLoopBusy(false)
+    }
+  }
+
+  const armGoalAgent = async () => {
+    if (!dailyGoalLoop) {
+      toast.error("Goal agent task is not installed")
+      return
+    }
+
+    setLoopBusy(true)
+    try {
+      await tipcClient.saveLoop({
+        loop: {
+          ...dailyGoalLoop,
+          enabled: true,
+          intervalMinutes: 15,
+          runContinuously: true,
+          continueInSession: true,
+        },
+      })
+      await tipcClient.startLoop?.({ loopId: dailyGoalLoop.id })
+      const result = await tipcClient.triggerLoop({ loopId: dailyGoalLoop.id })
+      if (result && !result.success) {
+        toast.error("Goal agent is online, but the immediate check could not start")
+      } else {
+        toast.success("24/7 goal agent online")
+      }
+      queryClient.invalidateQueries({ queryKey: ["loops"] })
+      queryClient.invalidateQueries({ queryKey: ["loopStatuses"] })
+      queryClient.invalidateQueries({ queryKey: ["agentSessions"] })
+      queryClient.invalidateQueries({ queryKey: ["goalProgressEvents"] })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to arm goal agent")
+    } finally {
+      setLoopBusy(false)
+    }
+  }
+
+  const pauseGoalAgent = async () => {
+    if (!dailyGoalLoop) {
+      toast.error("Goal agent task is not installed")
+      return
+    }
+
+    setLoopBusy(true)
+    try {
+      await tipcClient.stopLoop?.({ loopId: dailyGoalLoop.id })
+      await tipcClient.saveLoop({
+        loop: {
+          ...dailyGoalLoop,
+          enabled: false,
+          runContinuously: false,
+        },
+      })
+      toast.success("Goal agent supervisor paused")
+      queryClient.invalidateQueries({ queryKey: ["loops"] })
+      queryClient.invalidateQueries({ queryKey: ["loopStatuses"] })
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to pause goal agent")
+    } finally {
+      setLoopBusy(false)
+    }
+  }
+
+  const focusSession = async (session: AgentSessionRecord) => {
+    setFocusedSessionId(session.id)
+    try {
+      await tipcClient.focusAgentSession({ sessionId: session.id })
+      await tipcClient.setPanelMode({ mode: "agent" })
+      await tipcClient.showPanelWindow({})
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to open agent session")
+    }
+  }
+
+  const stopSession = async (session: AgentSessionRecord) => {
+    try {
+      await tipcClient.stopAgentSession({ sessionId: session.id })
+      if (focusedSessionId === session.id) setFocusedSessionId(null)
+      queryClient.invalidateQueries({ queryKey: ["agentSessions"] })
+      toast.success("Agent session stopped")
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to stop agent session")
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-7xl flex-col gap-6 p-6">
+      <div className="relative overflow-hidden rounded-3xl border border-border/70 bg-gradient-to-br from-slate-950 via-slate-900 to-blue-950 p-6 text-white shadow-xl">
+        <div className="absolute right-8 top-6 h-28 w-28 rounded-full bg-blue-400/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/3 h-24 w-48 rounded-full bg-emerald-300/10 blur-3xl" />
+        <div className="relative flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.24em] text-blue-200">
+              <Activity className="h-4 w-4" />
+              Goal command center
+            </div>
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight">Goals</h1>
+              <p className="mt-2 max-w-2xl text-sm text-slate-300">
+                Manage goal state, keep the goal agent online, and inspect every live or standby run from one dashboard.
+              </p>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <div className="rounded-2xl border border-white/10 bg-white/10 p-3 backdrop-blur">
+              <div className="text-xs uppercase tracking-wide text-slate-300">Active goals</div>
+              <div className="text-2xl font-semibold">{activeGoals.length}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 p-3 backdrop-blur">
+              <div className="text-xs uppercase tracking-wide text-slate-300">Agents live</div>
+              <div className="text-2xl font-semibold">{liveSessions.length}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 p-3 backdrop-blur">
+              <div className="text-xs uppercase tracking-wide text-slate-300">Today</div>
+              <div className="text-2xl font-semibold">{groupedGoals.today.length}</div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/10 p-3 backdrop-blur">
+              <div className="text-xs uppercase tracking-wide text-slate-300">Last change</div>
+              <div className="truncate text-lg font-semibold">{latestMeaningfulEvent ? formatRelativeTime(latestMeaningfulEvent.at) : "None"}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]">
+        <GoalLoopPanel
+          loop={dailyGoalLoop}
+          status={dailyGoalLoopStatus}
+          isBusy={loopBusy}
+          latestEvent={latestMeaningfulEvent}
+          liveSessionCount={liveSessions.length}
+          onArm={() => void armGoalAgent()}
+          onPause={() => void pauseGoalAgent()}
+          onCheckNow={() => void runDailyGoalLoop()}
+        />
+
+        <Card className="border-border/70">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <CardTitle>Live agents</CardTitle>
+                <CardDescription>Active sessions working now, including goal-loop runs.</CardDescription>
+              </div>
+              <Badge variant={liveSessions.length > 0 ? "default" : "outline"}>{liveSessions.length} live</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {liveSessions.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-border p-5 text-sm text-muted-foreground">
+                <div className="flex items-center gap-2 font-medium text-foreground">
+                  <CircleAlert className="h-4 w-4" />
+                  No agents are running.
+                </div>
+                <p className="mt-2">
+                  {dailyGoalLoopStatus?.enabled
+                    ? "The supervisor is online; no live session means standby between bounded checks."
+                    : "Start the 24/7 goal agent to run an immediate check and keep the supervisor online."}
+                </p>
+              </div>
+            ) : (
+              liveSessions.map((session) => (
+                <SessionCard
+                  key={session.id}
+                  session={session}
+                  progress={agentProgressById.get(session.id)}
+                  matchedGoal={goalBySessionId.get(session.id)}
+                  onFocus={(item) => void focusSession(item)}
+                  onStop={(item) => void stopSession(item)}
+                />
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(360px,0.85fr)_minmax(0,1.15fr)]">
+        <Card className="border-border/70">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <CardTitle>Current focus</CardTitle>
+                <CardDescription>Today-level goals selected from larger goals.</CardDescription>
+              </div>
+              <ListChecks className="h-5 w-5 text-muted-foreground" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {groupedGoals.today.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+                No today focus selected yet.
+              </div>
+            ) : (
+              groupedGoals.today.map((goal) => {
+                const latestGoalEvent = dashboardGoalEvents.find((event) => event.goalId === goal.id || event.parentGoalId === goal.id)
+                return (
+                  <div key={goal.id} className="rounded-lg border border-border/70 p-3">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{goal.title}</div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          Parent: {goal.parentId ? goalsById.get(goal.parentId)?.title ?? goal.parentId : "None"}
+                        </div>
+                      </div>
+                      <Badge className={statusTone(goal.status)} variant="secondary">{goal.status}</Badge>
+                    </div>
+                    <div className="mt-2 text-sm text-muted-foreground">{goal.successCriteria || "No success criteria yet."}</div>
+                    <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                      {latestGoalEvent ? `${formatEventType(latestGoalEvent.type)} · ${formatRelativeTime(latestGoalEvent.at)}` : "No event history yet"}
+                    </div>
+                  </div>
+                )
+              })
+            )}
+          </CardContent>
+        </Card>
+        <ProgressLedger events={dashboardGoalEvents} goalsById={goalsById} />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Create Goal</CardTitle>
+          <CardDescription>Keep it concrete: success criteria are what make a goal loop-visible.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label>Title</Label>
+            <Input value={form.title} onChange={(event) => setForm({ ...form, title: event.target.value })} />
+          </div>
+          <div className="space-y-2">
+            <Label>Level</Label>
+            <Select value={form.level} onValueChange={(level: GoalLevel) => setForm({ ...form, level })}>
+              <SelectTrigger><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="goal">Goal</SelectItem>
+                <SelectItem value="week">Week</SelectItem>
+                <SelectItem value="today">Today</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>Description</Label>
+            <Input value={form.description} onChange={(event) => setForm({ ...form, description: event.target.value })} />
+          </div>
+          <div className="space-y-2">
+            <Label>Priority</Label>
+            <Input value={form.priority} onChange={(event) => setForm({ ...form, priority: event.target.value })} />
+          </div>
+          <div className="space-y-2">
+            <Label>Parent Goal ID</Label>
+            <Input value={form.parentId} onChange={(event) => setForm({ ...form, parentId: event.target.value })} />
+          </div>
+          <div className="space-y-2">
+            <Label>Success Criteria</Label>
+            <Input value={form.successCriteria} onChange={(event) => setForm({ ...form, successCriteria: event.target.value })} />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <Label>Abandon If</Label>
+            <Input value={form.abandonIf} onChange={(event) => setForm({ ...form, abandonIf: event.target.value })} />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <Label>Context</Label>
+            <Textarea value={form.body} onChange={(event) => setForm({ ...form, body: event.target.value })} rows={4} />
+          </div>
+          <div className="md:col-span-2">
+            <Button onClick={() => void handleCreate()}>Create Goal</Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {(Object.keys(LEVEL_LABELS) as GoalLevel[]).map((level) => (
+        <section key={level} className="space-y-3">
+          <h2 className="text-lg font-semibold">{LEVEL_LABELS[level]}</h2>
+          {groupedGoals[level].length === 0 ? (
+            <Card><CardContent className="py-6 text-sm text-muted-foreground">No {LEVEL_LABELS[level].toLowerCase()} yet.</CardContent></Card>
+          ) : (
+            <div className="grid gap-3 lg:grid-cols-2">
+              {groupedGoals[level].map((goal) => (
+                <GoalCard
+                  key={goal.id}
+                  goal={goal}
+                  pendingDecisionCount={pendingCountByGoalId.get(goal.id) ?? 0}
+                  onStatus={(item, status) => void updateGoal(item, { status })}
+                  onPriority={(item, priority) => void updateGoal(item, { priority })}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  )
+}
+
+export const Component = GoalsPage

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -102,6 +102,14 @@ export const router: ReturnType<typeof createBrowserRouter> =
           path: "knowledge",
           lazy: () => import("./pages/knowledge"),
         },
+        {
+          path: "goals",
+          lazy: () => import("./pages/goals"),
+        },
+        {
+          path: "decisions",
+          lazy: () => import("./pages/decisions"),
+        },
       ],
     },
     {

--- a/apps/desktop/src/shared/runtime-tool-names.ts
+++ b/apps/desktop/src/shared/runtime-tool-names.ts
@@ -18,11 +18,23 @@ export const MARK_WORK_COMPLETE_TOOL = "mark_work_complete"
 export const SET_SESSION_TITLE_TOOL = "set_session_title"
 export const EXECUTE_COMMAND_TOOL = "execute_command"
 export const READ_MORE_CONTEXT_TOOL = "read_more_context"
+export const LIST_GOALS_TOOL = "list_goals"
+export const CREATE_GOAL_TOOL = "create_goal"
+export const UPDATE_GOAL_TOOL = "update_goal"
+export const LIST_DECISIONS_TOOL = "list_decisions"
+export const CREATE_DECISION_TOOL = "create_decision"
+export const ANSWER_DECISION_TOOL = "answer_decision"
 
 export const DEFAULT_AGENT_RUNTIME_TOOL_NAMES = [
   SET_SESSION_TITLE_TOOL,
   EXECUTE_COMMAND_TOOL,
   READ_MORE_CONTEXT_TOOL,
+  LIST_GOALS_TOOL,
+  CREATE_GOAL_TOOL,
+  UPDATE_GOAL_TOOL,
+  LIST_DECISIONS_TOOL,
+  CREATE_DECISION_TOOL,
+  ANSWER_DECISION_TOOL,
   MARK_WORK_COMPLETE_TOOL,
 ] as const
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1061,6 +1061,9 @@ export type LoopSchedule =
   | { type: "daily"; times: string[] }
   | { type: "weekly"; times: string[]; daysOfWeek: number[] }
 
+export type LoopType = "daily_planning" | "execution" | "recap" | "custom"
+export type LoopOutputType = "goals" | "tasks" | "decisions" | "summary"
+
 export interface LoopConfig {
   id: string               // unique identifier (uuid)
   name: string             // display name
@@ -1076,6 +1079,10 @@ export interface LoopConfig {
   runContinuously?: boolean // if true, starts the next run immediately after the previous run finishes
   maxIterations?: number   // optional per-task override for agent loop iterations
   schedule?: LoopSchedule  // wall-clock schedule; supersedes intervalMinutes when present
+  loopType?: LoopType
+  linkedGoalIds?: string[]
+  outputType?: LoopOutputType
+  tokenBudgetPerRun?: number
 }
 
 export interface SidebarSessionGroupConfig {

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -10,6 +10,9 @@ import AgentEditScreen from './src/screens/AgentEditScreen';
 import KnowledgeNoteEditScreen from './src/screens/KnowledgeNoteEditScreen';
 import LoopEditScreen from './src/screens/LoopEditScreen';
 import SkillEditScreen from './src/screens/SkillEditScreen';
+import GoalsScreen from './src/screens/GoalsScreen';
+import GoalEditScreen from './src/screens/GoalEditScreen';
+import DecisionsScreen from './src/screens/DecisionsScreen';
 import { AppConfig, ConfigContext, useConfig, saveConfig } from './src/store/config';
 import { SessionContext, useSessions } from './src/store/sessions';
 import { MessageQueueContext, useMessageQueue } from './src/store/message-queue';
@@ -595,6 +598,16 @@ function Navigation() {
                           component={SessionListScreen}
                           options={{ title: 'Chats' }}
                         />
+                        <Stack.Screen
+                          name="Goals"
+                          component={GoalsScreen}
+                          options={{ title: 'Goals' }}
+                        />
+                        <Stack.Screen
+                          name="Decisions"
+                          component={DecisionsScreen}
+                          options={{ title: 'Decisions' }}
+                        />
                         <Stack.Screen name="Chat" component={ChatScreen} />
                         <Stack.Screen
                           name="AgentEdit"
@@ -605,6 +618,11 @@ function Navigation() {
                           name="KnowledgeNoteEdit"
                           component={KnowledgeNoteEditScreen}
                           options={{ title: 'Note' }}
+                        />
+                        <Stack.Screen
+                          name="GoalEdit"
+                          component={GoalEditScreen}
+                          options={{ title: 'Goal' }}
                         />
                         <Stack.Screen
                           name="LoopEdit"

--- a/apps/mobile/src/lib/settingsApi.ts
+++ b/apps/mobile/src/lib/settingsApi.ts
@@ -44,6 +44,16 @@ export type {
   VerifyExternalAgentCommandResponse,
   AgentSessionCandidate,
   AgentSessionCandidatesResponse,
+  Goal,
+  GoalLevel,
+  GoalsResponse,
+  GoalCreateRequest,
+  GoalUpdateRequest,
+  Decision,
+  DecisionsResponse,
+  DecisionCreateRequest,
+  DecisionUpdateRequest,
+  DecisionRespondRequest,
   Loop,
   LoopsResponse,
   LoopSchedule,
@@ -132,6 +142,16 @@ import type {
   VerifyExternalAgentCommandResponse,
   AgentSessionCandidate,
   AgentSessionCandidatesResponse,
+  Goal,
+  GoalLevel,
+  GoalsResponse,
+  GoalCreateRequest,
+  GoalUpdateRequest,
+  Decision,
+  DecisionsResponse,
+  DecisionCreateRequest,
+  DecisionUpdateRequest,
+  DecisionRespondRequest,
   Loop,
   LoopSchedule,
   LoopsResponse,
@@ -473,6 +493,10 @@ export interface LoopCreateRequest {
   runContinuously?: boolean;
   maxIterations?: number;
   schedule?: LoopSchedule | null;
+  loopType?: Loop['loopType'];
+  linkedGoalIds?: string[];
+  outputType?: Loop['outputType'];
+  tokenBudgetPerRun?: number;
 }
 
 export interface LoopUpdateRequest {
@@ -488,6 +512,10 @@ export interface LoopUpdateRequest {
   runContinuously?: boolean;
   maxIterations?: number | null;
   schedule?: LoopSchedule | null;
+  loopType?: Loop['loopType'] | null;
+  linkedGoalIds?: string[] | null;
+  outputType?: Loop['outputType'] | null;
+  tokenBudgetPerRun?: number | null;
 }
 
 export interface EmergencyStopResponse {
@@ -1332,6 +1360,81 @@ export class ExtendedSettingsApiClient extends SettingsApiClient {
   async toggleAgentProfile(id: string): Promise<{ success: boolean; id: string; enabled: boolean }> {
     return this.request(`/agent-profiles/${encodeURIComponent(id)}/toggle`, {
       method: 'POST',
+    });
+  }
+
+  // ============================================
+  // Goals + Decisions Management
+  // ============================================
+
+  async getGoals(): Promise<GoalsResponse> {
+    return this.request<GoalsResponse>('/goals');
+  }
+
+  async getGoal(id: string): Promise<{ goal: Goal }> {
+    return this.request<{ goal: Goal }>(`/goals/${encodeURIComponent(id)}`);
+  }
+
+  async createGoal(data: GoalCreateRequest): Promise<{ goal: Goal }> {
+    return this.request<{ goal: Goal }>('/goals', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateGoal(id: string, data: GoalUpdateRequest): Promise<{ success: boolean; goal: Goal }> {
+    return this.request<{ success: boolean; goal: Goal }>(`/goals/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deleteGoal(id: string): Promise<{ success: boolean; id: string }> {
+    return this.request<{ success: boolean; id: string }>(`/goals/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+  }
+
+  async getDecisions(status: 'pending' | 'history' | 'all' = 'all'): Promise<DecisionsResponse> {
+    return this.request<DecisionsResponse>(`/decisions?status=${encodeURIComponent(status)}`);
+  }
+
+  async getDecision(id: string): Promise<{ decision: Decision }> {
+    return this.request<{ decision: Decision }>(`/decisions/${encodeURIComponent(id)}`);
+  }
+
+  async createDecision(data: DecisionCreateRequest): Promise<{ decision: Decision }> {
+    return this.request<{ decision: Decision }>('/decisions', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async updateDecision(id: string, data: DecisionUpdateRequest): Promise<{ success: boolean; decision: Decision }> {
+    return this.request<{ success: boolean; decision: Decision }>(`/decisions/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async respondToDecision(id: string, data: DecisionRespondRequest): Promise<{ success: boolean; decision: Decision }> {
+    return this.request<{ success: boolean; decision: Decision }>(`/decisions/${encodeURIComponent(id)}/respond`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
+  }
+
+  async deferDecision(id: string, note?: string): Promise<{ success: boolean; decision: Decision }> {
+    return this.request<{ success: boolean; decision: Decision }>(`/decisions/${encodeURIComponent(id)}/defer`, {
+      method: 'POST',
+      body: JSON.stringify({ note }),
+    });
+  }
+
+  async cancelDecision(id: string, note?: string): Promise<{ success: boolean; decision: Decision }> {
+    return this.request<{ success: boolean; decision: Decision }>(`/decisions/${encodeURIComponent(id)}/cancel`, {
+      method: 'POST',
+      body: JSON.stringify({ note }),
     });
   }
 

--- a/apps/mobile/src/screens/DecisionsScreen.tsx
+++ b/apps/mobile/src/screens/DecisionsScreen.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { useTheme } from '../ui/ThemeProvider';
+import { spacing, radius, type Theme } from '../ui/theme';
+import { Decision, ExtendedSettingsApiClient, Goal } from '../lib/settingsApi';
+import { useConfigContext } from '../store/config';
+
+type Tab = 'pending' | 'history';
+
+export default function DecisionsScreen({ navigation }: any) {
+  const { theme } = useTheme();
+  const { config } = useConfigContext();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [tab, setTab] = useState<Tab>('pending');
+  const [decisions, setDecisions] = useState<Decision[]>([]);
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const client = useMemo(() => {
+    if (!config.baseUrl || !config.apiKey) return null;
+    return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
+  }, [config.baseUrl, config.apiKey]);
+
+  const load = useCallback(async () => {
+    if (!client) {
+      setError('Configure Base URL and API key to load decisions');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [decisionResponse, goalResponse] = await Promise.all([
+        client.getDecisions(tab),
+        client.getGoals(),
+      ]);
+      setDecisions(decisionResponse.decisions);
+      setGoals(goalResponse.goals);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load decisions');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client, tab]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', load);
+    return unsubscribe;
+  }, [load, navigation]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const goalsById = useMemo(() => new Map(goals.map(goal => [goal.id, goal] as const)), [goals]);
+
+  const respond = async (decision: Decision, answer: string) => {
+    if (!client) return;
+    await client.respondToDecision(decision.id, { answer, answerSource: 'aj' });
+    await load();
+  };
+
+  const setAside = async (decision: Decision, action: 'defer' | 'cancel') => {
+    if (!client) return;
+    if (action === 'defer') await client.deferDecision(decision.id);
+    else await client.cancelDecision(decision.id);
+    await load();
+  };
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={isLoading} onRefresh={load} tintColor={theme.colors.primary} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.kicker}>Decision Queue</Text>
+        <Text style={styles.title}>Decisions</Text>
+        <Text style={styles.subtitle}>Fast answers for irreversible, path-changing, or expensive-to-revert calls.</Text>
+      </View>
+
+      <View style={styles.segmented}>
+        {(['pending', 'history'] as Tab[]).map((item) => (
+          <TouchableOpacity key={item} style={[styles.segment, tab === item && styles.segmentActive]} onPress={() => setTab(item)}>
+            <Text style={[styles.segmentText, tab === item && styles.segmentTextActive]}>{item}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {isLoading && decisions.length === 0 ? <ActivityIndicator color={theme.colors.primary} /> : null}
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      {decisions.length === 0 ? <Text style={styles.empty}>No {tab} decisions.</Text> : null}
+
+      {decisions.map((decision) => (
+        <DecisionCard
+          key={decision.id}
+          decision={decision}
+          goal={decision.goalId ? goalsById.get(decision.goalId) : undefined}
+          styles={styles}
+          onRespond={respond}
+          onSetAside={setAside}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+function DecisionCard({
+  decision,
+  goal,
+  styles,
+  onRespond,
+  onSetAside,
+}: {
+  decision: Decision;
+  goal?: Goal;
+  styles: ReturnType<typeof createStyles>;
+  onRespond: (decision: Decision, answer: string) => void;
+  onSetAside: (decision: Decision, action: 'defer' | 'cancel') => void;
+}) {
+  const [customAnswer, setCustomAnswer] = useState('');
+  const isPending = decision.status === 'pending';
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <View style={{ flex: 1 }}>
+          <Text style={styles.cardTitle}>{decision.question}</Text>
+          <Text style={styles.muted}>{goal ? `Goal: ${goal.title}` : decision.goalId || 'No linked goal'}</Text>
+        </View>
+        <Text style={styles.badge}>{decision.urgent ? 'urgent' : decision.type}</Text>
+      </View>
+      {decision.recommendation ? <Text style={styles.bodyText}>Recommendation: {decision.recommendation}</Text> : null}
+      {decision.why ? <Text style={styles.muted}>Why: {decision.why}</Text> : null}
+      {decision.risk ? <Text style={styles.muted}>Risk: {decision.risk}</Text> : null}
+      <Text style={styles.muted}>Default: {decision.defaultAction || 'None'}</Text>
+      {isPending ? (
+        <>
+          <View style={styles.actionGrid}>
+            {decision.recommendation ? (
+              <TouchableOpacity style={styles.primaryButton} onPress={() => onRespond(decision, decision.recommendation || '')}>
+                <Text style={styles.primaryButtonText}>Accept</Text>
+              </TouchableOpacity>
+            ) : null}
+            <TouchableOpacity style={styles.bigButton} onPress={() => onRespond(decision, 'yes')}><Text style={styles.bigButtonText}>Yes</Text></TouchableOpacity>
+            <TouchableOpacity style={styles.bigButton} onPress={() => onRespond(decision, 'no')}><Text style={styles.bigButtonText}>No</Text></TouchableOpacity>
+            <TouchableOpacity style={styles.bigButton} onPress={() => onSetAside(decision, 'defer')}><Text style={styles.bigButtonText}>Defer</Text></TouchableOpacity>
+          </View>
+          <View style={styles.customRow}>
+            <TextInput
+              value={customAnswer}
+              onChangeText={setCustomAnswer}
+              placeholder="Custom answer"
+              placeholderTextColor={styles.placeholder.color}
+              style={styles.input}
+            />
+            <TouchableOpacity style={styles.smallButton} onPress={() => {
+              if (!customAnswer.trim()) return;
+              onRespond(decision, customAnswer.trim());
+              setCustomAnswer('');
+            }}>
+              <Text style={styles.smallButtonText}>Send</Text>
+            </TouchableOpacity>
+          </View>
+          <TouchableOpacity onPress={() => onSetAside(decision, 'cancel')}>
+            <Text style={styles.cancelText}>Cancel decision</Text>
+          </TouchableOpacity>
+        </>
+      ) : (
+        <Text style={styles.bodyText}>Answer: {decision.answer || 'None'}</Text>
+      )}
+    </View>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    content: { padding: spacing.lg, gap: spacing.md, paddingBottom: spacing['3xl'] },
+    header: { gap: spacing.xs },
+    kicker: { ...theme.typography.caption, textTransform: 'uppercase', letterSpacing: 2 },
+    title: { ...theme.typography.h1 },
+    subtitle: { ...theme.typography.bodyMuted },
+    segmented: { flexDirection: 'row', gap: spacing.sm },
+    segment: { flex: 1, borderWidth: 1, borderColor: theme.colors.border, borderRadius: radius.md, padding: spacing.sm, alignItems: 'center' },
+    segmentActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+    segmentText: { ...theme.typography.label, textTransform: 'capitalize' },
+    segmentTextActive: { color: theme.colors.primaryForeground },
+    card: { ...theme.card, gap: spacing.sm },
+    cardHeader: { flexDirection: 'row', gap: spacing.sm, alignItems: 'flex-start' },
+    cardTitle: { ...theme.typography.label, fontSize: 17 },
+    muted: { ...theme.typography.bodyMuted },
+    bodyText: { ...theme.typography.body },
+    badge: { ...theme.typography.caption, color: theme.colors.primary, fontWeight: '700' },
+    actionGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+    primaryButton: { backgroundColor: theme.colors.primary, borderRadius: radius.lg, paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
+    primaryButtonText: { color: theme.colors.primaryForeground, fontWeight: '700' },
+    bigButton: { borderWidth: 1, borderColor: theme.colors.border, borderRadius: radius.lg, paddingHorizontal: spacing.lg, paddingVertical: spacing.md },
+    bigButtonText: { ...theme.typography.label },
+    customRow: { flexDirection: 'row', gap: spacing.sm },
+    input: { ...theme.input, flex: 1, color: theme.colors.foreground },
+    placeholder: { color: theme.colors.mutedForeground },
+    smallButton: { backgroundColor: theme.colors.secondary, borderRadius: radius.md, paddingHorizontal: spacing.md, justifyContent: 'center' },
+    smallButtonText: { color: theme.colors.secondaryForeground, fontWeight: '700' },
+    cancelText: { ...theme.typography.caption, color: theme.colors.destructive },
+    empty: { ...theme.typography.bodyMuted },
+    error: { ...theme.typography.body, color: theme.colors.destructive },
+  });
+}

--- a/apps/mobile/src/screens/GoalEditScreen.tsx
+++ b/apps/mobile/src/screens/GoalEditScreen.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from 'react';
+import { ActivityIndicator, ScrollView, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { useTheme } from '../ui/ThemeProvider';
+import { spacing, radius, type Theme } from '../ui/theme';
+import { ExtendedSettingsApiClient, Goal, GoalCreateRequest, GoalLevel } from '../lib/settingsApi';
+import { useConfigContext } from '../store/config';
+
+export default function GoalEditScreen({ navigation, route }: any) {
+  const { theme } = useTheme();
+  const { config } = useConfigContext();
+  const goal = route.params?.goal as Goal | undefined;
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [title, setTitle] = useState(goal?.title ?? '');
+  const [description, setDescription] = useState(goal?.description ?? '');
+  const [level, setLevel] = useState<GoalLevel>(goal?.level ?? 'goal');
+  const [priority, setPriority] = useState(String(goal?.priority ?? 3));
+  const [successCriteria, setSuccessCriteria] = useState(goal?.successCriteria ?? '');
+  const [abandonIf, setAbandonIf] = useState(goal?.abandonIf ?? '');
+  const [body, setBody] = useState(goal?.body ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const client = useMemo(() => {
+    if (!config.baseUrl || !config.apiKey) return null;
+    return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
+  }, [config.baseUrl, config.apiKey]);
+
+  const save = async () => {
+    if (!client) {
+      setError('Configure Base URL and API key to save goals');
+      return;
+    }
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    const payload: GoalCreateRequest = {
+      title: title.trim(),
+      description: description.trim(),
+      level,
+      priority: Number(priority) || 3,
+      successCriteria: successCriteria.trim() || undefined,
+      abandonIf: abandonIf.trim() || undefined,
+      body: body.trim(),
+      createdBy: 'aj',
+      createdFrom: 'manual',
+      linkedTaskIds: [],
+    };
+    try {
+      if (goal) await client.updateGoal(goal.id, payload);
+      else await client.createGoal(payload);
+      navigation.goBack();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save goal');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.title}>{goal ? 'Edit Goal' : 'Create Goal'}</Text>
+      <Field label="Title" value={title} onChangeText={setTitle} styles={styles} />
+      <Field label="Description" value={description} onChangeText={setDescription} styles={styles} />
+      <View style={styles.segmented}>
+        {(['goal', 'week', 'today'] as GoalLevel[]).map((item) => (
+          <TouchableOpacity key={item} style={[styles.segment, level === item && styles.segmentActive]} onPress={() => setLevel(item)}>
+            <Text style={[styles.segmentText, level === item && styles.segmentTextActive]}>{item}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <Field label="Priority 1-5" value={priority} onChangeText={setPriority} keyboardType="number-pad" styles={styles} />
+      <Field label="Success Criteria" value={successCriteria} onChangeText={setSuccessCriteria} styles={styles} />
+      <Field label="Abandon If" value={abandonIf} onChangeText={setAbandonIf} styles={styles} />
+      <Field label="Context" value={body} onChangeText={setBody} multiline styles={styles} />
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TouchableOpacity style={styles.primaryButton} onPress={save} disabled={isSaving}>
+        {isSaving ? <ActivityIndicator color={theme.colors.primaryForeground} /> : <Text style={styles.primaryButtonText}>Save Goal</Text>}
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+function Field({ label, styles, ...props }: { label: string; styles: ReturnType<typeof createStyles> } & React.ComponentProps<typeof TextInput>) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.label}>{label}</Text>
+      <TextInput {...props} style={[styles.input, props.multiline && styles.textarea]} placeholderTextColor={styles.placeholder.color} />
+    </View>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    content: { padding: spacing.lg, gap: spacing.md, paddingBottom: spacing['3xl'] },
+    title: { ...theme.typography.h1 },
+    field: { gap: spacing.xs },
+    label: { ...theme.typography.label },
+    input: { ...theme.input, color: theme.colors.foreground },
+    textarea: { minHeight: 120, textAlignVertical: 'top' },
+    placeholder: { color: theme.colors.mutedForeground },
+    segmented: { flexDirection: 'row', gap: spacing.sm },
+    segment: { flex: 1, borderWidth: 1, borderColor: theme.colors.border, borderRadius: radius.md, padding: spacing.sm, alignItems: 'center' },
+    segmentActive: { backgroundColor: theme.colors.primary, borderColor: theme.colors.primary },
+    segmentText: { ...theme.typography.label },
+    segmentTextActive: { color: theme.colors.primaryForeground },
+    primaryButton: { backgroundColor: theme.colors.primary, borderRadius: radius.lg, padding: spacing.md, alignItems: 'center' },
+    primaryButtonText: { color: theme.colors.primaryForeground, fontWeight: '700' },
+    error: { ...theme.typography.body, color: theme.colors.destructive },
+  });
+}

--- a/apps/mobile/src/screens/GoalsScreen.tsx
+++ b/apps/mobile/src/screens/GoalsScreen.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useTheme } from '../ui/ThemeProvider';
+import { spacing, radius, type Theme } from '../ui/theme';
+import { ExtendedSettingsApiClient, Goal, Decision } from '../lib/settingsApi';
+import { useConfigContext } from '../store/config';
+
+const LEVEL_LABELS = {
+  goal: 'Big Goals',
+  week: 'This Week',
+  today: "Today's Focus",
+} as const;
+
+export default function GoalsScreen({ navigation }: any) {
+  const { theme } = useTheme();
+  const { config } = useConfigContext();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const [goals, setGoals] = useState<Goal[]>([]);
+  const [pendingDecisions, setPendingDecisions] = useState<Decision[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const client = useMemo(() => {
+    if (!config.baseUrl || !config.apiKey) return null;
+    return new ExtendedSettingsApiClient(config.baseUrl, config.apiKey);
+  }, [config.baseUrl, config.apiKey]);
+
+  const load = useCallback(async () => {
+    if (!client) {
+      setError('Configure Base URL and API key to load goals');
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const [goalsResponse, decisionsResponse] = await Promise.all([
+        client.getGoals(),
+        client.getDecisions('pending'),
+      ]);
+      setGoals(goalsResponse.goals);
+      setPendingDecisions(decisionsResponse.decisions);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load goals');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [client]);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', load);
+    return unsubscribe;
+  }, [load, navigation]);
+
+  const pendingByGoalId = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const decision of pendingDecisions) {
+      if (!decision.goalId) continue;
+      counts.set(decision.goalId, (counts.get(decision.goalId) ?? 0) + 1);
+    }
+    return counts;
+  }, [pendingDecisions]);
+
+  const grouped = useMemo(() => {
+    const groups: Record<Goal['level'], Goal[]> = { goal: [], week: [], today: [] };
+    for (const goal of goals) groups[goal.level].push(goal);
+    for (const level of Object.keys(groups) as Goal['level'][]) {
+      groups[level].sort((a, b) => a.priority - b.priority || b.updatedAt - a.updatedAt);
+    }
+    return groups;
+  }, [goals]);
+
+  const updateStatus = async (goal: Goal, status: Goal['status']) => {
+    if (!client) return;
+    await client.updateGoal(goal.id, { status });
+    await load();
+  };
+
+  return (
+    <ScrollView
+      style={styles.container}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={isLoading} onRefresh={load} tintColor={theme.colors.primary} />}
+    >
+      <View style={styles.header}>
+        <Text style={styles.kicker}>Goal OS</Text>
+        <Text style={styles.title}>Goals</Text>
+        <Text style={styles.subtitle}>Active goals with success criteria are visible to repeat-task loops.</Text>
+      </View>
+
+      <View style={styles.statsGrid}>
+        <StatCard label="Active" value={goals.filter(goal => goal.status === 'active').length} styles={styles} />
+        <StatCard label="Today" value={grouped.today.length} styles={styles} />
+        <StatCard label="Blocked" value={new Set(pendingDecisions.map(d => d.goalId).filter(Boolean)).size} styles={styles} />
+      </View>
+
+      <TouchableOpacity
+        style={styles.primaryButton}
+        onPress={() => navigation.navigate('GoalEdit')}
+        accessibilityRole="button"
+        accessibilityLabel="Create goal"
+      >
+        <Text style={styles.primaryButtonText}>Create Goal</Text>
+      </TouchableOpacity>
+
+      {isLoading && goals.length === 0 ? <ActivityIndicator color={theme.colors.primary} /> : null}
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      {(Object.keys(LEVEL_LABELS) as Goal['level'][]).map((level) => (
+        <View key={level} style={styles.section}>
+          <Text style={styles.sectionTitle}>{LEVEL_LABELS[level]}</Text>
+          {grouped[level].length === 0 ? (
+            <Text style={styles.empty}>No {LEVEL_LABELS[level].toLowerCase()} yet.</Text>
+          ) : grouped[level].map((goal) => (
+            <View key={goal.id} style={styles.card}>
+              <View style={styles.cardHeader}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.cardTitle}>{goal.title}</Text>
+                  <Text style={styles.muted}>{goal.description || 'No description yet.'}</Text>
+                </View>
+                <Text style={styles.badge}>P{goal.priority}</Text>
+              </View>
+              <Text style={styles.bodyText}>Success: {goal.successCriteria || 'Hidden from loops until defined.'}</Text>
+              {(pendingByGoalId.get(goal.id) ?? 0) > 0 ? (
+                <Text style={styles.warning}>{pendingByGoalId.get(goal.id)} pending decision(s)</Text>
+              ) : null}
+              <View style={styles.actionRow}>
+                <TouchableOpacity style={styles.secondaryButton} onPress={() => navigation.navigate('GoalEdit', { goal })}>
+                  <Text style={styles.secondaryButtonText}>Edit</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.secondaryButton} onPress={() => updateStatus(goal, goal.status === 'active' ? 'paused' : 'active')}>
+                  <Text style={styles.secondaryButtonText}>{goal.status === 'active' ? 'Pause' : 'Activate'}</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.secondaryButton} onPress={() => updateStatus(goal, 'done')}>
+                  <Text style={styles.secondaryButtonText}>Done</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          ))}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+function StatCard({ label, value, styles }: { label: string; value: number; styles: ReturnType<typeof createStyles> }) {
+  return (
+    <View style={styles.statCard}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+function createStyles(theme: Theme) {
+  return StyleSheet.create({
+    container: { flex: 1, backgroundColor: theme.colors.background },
+    content: { padding: spacing.lg, gap: spacing.md, paddingBottom: spacing['3xl'] },
+    header: { gap: spacing.xs },
+    kicker: { ...theme.typography.caption, textTransform: 'uppercase', letterSpacing: 2 },
+    title: { ...theme.typography.h1 },
+    subtitle: { ...theme.typography.bodyMuted },
+    statsGrid: { flexDirection: 'row', gap: spacing.sm },
+    statCard: { ...theme.card, flex: 1, padding: spacing.md },
+    statLabel: { ...theme.typography.caption },
+    statValue: { ...theme.typography.h2 },
+    primaryButton: { backgroundColor: theme.colors.primary, borderRadius: radius.lg, padding: spacing.md, alignItems: 'center' },
+    primaryButtonText: { color: theme.colors.primaryForeground, fontWeight: '700' },
+    section: { gap: spacing.sm },
+    sectionTitle: { ...theme.typography.h2 },
+    card: { ...theme.card, gap: spacing.sm },
+    cardHeader: { flexDirection: 'row', gap: spacing.sm, alignItems: 'flex-start' },
+    cardTitle: { ...theme.typography.label, fontSize: 16 },
+    muted: { ...theme.typography.bodyMuted },
+    bodyText: { ...theme.typography.body },
+    warning: { ...theme.typography.body, color: theme.colors.warning ?? theme.colors.primary },
+    badge: { ...theme.typography.caption, color: theme.colors.primary, fontWeight: '700' },
+    actionRow: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
+    secondaryButton: { borderWidth: 1, borderColor: theme.colors.border, borderRadius: radius.md, paddingHorizontal: spacing.md, paddingVertical: spacing.sm },
+    secondaryButtonText: { ...theme.typography.label },
+    empty: { ...theme.typography.bodyMuted },
+    error: { ...theme.typography.body, color: theme.colors.destructive },
+  });
+}

--- a/apps/mobile/src/ui/appShell.ts
+++ b/apps/mobile/src/ui/appShell.ts
@@ -21,7 +21,7 @@ export function resolveAppShellLayout(width: number): AppShellLayout {
   return normalizedWidth >= APP_SHELL_BREAKPOINTS.desktopMinWidth ? 'desktop' : 'compact';
 }
 
-export type AppShellPrimaryNavItemId = 'sessions' | 'agents' | 'knowledge' | 'settings';
+export type AppShellPrimaryNavItemId = 'sessions' | 'agents' | 'knowledge' | 'goals' | 'decisions' | 'settings';
 
 export type AppShellMobileSettingsSectionId =
   | 'providerSelection'
@@ -110,6 +110,8 @@ export const APP_SHELL_PRIMARY_NAV_ITEMS: AppShellPrimaryNavItem[] = [
     mobileRouteName: 'Settings',
     mobileRouteParams: { initialSection: 'knowledgeNotes' },
   },
+  { id: 'goals', label: 'Goals', mobileRouteName: 'Goals' },
+  { id: 'decisions', label: 'Decisions', mobileRouteName: 'Decisions' },
   { id: 'settings', label: 'Settings', mobileRouteName: 'Settings' },
 ];
 
@@ -130,9 +132,12 @@ export const APP_SHELL_MOBILE_ROUTE_TITLES = {
   KnowledgeNoteEdit: 'Note',
   LoopEdit: 'Loop',
   SkillEdit: 'Skill',
+  Goals: 'Goals',
+  GoalEdit: 'Goal',
+  Decisions: 'Decisions',
 } as const;
 
-const APP_SHELL_MOBILE_DESKTOP_SHELL_HEADERLESS_ROUTES = ['Sessions', 'Settings'] as const;
+const APP_SHELL_MOBILE_DESKTOP_SHELL_HEADERLESS_ROUTES = ['Sessions', 'Settings', 'Goals', 'Decisions'] as const;
 
 export function shouldHideMobileStackHeaderForDesktopShell(routeName: string): boolean {
   return APP_SHELL_MOBILE_DESKTOP_SHELL_HEADERLESS_ROUTES.includes(
@@ -142,6 +147,8 @@ export function shouldHideMobileStackHeaderForDesktopShell(routeName: string): b
 
 export function getMobilePrimaryNavItemId(routeName: string): AppShellPrimaryNavItemId {
   if (routeName === 'Sessions' || routeName === 'Chat') return 'sessions';
+  if (routeName === 'Goals' || routeName === 'GoalEdit') return 'goals';
+  if (routeName === 'Decisions') return 'decisions';
   if (routeName === 'Settings') return 'settings';
   return 'sessions';
 }

--- a/packages/core/src/agents-files/decisions.test.ts
+++ b/packages/core/src/agents-files/decisions.test.ts
@@ -1,0 +1,75 @@
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { describe, expect, it } from "vitest"
+import { getAgentsLayerPaths } from "./modular-config"
+import {
+  decisionIdToFilePath,
+  loadDecisionsLayer,
+  parseDecisionMarkdown,
+  stringifyDecisionMarkdown,
+  writeDecisionFile,
+} from "./decisions"
+import type { Decision } from "../types"
+
+function makeDecision(overrides: Partial<Decision> = {}): Decision {
+  return {
+    id: "d_video_angle",
+    type: "yn",
+    status: "pending",
+    question: "Use this video angle?",
+    recommendation: "yes",
+    why: "Clearer thumbnail.",
+    risk: "Less technical depth.",
+    goalId: "g_publish_video",
+    taskId: "daily-goal-planning",
+    createdAt: 1780790000000,
+    updatedAt: 1780790000001,
+    answeredAt: null,
+    expiresAt: 1780876400000,
+    defaultAction: "continue_research",
+    answer: null,
+    answerSource: null,
+    urgent: true,
+    revertEffortHours: 4,
+    pathChanging: true,
+    irreversible: false,
+    history: [{ at: 1780790000000, type: "created", by: "agent", note: "blocked" }],
+    body: "Supporting context",
+    ...overrides,
+  }
+}
+
+describe("agents-files/decisions", () => {
+  it("roundtrips decision frontmatter and body", () => {
+    const markdown = stringifyDecisionMarkdown(makeDecision())
+    const parsed = parseDecisionMarkdown(markdown)
+
+    expect(markdown).toContain("kind: decision")
+    expect(parsed).toEqual(makeDecision())
+  })
+
+  it("loads and writes decisions from a layer", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-decisions-"))
+    const layer = getAgentsLayerPaths(path.join(dir, ".agents"))
+    const decision = makeDecision({ id: "d_layer_decision" })
+
+    writeDecisionFile(layer, decision)
+
+    expect(fs.existsSync(decisionIdToFilePath(layer, decision.id))).toBe(true)
+    const loaded = loadDecisionsLayer(layer)
+    expect(loaded.decisions).toEqual([decision])
+    expect(loaded.originById.get(decision.id)?.filePath).toBe(decisionIdToFilePath(layer, decision.id))
+  })
+
+  it("uses safe defaults for older sparse files", () => {
+    const parsed = parseDecisionMarkdown("Body only", { fallbackId: "d_sparse" })
+
+    expect(parsed?.id).toBe("d_sparse")
+    expect(parsed?.type).toBe("yn")
+    expect(parsed?.status).toBe("pending")
+    expect(parsed?.urgent).toBe(false)
+    expect(parsed?.revertEffortHours).toBe(0)
+    expect(parsed?.history).toEqual([])
+  })
+})

--- a/packages/core/src/agents-files/decisions.ts
+++ b/packages/core/src/agents-files/decisions.ts
@@ -1,0 +1,227 @@
+import fs from "fs"
+import path from "path"
+import type { Decision, DecisionAnswerSource, DecisionHistoryEntry, DecisionStatus, DecisionType } from "../types"
+import type { AgentsLayerPaths } from "./modular-config"
+import { AGENTS_DECISIONS_DIR } from "./modular-config"
+import { parseFrontmatterOrBody, stringifyFrontmatterDocument } from "./frontmatter"
+import { readTextFileIfExistsSync, safeWriteFileSync } from "./safe-file"
+
+export const DECISION_CANONICAL_FILENAME = "decision.md"
+
+export type DecisionOrigin = {
+  filePath: string
+}
+
+export type LoadedDecisionsLayer = {
+  decisions: Decision[]
+  originById: Map<string, DecisionOrigin>
+}
+
+const VALID_TYPES = new Set<DecisionType>(["yn", "ab", "ranked", "edit", "defer"])
+const VALID_STATUSES = new Set<DecisionStatus>(["pending", "answered", "deferred", "auto_resolved", "canceled"])
+const VALID_SOURCES = new Set<DecisionAnswerSource>(["aj", "agent", "timeout", "system"])
+
+function sanitizeFileComponent(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_")
+}
+
+function parseBoolean(raw: string | undefined, defaultValue: boolean): boolean {
+  const trimmed = (raw ?? "").trim().toLowerCase()
+  if (!trimmed) return defaultValue
+  if (["1", "true", "yes", "y", "on"].includes(trimmed)) return true
+  if (["0", "false", "no", "n", "off"].includes(trimmed)) return false
+  return defaultValue
+}
+
+function parseNumber(raw: string | undefined, defaultValue: number): number {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return defaultValue
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : defaultValue
+}
+
+function parseNullableNumber(raw: string | undefined): number | null | undefined {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return undefined
+  if (trimmed === "null") return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function parseNullableString(raw: string | undefined): string | null | undefined {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return undefined
+  if (trimmed === "null") return null
+  return trimmed
+}
+
+function parseAnswerSource(raw: string | undefined): DecisionAnswerSource | null | undefined {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return undefined
+  if (trimmed === "null") return null
+  return VALID_SOURCES.has(trimmed as DecisionAnswerSource) ? (trimmed as DecisionAnswerSource) : undefined
+}
+
+function parseHistory(raw: string | undefined): DecisionHistoryEntry[] {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return []
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (!Array.isArray(parsed)) return []
+    return parsed.flatMap((entry): DecisionHistoryEntry[] => {
+      if (!entry || typeof entry !== "object") return []
+      const obj = entry as Record<string, unknown>
+      const at = typeof obj.at === "number" && Number.isFinite(obj.at) ? obj.at : undefined
+      const type = typeof obj.type === "string" ? obj.type.trim() : ""
+      const by = typeof obj.by === "string" && VALID_SOURCES.has(obj.by as DecisionAnswerSource)
+        ? (obj.by as DecisionAnswerSource)
+        : undefined
+      if (!at || !type || !by) return []
+      const note = typeof obj.note === "string" && obj.note.trim() ? obj.note.trim() : undefined
+      return [{ at, type, by, note }]
+    })
+  } catch {
+    return []
+  }
+}
+
+function stringifyHistory(history: DecisionHistoryEntry[]): string {
+  return JSON.stringify(history)
+}
+
+function setIfPresent(frontmatter: Record<string, string>, key: string, value: string | number | boolean | undefined | null): void {
+  if (value === undefined || value === "") return
+  frontmatter[key] = value === null ? "null" : String(value)
+}
+
+export function getDecisionsDir(layer: AgentsLayerPaths): string {
+  return path.join(layer.agentsDir, AGENTS_DECISIONS_DIR)
+}
+
+export function getDecisionsBackupDir(layer: AgentsLayerPaths): string {
+  return path.join(layer.backupsDir, AGENTS_DECISIONS_DIR)
+}
+
+export function decisionIdToDirPath(layer: AgentsLayerPaths, id: string): string {
+  return path.join(getDecisionsDir(layer), sanitizeFileComponent(id))
+}
+
+export function decisionIdToFilePath(layer: AgentsLayerPaths, id: string): string {
+  return path.join(decisionIdToDirPath(layer, id), DECISION_CANONICAL_FILENAME)
+}
+
+export function stringifyDecisionMarkdown(decision: Decision): string {
+  const frontmatter: Record<string, string> = {
+    kind: "decision",
+    id: decision.id,
+    type: decision.type,
+    status: decision.status,
+    question: decision.question,
+    createdAt: String(decision.createdAt),
+    updatedAt: String(decision.updatedAt),
+    urgent: String(decision.urgent),
+    revertEffortHours: String(decision.revertEffortHours),
+    pathChanging: String(decision.pathChanging),
+    irreversible: String(decision.irreversible),
+    history: stringifyHistory(decision.history),
+  }
+
+  setIfPresent(frontmatter, "recommendation", decision.recommendation)
+  setIfPresent(frontmatter, "why", decision.why)
+  setIfPresent(frontmatter, "risk", decision.risk)
+  setIfPresent(frontmatter, "goalId", decision.goalId)
+  setIfPresent(frontmatter, "taskId", decision.taskId)
+  setIfPresent(frontmatter, "answeredAt", decision.answeredAt)
+  setIfPresent(frontmatter, "expiresAt", decision.expiresAt)
+  setIfPresent(frontmatter, "defaultAction", decision.defaultAction)
+  setIfPresent(frontmatter, "answer", decision.answer)
+  setIfPresent(frontmatter, "answerSource", decision.answerSource)
+
+  return stringifyFrontmatterDocument({ frontmatter, body: decision.body || "" })
+}
+
+export function parseDecisionMarkdown(markdown: string, options: { fallbackId?: string; filePath?: string } = {}): Decision | null {
+  const { frontmatter: fm, body } = parseFrontmatterOrBody(markdown)
+  if ((fm.kind ?? "decision").trim() !== "decision") return null
+
+  const now = Date.now()
+  const fallbackId = options.fallbackId?.trim()
+  const id = (fm.id ?? "").trim() || fallbackId
+  if (!id) return null
+
+  const type = VALID_TYPES.has(fm.type as DecisionType) ? (fm.type as DecisionType) : "yn"
+  const status = VALID_STATUSES.has(fm.status as DecisionStatus) ? (fm.status as DecisionStatus) : "pending"
+  const createdAt = parseNumber(fm.createdAt, now)
+  const updatedAt = parseNumber(fm.updatedAt, createdAt)
+  const answerSource = parseAnswerSource(fm.answerSource)
+
+  return {
+    id,
+    type,
+    status,
+    question: (fm.question ?? "").trim() || id,
+    recommendation: (fm.recommendation ?? "").trim() || undefined,
+    why: (fm.why ?? "").trim() || undefined,
+    risk: (fm.risk ?? "").trim() || undefined,
+    goalId: (fm.goalId ?? "").trim() || undefined,
+    taskId: (fm.taskId ?? "").trim() || undefined,
+    createdAt,
+    updatedAt,
+    answeredAt: parseNullableNumber(fm.answeredAt),
+    expiresAt: parseNullableNumber(fm.expiresAt),
+    defaultAction: (fm.defaultAction ?? "").trim() || undefined,
+    answer: parseNullableString(fm.answer),
+    answerSource,
+    urgent: parseBoolean(fm.urgent, false),
+    revertEffortHours: parseNumber(fm.revertEffortHours, 0),
+    pathChanging: parseBoolean(fm.pathChanging, false),
+    irreversible: parseBoolean(fm.irreversible, false),
+    history: parseHistory(fm.history),
+    body: body.trim(),
+  }
+}
+
+export function loadDecisionsLayer(layer: AgentsLayerPaths): LoadedDecisionsLayer {
+  const decisions: Decision[] = []
+  const originById = new Map<string, DecisionOrigin>()
+  const decisionsDir = getDecisionsDir(layer)
+
+  try {
+    if (!fs.existsSync(decisionsDir) || !fs.statSync(decisionsDir).isDirectory()) {
+      return { decisions, originById }
+    }
+
+    for (const entry of fs.readdirSync(decisionsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith(".")) continue
+      const filePath = path.join(decisionsDir, entry.name, DECISION_CANONICAL_FILENAME)
+      const raw = readTextFileIfExistsSync(filePath, "utf8")
+      if (raw === null) continue
+      const decision = parseDecisionMarkdown(raw, { fallbackId: entry.name, filePath })
+      if (!decision) continue
+      decisions.push(decision)
+      originById.set(decision.id, { filePath })
+    }
+  } catch {
+    // best-effort
+  }
+
+  return { decisions, originById }
+}
+
+export function writeDecisionFile(layer: AgentsLayerPaths, decision: Decision, options: { maxBackups?: number } = {}): void {
+  const decisionDir = decisionIdToDirPath(layer, decision.id)
+  fs.mkdirSync(decisionDir, { recursive: true })
+  safeWriteFileSync(decisionIdToFilePath(layer, decision.id), stringifyDecisionMarkdown(decision), {
+    backupDir: getDecisionsBackupDir(layer),
+    maxBackups: options.maxBackups ?? 10,
+  })
+}
+
+export function deleteDecisionFiles(layer: AgentsLayerPaths, id: string): void {
+  try {
+    const decisionDir = decisionIdToDirPath(layer, id)
+    if (fs.existsSync(decisionDir)) fs.rmSync(decisionDir, { recursive: true, force: true })
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/core/src/agents-files/goals.test.ts
+++ b/packages/core/src/agents-files/goals.test.ts
@@ -1,0 +1,67 @@
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { describe, expect, it } from "vitest"
+import { getAgentsLayerPaths } from "./modular-config"
+import { goalIdToFilePath, loadGoalsLayer, parseGoalMarkdown, stringifyGoalMarkdown, writeGoalFile } from "./goals"
+import type { Goal } from "../types"
+
+function makeGoal(overrides: Partial<Goal> = {}): Goal {
+  return {
+    id: "g_publish_video",
+    title: "Publish video",
+    description: "Finish and publish the video.",
+    level: "goal",
+    priority: 2,
+    status: "active",
+    parentId: undefined,
+    successCriteria: "Video published",
+    signalToWatch: "views",
+    abandonIf: "No outline in 14 days",
+    createdAt: 1780790000000,
+    updatedAt: 1780790000001,
+    lastTouchedAt: 1780790000002,
+    createdBy: "agent",
+    createdFrom: "loop_daily_planning",
+    provenance: "Daily planning found a missing focus.",
+    linkedTaskIds: ["daily-goal-planning"],
+    notes: "Important",
+    body: "Long-form context",
+    ...overrides,
+  }
+}
+
+describe("agents-files/goals", () => {
+  it("roundtrips goal frontmatter and body", () => {
+    const markdown = stringifyGoalMarkdown(makeGoal())
+    const parsed = parseGoalMarkdown(markdown)
+
+    expect(markdown).toContain("kind: goal")
+    expect(parsed).toEqual(makeGoal())
+  })
+
+  it("loads and writes goals from a layer", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "dotagents-goals-"))
+    const layer = getAgentsLayerPaths(path.join(dir, ".agents"))
+    const goal = makeGoal({ id: "g_layer_goal" })
+
+    writeGoalFile(layer, goal)
+
+    expect(fs.existsSync(goalIdToFilePath(layer, goal.id))).toBe(true)
+    const loaded = loadGoalsLayer(layer)
+    expect(loaded.goals).toEqual([goal])
+    expect(loaded.originById.get(goal.id)?.filePath).toBe(goalIdToFilePath(layer, goal.id))
+  })
+
+  it("uses safe defaults for older sparse files", () => {
+    const parsed = parseGoalMarkdown("Body only", { fallbackId: "g_sparse" })
+
+    expect(parsed?.id).toBe("g_sparse")
+    expect(parsed?.title).toBe("g_sparse")
+    expect(parsed?.level).toBe("goal")
+    expect(parsed?.priority).toBe(3)
+    expect(parsed?.status).toBe("active")
+    expect(parsed?.createdBy).toBe("aj")
+    expect(parsed?.createdFrom).toBe("manual")
+  })
+})

--- a/packages/core/src/agents-files/goals.ts
+++ b/packages/core/src/agents-files/goals.ts
@@ -1,0 +1,184 @@
+import fs from "fs"
+import path from "path"
+import type { Goal, GoalCreatedBy, GoalLevel, GoalStatus } from "../types"
+import type { AgentsLayerPaths } from "./modular-config"
+import { AGENTS_GOALS_DIR } from "./modular-config"
+import { parseFrontmatterOrBody, stringifyFrontmatterDocument } from "./frontmatter"
+import { readTextFileIfExistsSync, safeWriteFileSync } from "./safe-file"
+
+export const GOAL_CANONICAL_FILENAME = "goal.md"
+
+export type GoalOrigin = {
+  filePath: string
+}
+
+export type LoadedGoalsLayer = {
+  goals: Goal[]
+  originById: Map<string, GoalOrigin>
+}
+
+const VALID_LEVELS = new Set<GoalLevel>(["goal", "week", "today"])
+const VALID_STATUSES = new Set<GoalStatus>(["active", "paused", "done", "abandoned"])
+const VALID_CREATED_BY = new Set<GoalCreatedBy>(["aj", "agent"])
+
+function sanitizeFileComponent(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, "_")
+}
+
+function parseNumber(raw: string | undefined, defaultValue: number): number {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return defaultValue
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : defaultValue
+}
+
+function parseListValue(raw: string | undefined): string[] {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return []
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) {
+        return parsed.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean)
+      }
+    } catch {
+      // fall through to CSV
+    }
+  }
+  return trimmed.split(",").map((value) => value.trim()).filter(Boolean)
+}
+
+function formatListValue(values: string[] | undefined): string {
+  return Array.isArray(values) ? values.map((value) => value.trim()).filter(Boolean).join(", ") : ""
+}
+
+function setIfPresent(frontmatter: Record<string, string>, key: string, value: string | number | undefined | null): void {
+  if (value === undefined || value === null || value === "") return
+  frontmatter[key] = String(value)
+}
+
+export function getGoalsDir(layer: AgentsLayerPaths): string {
+  return path.join(layer.agentsDir, AGENTS_GOALS_DIR)
+}
+
+export function getGoalsBackupDir(layer: AgentsLayerPaths): string {
+  return path.join(layer.backupsDir, AGENTS_GOALS_DIR)
+}
+
+export function goalIdToDirPath(layer: AgentsLayerPaths, id: string): string {
+  return path.join(getGoalsDir(layer), sanitizeFileComponent(id))
+}
+
+export function goalIdToFilePath(layer: AgentsLayerPaths, id: string): string {
+  return path.join(goalIdToDirPath(layer, id), GOAL_CANONICAL_FILENAME)
+}
+
+export function stringifyGoalMarkdown(goal: Goal): string {
+  const frontmatter: Record<string, string> = {
+    kind: "goal",
+    id: goal.id,
+    title: goal.title,
+    description: goal.description,
+    level: goal.level,
+    priority: String(goal.priority),
+    status: goal.status,
+    createdAt: String(goal.createdAt),
+    updatedAt: String(goal.updatedAt),
+    createdBy: goal.createdBy,
+    createdFrom: goal.createdFrom,
+  }
+
+  setIfPresent(frontmatter, "parentId", goal.parentId)
+  setIfPresent(frontmatter, "successCriteria", goal.successCriteria)
+  setIfPresent(frontmatter, "signalToWatch", goal.signalToWatch)
+  setIfPresent(frontmatter, "abandonIf", goal.abandonIf)
+  setIfPresent(frontmatter, "lastTouchedAt", goal.lastTouchedAt)
+  setIfPresent(frontmatter, "provenance", goal.provenance)
+  if (goal.linkedTaskIds.length > 0) frontmatter.linkedTaskIds = formatListValue(goal.linkedTaskIds)
+  setIfPresent(frontmatter, "notes", goal.notes)
+
+  return stringifyFrontmatterDocument({ frontmatter, body: goal.body || "" })
+}
+
+export function parseGoalMarkdown(markdown: string, options: { fallbackId?: string; filePath?: string } = {}): Goal | null {
+  const { frontmatter: fm, body } = parseFrontmatterOrBody(markdown)
+  if ((fm.kind ?? "goal").trim() !== "goal") return null
+
+  const now = Date.now()
+  const fallbackId = options.fallbackId?.trim()
+  const id = (fm.id ?? "").trim() || fallbackId
+  if (!id) return null
+
+  const level = VALID_LEVELS.has(fm.level as GoalLevel) ? (fm.level as GoalLevel) : "goal"
+  const status = VALID_STATUSES.has(fm.status as GoalStatus) ? (fm.status as GoalStatus) : "active"
+  const createdBy = VALID_CREATED_BY.has(fm.createdBy as GoalCreatedBy) ? (fm.createdBy as GoalCreatedBy) : "aj"
+  const createdAt = parseNumber(fm.createdAt, now)
+  const updatedAt = parseNumber(fm.updatedAt, createdAt)
+
+  return {
+    id,
+    title: (fm.title ?? "").trim() || id,
+    description: (fm.description ?? "").trim(),
+    level,
+    priority: parseNumber(fm.priority, 3),
+    status,
+    parentId: (fm.parentId ?? "").trim() || undefined,
+    successCriteria: (fm.successCriteria ?? "").trim() || undefined,
+    signalToWatch: (fm.signalToWatch ?? "").trim() || undefined,
+    abandonIf: (fm.abandonIf ?? "").trim() || undefined,
+    createdAt,
+    updatedAt,
+    lastTouchedAt: fm.lastTouchedAt ? parseNumber(fm.lastTouchedAt, updatedAt) : undefined,
+    createdBy,
+    createdFrom: (fm.createdFrom ?? "").trim() || "manual",
+    provenance: (fm.provenance ?? "").trim() || undefined,
+    linkedTaskIds: parseListValue(fm.linkedTaskIds),
+    notes: (fm.notes ?? "").trim() || undefined,
+    body: body.trim(),
+  }
+}
+
+export function loadGoalsLayer(layer: AgentsLayerPaths): LoadedGoalsLayer {
+  const goals: Goal[] = []
+  const originById = new Map<string, GoalOrigin>()
+  const goalsDir = getGoalsDir(layer)
+
+  try {
+    if (!fs.existsSync(goalsDir) || !fs.statSync(goalsDir).isDirectory()) {
+      return { goals, originById }
+    }
+
+    for (const entry of fs.readdirSync(goalsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith(".")) continue
+      const filePath = path.join(goalsDir, entry.name, GOAL_CANONICAL_FILENAME)
+      const raw = readTextFileIfExistsSync(filePath, "utf8")
+      if (raw === null) continue
+      const goal = parseGoalMarkdown(raw, { fallbackId: entry.name, filePath })
+      if (!goal) continue
+      goals.push(goal)
+      originById.set(goal.id, { filePath })
+    }
+  } catch {
+    // best-effort
+  }
+
+  return { goals, originById }
+}
+
+export function writeGoalFile(layer: AgentsLayerPaths, goal: Goal, options: { maxBackups?: number } = {}): void {
+  const goalDir = goalIdToDirPath(layer, goal.id)
+  fs.mkdirSync(goalDir, { recursive: true })
+  safeWriteFileSync(goalIdToFilePath(layer, goal.id), stringifyGoalMarkdown(goal), {
+    backupDir: getGoalsBackupDir(layer),
+    maxBackups: options.maxBackups ?? 10,
+  })
+}
+
+export function deleteGoalFiles(layer: AgentsLayerPaths, id: string): void {
+  try {
+    const goalDir = goalIdToDirPath(layer, id)
+    if (fs.existsSync(goalDir)) fs.rmSync(goalDir, { recursive: true, force: true })
+  } catch {
+    // best-effort
+  }
+}

--- a/packages/core/src/agents-files/modular-config.ts
+++ b/packages/core/src/agents-files/modular-config.ts
@@ -34,10 +34,14 @@ export type AgentsLayerPaths = {
   agentsMdPath: string
   agentProfilesDir: string
   tasksDir: string
+  goalsDir: string
+  decisionsDir: string
 }
 
 export const AGENTS_AGENT_PROFILES_DIR = "agents"
 export const AGENTS_TASKS_DIR = "tasks"
+export const AGENTS_GOALS_DIR = "goals"
+export const AGENTS_DECISIONS_DIR = "decisions"
 
 export function getAgentsLayerPaths(agentsDir: string): AgentsLayerPaths {
   return {
@@ -52,6 +56,8 @@ export function getAgentsLayerPaths(agentsDir: string): AgentsLayerPaths {
     agentsMdPath: path.join(agentsDir, AGENTS_AGENTS_MD),
     agentProfilesDir: path.join(agentsDir, AGENTS_AGENT_PROFILES_DIR),
     tasksDir: path.join(agentsDir, AGENTS_TASKS_DIR),
+    goalsDir: path.join(agentsDir, AGENTS_GOALS_DIR),
+    decisionsDir: path.join(agentsDir, AGENTS_DECISIONS_DIR),
   }
 }
 

--- a/packages/core/src/agents-files/tasks.ts
+++ b/packages/core/src/agents-files/tasks.ts
@@ -40,6 +40,26 @@ function parseNumber(raw: string | undefined, defaultValue: number): number {
   return Number.isFinite(n) ? n : defaultValue
 }
 
+function parseListValue(raw: string | undefined): string[] {
+  const trimmed = (raw ?? "").trim()
+  if (!trimmed) return []
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (Array.isArray(parsed)) {
+        return parsed.filter((value): value is string => typeof value === "string").map((value) => value.trim()).filter(Boolean)
+      }
+    } catch {
+      // fall through to CSV
+    }
+  }
+  return trimmed.split(",").map((value) => value.trim()).filter(Boolean)
+}
+
+function formatListValue(values: string[] | undefined): string {
+  return Array.isArray(values) ? values.map((value) => value.trim()).filter(Boolean).join(", ") : ""
+}
+
 // ---- Schedule (de)serialization ---------------------------------------------
 
 const TIME_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
@@ -136,6 +156,10 @@ export function stringifyTaskMarkdown(task: LoopConfig): string {
   if (task.runContinuously) frontmatter.runContinuously = "true"
   if (task.lastRunAt) frontmatter.lastRunAt = String(task.lastRunAt)
   if (task.schedule) frontmatter.schedule = stringifySchedule(task.schedule)
+  if (task.loopType) frontmatter.loopType = task.loopType
+  if (task.linkedGoalIds?.length) frontmatter.linkedGoalIds = formatListValue(task.linkedGoalIds)
+  if (task.outputType) frontmatter.outputType = task.outputType
+  if (task.tokenBudgetPerRun) frontmatter.tokenBudgetPerRun = String(task.tokenBudgetPerRun)
 
   return stringifyFrontmatterDocument({ frontmatter, body: task.prompt || "" })
 }
@@ -173,6 +197,14 @@ export function parseTaskMarkdown(
     runContinuously: parseBoolean(fm.runContinuously, false) || undefined,
     lastRunAt: fm.lastRunAt ? parseNumber(fm.lastRunAt, 0) || undefined : undefined,
     schedule,
+    loopType: ["daily_planning", "execution", "recap", "custom"].includes(fm.loopType ?? "")
+      ? (fm.loopType as LoopConfig["loopType"])
+      : undefined,
+    linkedGoalIds: parseListValue(fm.linkedGoalIds),
+    outputType: ["goals", "tasks", "decisions", "summary"].includes(fm.outputType ?? "")
+      ? (fm.outputType as LoopConfig["outputType"])
+      : undefined,
+    tokenBudgetPerRun: fm.tokenBudgetPerRun ? parseNumber(fm.tokenBudgetPerRun, 0) || undefined : undefined,
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -207,6 +207,36 @@ export {
 } from './agents-files/tasks';
 export type { TaskOrigin, LoadedTasksLayer } from './agents-files/tasks';
 
+// Agents files — goals
+export {
+  GOAL_CANONICAL_FILENAME,
+  getGoalsDir,
+  getGoalsBackupDir,
+  goalIdToDirPath,
+  goalIdToFilePath,
+  stringifyGoalMarkdown,
+  parseGoalMarkdown,
+  loadGoalsLayer,
+  writeGoalFile,
+  deleteGoalFiles,
+} from './agents-files/goals';
+export type { GoalOrigin, LoadedGoalsLayer } from './agents-files/goals';
+
+// Agents files — decisions
+export {
+  DECISION_CANONICAL_FILENAME,
+  getDecisionsDir,
+  getDecisionsBackupDir,
+  decisionIdToDirPath,
+  decisionIdToFilePath,
+  stringifyDecisionMarkdown,
+  parseDecisionMarkdown,
+  loadDecisionsLayer,
+  writeDecisionFile,
+  deleteDecisionFiles,
+} from './agents-files/decisions';
+export type { DecisionOrigin, LoadedDecisionsLayer } from './agents-files/decisions';
+
 // Agents files — agent-profiles
 export {
   AGENTS_PROFILE_CANONICAL_FILENAME,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,6 +67,9 @@ export type LoopSchedule =
   | { type: "daily"; times: string[] }
   | { type: "weekly"; times: string[]; daysOfWeek: number[] }
 
+export type LoopType = "daily_planning" | "execution" | "recap" | "custom"
+export type LoopOutputType = "goals" | "tasks" | "decisions" | "summary"
+
 export interface LoopConfig {
   id: string
   name: string
@@ -105,6 +108,77 @@ export interface LoopConfig {
   runContinuously?: boolean
   /** Wall-clock schedule. When present, supersedes `intervalMinutes`. */
   schedule?: LoopSchedule
+  loopType?: LoopType
+  linkedGoalIds?: string[]
+  outputType?: LoopOutputType
+  tokenBudgetPerRun?: number
+}
+
+// ============================================================================
+// Goals + Decisions
+// ============================================================================
+
+export type GoalLevel = "goal" | "week" | "today"
+export type GoalStatus = "active" | "paused" | "done" | "abandoned"
+export type GoalCreatedBy = "aj" | "agent"
+export type GoalCreatedFrom = "manual" | "loop_daily_planning" | string
+
+export interface Goal {
+  id: string
+  title: string
+  description: string
+  level: GoalLevel
+  priority: number
+  status: GoalStatus
+  body: string
+  parentId?: string
+  successCriteria?: string
+  signalToWatch?: string
+  abandonIf?: string
+  createdAt: number
+  updatedAt: number
+  lastTouchedAt?: number
+  createdBy: GoalCreatedBy
+  createdFrom: GoalCreatedFrom
+  provenance?: string
+  linkedTaskIds: string[]
+  notes?: string
+}
+
+export type DecisionType = "yn" | "ab" | "ranked" | "edit" | "defer"
+export type DecisionStatus = "pending" | "answered" | "deferred" | "auto_resolved" | "canceled"
+export type DecisionAnswerSource = "aj" | "agent" | "timeout" | "system"
+
+export interface DecisionHistoryEntry {
+  at: number
+  type: string
+  by: DecisionAnswerSource
+  note?: string
+}
+
+export interface Decision {
+  id: string
+  type: DecisionType
+  status: DecisionStatus
+  question: string
+  recommendation?: string
+  why?: string
+  risk?: string
+  goalId?: string
+  taskId?: string
+  createdAt: number
+  updatedAt: number
+  answeredAt?: number | null
+  expiresAt?: number | null
+  defaultAction?: string
+  answer?: string | null
+  answerSource?: DecisionAnswerSource | null
+  urgent: boolean
+  revertEffortHours: number
+  pathChanging: boolean
+  irreversible: boolean
+  history: DecisionHistoryEntry[]
+  body: string
 }
 
 // ============================================================================

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -1009,10 +1009,179 @@ export interface VerifyExternalAgentCommandResponse {
   warnings?: string[];
 }
 
+// Goals + Decisions
+export type GoalLevel = "goal" | "week" | "today";
+export type GoalStatus = "active" | "paused" | "done" | "abandoned";
+export type GoalCreatedBy = "aj" | "agent";
+export type GoalCreatedFrom = "manual" | "loop_daily_planning" | string;
+
+export interface Goal {
+  id: string;
+  title: string;
+  description: string;
+  level: GoalLevel;
+  priority: number;
+  status: GoalStatus;
+  body: string;
+  parentId?: string;
+  successCriteria?: string;
+  signalToWatch?: string;
+  abandonIf?: string;
+  createdAt: number;
+  updatedAt: number;
+  lastTouchedAt?: number;
+  createdBy: GoalCreatedBy;
+  createdFrom: GoalCreatedFrom;
+  provenance?: string;
+  linkedTaskIds: string[];
+  notes?: string;
+}
+
+export interface GoalsResponse {
+  goals: Goal[];
+}
+
+export interface GoalCreateRequest {
+  id?: string;
+  title: string;
+  description?: string;
+  level?: GoalLevel;
+  priority?: number;
+  status?: GoalStatus;
+  parentId?: string;
+  successCriteria?: string;
+  signalToWatch?: string;
+  abandonIf?: string;
+  createdBy?: GoalCreatedBy;
+  createdFrom?: GoalCreatedFrom;
+  provenance?: string;
+  linkedTaskIds?: string[];
+  notes?: string;
+  body?: string;
+}
+
+export interface GoalUpdateRequest extends Partial<Omit<GoalCreateRequest, "id">> {
+  id?: string;
+  lastTouchedAt?: number;
+}
+
+export type DecisionType = "yn" | "ab" | "ranked" | "edit" | "defer";
+export type DecisionStatus = "pending" | "answered" | "deferred" | "auto_resolved" | "canceled";
+export type DecisionAnswerSource = "aj" | "agent" | "timeout" | "system";
+
+export interface DecisionHistoryEntry {
+  at: number;
+  type: string;
+  by: DecisionAnswerSource;
+  note?: string;
+}
+
+export interface Decision {
+  id: string;
+  type: DecisionType;
+  status: DecisionStatus;
+  question: string;
+  recommendation?: string;
+  why?: string;
+  risk?: string;
+  goalId?: string;
+  taskId?: string;
+  createdAt: number;
+  updatedAt: number;
+  answeredAt?: number | null;
+  expiresAt?: number | null;
+  defaultAction?: string;
+  answer?: string | null;
+  answerSource?: DecisionAnswerSource | null;
+  urgent: boolean;
+  revertEffortHours: number;
+  pathChanging: boolean;
+  irreversible: boolean;
+  history: DecisionHistoryEntry[];
+  body: string;
+}
+
+export interface DecisionsResponse {
+  decisions: Decision[];
+}
+
+export interface DecisionCreateRequest {
+  id?: string;
+  type?: DecisionType;
+  status?: DecisionStatus;
+  question: string;
+  recommendation?: string;
+  why?: string;
+  risk?: string;
+  goalId?: string;
+  taskId?: string;
+  expiresAt?: number | null;
+  defaultAction?: string;
+  urgent?: boolean;
+  revertEffortHours?: number;
+  pathChanging?: boolean;
+  irreversible?: boolean;
+  body?: string;
+}
+
+export interface DecisionUpdateRequest extends Partial<Omit<DecisionCreateRequest, "id">> {
+  id?: string;
+  answer?: string | null;
+  answerSource?: DecisionAnswerSource | null;
+}
+
+export interface DecisionRespondRequest {
+  answer: string;
+  answerSource?: DecisionAnswerSource;
+}
+
+export type GoalProgressEventType =
+  | "goal_created"
+  | "goal_updated"
+  | "goal_status_changed"
+  | "goal_deleted"
+  | "goal_touched"
+  | "focus_selected"
+  | "decision_created"
+  | "decision_answered"
+  | "decision_deferred"
+  | "decision_canceled"
+  | "planner_run_started"
+  | "planner_run_completed"
+  | "planner_run_noop"
+  | "evidence_added"
+  | "criterion_completed";
+
+export type GoalProgressActor = "aj" | "agent" | "system";
+
+export interface GoalProgressEvent {
+  id: string;
+  type: GoalProgressEventType;
+  at: number;
+  actor: GoalProgressActor;
+  goalId?: string;
+  parentGoalId?: string;
+  decisionId?: string;
+  loopId?: string;
+  sessionId?: string;
+  conversationId?: string;
+  title: string;
+  summary?: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GoalProgressEventsResponse {
+  events: GoalProgressEvent[];
+}
+
 // Agent Loops Types
 export type LoopSchedule =
   | { type: "daily"; times: string[] }
   | { type: "weekly"; times: string[]; daysOfWeek: number[] };
+
+export type LoopType = "daily_planning" | "execution" | "recap" | "custom";
+export type LoopOutputType = "goals" | "tasks" | "decisions" | "summary";
 
 export interface Loop {
   id: string;
@@ -1032,6 +1201,10 @@ export interface Loop {
   isRunning: boolean;
   nextRunAt?: number;
   schedule?: LoopSchedule;
+  loopType?: LoopType;
+  linkedGoalIds?: string[];
+  outputType?: LoopOutputType;
+  tokenBudgetPerRun?: number;
 }
 
 export interface LoopsResponse {


### PR DESCRIPTION
## Summary
- Add goals and decisions as first-class .agents data files with core loaders, writers, exports, and tests.
- Add desktop goal/decision services, remote routes, TIPC routes, runtime tools, and MCP tool allowlisting.
- Add desktop Goals and Decisions dashboards, including a 24/7 goal supervisor card, active agents, current focus, decisions, and progress ledger.
- Add mobile Goals, Goal Edit, and Decisions screens plus settings API wiring and navigation.
- Seed the backward-compatible daily-goal-planning repeat task as a disabled 24/7 Goal Agent template with a bounded 15-minute supervisor cadence.

## UX Notes
- Keeps the existing daily-goal-planning task id for compatibility while changing new installs to show a 24/7 Goal Agent template.
- Starting the supervisor now enables a continuous goal loop with intervalMinutes=15, continueInSession=true, and runContinuously=true.
- Removes sleeping/sleep language from the dashboard and presents standby/online state as always-on bounded cadence.

## Validation
- Passed: pnpm build:shared
- Passed: pnpm --filter @dotagents/core test
- Passed: pnpm --filter @dotagents/desktop typecheck
- Passed: pnpm --filter @dotagents/desktop exec vitest run src/main/loop-service.continuous.test.ts src/main/loop-service.save-semantics.test.ts src/main/loop-service.folder-watcher.test.ts src/main/mcp-service.option-b.test.ts src/main/remote-server.routes.test.ts
- Failed: pnpm --filter @dotagents/mobile test. Failures are existing node source-assertion tests in chat/settings files not touched by this PR; the mobile goal/decision changes are included but the full mobile suite is not currently clean on this branch.

## Compatibility
- Existing repeat tasks remain supported.
- Existing installations with a user-level daily-goal-planning task keep their local file; new bundled/default creation uses the updated 24/7 Goal Agent template.