### PR TITLE
Improve tool activity summaries in agent progress

### DIFF
--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -72,9 +72,6 @@ describe("constructSystemPrompt", () => {
     expect(DEFAULT_SYSTEM_PROMPT).toContain("search relevant knowledge notes first and prior conversations second")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("Before asking the user for facts that may already be known")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("whenever the current task likely relates to prior work")
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("always prefer knowledge notes over recalled conversation context when they conflict")
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("personal legal/immigration")
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("inspect both relevant knowledge notes and recent conversations with a shell/file tool")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("configured knowledge roots")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("global and workspace .agents/knowledge")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("<knowledge-root>/<slug>/<slug>.md")
@@ -88,7 +85,6 @@ describe("constructSystemPrompt", () => {
     expect(DEFAULT_SYSTEM_PROMPT).toContain("RUNTIME METADATA")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("DOTAGENTS_RUNTIME_DIR")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("tools/index.json")
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("OS-appropriate")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("index.json")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("conv_*.json")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("layered global and workspace .agents folders")
@@ -116,14 +112,13 @@ describe("constructSystemPrompt", () => {
   it("instructs agents to search prior conversations whenever they need more context", async () => {
     const { DEFAULT_SYSTEM_PROMPT, constructSystemPrompt } = await import("./system-prompts")
 
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("Whenever you determine you need more context before answering or proceeding")
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("continuation, status, debugging, or high-context planning")
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("Prior DotAgents conversations are JSON in the runtime-supplied conversations directory")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("searching the conversations index and relevant conv_*.json history is a standard context-gathering step")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("do this before asking the user")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("If recovered conversations contain enough facts to answer or continue, use them and respond")
     expect(DEFAULT_SYSTEM_PROMPT).toContain("only ask the user when prior conversations do not contain the needed information, or when credentials/approval are required")
-    // The "knowledge notes take precedence" guarantee from #494 must remain intact
-    expect(DEFAULT_SYSTEM_PROMPT).toContain("always prefer knowledge notes over recalled conversation context when they conflict")
+    // The note-first lookup guarantee from #494 must remain intact.
+    expect(DEFAULT_SYSTEM_PROMPT).toContain("search relevant knowledge notes first and prior conversations second")
 
     const agentPrompt = constructSystemPrompt([
       { name: "execute_command", description: "Execute command", inputSchema: { type: "object", properties: {} } },

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -661,6 +661,53 @@ describe("agent progress response history", () => {
     expect(text).not.toContain("Thinking...")
   })
 
+  it("uses empty timeline space to persist the latest substantive thinking while tools are active", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const progress = {
+      sessionId: "session-whitespace-thinking-context",
+      conversationId: "conversation-whitespace-thinking-context",
+      currentIteration: 1,
+      maxIterations: 10,
+      steps: [],
+      isComplete: false,
+      finalContent: "",
+      conversationHistory: [
+        { role: "user", content: "Gather context", timestamp: 100 },
+        {
+          role: "assistant",
+          content: "I'm locating the transcript and clip folders before deciding the edit path.",
+          timestamp: 150,
+          toolCalls: [
+            { name: "execute_command", arguments: { command: "rg -n transcript /tmp/project" } },
+          ],
+        },
+        {
+          role: "assistant",
+          content: "<think>\nNext I'm checking the exported audio details so the clip timing stays aligned.\n</think>",
+          timestamp: 160,
+          toolCalls: [
+            { name: "execute_command", arguments: { command: "ffprobe video.mp4" } },
+          ],
+        },
+      ],
+    }
+
+    const tree = runtime.render(AgentProgress, { progress, variant: "tile" })
+    const text = getTextContent(tree)
+    const fillers = findAll(
+      tree,
+      (value) => typeof value?.props?.className === "string"
+        && value.props.className.includes("agent-progress-whitespace-context"),
+    )
+
+    expect(fillers).toHaveLength(1)
+    expect(text).toContain("Latest thinking")
+    expect(text).toContain("Next I'm checking the exported audio details")
+    expect(text).not.toContain("<think>")
+    expect(text).not.toContain("</think>")
+  })
+
   it("shows a live thinking placeholder when only previous turns have tool activity", async () => {
     const runtime = createHookRuntime()
     const { AgentProgress } = await loadAgentProgress(runtime)

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -340,81 +340,118 @@ async function loadAgentProgress(
       call: { name: string; arguments?: Record<string, unknown> },
       result?: { success: boolean; content: string; error?: string } | null,
     ) => {
-      const cmd = (call.arguments as { command?: string } | undefined)?.command ?? ""
-      const firstWord = typeof cmd === "string" ? cmd.trim().split(/\s+/)[0] : ""
-      const failed = result?.success === false
-      let title = "Using a tool"
-      let detail: string | undefined
-      if (call.name === "execute_command") {
-        if (firstWord === "sed" || firstWord === "cat") title = "Reading file"
-        else if (firstWord === "rg" || firstWord === "grep") title = "Searching code"
-        else if (firstWord === "find") title = "Finding files"
-        else if (cmd.includes("typecheck")) title = "Checking types"
-        else if (cmd.includes("lint")) title = "Linting code"
-        else if (cmd.includes("test")) title = "Running tests"
-        else if (cmd.startsWith("git status")) title = "Checking git status"
-        else if (firstWord === "git") title = "Checking repository state"
-        else if (firstWord === "python3" || firstWord === "python") title = "Running a script"
-        else title = "Running a command"
-      } else if (call.name.includes("search") || call.name.includes("read")) {
-        title = "Inspecting context"
-      } else if (call.name === "set_session_title") {
-        title = "Updating the session title"
+      const commandHint = () => {
+        const command = typeof call.arguments?.command === "string" ? call.arguments.command : ""
+        const header = command.match(/['"][-=]{3,}\s*([^'"]*?)\s*[-=]{3,}['"]/)?.[1]?.trim()
+        if (header) return header
+        const pathToken = command.split(/\s+/).reverse().find((token) => token.includes("/") || /\.[A-Za-z0-9]{1,8}$/.test(token))
+        if (pathToken) {
+          const cleaned = pathToken.replace(/^['"]|['"],?;?$/g, "").replace(/[),;]+$/g, "")
+          const parts = cleaned.split("/").filter(Boolean)
+          return parts.at(-1)
+        }
+        if (command.includes("<<")) return `inline ${command.trim().split(/\s+/)[0]}`
+        return undefined
       }
-      if (result) {
-        const output = (result.error || result.content || "").trim()
-        if (!result.success) detail = output ? `Failed: ${output}` : "Failed"
-        else if (cmd.startsWith("git status")) detail = output ? `${output.split("\n").filter(Boolean).length} changed files` : "Working tree clean"
-        else if (cmd.includes("test") && /pass/i.test(output)) detail = "Passed"
-        else if (output) detail = output.split("\n").filter(Boolean)[0]
+      const preview = (text: string) => {
+        for (const line of text.split("\n")) {
+          const trimmed = line.trim()
+          if (!trimmed || /^[-=*_]{3,}$/.test(trimmed) || /^[\s[\]{}(),:;'"`-]+$/.test(trimmed)) continue
+          const markdownHeading = trimmed.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim()
+          if (markdownHeading) {
+            if (/^(result|results|page|ran playwright code|error)$/i.test(markdownHeading)) continue
+            return markdownHeading
+          }
+          const header = trimmed.match(/^[-=]{3,}\s*(.*?)\s*[-=]{3,}$/)?.[1]?.trim()
+          return header || trimmed
+        }
+        return undefined
       }
-      return { title: failed ? `${title} failed` : title, ...(detail ? { detail } : {}) }
+      const toolName = call.name === "execute_command"
+        ? "Command"
+        : (() => {
+          const cleaned = call.name.replace(/^[^:]+:/, "").replace(/[_-]+/g, " ").trim()
+          return cleaned ? cleaned.charAt(0).toUpperCase() + cleaned.slice(1) : "Using a tool"
+        })()
+      const output = (result?.error || result?.content || "").trim()
+      const detailPreview = preview(output) || (call.name === "execute_command" ? commandHint() : undefined)
+      const detail = result
+        ? !result.success
+          ? output ? `Failed: ${output}` : "Failed"
+          : detailPreview
+        : call.name === "execute_command" ? commandHint() : undefined
+      if (!result) return { title: call.name === "execute_command" ? "Running command" : toolName, ...(detail ? { detail } : {}) }
+      return {
+        title: result.success ? `${toolName} completed` : `${toolName} failed`,
+        ...(detail ? { detail } : {}),
+      }
     },
     getToolActivitySummary: (
       calls: Array<{ name: string; arguments?: Record<string, unknown> }>,
       results?: Array<{ success: boolean; content: string; error?: string } | undefined | null>,
     ) => {
-      const labels = calls.map((call, index) => {
-        const cmd = (call.arguments as { command?: string } | undefined)?.command ?? ""
-        const firstWord = typeof cmd === "string" ? cmd.trim().split(/\s+/)[0] : ""
-        const failed = results?.[index]?.success === false
-        let title = "Using a tool"
-        let detail: string | undefined
-        if (call.name === "execute_command") {
-          if (firstWord === "sed" || firstWord === "cat") title = "Reading file"
-          else if (firstWord === "rg" || firstWord === "grep") title = "Searching code"
-          else if (firstWord === "find") title = "Finding files"
-          else if (cmd.includes("typecheck")) title = "Checking types"
-          else if (cmd.includes("lint")) title = "Linting code"
-          else if (cmd.includes("test")) title = "Running tests"
-          else if (cmd.startsWith("git status")) title = "Checking git status"
-          else if (firstWord === "git") title = "Checking repository state"
-          else if (firstWord === "python3" || firstWord === "python") title = "Running a script"
-          else title = "Running a command"
-        } else if (call.name.includes("search") || call.name.includes("read")) {
-          title = "Inspecting context"
-        } else if (call.name === "set_session_title") {
-          title = "Updating the session title"
+      const labelFor = (call: { name: string; arguments?: Record<string, unknown> }, result?: { success: boolean; content: string; error?: string } | null) => {
+        const commandHint = () => {
+          const command = typeof call.arguments?.command === "string" ? call.arguments.command : ""
+          const header = command.match(/['"][-=]{3,}\s*([^'"]*?)\s*[-=]{3,}['"]/)?.[1]?.trim()
+          if (header) return header
+          const pathToken = command.split(/\s+/).reverse().find((token) => token.includes("/") || /\.[A-Za-z0-9]{1,8}$/.test(token))
+          if (pathToken) {
+            const cleaned = pathToken.replace(/^['"]|['"],?;?$/g, "").replace(/[),;]+$/g, "")
+            const parts = cleaned.split("/").filter(Boolean)
+            return parts.at(-1)
+          }
+          if (command.includes("<<")) return `inline ${command.trim().split(/\s+/)[0]}`
+          return undefined
         }
-        const result = results?.[index]
+        const preview = (text: string) => {
+          for (const line of text.split("\n")) {
+            const trimmed = line.trim()
+            if (!trimmed || /^[-=*_]{3,}$/.test(trimmed) || /^[\s[\]{}(),:;'"`-]+$/.test(trimmed)) continue
+            const markdownHeading = trimmed.match(/^#{1,6}\s+(.+)$/)?.[1]?.trim()
+            if (markdownHeading) {
+              if (/^(result|results|page|ran playwright code|error)$/i.test(markdownHeading)) continue
+              return markdownHeading
+            }
+            const header = trimmed.match(/^[-=]{3,}\s*(.*?)\s*[-=]{3,}$/)?.[1]?.trim()
+            return header || trimmed
+          }
+          return undefined
+        }
+        const toolName = call.name === "execute_command"
+          ? "Command"
+          : (() => {
+            const cleaned = call.name.replace(/^[^:]+:/, "").replace(/[_-]+/g, " ").trim()
+            return cleaned ? cleaned.charAt(0).toUpperCase() + cleaned.slice(1) : "Using a tool"
+          })()
         const output = (result?.error || result?.content || "").trim()
-        if (result) {
-          if (!result.success) detail = output ? `Failed: ${output}` : "Failed"
-          else if (cmd.startsWith("git status")) detail = output ? `${output.split("\n").filter(Boolean).length} changed files` : "Working tree clean"
-          else if (cmd.includes("test") && /pass/i.test(output)) detail = "Passed"
-          else if (output) detail = output.split("\n").filter(Boolean)[0]
+        const detailPreview = preview(output) || (call.name === "execute_command" ? commandHint() : undefined)
+        const detail = result
+          ? !result.success
+            ? output ? `Failed: ${output}` : "Failed"
+            : detailPreview
+          : call.name === "execute_command" ? commandHint() : undefined
+        if (!result) return { title: call.name === "execute_command" ? "Running command" : toolName, ...(detail ? { detail } : {}) }
+        return {
+          title: result.success ? `${toolName} completed` : `${toolName} failed`,
+          ...(detail ? { detail } : {}),
         }
-        return { title: failed ? `${title} failed` : title, ...(detail ? { detail } : {}) }
-      })
-      const unique = Array.from(new Set(labels.map((label) => label.title)))
-      if (calls.length === 1) return labels[0]
-      if (unique.length === 1) {
-        const details = labels.map((label) => label.detail).filter(Boolean)
-        return { title: unique[0], detail: details.length > 0 ? details.join("; ") : `${calls.length} tool calls` }
       }
+      const promote = (label: { title: string; detail?: string }) => {
+        if (label.detail && /\bcompleted$/i.test(label.title)) return { title: label.detail }
+        return label
+      }
+      if (calls.length === 1) return promote(labelFor(calls[0], results?.[0] ?? null))
+      const visible = calls
+        .map((call, index) => ({ call, index }))
+        .filter(({ call }) => call.name !== "set_session_title")
+      const candidates = visible.length > 0 ? visible : calls.map((call, index) => ({ call, index }))
+      const latest = [...candidates].reverse().find(({ index }) => !results?.[index]) ?? [...candidates].reverse().find(({ index }) => !!results?.[index])
+      const label = latest ? labelFor(latest.call, results?.[latest.index] ?? null) : { title: "Using tools" }
+      const promoted = promote(label)
       return {
-        title: results?.some((result) => !result) ? `Using ${calls.length} tool actions` : `Completed ${calls.length} tool actions`,
-        detail: labels.map((label) => label.detail ? `${label.title} (${label.detail})` : label.title).join("; "),
+        title: promoted.detail || promoted.title,
+        ...(promoted.detail ? { detail: promoted.title } : {}),
       }
     },
     normalizeAgentConversationState: (state: string | null | undefined, fallback: string) => state ?? fallback,
@@ -972,10 +1009,11 @@ describe("agent progress response history", () => {
     expect(text).not.toContain("Processing with tools")
     expect(text).not.toContain("Thinking first")
     expect(text).not.toContain("Tool activity")
-    expect(text).toContain("Inspecting context")
+    expect(text).toContain("match")
+    expect(text).not.toContain("Search repo completed")
     expect(text).not.toContain("search_repo")
     expect(text).not.toContain("1 tool")
-    expect(text.indexOf("Inspecting context")).toBeLessThan(text.indexOf("Found the issue"))
+    expect(text.indexOf("match")).toBeLessThan(text.indexOf("Found the issue"))
   })
 
   it("does not show completed historical tool calls with missing results as still running", async () => {
@@ -1008,7 +1046,7 @@ describe("agent progress response history", () => {
     const spinners = findAll(tree, (value) => value?.type === "Loader2")
     const clocks = findAll(tree, (value) => value?.type === "Clock")
 
-    expect(text).toContain("Running a script")
+    expect(text).toContain("Running command")
     expect(text).not.toContain("python3 make_slides.py")
     expect(text).toContain("It is no longer running.")
     expect(text).not.toContain("Waiting for response")
@@ -1019,7 +1057,7 @@ describe("agent progress response history", () => {
       tree,
       (value) => value?.type === "button"
         && typeof value?.props?.title === "string"
-        && value.props.title.includes("Running a script"),
+        && value.props.title.includes("Running command"),
     )[0]
     expect(detailsButton).toBeTruthy()
 
@@ -1088,14 +1126,13 @@ describe("agent progress response history", () => {
     expect(text).not.toMatch(/2 step(?:\s*s)?/)
     expect(text).not.toContain("First tool thought")
     expect(text).not.toContain("Second tool thought")
-    expect(text).toContain("Completed 2 tool actions")
-    expect(text).toContain("Checking git status")
-    expect(text).toContain("Running tests")
+    expect(text).toContain("all suites passed")
+    expect(text).not.toContain("Command completed")
     expect(text).not.toContain("git status --short:M file.ts branch main")
     expect(text).not.toContain("pnpm test:all suites passed")
-    expect(text.indexOf("Completed 2 tool actions")).toBeLessThan(text.indexOf("Now here is the answer"))
-    // 2 tool calls in the run (count badge before the readable summary).
-    expect(text).toMatch(/2\s+Completed 2 tool actions/)
+    expect(text.indexOf("all suites passed")).toBeLessThan(text.indexOf("Now here is the answer"))
+    // 2 tool calls in the run (count badge before the latest-tool summary).
+    expect(text).toMatch(/2\s+all suites passed/)
   })
 
   it("keeps opened assistant tool details expanded when the tool result arrives", async () => {
@@ -1126,7 +1163,7 @@ describe("agent progress response history", () => {
       tree,
       (value) => value?.type === "button"
         && typeof value?.props?.title === "string"
-        && value.props.title.includes("Running a script"),
+        && value.props.title.includes("Running command"),
     )[0]
     expect(detailsButton).toBeTruthy()
     detailsButton.props.onClick({ stopPropagation: vi.fn() })
@@ -1196,7 +1233,8 @@ describe("agent progress response history", () => {
     const text = getTextContent(tree)
     const spinners = findAll(tree, (value) => value?.type === "Loader2")
 
-    expect(text).toContain("Using 2 tool actions")
+    expect(text).toContain("generate_slide.py")
+    expect(text).toContain("Running command")
     expect(text).not.toContain("Thinking...")
     expect(spinners.length).toBeGreaterThan(0)
   })
@@ -1369,7 +1407,7 @@ describe("agent progress response history", () => {
         && value.props.className.includes("cursor-pointer")
         && (
           getTextContent(value).includes("Visible pending tool") ||
-          getTextContent(value).includes("Visible success tool")
+          getTextContent(value).includes("visible success")
         ),
     )
     const pendingRow = toolRows[0]

--- a/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.response-history.test.ts
@@ -152,19 +152,6 @@ function countTextOccurrences(text: string, needle: string) {
   return text.match(new RegExp(needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"))?.length ?? 0
 }
 
-function findToolRow(tree: any, toolName: string) {
-  const match = findAll(
-    tree,
-    (value) => value?.type === "div"
-      && typeof value?.props?.className === "string"
-      && value.props.className.includes("text-[11px]")
-      && value.props.className.includes("cursor-pointer")
-      && getTextContent(value).includes(toolName),
-  )[0]
-  if (!match) throw new Error(`Tool row for \"${toolName}\" not found`)
-  return match
-}
-
 async function loadAgentProgress(
   runtime: ReturnType<typeof createHookRuntime>,
   options?: { ttsEnabled?: boolean; ttsAutoPlay?: boolean },
@@ -247,7 +234,6 @@ async function loadAgentProgress(
     Copy: icon("Copy"),
     CheckCheck: icon("CheckCheck"),
     GripHorizontal: icon("GripHorizontal"),
-    Activity: icon("Activity"),
     Moon: icon("Moon"),
     Maximize2: icon("Maximize2"),
     LayoutGrid: icon("LayoutGrid"),
@@ -349,6 +335,87 @@ async function loadAgentProgress(
         return `${call.name}:${firstLine}`
       }
       return call.name
+    },
+    getToolActivityLabel: (
+      call: { name: string; arguments?: Record<string, unknown> },
+      result?: { success: boolean; content: string; error?: string } | null,
+    ) => {
+      const cmd = (call.arguments as { command?: string } | undefined)?.command ?? ""
+      const firstWord = typeof cmd === "string" ? cmd.trim().split(/\s+/)[0] : ""
+      const failed = result?.success === false
+      let title = "Using a tool"
+      let detail: string | undefined
+      if (call.name === "execute_command") {
+        if (firstWord === "sed" || firstWord === "cat") title = "Reading file"
+        else if (firstWord === "rg" || firstWord === "grep") title = "Searching code"
+        else if (firstWord === "find") title = "Finding files"
+        else if (cmd.includes("typecheck")) title = "Checking types"
+        else if (cmd.includes("lint")) title = "Linting code"
+        else if (cmd.includes("test")) title = "Running tests"
+        else if (cmd.startsWith("git status")) title = "Checking git status"
+        else if (firstWord === "git") title = "Checking repository state"
+        else if (firstWord === "python3" || firstWord === "python") title = "Running a script"
+        else title = "Running a command"
+      } else if (call.name.includes("search") || call.name.includes("read")) {
+        title = "Inspecting context"
+      } else if (call.name === "set_session_title") {
+        title = "Updating the session title"
+      }
+      if (result) {
+        const output = (result.error || result.content || "").trim()
+        if (!result.success) detail = output ? `Failed: ${output}` : "Failed"
+        else if (cmd.startsWith("git status")) detail = output ? `${output.split("\n").filter(Boolean).length} changed files` : "Working tree clean"
+        else if (cmd.includes("test") && /pass/i.test(output)) detail = "Passed"
+        else if (output) detail = output.split("\n").filter(Boolean)[0]
+      }
+      return { title: failed ? `${title} failed` : title, ...(detail ? { detail } : {}) }
+    },
+    getToolActivitySummary: (
+      calls: Array<{ name: string; arguments?: Record<string, unknown> }>,
+      results?: Array<{ success: boolean; content: string; error?: string } | undefined | null>,
+    ) => {
+      const labels = calls.map((call, index) => {
+        const cmd = (call.arguments as { command?: string } | undefined)?.command ?? ""
+        const firstWord = typeof cmd === "string" ? cmd.trim().split(/\s+/)[0] : ""
+        const failed = results?.[index]?.success === false
+        let title = "Using a tool"
+        let detail: string | undefined
+        if (call.name === "execute_command") {
+          if (firstWord === "sed" || firstWord === "cat") title = "Reading file"
+          else if (firstWord === "rg" || firstWord === "grep") title = "Searching code"
+          else if (firstWord === "find") title = "Finding files"
+          else if (cmd.includes("typecheck")) title = "Checking types"
+          else if (cmd.includes("lint")) title = "Linting code"
+          else if (cmd.includes("test")) title = "Running tests"
+          else if (cmd.startsWith("git status")) title = "Checking git status"
+          else if (firstWord === "git") title = "Checking repository state"
+          else if (firstWord === "python3" || firstWord === "python") title = "Running a script"
+          else title = "Running a command"
+        } else if (call.name.includes("search") || call.name.includes("read")) {
+          title = "Inspecting context"
+        } else if (call.name === "set_session_title") {
+          title = "Updating the session title"
+        }
+        const result = results?.[index]
+        const output = (result?.error || result?.content || "").trim()
+        if (result) {
+          if (!result.success) detail = output ? `Failed: ${output}` : "Failed"
+          else if (cmd.startsWith("git status")) detail = output ? `${output.split("\n").filter(Boolean).length} changed files` : "Working tree clean"
+          else if (cmd.includes("test") && /pass/i.test(output)) detail = "Passed"
+          else if (output) detail = output.split("\n").filter(Boolean)[0]
+        }
+        return { title: failed ? `${title} failed` : title, ...(detail ? { detail } : {}) }
+      })
+      const unique = Array.from(new Set(labels.map((label) => label.title)))
+      if (calls.length === 1) return labels[0]
+      if (unique.length === 1) {
+        const details = labels.map((label) => label.detail).filter(Boolean)
+        return { title: unique[0], detail: details.length > 0 ? details.join("; ") : `${calls.length} tool calls` }
+      }
+      return {
+        title: results?.some((result) => !result) ? `Using ${calls.length} tool actions` : `Completed ${calls.length} tool actions`,
+        detail: labels.map((label) => label.detail ? `${label.title} (${label.detail})` : label.title).join("; "),
+      }
     },
     normalizeAgentConversationState: (state: string | null | undefined, fallback: string) => state ?? fallback,
     getBuiltInModelPresets: () => [{ id: "default", name: "OpenAI", baseUrl: "https://api.openai.com/v1", agentModel: "gpt-4.1-mini", isBuiltIn: true }],
@@ -552,8 +619,8 @@ describe("agent progress response history", () => {
     const tree = runtime.render(AgentProgress, { progress, variant: "tile" })
     const text = getTextContent(tree)
 
-    expect(text).toContain("inspect_workspace")
-    expect(text).toContain("Running inspect_workspace")
+    expect(text).toContain("Inspect workspace")
+    expect(text).not.toContain("inspect_workspace")
     expect(text).not.toContain("Thinking...")
   })
 
@@ -905,9 +972,10 @@ describe("agent progress response history", () => {
     expect(text).not.toContain("Processing with tools")
     expect(text).not.toContain("Thinking first")
     expect(text).not.toContain("Tool activity")
-    expect(text).toContain("search_repo")
+    expect(text).toContain("Inspecting context")
+    expect(text).not.toContain("search_repo")
     expect(text).not.toContain("1 tool")
-    expect(text.indexOf("search_repo")).toBeLessThan(text.indexOf("Found the issue"))
+    expect(text.indexOf("Inspecting context")).toBeLessThan(text.indexOf("Found the issue"))
   })
 
   it("does not show completed historical tool calls with missing results as still running", async () => {
@@ -940,7 +1008,8 @@ describe("agent progress response history", () => {
     const spinners = findAll(tree, (value) => value?.type === "Loader2")
     const clocks = findAll(tree, (value) => value?.type === "Clock")
 
-    expect(text).toContain("python3 make_slides.py")
+    expect(text).toContain("Running a script")
+    expect(text).not.toContain("python3 make_slides.py")
     expect(text).toContain("It is no longer running.")
     expect(text).not.toContain("Waiting for response")
     expect(spinners).toHaveLength(0)
@@ -948,7 +1017,9 @@ describe("agent progress response history", () => {
 
     const detailsButton = findAll(
       tree,
-      (value) => value?.type === "button" && value.props?.title === "python3 make_slides.py",
+      (value) => value?.type === "button"
+        && typeof value?.props?.title === "string"
+        && value.props.title.includes("Running a script"),
     )[0]
     expect(detailsButton).toBeTruthy()
 
@@ -956,6 +1027,7 @@ describe("agent progress response history", () => {
     tree = runtime.render(AgentProgress, { progress })
     text = getTextContent(tree)
 
+    expect(text).toContain("python3 make_slides.py")
     expect(text).toContain("No result recorded")
     expect(text).not.toContain("Waiting for response")
   })
@@ -1016,15 +1088,68 @@ describe("agent progress response history", () => {
     expect(text).not.toMatch(/2 step(?:\s*s)?/)
     expect(text).not.toContain("First tool thought")
     expect(text).not.toContain("Second tool thought")
-    // Collapsed groups list every execute_command as
-    // "<command>:<output-preview>" in chronological order, with a call count
-    // next to the wrench icon.
-    expect(text).toContain("git status --short:M file.ts branch main")
-    expect(text).toContain("pnpm test:all suites passed")
-    expect(text.indexOf("git status --short:M file.ts branch main")).toBeLessThan(text.indexOf("pnpm test:all suites passed"))
-    expect(text.indexOf("pnpm test:all suites passed")).toBeLessThan(text.indexOf("Now here is the answer"))
-    // 2 tool calls in the run (search count badge before previews).
-    expect(text).toMatch(/2\s+git status --short:M file\.ts branch main/)
+    expect(text).toContain("Completed 2 tool actions")
+    expect(text).toContain("Checking git status")
+    expect(text).toContain("Running tests")
+    expect(text).not.toContain("git status --short:M file.ts branch main")
+    expect(text).not.toContain("pnpm test:all suites passed")
+    expect(text.indexOf("Completed 2 tool actions")).toBeLessThan(text.indexOf("Now here is the answer"))
+    // 2 tool calls in the run (count badge before the readable summary).
+    expect(text).toMatch(/2\s+Completed 2 tool actions/)
+  })
+
+  it("keeps opened assistant tool details expanded when the tool result arrives", async () => {
+    const runtime = createHookRuntime()
+    const { AgentProgress } = await loadAgentProgress(runtime)
+    const baseProgress = {
+      sessionId: "session-persistent-tool-details",
+      conversationId: "conversation-persistent-tool-details",
+      currentIteration: 1,
+      maxIterations: 2,
+      steps: [],
+      isComplete: false,
+      finalContent: "",
+      conversationHistory: [
+        {
+          role: "assistant",
+          content: "",
+          timestamp: 200,
+          toolCalls: [
+            { name: "execute_command", arguments: { command: "python3 job.py" } },
+          ],
+        },
+      ],
+    }
+
+    let tree = runtime.render(AgentProgress, { progress: baseProgress })
+    const detailsButton = findAll(
+      tree,
+      (value) => value?.type === "button"
+        && typeof value?.props?.title === "string"
+        && value.props.title.includes("Running a script"),
+    )[0]
+    expect(detailsButton).toBeTruthy()
+    detailsButton.props.onClick({ stopPropagation: vi.fn() })
+
+    const completedProgress = {
+      ...baseProgress,
+      conversationHistory: [
+        baseProgress.conversationHistory[0],
+        {
+          role: "tool",
+          content: "",
+          timestamp: 210,
+          toolResults: [
+            { success: true, content: "done" },
+          ],
+        },
+      ],
+    }
+    tree = runtime.render(AgentProgress, { progress: completedProgress })
+    const text = getTextContent(tree)
+
+    expect(text).toContain("python3 job.py")
+    expect(text).toContain("done")
   })
 
   it("surfaces a running label when the current pending tool is inside a collapsed group", async () => {
@@ -1071,7 +1196,7 @@ describe("agent progress response history", () => {
     const text = getTextContent(tree)
     const spinners = findAll(tree, (value) => value?.type === "Loader2")
 
-    expect(text).toContain("Running execute_command")
+    expect(text).toContain("Using 2 tool actions")
     expect(text).not.toContain("Thinking...")
     expect(spinners.length).toBeGreaterThan(0)
   })
@@ -1227,18 +1352,33 @@ describe("agent progress response history", () => {
       tree,
       (value) => value?.type === "button"
         && typeof value?.props?.title === "string"
-        && value.props.title.includes("visible_pending_tool")
-        && value.props.title.includes("visible_success_tool"),
+        && value.props.title.includes("Visible pending tool"),
     )[0]
     expect(compactToolSummary).toBeTruthy()
+    expect(getTextContent(tree)).not.toContain("visible_pending_tool")
+    expect(getTextContent(tree)).not.toContain("visible_success_tool")
+
     compactToolSummary.props.onClick({ stopPropagation: vi.fn() })
     tree = runtime.render(AgentProgress, { progress })
 
-    const pendingRow = findToolRow(tree, "visible_pending_tool")
-    const successRow = findToolRow(tree, "visible_success_tool")
+    const toolRows = findAll(
+      tree,
+      (value) => value?.type === "div"
+        && typeof value?.props?.className === "string"
+        && value.props.className.includes("text-[11px]")
+        && value.props.className.includes("cursor-pointer")
+        && (
+          getTextContent(value).includes("Visible pending tool") ||
+          getTextContent(value).includes("Visible success tool")
+        ),
+    )
+    const pendingRow = toolRows[0]
+    const successRow = toolRows[1]
 
     expect(pendingRow.props.className).toContain("text-blue-600")
     expect(successRow.props.className).toContain("text-green-600")
+    expect(getTextContent(tree)).toContain("visible_pending_tool")
+    expect(getTextContent(tree)).toContain("visible_success_tool")
     expect(getTextContent(tree)).not.toContain("respond_to_user")
     expect(getTextContent(tree)).not.toContain("No result recorded")
     expect(getTextContent(tree)).toContain("Waiting for response")

--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -120,9 +120,10 @@ describe("agent progress tile layout", () => {
   })
 
   it("renders collapsed tool previews inline as the single-line summary", () => {
-    expect(agentProgressSource).toContain('const collapsedPreviewLine = group.previewLines.join')
-    expect(agentProgressSource).toContain(': collapsedPreviewLine || "Tool activity"')
-    expect(agentProgressSource).toContain('const collapsedToolPreviewLine = data.calls')
+    expect(agentProgressSource).toContain('const collapsedStatusLine = group.activitySummary.title')
+    expect(agentProgressSource).toContain('const collapsedToolStatusLine = activitySummary.title')
+    expect(agentProgressSource).toContain('const primaryActivityText = activityLabel.detail || activityLabel.title')
+    expect(agentProgressSource).toContain('const secondaryActivityText = activityLabel.detail && activityLabel.detail !== activityLabel.title')
     expect(agentProgressSource).toContain('const toolStatusTextClass = isPending')
     expect(agentProgressSource).toContain('className={cn("flex w-full min-w-0 items-center gap-1 rounded px-1 py-0.5 text-left text-[11px] transition-colors hover:bg-muted/30", toolStatusTextClass)}')
     expect(agentProgressSource).toContain('flex-1 truncate whitespace-nowrap font-mono')
@@ -138,7 +139,8 @@ describe("agent progress tile layout", () => {
   it("keeps tool group expansion state separate from child rows", () => {
     expect(agentProgressSource).toContain('const groupId = `tool-activity-group:${runItems[0]?.id ?? runStart}`')
     expect(agentProgressSource).toContain('getToolActivityGroupDefaultExpanded')
-    expect(agentProgressSource).toContain('next[item.id] = true')
+    expect(agentProgressSource).toContain('return item.data.items.some((child) => getRunningToolCallNames(child).length > 0)')
+    expect(agentProgressSource).not.toContain('next[item.id] = true')
   })
 
   it("stops delegated tool rows from showing a loading spinner after terminal completion", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -770,6 +770,7 @@ const normalizeThinkingStatusText = (text?: string): string => {
   const normalized = trimmed.replace(/\.+$/, "").toLowerCase()
   if (
     normalized === "agent is thinking" ||
+    normalized === "thinking" ||
     normalized === "analyzing request" ||
     normalized === "analyzing requests" ||
     normalized === "generating response" ||
@@ -783,7 +784,67 @@ const normalizeThinkingStatusText = (text?: string): string => {
 }
 
 const stripThinkingPreamble = (text: string): string =>
-  text.replace(/^Thinking\.\.\.(?:\s*\n\s*\n)?/i, "")
+  text
+    .replace(/&lt;\/?think&gt;|<\/?think>/gi, "")
+    .replace(/^Thinking(?:\.\.\.)?(?=$|\s)(?:\s*\n\s*\n|\s+)?/i, "")
+
+type WhitespaceContext = {
+  title: string
+  text: string
+  tone: "thinking" | "response"
+}
+
+const getWhitespaceContextText = (text: string | undefined): string => {
+  const stripped = stripThinkingPreamble(text ?? "").trim()
+  if (!stripped) return ""
+  return normalizeThinkingStatusText(stripped) === "Thinking..." ? "" : stripped
+}
+
+const getWhitespaceContextFromItem = (item: DisplayItem): WhitespaceContext | null => {
+  if (item.kind === "tool_activity_group") {
+    for (let i = item.data.items.length - 1; i >= 0; i--) {
+      const context = getWhitespaceContextFromItem(item.data.items[i])
+      if (context) return context
+    }
+    return null
+  }
+
+  if (item.kind === "assistant_with_tools") {
+    const text = getWhitespaceContextText(item.data.thought)
+    return text ? { title: "Latest thinking", text, tone: "thinking" } : null
+  }
+
+  if (item.kind === "streaming") {
+    const text = getWhitespaceContextText(item.data.text)
+    if (!text) return null
+    const tone = item.data.isPlaceholder ? "thinking" : "response"
+    return { title: tone === "thinking" ? "Latest thinking" : "Latest response", text, tone }
+  }
+
+  if (item.kind === "message" && item.data.role === "assistant" && !item.data.isThinking) {
+    const text = getWhitespaceContextText(item.data.responseEvent?.text ?? item.data.content)
+    if (!text) return null
+    return item.data.isAssistantThought
+      ? { title: "Latest thinking", text, tone: "thinking" }
+      : { title: "Latest response", text, tone: "response" }
+  }
+
+  return null
+}
+
+const isVisibleContextSurface = (item: DisplayItem | undefined): boolean => {
+  if (!item) return false
+  if (item.kind === "message" && item.data.role === "assistant" && !item.data.isThinking) {
+    return getWhitespaceContextText(item.data.responseEvent?.text ?? item.data.content).length > 0
+  }
+  if (item.kind === "streaming" && !item.data.isPlaceholder) {
+    return getWhitespaceContextText(item.data.text).length > 0
+  }
+  if (item.kind === "assistant_with_tools") {
+    return getWhitespaceContextText(item.data.thought).length > 0
+  }
+  return false
+}
 
 const CompactThinkingIndicator: React.FC<{ text?: string }> = ({ text }) => (
   <div
@@ -3608,6 +3669,43 @@ const StreamingContentBubble: React.FC<{
   )
 }
 
+const WhitespaceContextFiller: React.FC<{ context: WhitespaceContext | null }> = ({ context }) => {
+  if (!context) return null
+
+  const isThinking = context.tone === "thinking"
+  const displayText = isThinking ? getWhitespaceContextText(context.text) : context.text.trim()
+  if (!displayText) return null
+
+  return (
+    <div
+      className="agent-progress-whitespace-context flex min-h-0 flex-1 overflow-hidden pt-1"
+      aria-label={context.title}
+    >
+      <div className={cn(
+        "flex min-h-0 w-full flex-col overflow-hidden rounded-md border px-2.5 py-2 text-xs",
+        isThinking
+          ? "border-amber-200/70 bg-amber-50/25 text-amber-950/90 dark:border-amber-900/45 dark:bg-amber-950/15 dark:text-amber-50/90"
+          : "border-blue-200/70 bg-blue-50/25 text-blue-950/90 dark:border-blue-900/45 dark:bg-blue-950/15 dark:text-blue-50/90",
+      )}>
+        <div className="mb-1.5 flex shrink-0 items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide opacity-65">
+          {isThinking ? (
+            <Brain className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <MessageSquare className="h-3 w-3" aria-hidden="true" />
+          )}
+          <span>{context.title}</span>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden [mask-image:linear-gradient(to_bottom,black_78%,transparent_100%)]">
+          <MarkdownRenderer
+            content={displayText}
+            className="markdown-selectable whitespace-pre-wrap break-words text-[12px] leading-relaxed [overflow-wrap:anywhere]"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 
 
 export const AgentProgress: React.FC<AgentProgressProps> = ({
@@ -4669,6 +4767,16 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   }, [enrichedMessages, effectiveUserResponse, progress.isComplete, progress.retryInfo, progress.steps, progress.streamingContent, toolCallSteps])
 
   const visibleDisplayItems = displayItems
+  const whitespaceContext = useMemo<WhitespaceContext | null>(() => {
+    if (isComplete || visibleDisplayItems.length === 0) return null
+    if (isVisibleContextSurface(visibleDisplayItems[visibleDisplayItems.length - 1])) return null
+
+    for (let i = visibleDisplayItems.length - 1; i >= 0; i--) {
+      const context = getWhitespaceContextFromItem(visibleDisplayItems[i])
+      if (context) return context
+    }
+    return null
+  }, [isComplete, visibleDisplayItems])
   const loadedConversationHistoryCount = conversationHistory?.length ?? 0
   const conversationHistoryTotalCount = Math.max(
     progress.conversationHistoryTotalCount ?? loadedConversationHistoryCount,
@@ -5215,7 +5323,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                 className="flex-1 min-h-0 overflow-y-auto scrollbar-none"
               >
                 {visibleDisplayItems.length > 0 ? (
-                  <div ref={scrollContentRef} className="space-y-1 p-2">
+                  <div ref={scrollContentRef} className="flex min-h-full flex-col gap-1 p-2">
                     {displayItems.length > visibleDisplayItems.length && (
                       <div className="px-2 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground/70">
                         Showing latest {visibleDisplayItems.length} updates
@@ -5361,6 +5469,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                         )
                       }
                     })}
+                    <WhitespaceContextFiller context={whitespaceContext} />
                   </div>
                 ) : (
                   <div className="flex h-full items-center justify-center">
@@ -5690,7 +5799,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           className="flex-1 min-h-0 overflow-y-auto"
         >
           {visibleDisplayItems.length > 0 ? (
-            <div ref={scrollContentRef} className="space-y-1 p-2">
+            <div ref={scrollContentRef} className="flex min-h-full flex-col gap-1 p-2">
               {displayItems.length > visibleDisplayItems.length && (
                 <div className="px-2 pb-1 text-[10px] uppercase tracking-wide text-muted-foreground/70">
                   Showing latest {visibleDisplayItems.length} updates
@@ -5852,6 +5961,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                   )
                 }
               })}
+              <WhitespaceContextFiller context={whitespaceContext} />
             </div>
           ) : (
             <div className="flex h-full items-center justify-center">

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -25,9 +25,9 @@ import {
   formatArgumentsPreview,
   formatToolArguments,
   getToolArgumentEntries,
-  getCompactToolExecutionPreview,
   getExecuteCommandResultPreview,
-  getToolResultsSummary,
+  getToolActivityLabel,
+  getToolActivitySummary,
   TOOL_GROUP_MIN_SIZE,
   getToolCallPreview,
   getBuiltInModelPresets,
@@ -151,6 +151,11 @@ type DisplayItem =
       previewLines: string[]
       /** Total number of underlying tool calls across all collapsed items. */
       callCount: number
+      /** Human-readable summary for the collapsed group. */
+      activitySummary: {
+        title: string
+        detail?: string
+      }
     } }
 
 const getRunningToolCallNames = (item: DisplayItem): string[] => {
@@ -158,12 +163,6 @@ const getRunningToolCallNames = (item: DisplayItem): string[] => {
   return item.data.calls
     .filter((_, index) => !item.data.results[index])
     .map((call) => call.name)
-}
-
-const formatRunningToolLabel = (toolNames: string[]): string => {
-  if (toolNames.length === 0) return "tool"
-  if (toolNames.length === 1) return toolNames[0]
-  return `${toolNames.length} tools`
 }
 
 type ChatProviderId = NonNullable<Config["agentProviderId"]>
@@ -1656,10 +1655,13 @@ const CompactToolExecutionList: React.FC<{
           const callIsPending = callIsMissingResult && !isHistoricalComplete
           const callIsUnrecorded = callIsMissingResult && isHistoricalComplete
           const callSuccess = result?.success
-          const toolPreview = getCompactToolExecutionPreview(
+          const activityLabel = getToolActivityLabel(
             { name: call.name, arguments: call.arguments ?? {} },
             result ?? null,
           )
+          const activityText = activityLabel.detail
+            ? `${activityLabel.title} - ${activityLabel.detail}`
+            : activityLabel.title
 
           return (
             <div key={idx}>
@@ -1677,8 +1679,8 @@ const CompactToolExecutionList: React.FC<{
                 )}
                 onClick={onToggleDetails}
               >
-                <span className="min-w-0 flex-1 truncate whitespace-nowrap font-mono font-medium" title={toolPreview}>
-                  {toolPreview}
+                <span className="min-w-0 flex-1 truncate whitespace-nowrap font-medium" title={activityText}>
+                  {activityText}
                 </span>
                 <span className="shrink-0 text-[10px] opacity-60">
                   {callIsPending ? (
@@ -1710,6 +1712,12 @@ const CompactToolExecutionList: React.FC<{
             const formattedArguments = formatToolArguments(call.arguments)
             return (
               <div key={idx} className="text-[10px] space-y-1">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="shrink-0 font-medium opacity-70">Tool</span>
+                  <code className="min-w-0 truncate rounded bg-muted/50 px-1 py-0.5 font-mono text-[10px] text-foreground">
+                    {call.name}
+                  </code>
+                </div>
                 {formattedArguments && (
                   <>
                     <div className="flex flex-wrap items-center justify-between gap-1.5">
@@ -1828,11 +1836,11 @@ const AssistantWithToolsBubble: React.FC<{
   }
   isExpanded: boolean
   onToggleExpand: () => void
-}> = ({ data, isExpanded, onToggleExpand }) => {
-  const [showToolDetails, setShowToolDetails] = useState(false)
+  toolDetailsExpanded: boolean
+  onToggleToolDetails: () => void
+}> = ({ data, isExpanded, onToggleExpand, toolDetailsExpanded, onToggleToolDetails }) => {
 
   const toolCallEntries = data.calls.map((call, idx) => ({ call, result: data.results[idx] }))
-  const resolvedResults = data.results.filter((result): result is NonNullable<typeof result> => Boolean(result))
   const hasMissingResults = toolCallEntries.some(({ result }) => !result)
   const isPending = hasMissingResults && !data.isComplete
   const hasUnrecordedResults = hasMissingResults && data.isComplete
@@ -1840,11 +1848,6 @@ const AssistantWithToolsBubble: React.FC<{
   const allToolsSucceeded = toolCallEntries.length > 0 && toolCallEntries.every(({ result }) => result?.success === true)
   const hasThought = data.thought && data.thought.trim().length > 0
   const shouldCollapse = (data.thought?.length ?? 0) > 100 || toolCallEntries.length > 0
-  const runningToolNames = isPending
-    ? toolCallEntries
-      .filter(({ result }) => !result)
-      .map(({ call }) => call.name)
-    : []
   const toolStatusTextClass = isPending
     ? "text-blue-600 dark:text-blue-400"
     : hasUnrecordedResults
@@ -1854,33 +1857,15 @@ const AssistantWithToolsBubble: React.FC<{
         : allToolsSucceeded
           ? "text-green-600 dark:text-green-400"
           : "text-sky-700 dark:text-sky-300"
-  const collapsedToolPreviewLine = data.calls
-    .map((call, idx) => {
-      const result = data.results[idx]
-      return getCompactToolExecutionPreview(
-        { name: call.name, arguments: call.arguments ?? {} },
-        result ?? null,
-      )
-    })
-    .join(", ")
-  const collapsedToolStatusLine = isPending
-    ? `Running ${formatRunningToolLabel(runningToolNames)}`
-    : collapsedToolPreviewLine
-  const collapsedToolTitle = isPending && collapsedToolPreviewLine
-    ? `${collapsedToolStatusLine} - ${collapsedToolPreviewLine}`
+  const activitySummary = getToolActivitySummary(
+    data.calls.map((call) => ({ name: call.name, arguments: call.arguments ?? {} })),
+    data.results,
+  )
+  const collapsedToolStatusLine = activitySummary.title
+  const collapsedToolDetail = activitySummary.detail
+  const collapsedToolTitle = collapsedToolDetail
+    ? `${collapsedToolStatusLine} - ${collapsedToolDetail}`
     : collapsedToolStatusLine
-
-  // Generate result summary for collapsed state
-  const collapsedResultSummary = (() => {
-    if (isExpanded || isPending) return null
-    if (resolvedResults.length === 0) return null
-    const toolResults = resolvedResults.map(r => ({
-      success: r.success,
-      content: r.content,
-      error: r.error,
-    }))
-    return getToolResultsSummary(toolResults)
-  })()
 
   const handleToggleExpand = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!shouldCollapse || hasActiveTextSelection(event.currentTarget)) {
@@ -1897,7 +1882,7 @@ const AssistantWithToolsBubble: React.FC<{
 
   const handleToggleToolDetails = (e: React.MouseEvent) => {
     e.stopPropagation()
-    setShowToolDetails(!showToolDetails)
+    onToggleToolDetails()
   }
 
   const longThought = (data.thought?.length ?? 0) > 100
@@ -1929,7 +1914,7 @@ const AssistantWithToolsBubble: React.FC<{
             <Brain className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
           )}
           <div className="min-w-0 flex-1">
-            {!showToolDetails ? (
+            {!toolDetailsExpanded ? (
               <button
                 type="button"
                 className={cn("flex w-full min-w-0 items-center gap-1 rounded px-1 py-0.5 text-left text-[11px] transition-colors hover:bg-muted/30", toolStatusTextClass)}
@@ -1942,16 +1927,21 @@ const AssistantWithToolsBubble: React.FC<{
                 <span className="min-w-0 flex-1 truncate whitespace-nowrap font-mono font-medium">
                   {collapsedToolStatusLine}
                 </span>
+                {collapsedToolDetail && (
+                  <span className="min-w-0 flex-[1.4] truncate whitespace-nowrap text-[10px] opacity-75">
+                    {collapsedToolDetail}
+                  </span>
+                )}
                 <ChevronRight className="h-2.5 w-2.5 shrink-0 opacity-40" aria-hidden="true" />
               </button>
             ) : (
               <CompactToolExecutionList
                 calls={data.calls}
                 results={data.results}
-                detailsExpanded={showToolDetails}
+                detailsExpanded={toolDetailsExpanded}
                 onToggleDetails={handleToggleToolDetails}
                 rowClassName="px-1 py-0.5"
-                detailsClassName="mt-1 ml-3 space-y-1 border-l border-border/50 pl-2"
+                detailsClassName="mt-1 ml-3 max-h-[min(68vh,42rem)] space-y-1 overflow-y-auto border-l border-border/50 pl-2 pr-1 scrollbar-thin"
                 isHistoricalComplete={data.isComplete}
                 executionStats={data.executionStats}
               />
@@ -1969,29 +1959,31 @@ const AssistantWithToolsBubble: React.FC<{
 }
 
 // Collapsed group of consecutive tool-call activity.
-// Each collapsed group shows compact tool preview lines so historical session
-// views still communicate which tools were called without expansion.
+// The collapsed row stays human-readable; raw command details live inside
+// the expanded child rows.
 const ToolActivityGroupBubble: React.FC<{
   group: {
     items: DisplayItem[]
     previewLines: string[]
     callCount: number
+    activitySummary: {
+      title: string
+      detail?: string
+    }
   }
   isExpanded: boolean
   onToggleExpand: () => void
   /** Render a single child DisplayItem when the group is expanded. */
   renderItem: (item: DisplayItem, index: number) => React.ReactNode
 }> = ({ group, isExpanded, onToggleExpand, renderItem }) => {
-  const collapsedPreviewLine = group.previewLines.join(', ')
   const thinkingCount = group.items.filter((item) => item.kind === "assistant_with_tools" && item.data.thought.trim().length > 0).length
   const callCount = group.callCount
   const runningToolNames = group.items.flatMap(getRunningToolCallNames)
   const hasRunningTools = runningToolNames.length > 0
-  const collapsedStatusLine = hasRunningTools
-    ? `Running ${formatRunningToolLabel(runningToolNames)}`
-    : collapsedPreviewLine || "Tool activity"
-  const collapsedTitle = hasRunningTools && collapsedPreviewLine
-    ? `${collapsedStatusLine} - ${collapsedPreviewLine}`
+  const collapsedStatusLine = group.activitySummary.title
+  const collapsedDetail = group.activitySummary.detail
+  const collapsedTitle = collapsedDetail
+    ? `${collapsedStatusLine} - ${collapsedDetail}`
     : collapsedStatusLine
 
   return (
@@ -2027,6 +2019,11 @@ const ToolActivityGroupBubble: React.FC<{
         )}>
           {collapsedStatusLine}
         </span>
+        {collapsedDetail && (
+          <span className="min-w-0 flex-[1.6] truncate whitespace-nowrap text-[10px] text-sky-900/60 dark:text-sky-100/60">
+            {collapsedDetail}
+          </span>
+        )}
         {thinkingCount > 0 && (
           <Brain className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400" aria-hidden="true" />
         )}
@@ -2045,7 +2042,7 @@ const ToolActivityGroupBubble: React.FC<{
 
       {/* Expanded: render all child items */}
       {isExpanded && (
-        <div className="space-y-1 px-1.5 pb-1.5">
+        <div className="max-h-[min(72vh,46rem)] space-y-1 overflow-y-auto px-1.5 pb-1.5 pr-1 scrollbar-thin">
           <div className="space-y-1">
             {group.items.map((item, idx) => renderItem(item, idx))}
           </div>
@@ -4579,12 +4576,11 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
         return
       }
       const runItems = sortedItems.slice(runStart, runEnd + 1)
-      // Collapsed preview surfaces every tool call in the run as a compact
-      // token, in chronological order. execute_command renders as a balanced
-      // `<command>:<output-preview>` label; other tools fall back to the tool
-      // name. The CSS truncate handles overflow on narrow tiles, so we emit the
-      // full list and let the layout shrink it.
+      // Preserve raw preview data for expanded details, but compute a separate
+      // human-readable summary for the collapsed row.
       const previewLines: string[] = []
+      const activityCalls: Array<{ name: string; arguments: any }> = []
+      const activityResults: Array<{ success: boolean; content: string; error?: string } | undefined | null> = []
       let callCount = 0
       for (let j = 0; j < runItems.length; j++) {
         const it = runItems[j]
@@ -4605,6 +4601,8 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
           if (!call) continue
           callCount += 1
           const result = results[k] ?? null
+          activityCalls.push({ name: call.name, arguments: call.arguments ?? {} })
+          activityResults.push(result)
           const execPreview = getExecuteCommandResultPreview(
             { name: call.name, arguments: call.arguments ?? {} },
             result,
@@ -4623,7 +4621,12 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
       grouped.push({
         kind: "tool_activity_group",
         id: groupId,
-        data: { items: runItems, previewLines, callCount },
+        data: {
+          items: runItems,
+          previewLines,
+          callCount,
+          activitySummary: getToolActivitySummary(activityCalls, activityResults),
+        },
       })
       runStart = null
     }
@@ -5269,12 +5272,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                           />
                         )
                       } else if (item.kind === "assistant_with_tools") {
+                        const toolDetailsKey = `${itemKey}:tool-details`
                         return (
                           <AssistantWithToolsBubble
                             key={itemKey}
                             data={item.data}
                             isExpanded={isExpanded}
                             onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
+                            toolDetailsExpanded={expandedItems[toolDetailsKey] ?? false}
+                            onToggleToolDetails={() => toggleItemExpansion(toolDetailsKey, false)}
                           />
                         )
                       } else if (item.kind === "tool_approval") {
@@ -5315,12 +5321,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                               const childKey = child.id || `group-child-${childIdx}`
                               const childExpanded = expandedItems[childKey] ?? false
                               if (child.kind === "assistant_with_tools") {
+                                const childToolDetailsKey = `${childKey}:tool-details`
                                 return (
                                   <AssistantWithToolsBubble
                                     key={childKey}
                                     data={child.data}
                                     isExpanded={childExpanded}
                                     onToggleExpand={() => toggleItemExpansion(childKey, childExpanded)}
+                                    toolDetailsExpanded={expandedItems[childToolDetailsKey] ?? false}
+                                    onToggleToolDetails={() => toggleItemExpansion(childToolDetailsKey, false)}
                                   />
                                 )
                               }
@@ -5743,12 +5752,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     />
                   )
                 } else if (item.kind === "assistant_with_tools") {
+                  const toolDetailsKey = `${itemKey}:tool-details`
                   return (
                     <AssistantWithToolsBubble
                       key={itemKey}
                       data={item.data}
                       isExpanded={isExpanded}
                       onToggleExpand={() => toggleItemExpansion(itemKey, isExpanded)}
+                      toolDetailsExpanded={expandedItems[toolDetailsKey] ?? false}
+                      onToggleToolDetails={() => toggleItemExpansion(toolDetailsKey, false)}
                     />
                   )
                 } else if (item.kind === "tool_approval") {
@@ -5800,12 +5812,15 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                         const childKey = child.id || `group-child-${childIdx}`
                         const childExpanded = expandedItems[childKey] ?? false
                         if (child.kind === "assistant_with_tools") {
+                          const childToolDetailsKey = `${childKey}:tool-details`
                           return (
                             <AssistantWithToolsBubble
                               key={childKey}
                               data={child.data}
                               isExpanded={childExpanded}
                               onToggleExpand={() => toggleItemExpansion(childKey, childExpanded)}
+                              toolDetailsExpanded={expandedItems[childToolDetailsKey] ?? false}
+                              onToggleToolDetails={() => toggleItemExpansion(childToolDetailsKey, false)}
                             />
                           )
                         }

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1659,9 +1659,14 @@ const CompactToolExecutionList: React.FC<{
             { name: call.name, arguments: call.arguments ?? {} },
             result ?? null,
           )
-          const activityText = activityLabel.detail
-            ? `${activityLabel.title} - ${activityLabel.detail}`
-            : activityLabel.title
+          const primaryActivityText = activityLabel.detail || activityLabel.title
+          const secondaryActivityText = activityLabel.detail && activityLabel.detail !== activityLabel.title
+            && !/\bcompleted$/i.test(activityLabel.title)
+            ? activityLabel.title
+            : undefined
+          const activityText = secondaryActivityText
+            ? `${primaryActivityText} - ${secondaryActivityText}`
+            : primaryActivityText
 
           return (
             <div key={idx}>
@@ -1680,8 +1685,13 @@ const CompactToolExecutionList: React.FC<{
                 onClick={onToggleDetails}
               >
                 <span className="min-w-0 flex-1 truncate whitespace-nowrap font-medium" title={activityText}>
-                  {activityText}
+                  {primaryActivityText}
                 </span>
+                {secondaryActivityText && (
+                  <span className="min-w-0 flex-[0.9] truncate whitespace-nowrap text-[10px] opacity-70">
+                    {secondaryActivityText}
+                  </span>
+                )}
                 <span className="shrink-0 text-[10px] opacity-60">
                   {callIsPending ? (
                     <Loader2 className="h-2.5 w-2.5 animate-spin" />
@@ -1705,6 +1715,20 @@ const CompactToolExecutionList: React.FC<{
 
       {detailsExpanded && (
         <div className={detailsClassName}>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggleDetails()
+              }}
+              className="rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+              aria-label="Hide tool details"
+              title="Hide tool details"
+            >
+              Hide details
+            </button>
+          </div>
           {toolCallEntries.map(({ call, result }, idx) => {
             const callIsMissingResult = !result
             const callIsPending = callIsMissingResult && !isHistoricalComplete
@@ -4656,26 +4680,8 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
   )
 
   const getToolActivityGroupDefaultExpanded = useCallback((item: Extract<DisplayItem, { kind: "tool_activity_group" }>) => {
-    if (item.data.items.some((child) => getRunningToolCallNames(child).length > 0)) {
-      return true
-    }
-    const firstChildId = item.data.items[0]?.id
-    return !!firstChildId && expandedItems[firstChildId] === true
-  }, [expandedItems])
-
-  useEffect(() => {
-    setExpandedItems(prev => {
-      let next = prev
-      for (const item of displayItems) {
-        if (item.kind !== "tool_activity_group" || item.id in prev) continue
-        const firstChildId = item.data.items[0]?.id
-        if (!firstChildId || prev[firstChildId] !== true) continue
-        if (next === prev) next = { ...prev }
-        next[item.id] = true
-      }
-      return next
-    })
-  }, [displayItems])
+    return item.data.items.some((child) => getRunningToolCallNames(child).length > 0)
+  }, [])
 
   const delegationSummaryEntries = useMemo<DelegationSummaryEntry[]>(() => {
     const latestByRunId = new Map<string, { delegation: ACPDelegationProgress; timestamp: number }>()

--- a/apps/desktop/src/renderer/src/lib/pinned-session-history.test.ts
+++ b/apps/desktop/src/renderer/src/lib/pinned-session-history.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest"
 
 import type { ConversationHistoryItem } from "@shared/types"
 
-import { orderConversationHistoryByPinnedFirst } from "./pinned-session-history"
+import {
+  orderConversationHistoryByPinnedFirst,
+  orderConversationHistoryByRecentActivity,
+} from "./pinned-session-history"
 
 const createSession = (id: string, updatedAt: number): ConversationHistoryItem => ({
   id,
@@ -69,6 +72,29 @@ describe("orderConversationHistoryByPinnedFirst", () => {
     expect(ordered.map((session) => session.id)).toEqual([
       "session-message-newer",
       "session-updated-newer",
+    ])
+  })
+})
+
+describe("orderConversationHistoryByRecentActivity", () => {
+  it("keeps the home recent list ordered by actual activity instead of pin state", () => {
+    const pinnedOld = createSession("pinned-old", 10)
+    const latest = createSession("latest", 50)
+    const recentlyMessaged = {
+      ...createSession("recent-message", 20),
+      lastMessageAt: 60,
+    }
+
+    const ordered = orderConversationHistoryByRecentActivity([
+      pinnedOld,
+      latest,
+      recentlyMessaged,
+    ])
+
+    expect(ordered.map((session) => session.id)).toEqual([
+      "recent-message",
+      "latest",
+      "pinned-old",
     ])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/pinned-session-history.ts
+++ b/apps/desktop/src/renderer/src/lib/pinned-session-history.ts
@@ -10,6 +10,14 @@ function getConversationHistoryActivityTimestamp(session: ConversationHistoryIte
   return Math.max(updatedAt, lastMessageAt)
 }
 
+export function orderConversationHistoryByRecentActivity(
+  sessions: ConversationHistoryItem[],
+): ConversationHistoryItem[] {
+  return [...sessions].sort((a, b) =>
+    getConversationHistoryActivityTimestamp(b) - getConversationHistoryActivityTimestamp(a)
+  )
+}
+
 export function orderConversationHistoryByPinnedFirst(
   sessions: ConversationHistoryItem[],
   pinnedSessionIds: ReadonlySet<string>,

--- a/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
+++ b/apps/desktop/src/renderer/src/lib/sidebar-sessions.test.ts
@@ -468,7 +468,7 @@ describe("getSidebarActivityPresentation", () => {
         {
           id: "tool-1",
           type: "tool_call",
-          title: "Reading file",
+          title: "Running command",
           description: "Inspecting active-agents-sidebar.tsx",
           status: "in_progress",
           timestamp: 2,
@@ -492,7 +492,7 @@ describe("getSidebarActivityPresentation", () => {
         {
           id: "tool-1",
           type: "tool_call",
-          title: "Reading file",
+          title: "Running command",
           description: "Inspecting source",
           status: "in_progress",
           timestamp: 2,

--- a/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
+++ b/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
@@ -124,6 +124,11 @@ describe("sessions in-app actions", () => {
     expect(agentProgressSource).toContain("togglePinSession(conversationId)")
   })
 
+  it("keeps the home recent conversations splash ordered by recent activity, not pin state", () => {
+    expect(sessionsSource).toContain("orderConversationHistoryByRecentActivity(")
+    expect(sessionsSource).not.toContain("orderConversationHistoryByPinnedFirst(")
+  })
+
   it("lets tile voice continuation use the in-app dialog path while keeping the IPC fallback", () => {
     expect(tileFollowUpSource).toContain("if (onVoiceContinue) {")
     expect(tileFollowUpSource).toContain("continueConversationTitle: conversationTitle")

--- a/apps/desktop/src/renderer/src/pages/sessions.tsx
+++ b/apps/desktop/src/renderer/src/pages/sessions.tsx
@@ -11,7 +11,7 @@ import { getBranchMessageIndexMap } from "@shared/conversation-progress"
 import { toast } from "sonner"
 
 import { logUI } from "@renderer/lib/debug"
-import { orderConversationHistoryByPinnedFirst } from "@renderer/lib/pinned-session-history"
+import { orderConversationHistoryByRecentActivity } from "@renderer/lib/pinned-session-history"
 import { PredefinedPromptsMenu } from "@renderer/components/predefined-prompts-menu"
 import { AgentSelector } from "@renderer/components/agent-selector"
 import { useConfigQuery } from "@renderer/lib/query-client"
@@ -318,13 +318,13 @@ function EmptyState({ onTextClick, onVoiceClick, onSelectPrompt, onSavedConversa
   const savedConversationsQuery = useSavedConversationsQuery()
   const pinnedSessionIds = useAgentStore((state) => state.pinnedSessionIds)
   const togglePinSession = useAgentStore((state) => state.togglePinSession)
-  const sortedSavedConversations = useMemo(
-    () => orderConversationHistoryByPinnedFirst(savedConversationsQuery.data ?? [], pinnedSessionIds),
-    [savedConversationsQuery.data, pinnedSessionIds],
+  const recentOrderedSavedConversations = useMemo(
+    () => orderConversationHistoryByRecentActivity(savedConversationsQuery.data ?? []),
+    [savedConversationsQuery.data],
   )
   const recentSavedConversations = useMemo(
-    () => sortedSavedConversations.slice(0, RECENT_SESSIONS_LIMIT),
-    [sortedSavedConversations],
+    () => recentOrderedSavedConversations.slice(0, RECENT_SESSIONS_LIMIT),
+    [recentOrderedSavedConversations],
   )
   const totalCount = savedConversationsQuery.data?.length ?? 0
 

--- a/apps/mobile/src/screens/ChatScreen.tsx
+++ b/apps/mobile/src/screens/ChatScreen.tsx
@@ -61,7 +61,7 @@ import {
   preprocessTextForTTS,
   shouldCollapseMessage,
   formatToolArguments,
-  getCompactToolExecutionPreview,
+  getToolActivityLabel,
   getToolResultsSummary,
   extractRespondToUserContentFromArgs,
   RESPOND_TO_USER_TOOL,
@@ -7176,7 +7176,20 @@ export default function ChatScreen({ route, navigation }: any) {
                               const tcPending = !tcResult;
                               const tcSuccess = tcResult?.success === true;
                               const tcError = tcResult?.success === false;
-                              const toolPreview = label ?? getCompactToolExecutionPreview(toolCall, tcResult ?? null);
+                              const activityLabel = label
+                                ? { title: label }
+                                : getToolActivityLabel(
+                                    { name: toolCall.name, arguments: toolCall.arguments ?? {} },
+                                    tcResult ?? null,
+                                  );
+                              const primaryActivityText = activityLabel.detail || activityLabel.title;
+                              const secondaryActivityText = activityLabel.detail && activityLabel.detail !== activityLabel.title
+                                && !/\bcompleted$/i.test(activityLabel.title)
+                                ? activityLabel.title
+                                : undefined;
+                              const toolPreview = secondaryActivityText
+                                ? `${primaryActivityText} - ${secondaryActivityText}`
+                                : primaryActivityText;
                               return (
                                 <View key={tcIdx} style={styles.toolCallCompactLine}>
                                   <Text style={[

--- a/apps/mobile/tests/chat-screen-density.test.js
+++ b/apps/mobile/tests/chat-screen-density.test.js
@@ -145,7 +145,8 @@ test('keeps Codex thinking blocks display-only on mobile', () => {
 
 test('labels result-only tool entries without showing raw tool_call text', () => {
   assert.match(screenSource, /label: 'Tool result'/);
-  assert.match(screenSource, /const toolPreview = label \?\? getCompactToolExecutionPreview\(toolCall, tcResult \?\? null\);/);
+  assert.match(screenSource, /const activityLabel = label\s+\?\s+\{ title: label \}\s+: getToolActivityLabel\(/);
+  assert.match(screenSource, /const primaryActivityText = activityLabel\.detail \|\| activityLabel\.title;/);
   assert.match(screenSource, /const toolNameLabel = label \?\? toolCall\.name;/);
   assert.match(screenSource, /\{toolNameLabel\}/);
 });

--- a/packages/shared/src/agent-progress.test.ts
+++ b/packages/shared/src/agent-progress.test.ts
@@ -33,7 +33,7 @@ describe('AgentProgressStep', () => {
     const step: AgentProgressStep = {
       id: 'step-1',
       type: 'tool_call',
-      title: 'Reading file',
+      title: 'Command completed',
       status: 'completed',
       timestamp: Date.now(),
     }

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -93,6 +93,53 @@ describe('getToolActivityLabel', () => {
     ).toBe('Command failed')
   })
 
+  it('uses structured command stderr for failed activity details', () => {
+    expect(
+      getToolActivityLabel(
+        { name: 'execute_command', arguments: { command: "sed 's#^#/## '" } },
+        {
+          success: false,
+          content: JSON.stringify({
+            success: false,
+            command: "sed 's#^#/## '",
+            cwd: '/repo',
+            stdout: '',
+            stderr: 'sed: bad flag in substitute command',
+            error: 'Command failed',
+          }, null, 2),
+        },
+      ),
+    ).toEqual({
+      title: 'Command failed',
+      detail: 'Failed: sed: bad flag in substitute command',
+    })
+  })
+
+  it('does not leak structured failed command JSON when only error is present', () => {
+    const payload = JSON.stringify({
+      success: false,
+      command: 'find . -badflag',
+      cwd: '/repo',
+      stdout: '',
+      stderr: '',
+      error: 'Command failed',
+    }, null, 2)
+
+    expect(
+      getToolActivityLabel(
+        { name: 'execute_command', arguments: { command: 'find . -badflag' } },
+        {
+          success: false,
+          content: payload,
+          error: payload,
+        },
+      ),
+    ).toEqual({
+      title: 'Command failed',
+      detail: 'Failed: Command failed',
+    })
+  })
+
   it('does not derive labels from heredoc script syntax', () => {
     expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: "python3 - <<'PY'" } })).toEqual({
       title: 'Running command',

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -68,25 +68,19 @@ describe('shouldCollapseMessage', () => {
 })
 
 describe('getToolActivityLabel', () => {
-  it('maps file inspection shell commands to a human-readable label', () => {
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: "sed -n '1,120p' apps/desktop/src/main/llm.ts" } }).title).toBe('Reading llm.ts')
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'rg -n "agentProgress" packages/shared/src' } })).toEqual({
-      title: 'Searching code',
-      detail: 'agentProgress in src',
+  it('uses generic command status with command target detail', () => {
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: "sed -n '1,120p' apps/desktop/src/main/llm.ts" } })).toEqual({
+      title: 'Running command',
+      detail: 'llm.ts',
     })
-  })
-
-  it('maps project checks to specific labels', () => {
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'pnpm test --filter agent-progress' } }).title).toBe('Running tests')
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'pnpm typecheck' } }).title).toBe('Checking types')
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'pnpm lint' } }).title).toBe('Linting code')
-  })
-
-  it('maps git inspection commands to repository state checks', () => {
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'git status --short' } }).title).toBe('Checking git status')
-    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'git diff -- apps/desktop' } })).toEqual({
-      title: 'Reviewing git diff',
-      detail: 'desktop',
+    expect(
+      getToolActivityLabel(
+        { name: 'execute_command', arguments: { command: 'rg -n "agentProgress" packages/shared/src' } },
+        { success: true, content: 'packages/shared/src/chat-utils.ts:1:agentProgress' },
+      ),
+    ).toEqual({
+      title: 'Command completed',
+      detail: 'packages/shared/src/chat-utils.ts:1:agentProgress',
     })
   })
 
@@ -96,50 +90,77 @@ describe('getToolActivityLabel', () => {
         { name: 'execute_command', arguments: { command: 'pnpm test' } },
         { success: false, content: '', error: 'failed' },
       ).title,
-    ).toBe('Running tests failed')
+    ).toBe('Command failed')
   })
 
-  it('does not treat heredoc script syntax as a script name', () => {
+  it('does not derive labels from heredoc script syntax', () => {
     expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: "python3 - <<'PY'" } })).toEqual({
-      title: 'Running a script',
+      title: 'Running command',
+      detail: 'inline python3',
     })
   })
 
-  it('summarizes pwd results as a folder instead of raw success metadata', () => {
+  it('summarizes structured command cwd instead of raw success metadata', () => {
     expect(
       getToolActivityLabel(
         { name: 'execute_command', arguments: { command: 'pwd' } },
         { success: true, content: '{"success":true,"cwd":"/tmp/dotagents-mono"}' },
       ),
     ).toEqual({
-      title: 'Checking current folder',
+      title: 'Command completed',
       detail: 'dotagents-mono',
+    })
+  })
+
+  it('summarizes JSON command output instead of bracket syntax', () => {
+    expect(
+      getToolActivityLabel(
+        { name: 'execute_command', arguments: { command: "python3 - <<'PY'" } },
+        { success: true, content: '[\n  { "title": "Publish YouTube Draft Unlisted" }\n]' },
+      ),
+    ).toEqual({
+      title: 'Command completed',
+      detail: 'Publish YouTube Draft Unlisted',
+    })
+  })
+
+  it('skips generic markdown headings in tool result previews', () => {
+    expect(
+      getToolActivityLabel(
+        { name: 'browser:network_requests', arguments: {} },
+        { success: true, content: '### Result\nBrowser network requests completed' },
+      ),
+    ).toEqual({
+      title: 'Network requests completed',
+      detail: 'Browser network requests completed',
+    })
+  })
+
+  it('keeps web search result text as the useful detail', () => {
+    expect(
+      getToolActivityLabel(
+        { name: 'exa:web_search_exa', arguments: { query: 'Hermes Agent' } },
+        { success: true, content: 'Learned that Hermes Agent has a newly added native desktop surface.' },
+      ),
+    ).toEqual({
+      title: 'Web search exa completed',
+      detail: 'Learned that Hermes Agent has a newly added native desktop surface.',
     })
   })
 })
 
 describe('getToolActivitySummary', () => {
-  it('collapses homogeneous tool batches to one label with a count detail', () => {
+  it('summarizes pending tool batches with the latest tool detail', () => {
     expect(getToolActivitySummary([
       { name: 'execute_command', arguments: { command: 'rg AgentProgress' } },
       { name: 'execute_command', arguments: { command: 'sed -n 1,20p file.ts' } },
     ])).toEqual({
-      title: 'Using 2 tool actions',
-      detail: 'Searching code (AgentProgress); Reading file.ts',
+      title: 'file.ts',
+      detail: 'Running command',
     })
   })
 
-  it('uses a generic multiple-tools label for mixed tool batches', () => {
-    expect(getToolActivitySummary([
-      { name: 'execute_command', arguments: { command: 'git status --short' } },
-      { name: 'execute_command', arguments: { command: 'pnpm test' } },
-    ])).toEqual({
-      title: 'Using 2 tool actions',
-      detail: 'Checking git status; Running tests',
-    })
-  })
-
-  it('adds compact result outcomes when available', () => {
+  it('uses the latest completed tool result for finished batches', () => {
     expect(getToolActivitySummary(
       [
         { name: 'execute_command', arguments: { command: 'git status --short' } },
@@ -150,8 +171,38 @@ describe('getToolActivitySummary', () => {
         { success: true, content: 'all suites passed' },
       ],
     )).toEqual({
-      title: 'Completed 2 tool actions',
-      detail: 'Checking git status (2 changed files); Running tests (Passed)',
+      title: 'all suites passed',
+    })
+  })
+
+  it('uses the latest failure for failed batches', () => {
+    expect(getToolActivitySummary(
+      [
+        { name: 'execute_command', arguments: { command: 'git status --short' } },
+        { name: 'execute_command', arguments: { command: 'pnpm test' } },
+      ],
+      [
+        { success: true, content: 'M file.ts' },
+        { success: false, content: '', error: 'failed' },
+      ],
+    )).toEqual({
+      title: 'Failed: failed',
+      detail: 'Command failed',
+    })
+  })
+
+  it('ignores metadata tools when choosing the latest group headline', () => {
+    expect(getToolActivitySummary(
+      [
+        { name: 'execute_command', arguments: { command: 'python3 research.py' } },
+        { name: 'set_session_title', arguments: { title: 'Research' } },
+      ],
+      [
+        { success: true, content: 'research complete' },
+        { success: true, content: '{"success":true,"title":"Research"}' },
+      ],
+    )).toEqual({
+      title: 'research complete',
     })
   })
 })

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -6,6 +6,8 @@ import {
   getIndividualToolCallPreview,
   getCompactToolExecutionPreview,
   getExecuteCommandResultPreview,
+  getToolActivityLabel,
+  getToolActivitySummary,
   getToolResultsSummary,
   getToolArgumentEntries,
   formatToolArguments,
@@ -62,6 +64,95 @@ describe('shouldCollapseMessage', () => {
 
   it('returns false for undefined content with no extras', () => {
     expect(shouldCollapseMessage(undefined)).toBe(false)
+  })
+})
+
+describe('getToolActivityLabel', () => {
+  it('maps file inspection shell commands to a human-readable label', () => {
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: "sed -n '1,120p' apps/desktop/src/main/llm.ts" } }).title).toBe('Reading llm.ts')
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'rg -n "agentProgress" packages/shared/src' } })).toEqual({
+      title: 'Searching code',
+      detail: 'agentProgress in src',
+    })
+  })
+
+  it('maps project checks to specific labels', () => {
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'pnpm test --filter agent-progress' } }).title).toBe('Running tests')
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'pnpm typecheck' } }).title).toBe('Checking types')
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'pnpm lint' } }).title).toBe('Linting code')
+  })
+
+  it('maps git inspection commands to repository state checks', () => {
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'git status --short' } }).title).toBe('Checking git status')
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'git diff -- apps/desktop' } })).toEqual({
+      title: 'Reviewing git diff',
+      detail: 'desktop',
+    })
+  })
+
+  it('marks failed command labels without leaking the raw command', () => {
+    expect(
+      getToolActivityLabel(
+        { name: 'execute_command', arguments: { command: 'pnpm test' } },
+        { success: false, content: '', error: 'failed' },
+      ).title,
+    ).toBe('Running tests failed')
+  })
+
+  it('does not treat heredoc script syntax as a script name', () => {
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: "python3 - <<'PY'" } })).toEqual({
+      title: 'Running a script',
+    })
+  })
+
+  it('summarizes pwd results as a folder instead of raw success metadata', () => {
+    expect(
+      getToolActivityLabel(
+        { name: 'execute_command', arguments: { command: 'pwd' } },
+        { success: true, content: '{"success":true,"cwd":"/tmp/dotagents-mono"}' },
+      ),
+    ).toEqual({
+      title: 'Checking current folder',
+      detail: 'dotagents-mono',
+    })
+  })
+})
+
+describe('getToolActivitySummary', () => {
+  it('collapses homogeneous tool batches to one label with a count detail', () => {
+    expect(getToolActivitySummary([
+      { name: 'execute_command', arguments: { command: 'rg AgentProgress' } },
+      { name: 'execute_command', arguments: { command: 'sed -n 1,20p file.ts' } },
+    ])).toEqual({
+      title: 'Using 2 tool actions',
+      detail: 'Searching code (AgentProgress); Reading file.ts',
+    })
+  })
+
+  it('uses a generic multiple-tools label for mixed tool batches', () => {
+    expect(getToolActivitySummary([
+      { name: 'execute_command', arguments: { command: 'git status --short' } },
+      { name: 'execute_command', arguments: { command: 'pnpm test' } },
+    ])).toEqual({
+      title: 'Using 2 tool actions',
+      detail: 'Checking git status; Running tests',
+    })
+  })
+
+  it('adds compact result outcomes when available', () => {
+    expect(getToolActivitySummary(
+      [
+        { name: 'execute_command', arguments: { command: 'git status --short' } },
+        { name: 'execute_command', arguments: { command: 'pnpm test' } },
+      ],
+      [
+        { success: true, content: 'M file.ts\nM other.ts' },
+        { success: true, content: 'all suites passed' },
+      ],
+    )).toEqual({
+      title: 'Completed 2 tool actions',
+      detail: 'Checking git status (2 changed files); Running tests (Passed)',
+    })
   })
 })
 // ── Tool Preview ─────────────────────────────────────────────────────────────

--- a/packages/shared/src/chat-utils.test.ts
+++ b/packages/shared/src/chat-utils.test.ts
@@ -147,6 +147,12 @@ describe('getToolActivityLabel', () => {
     })
   })
 
+  it('does not use command flags as activity detail', () => {
+    expect(getToolActivityLabel({ name: 'execute_command', arguments: { command: 'rg -n foo' } })).toEqual({
+      title: 'Running command',
+    })
+  })
+
   it('summarizes structured command cwd instead of raw success metadata', () => {
     expect(
       getToolActivityLabel(

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -87,6 +87,7 @@ export function getIndividualToolCallPreview(toolCall: ToolCall): string {
 type StructuredCommandOutput = {
   found: boolean;
   output: string;
+  cwd?: string;
 };
 
 function extractStringFields(obj: Record<string, unknown>, keys: string[]): string[] {
@@ -125,6 +126,7 @@ function extractStructuredCommandOutput(raw: string): StructuredCommandOutput | 
       return {
         found: true,
         output: (streamOutput.length > 0 ? streamOutput : fallbackOutput).join('\n'),
+        cwd: typeof obj.cwd === 'string' ? obj.cwd : undefined,
       };
     } catch {
       // Try the next candidate. Plain-text tool results are handled by the caller.
@@ -265,6 +267,344 @@ export function getCompactToolExecutionPreview(
   }
 
   return getIndividualToolCallPreview(toolCall);
+}
+
+export type ToolActivityLabel = {
+  title: string;
+  detail?: string;
+};
+
+const FILE_INSPECTION_COMMANDS = new Set([
+  'rg',
+  'grep',
+  'sed',
+  'cat',
+  'less',
+  'head',
+  'tail',
+  'find',
+  'fd',
+  'ls',
+  'pwd',
+  'wc',
+  'nl',
+]);
+
+const REPOSITORY_READ_COMMANDS = new Set([
+  'status',
+  'diff',
+  'log',
+  'show',
+  'branch',
+  'rev-parse',
+  'ls-files',
+]);
+
+function commandWords(command: string): string[] {
+  return command
+    .trim()
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .filter(Boolean);
+}
+
+function cleanCommandToken(token: string | undefined): string {
+  return (token ?? '').replace(/^['"]|['"]$/g, '').trim();
+}
+
+function basenameForActivity(path: string | undefined): string {
+  const cleaned = cleanCommandToken(path);
+  if (!cleaned || cleaned === '-' || cleaned.startsWith('<') || cleaned.includes('<<')) return '';
+  const parts = cleaned.split('/').filter(Boolean);
+  return parts[parts.length - 1] || cleaned;
+}
+
+function commandTarget(words: string[], startIndex = 1): string {
+  const candidates = words
+    .slice(startIndex)
+    .map(cleanCommandToken)
+    .filter((word) => (
+      !!word &&
+      !word.startsWith('-') &&
+      word !== '|' &&
+      word !== '>' &&
+      word !== '2>' &&
+      !/^\d+(?:,\d+)?p?$/.test(word)
+    ));
+  return basenameForActivity(candidates[candidates.length - 1]);
+}
+
+function commandOutput(toolResult?: ToolResult | null): string {
+  if (!toolResult) return '';
+
+  const outputParts: string[] = [];
+  for (const rawPart of [toolResult.content, toolResult.error]) {
+    if (!rawPart?.trim()) continue;
+    const structured = extractStructuredCommandOutput(rawPart);
+    outputParts.push(structured?.found ? structured.output : rawPart);
+  }
+
+  return Array.from(new Set(outputParts.map(part => part.trim()).filter(Boolean))).join('\n');
+}
+
+function commandCwd(toolResult?: ToolResult | null): string {
+  if (!toolResult) return '';
+  for (const rawPart of [toolResult.content, toolResult.error]) {
+    if (!rawPart?.trim()) continue;
+    const structured = extractStructuredCommandOutput(rawPart);
+    if (structured?.cwd) return structured.cwd;
+  }
+  return '';
+}
+
+function countNonEmptyLines(text: string): number {
+  return text.split('\n').filter(line => line.trim()).length;
+}
+
+function commandResultDetail(
+  executable: string,
+  subcommand: string,
+  baseDetail: string | undefined,
+  toolResult?: ToolResult | null,
+): string | undefined {
+  if (!toolResult) return baseDetail;
+  const output = commandOutput(toolResult);
+  const lineCount = countNonEmptyLines(output);
+
+  if (!toolResult.success) {
+    const preview = generateToolResultPreview(toolResult);
+    return preview ? `Failed: ${preview}` : baseDetail ? `${baseDetail}; failed` : 'Failed';
+  }
+
+  if (executable === 'sed' || executable === 'cat' || executable === 'head' || executable === 'tail' || executable === 'nl' || executable === 'less') {
+    const suffix = `${lineCount.toLocaleString()} line${lineCount === 1 ? '' : 's'}`;
+    return baseDetail ? `${baseDetail}; ${suffix}` : suffix;
+  }
+
+  if (executable === 'rg' || executable === 'grep' || executable === 'find' || executable === 'fd') {
+    if (!output.trim()) return baseDetail ? `${baseDetail}; no matches` : 'No matches';
+    const suffix = `${lineCount.toLocaleString()} match${lineCount === 1 ? '' : 'es'}`;
+    return baseDetail ? `${baseDetail}; ${suffix}` : suffix;
+  }
+
+  if (executable === 'ls') {
+    const suffix = `${lineCount.toLocaleString()} entr${lineCount === 1 ? 'y' : 'ies'}`;
+    return baseDetail ? `${baseDetail}; ${suffix}` : suffix;
+  }
+
+  if (executable === 'pwd') {
+    const folder = basenameForActivity(output) || basenameForActivity(commandCwd(toolResult));
+    return folder || baseDetail;
+  }
+
+  if (executable === 'git' && subcommand === 'status') {
+    if (!output.trim()) return 'Working tree clean';
+    return `${lineCount.toLocaleString()} changed file${lineCount === 1 ? '' : 's'}`;
+  }
+
+  if (/\b(pass|passed|success|succeeded)\b/i.test(output) && !/\b(fail|failed|error)\b/i.test(output)) {
+    return 'Passed';
+  }
+
+  const preview = generateToolResultPreview(toolResult);
+  return preview || baseDetail;
+}
+
+function getExecuteCommandActivityLabel(command: string, toolResult?: ToolResult | null): ToolActivityLabel {
+  const words = commandWords(command);
+  const executable = words[0]?.toLowerCase() ?? '';
+  const subcommand = words[1]?.toLowerCase() ?? '';
+  const normalized = words.join(' ').toLowerCase();
+
+  if (!executable) return { title: 'Running a command' };
+
+  let label: ToolActivityLabel;
+
+  if (executable === 'git') {
+    if (subcommand === 'status') {
+      label = { title: 'Checking git status' };
+    } else if (subcommand === 'diff') {
+      label = { title: 'Reviewing git diff', detail: commandTarget(words, 2) || undefined };
+    } else if (subcommand === 'log') {
+      label = { title: 'Reviewing git history' };
+    } else if (REPOSITORY_READ_COMMANDS.has(subcommand)) {
+      label = { title: 'Checking repository state' };
+    } else {
+      label = { title: 'Updating the repository' };
+    }
+    return {
+      ...label,
+      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+    };
+  }
+
+  if (
+    executable === 'pnpm' ||
+    executable === 'npm' ||
+    executable === 'yarn' ||
+    executable === 'bun'
+  ) {
+    if (/\b(test|typecheck|lint|check)\b/.test(normalized)) {
+      if (/\btypecheck\b/.test(normalized)) label = { title: 'Checking types' };
+      else if (/\blint\b/.test(normalized)) label = { title: 'Linting code' };
+      else if (/\btest\b/.test(normalized)) label = { title: 'Running tests' };
+      else label = { title: 'Running checks' };
+      return {
+        ...label,
+        detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+      };
+    }
+    if (/\b(build|compile)\b/.test(normalized)) {
+      label = { title: 'Building the project' };
+      return {
+        ...label,
+        detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+      };
+    }
+    label = { title: 'Running project tooling' };
+    return {
+      ...label,
+      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+    };
+  }
+
+  if (FILE_INSPECTION_COMMANDS.has(executable)) {
+    if (executable === 'rg' || executable === 'grep') {
+      const searchTerm = cleanCommandToken(words.slice(1).find(word => !word.startsWith('-')));
+      const target = commandTarget(words, 2);
+      label = {
+        title: 'Searching code',
+        detail: [searchTerm, target ? `in ${target}` : ''].filter(Boolean).join(' '),
+      };
+    } else if (executable === 'find' || executable === 'fd') {
+      label = { title: 'Finding files', detail: commandTarget(words) || undefined };
+    } else if (executable === 'ls') {
+      label = { title: 'Listing files', detail: commandTarget(words) || undefined };
+    } else if (executable === 'pwd') {
+      label = { title: 'Checking current folder' };
+    } else {
+      const target = commandTarget(words);
+      label = { title: target ? `Reading ${target}` : 'Reading files' };
+    }
+    return {
+      ...label,
+      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+    };
+  }
+
+  if (
+    executable === 'python' ||
+    executable === 'python3' ||
+    executable === 'node' ||
+    executable === 'tsx' ||
+    executable === 'ts-node'
+  ) {
+    if (/\b(test|pytest|vitest|jest)\b/.test(normalized)) {
+      label = { title: 'Running tests' };
+      return {
+        ...label,
+        detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+      };
+    }
+    label = { title: 'Running a script', detail: basenameForActivity(words[1]) || undefined };
+    return {
+      ...label,
+      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+    };
+  }
+
+  label = { title: 'Running a command' };
+  return {
+    ...label,
+    detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
+  };
+}
+
+function titleFromToolName(name: string): string {
+  const cleaned = name
+    .replace(/^[^:]+:/, '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return 'Using a tool';
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/**
+ * Produce a human-readable activity label for a tool call.
+ *
+ * This intentionally avoids raw command strings and long argument previews.
+ * Those remain available in expanded tool details.
+ */
+export function getToolActivityLabel(
+  toolCall: Pick<ToolCall, 'name' | 'arguments'>,
+  toolResult?: ToolResult | null,
+): ToolActivityLabel {
+  const toolName = toolCall.name?.trim() || '';
+  const normalizedName = toolName.toLowerCase();
+  const failed = toolResult?.success === false;
+
+  if (normalizedName === 'execute_command' || normalizedName.endsWith(':execute_command')) {
+    const args = normalizeToolArguments(toolCall.arguments);
+    const command = typeof args?.command === 'string' ? args.command.trim() : '';
+    const base = getExecuteCommandActivityLabel(command, toolResult);
+    return failed ? { ...base, title: `${base.title} failed` } : base;
+  }
+
+  if (normalizedName === 'set_session_title' || normalizedName.endsWith(':set_session_title')) {
+    return { title: failed ? 'Updating the session title failed' : 'Updating the session title' };
+  }
+
+  if (normalizedName.includes('read') || normalizedName.includes('search') || normalizedName.includes('find')) {
+    return { title: failed ? 'Inspecting context failed' : 'Inspecting context' };
+  }
+
+  const title = titleFromToolName(toolName);
+  return { title: failed ? `${title} failed` : title };
+}
+
+export function getToolActivitySummary(
+  toolCalls: Array<Pick<ToolCall, 'name' | 'arguments'>>,
+  toolResults?: Array<ToolResult | undefined | null>,
+): ToolActivityLabel {
+  if (toolCalls.length === 0) return { title: 'Using tools' };
+
+  const labels = toolCalls.map((toolCall, index) => (
+    getToolActivityLabel(toolCall, toolResults?.[index] ?? null)
+  ));
+  const uniqueTitles = Array.from(new Set(labels.map(label => label.title)));
+  const hasFailure = toolResults?.some((result) => result?.success === false) ?? false;
+  const hasPending = !toolResults || toolResults.length < toolCalls.length || toolResults.some((result) => !result);
+
+  if (toolCalls.length === 1) {
+    return labels[0];
+  }
+
+  if (uniqueTitles.length === 1) {
+    const details = labels
+      .map(label => label.detail)
+      .filter((detail): detail is string => Boolean(detail));
+    return {
+      title: uniqueTitles[0],
+      detail: details.length > 0
+        ? `${details.slice(0, 2).join('; ')}${details.length > 2 ? `; +${details.length - 2} more` : ''}`
+        : `${toolCalls.length} tool calls`,
+    };
+  }
+
+  const detail = labels
+    .map(label => label.detail ? `${label.title} (${label.detail})` : label.title)
+    .slice(0, 3)
+    .join('; ');
+
+  return {
+    title: hasFailure
+      ? `Finished ${toolCalls.length} tool actions with errors`
+      : hasPending
+        ? `Using ${toolCalls.length} tool actions`
+        : `Completed ${toolCalls.length} tool actions`,
+    detail: `${detail}${labels.length > 3 ? `; +${labels.length - 3} more` : ''}`,
+  };
 }
 
 /**

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -311,8 +311,11 @@ function commandStderr(toolResult?: ToolResult | null): string {
   for (const rawPart of [toolResult.content, toolResult.error]) {
     if (!rawPart?.trim()) continue;
     const structured = extractStructuredCommandOutput(rawPart);
-    if (structured?.stderr) outputParts.push(structured.stderr);
-    else if (rawPart === toolResult.error) outputParts.push(rawPart);
+    if (structured?.found) {
+      if (structured.stderr) outputParts.push(structured.stderr);
+      continue;
+    }
+    if (rawPart === toolResult.error) outputParts.push(rawPart);
   }
 
   return Array.from(new Set(outputParts.map(part => part.trim()).filter(Boolean))).join('\n');
@@ -440,11 +443,22 @@ function jsonTextPreview(text: string): string {
   }
 }
 
+function failedToolResultPreview(result: ToolResult, maxLength: number): string {
+  const stderr = meaningfulTextPreview(commandStderr(result));
+  if (stderr) return truncatePreview(stderr, maxLength);
+
+  const output = commandOutput(result);
+  const outputPreview = jsonTextPreview(output) || meaningfulTextPreview(output);
+  if (outputPreview) return truncatePreview(outputPreview, maxLength);
+
+  return truncatePreview(result.error || result.content || 'Error', maxLength);
+}
+
 function resultOutcome(result?: ToolResult | null, fallbackDetail?: string): string | undefined {
   if (!result) return undefined;
 
   if (!result.success) {
-    const preview = generateToolResultPreview(result);
+    const preview = failedToolResultPreview(result, 80);
     return preview ? `Failed: ${preview}` : fallbackDetail ? `Failed: ${fallbackDetail}` : 'Failed';
   }
 
@@ -545,8 +559,7 @@ function generateToolResultPreview(result: ToolResult): string {
   if (!result) return '';
 
   if (!result.success) {
-    const errorText = result.error || result.content || 'Error';
-    return truncatePreview(errorText, 40);
+    return failedToolResultPreview(result, 40);
   }
 
   const content = result.content || '';

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -365,7 +365,7 @@ function shortPathForActivity(path: string | undefined): string {
   const cleaned = cleanCommandToken(path)
     .replace(/[),;]+$/g, '')
     .trim();
-  if (!cleaned || cleaned === '-' || cleaned.startsWith('<') || cleaned.includes('<<')) return '';
+  if (!cleaned || cleaned.startsWith('-') || cleaned.startsWith('<') || cleaned.includes('<<')) return '';
 
   const parts = cleaned.split('/').filter(Boolean);
   if (parts.length === 0) return cleaned;

--- a/packages/shared/src/chat-utils.ts
+++ b/packages/shared/src/chat-utils.ts
@@ -87,6 +87,8 @@ export function getIndividualToolCallPreview(toolCall: ToolCall): string {
 type StructuredCommandOutput = {
   found: boolean;
   output: string;
+  stdout?: string;
+  stderr?: string;
   cwd?: string;
 };
 
@@ -122,10 +124,14 @@ function extractStructuredCommandOutput(raw: string): StructuredCommandOutput | 
 
       const streamOutput = extractStringFields(obj, ['stdout', 'stderr']);
       const fallbackOutput = extractStringFields(obj, ['output', 'result', 'message', 'error']);
+      const stdout = extractStringFields(obj, ['stdout']).join('\n');
+      const stderr = extractStringFields(obj, ['stderr']).join('\n');
 
       return {
         found: true,
         output: (streamOutput.length > 0 ? streamOutput : fallbackOutput).join('\n'),
+        stdout: stdout || undefined,
+        stderr: stderr || undefined,
         cwd: typeof obj.cwd === 'string' ? obj.cwd : undefined,
       };
     } catch {
@@ -274,40 +280,6 @@ export type ToolActivityLabel = {
   detail?: string;
 };
 
-const FILE_INSPECTION_COMMANDS = new Set([
-  'rg',
-  'grep',
-  'sed',
-  'cat',
-  'less',
-  'head',
-  'tail',
-  'find',
-  'fd',
-  'ls',
-  'pwd',
-  'wc',
-  'nl',
-]);
-
-const REPOSITORY_READ_COMMANDS = new Set([
-  'status',
-  'diff',
-  'log',
-  'show',
-  'branch',
-  'rev-parse',
-  'ls-files',
-]);
-
-function commandWords(command: string): string[] {
-  return command
-    .trim()
-    .replace(/\s+/g, ' ')
-    .split(' ')
-    .filter(Boolean);
-}
-
 function cleanCommandToken(token: string | undefined): string {
   return (token ?? '').replace(/^['"]|['"]$/g, '').trim();
 }
@@ -319,21 +291,6 @@ function basenameForActivity(path: string | undefined): string {
   return parts[parts.length - 1] || cleaned;
 }
 
-function commandTarget(words: string[], startIndex = 1): string {
-  const candidates = words
-    .slice(startIndex)
-    .map(cleanCommandToken)
-    .filter((word) => (
-      !!word &&
-      !word.startsWith('-') &&
-      word !== '|' &&
-      word !== '>' &&
-      word !== '2>' &&
-      !/^\d+(?:,\d+)?p?$/.test(word)
-    ));
-  return basenameForActivity(candidates[candidates.length - 1]);
-}
-
 function commandOutput(toolResult?: ToolResult | null): string {
   if (!toolResult) return '';
 
@@ -342,6 +299,20 @@ function commandOutput(toolResult?: ToolResult | null): string {
     if (!rawPart?.trim()) continue;
     const structured = extractStructuredCommandOutput(rawPart);
     outputParts.push(structured?.found ? structured.output : rawPart);
+  }
+
+  return Array.from(new Set(outputParts.map(part => part.trim()).filter(Boolean))).join('\n');
+}
+
+function commandStderr(toolResult?: ToolResult | null): string {
+  if (!toolResult) return '';
+
+  const outputParts: string[] = [];
+  for (const rawPart of [toolResult.content, toolResult.error]) {
+    if (!rawPart?.trim()) continue;
+    const structured = extractStructuredCommandOutput(rawPart);
+    if (structured?.stderr) outputParts.push(structured.stderr);
+    else if (rawPart === toolResult.error) outputParts.push(rawPart);
   }
 
   return Array.from(new Set(outputParts.map(part => part.trim()).filter(Boolean))).join('\n');
@@ -361,165 +332,6 @@ function countNonEmptyLines(text: string): number {
   return text.split('\n').filter(line => line.trim()).length;
 }
 
-function commandResultDetail(
-  executable: string,
-  subcommand: string,
-  baseDetail: string | undefined,
-  toolResult?: ToolResult | null,
-): string | undefined {
-  if (!toolResult) return baseDetail;
-  const output = commandOutput(toolResult);
-  const lineCount = countNonEmptyLines(output);
-
-  if (!toolResult.success) {
-    const preview = generateToolResultPreview(toolResult);
-    return preview ? `Failed: ${preview}` : baseDetail ? `${baseDetail}; failed` : 'Failed';
-  }
-
-  if (executable === 'sed' || executable === 'cat' || executable === 'head' || executable === 'tail' || executable === 'nl' || executable === 'less') {
-    const suffix = `${lineCount.toLocaleString()} line${lineCount === 1 ? '' : 's'}`;
-    return baseDetail ? `${baseDetail}; ${suffix}` : suffix;
-  }
-
-  if (executable === 'rg' || executable === 'grep' || executable === 'find' || executable === 'fd') {
-    if (!output.trim()) return baseDetail ? `${baseDetail}; no matches` : 'No matches';
-    const suffix = `${lineCount.toLocaleString()} match${lineCount === 1 ? '' : 'es'}`;
-    return baseDetail ? `${baseDetail}; ${suffix}` : suffix;
-  }
-
-  if (executable === 'ls') {
-    const suffix = `${lineCount.toLocaleString()} entr${lineCount === 1 ? 'y' : 'ies'}`;
-    return baseDetail ? `${baseDetail}; ${suffix}` : suffix;
-  }
-
-  if (executable === 'pwd') {
-    const folder = basenameForActivity(output) || basenameForActivity(commandCwd(toolResult));
-    return folder || baseDetail;
-  }
-
-  if (executable === 'git' && subcommand === 'status') {
-    if (!output.trim()) return 'Working tree clean';
-    return `${lineCount.toLocaleString()} changed file${lineCount === 1 ? '' : 's'}`;
-  }
-
-  if (/\b(pass|passed|success|succeeded)\b/i.test(output) && !/\b(fail|failed|error)\b/i.test(output)) {
-    return 'Passed';
-  }
-
-  const preview = generateToolResultPreview(toolResult);
-  return preview || baseDetail;
-}
-
-function getExecuteCommandActivityLabel(command: string, toolResult?: ToolResult | null): ToolActivityLabel {
-  const words = commandWords(command);
-  const executable = words[0]?.toLowerCase() ?? '';
-  const subcommand = words[1]?.toLowerCase() ?? '';
-  const normalized = words.join(' ').toLowerCase();
-
-  if (!executable) return { title: 'Running a command' };
-
-  let label: ToolActivityLabel;
-
-  if (executable === 'git') {
-    if (subcommand === 'status') {
-      label = { title: 'Checking git status' };
-    } else if (subcommand === 'diff') {
-      label = { title: 'Reviewing git diff', detail: commandTarget(words, 2) || undefined };
-    } else if (subcommand === 'log') {
-      label = { title: 'Reviewing git history' };
-    } else if (REPOSITORY_READ_COMMANDS.has(subcommand)) {
-      label = { title: 'Checking repository state' };
-    } else {
-      label = { title: 'Updating the repository' };
-    }
-    return {
-      ...label,
-      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-    };
-  }
-
-  if (
-    executable === 'pnpm' ||
-    executable === 'npm' ||
-    executable === 'yarn' ||
-    executable === 'bun'
-  ) {
-    if (/\b(test|typecheck|lint|check)\b/.test(normalized)) {
-      if (/\btypecheck\b/.test(normalized)) label = { title: 'Checking types' };
-      else if (/\blint\b/.test(normalized)) label = { title: 'Linting code' };
-      else if (/\btest\b/.test(normalized)) label = { title: 'Running tests' };
-      else label = { title: 'Running checks' };
-      return {
-        ...label,
-        detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-      };
-    }
-    if (/\b(build|compile)\b/.test(normalized)) {
-      label = { title: 'Building the project' };
-      return {
-        ...label,
-        detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-      };
-    }
-    label = { title: 'Running project tooling' };
-    return {
-      ...label,
-      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-    };
-  }
-
-  if (FILE_INSPECTION_COMMANDS.has(executable)) {
-    if (executable === 'rg' || executable === 'grep') {
-      const searchTerm = cleanCommandToken(words.slice(1).find(word => !word.startsWith('-')));
-      const target = commandTarget(words, 2);
-      label = {
-        title: 'Searching code',
-        detail: [searchTerm, target ? `in ${target}` : ''].filter(Boolean).join(' '),
-      };
-    } else if (executable === 'find' || executable === 'fd') {
-      label = { title: 'Finding files', detail: commandTarget(words) || undefined };
-    } else if (executable === 'ls') {
-      label = { title: 'Listing files', detail: commandTarget(words) || undefined };
-    } else if (executable === 'pwd') {
-      label = { title: 'Checking current folder' };
-    } else {
-      const target = commandTarget(words);
-      label = { title: target ? `Reading ${target}` : 'Reading files' };
-    }
-    return {
-      ...label,
-      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-    };
-  }
-
-  if (
-    executable === 'python' ||
-    executable === 'python3' ||
-    executable === 'node' ||
-    executable === 'tsx' ||
-    executable === 'ts-node'
-  ) {
-    if (/\b(test|pytest|vitest|jest)\b/.test(normalized)) {
-      label = { title: 'Running tests' };
-      return {
-        ...label,
-        detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-      };
-    }
-    label = { title: 'Running a script', detail: basenameForActivity(words[1]) || undefined };
-    return {
-      ...label,
-      detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-    };
-  }
-
-  label = { title: 'Running a command' };
-  return {
-    ...label,
-    detail: commandResultDetail(executable, subcommand, label.detail, toolResult),
-  };
-}
-
 function titleFromToolName(name: string): string {
   const cleaned = name
     .replace(/^[^:]+:/, '')
@@ -530,37 +342,170 @@ function titleFromToolName(name: string): string {
   return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
 }
 
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count.toLocaleString()} ${count === 1 ? singular : plural}`;
+}
+
+function isExecuteCommandName(name: string): boolean {
+  const normalizedName = name.toLowerCase();
+  return normalizedName === 'execute_command' || normalizedName.endsWith(':execute_command');
+}
+
+function isMetadataActivityTool(name: string): boolean {
+  const normalizedName = name.toLowerCase().replace(/^[^:]+:/, '');
+  return normalizedName === 'set_session_title' ||
+    normalizedName === RESPOND_TO_USER_TOOL ||
+    normalizedName === MARK_WORK_COMPLETE_TOOL;
+}
+
+function shortPathForActivity(path: string | undefined): string {
+  const cleaned = cleanCommandToken(path)
+    .replace(/[),;]+$/g, '')
+    .trim();
+  if (!cleaned || cleaned === '-' || cleaned.startsWith('<') || cleaned.includes('<<')) return '';
+
+  const parts = cleaned.split('/').filter(Boolean);
+  if (parts.length === 0) return cleaned;
+  if (parts.length >= 2 && parts[parts.length - 1].toLowerCase() === 'skill.md') {
+    return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+  }
+  return parts[parts.length - 1] || cleaned;
+}
+
+function commandActivityHint(command: string | undefined): string | undefined {
+  const normalized = (command ?? '').replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+
+  const headerMatch = normalized.match(/['"][-=]{3,}\s*([^'"]*?)\s*[-=]{3,}['"]/);
+  if (headerMatch?.[1]?.trim()) return truncatePreview(headerMatch[1].trim(), 80);
+
+  const tokens = normalized
+    .split(/\s+/)
+    .map(cleanCommandToken)
+    .filter(Boolean);
+  const pathToken = [...tokens].reverse().find((token) => (
+    !token.startsWith('-') &&
+    token !== '|' &&
+    token !== '>' &&
+    token !== '2>' &&
+    (token.includes('/') || /\.[A-Za-z0-9]{1,8}$/.test(token))
+  ));
+  const pathHint = shortPathForActivity(pathToken);
+  if (pathHint) return truncatePreview(pathHint, 80);
+
+  const executable = tokens[0];
+  const script = shortPathForActivity(tokens[1]);
+  if (script) return truncatePreview(script, 80);
+  if (executable && normalized.includes('<<')) return `inline ${executable}`;
+
+  return undefined;
+}
+
+function normalizeOutputPreviewLine(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed) return '';
+
+  const markdownHeadingMatch = trimmed.match(/^#{1,6}\s+(.+)$/);
+  if (markdownHeadingMatch) {
+    const heading = markdownHeadingMatch[1].trim();
+    if (/^(result|results|page|ran playwright code|error)$/i.test(heading)) return '';
+    return heading;
+  }
+
+  const headerMatch = trimmed.match(/^[-=]{3,}\s*(.*?)\s*[-=]{3,}$/);
+  if (headerMatch) return headerMatch[1].trim();
+  if (/^[-=*_]{3,}$/.test(trimmed)) return '';
+  if (/^[\s[\]{}(),:;'"`-]+$/.test(trimmed)) return '';
+
+  return trimmed;
+}
+
+function meaningfulTextPreview(text: string): string {
+  const lines = text.split('\n').filter(line => line.trim());
+  for (const line of lines) {
+    const preview = normalizeOutputPreviewLine(line);
+    if (preview) return truncatePreview(preview, 80);
+  }
+  return '';
+}
+
+function jsonTextPreview(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed || (!trimmed.startsWith('{') && !trimmed.startsWith('['))) return '';
+
+  try {
+    return extractJsonPreview(JSON.parse(trimmed));
+  } catch {
+    return '';
+  }
+}
+
+function resultOutcome(result?: ToolResult | null, fallbackDetail?: string): string | undefined {
+  if (!result) return undefined;
+
+  if (!result.success) {
+    const preview = generateToolResultPreview(result);
+    return preview ? `Failed: ${preview}` : fallbackDetail ? `Failed: ${fallbackDetail}` : 'Failed';
+  }
+
+  const stderr = meaningfulTextPreview(commandStderr(result));
+  if (stderr) return `Warning: ${stderr}`;
+
+  const output = commandOutput(result);
+  if (!output.trim()) {
+    const folder = basenameForActivity(commandCwd(result));
+    return folder || fallbackDetail;
+  }
+
+  return jsonTextPreview(output) ||
+    meaningfulTextPreview(output) ||
+    fallbackDetail ||
+    `${pluralize(countNonEmptyLines(output), 'line')} returned`;
+}
+
+function isGenericCompletedActivityTitle(title: string | undefined): boolean {
+  return /\bcompleted$/i.test(title ?? '');
+}
+
+function promoteActivityDetail(label: ToolActivityLabel): ToolActivityLabel {
+  if (!label.detail) return label;
+  return {
+    title: label.detail,
+    detail: isGenericCompletedActivityTitle(label.title) ? undefined : label.title,
+  };
+}
+
 /**
  * Produce a human-readable activity label for a tool call.
  *
- * This intentionally avoids raw command strings and long argument previews.
- * Those remain available in expanded tool details.
+ * This intentionally avoids command-specific intent labels. Raw commands and
+ * payloads remain available in expanded tool details.
  */
 export function getToolActivityLabel(
   toolCall: Pick<ToolCall, 'name' | 'arguments'>,
   toolResult?: ToolResult | null,
 ): ToolActivityLabel {
   const toolName = toolCall.name?.trim() || '';
-  const normalizedName = toolName.toLowerCase();
-  const failed = toolResult?.success === false;
+  const isCommand = isExecuteCommandName(toolName);
+  const baseTitle = isCommand ? 'Command' : titleFromToolName(toolName);
+  const args = isCommand ? normalizeToolArguments(toolCall.arguments) : null;
+  const commandHint = isCommand && typeof args?.command === 'string'
+    ? commandActivityHint(args.command)
+    : undefined;
+  const detail = resultOutcome(toolResult, commandHint);
 
-  if (normalizedName === 'execute_command' || normalizedName.endsWith(':execute_command')) {
-    const args = normalizeToolArguments(toolCall.arguments);
-    const command = typeof args?.command === 'string' ? args.command.trim() : '';
-    const base = getExecuteCommandActivityLabel(command, toolResult);
-    return failed ? { ...base, title: `${base.title} failed` } : base;
+  if (!toolResult) {
+    return {
+      title: isCommand ? 'Running command' : baseTitle,
+      ...(commandHint ? { detail: commandHint } : {}),
+    };
   }
 
-  if (normalizedName === 'set_session_title' || normalizedName.endsWith(':set_session_title')) {
-    return { title: failed ? 'Updating the session title failed' : 'Updating the session title' };
+  if (!toolResult.success) {
+    return { title: `${baseTitle} failed`, ...(detail ? { detail } : {}) };
   }
 
-  if (normalizedName.includes('read') || normalizedName.includes('search') || normalizedName.includes('find')) {
-    return { title: failed ? 'Inspecting context failed' : 'Inspecting context' };
-  }
-
-  const title = titleFromToolName(toolName);
-  return { title: failed ? `${title} failed` : title };
+  return { title: `${baseTitle} completed`, ...(detail ? { detail } : {}) };
 }
 
 export function getToolActivitySummary(
@@ -569,42 +514,26 @@ export function getToolActivitySummary(
 ): ToolActivityLabel {
   if (toolCalls.length === 0) return { title: 'Using tools' };
 
-  const labels = toolCalls.map((toolCall, index) => (
-    getToolActivityLabel(toolCall, toolResults?.[index] ?? null)
-  ));
-  const uniqueTitles = Array.from(new Set(labels.map(label => label.title)));
-  const hasFailure = toolResults?.some((result) => result?.success === false) ?? false;
-  const hasPending = !toolResults || toolResults.length < toolCalls.length || toolResults.some((result) => !result);
+  const results = Array.from({ length: toolCalls.length }, (_, index) => toolResults?.[index] ?? null);
 
   if (toolCalls.length === 1) {
-    return labels[0];
+    return promoteActivityDetail(getToolActivityLabel(toolCalls[0], results[0]));
   }
 
-  if (uniqueTitles.length === 1) {
-    const details = labels
-      .map(label => label.detail)
-      .filter((detail): detail is string => Boolean(detail));
-    return {
-      title: uniqueTitles[0],
-      detail: details.length > 0
-        ? `${details.slice(0, 2).join('; ')}${details.length > 2 ? `; +${details.length - 2} more` : ''}`
-        : `${toolCalls.length} tool calls`,
-    };
-  }
+  const visibleIndexes = toolCalls
+    .map((toolCall, index) => ({ toolCall, index }))
+    .filter(({ toolCall }) => !isMetadataActivityTool(toolCall.name));
+  const candidateIndexes = visibleIndexes.length > 0
+    ? visibleIndexes
+    : toolCalls.map((toolCall, index) => ({ toolCall, index }));
+  const latestPending = [...candidateIndexes].reverse().find(({ index }) => !results[index]);
+  const latestCompleted = [...candidateIndexes].reverse().find(({ index }) => !!results[index]);
+  const latest = latestPending ?? latestCompleted ?? candidateIndexes[candidateIndexes.length - 1];
+  const latestLabel = latest
+    ? getToolActivityLabel(latest.toolCall, results[latest.index])
+    : { title: 'Using tools' };
 
-  const detail = labels
-    .map(label => label.detail ? `${label.title} (${label.detail})` : label.title)
-    .slice(0, 3)
-    .join('; ');
-
-  return {
-    title: hasFailure
-      ? `Finished ${toolCalls.length} tool actions with errors`
-      : hasPending
-        ? `Using ${toolCalls.length} tool actions`
-        : `Completed ${toolCalls.length} tool actions`,
-    detail: `${detail}${labels.length > 3 ? `; +${labels.length - 3} more` : ''}`,
-  };
+  return promoteActivityDetail(latestLabel);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replace raw tool-name previews with human-readable activity labels in agent progress views
- Keep collapsed and expanded tool details in sync as results arrive
- Update tests for the new tool activity labeling and summary behavior

## Testing
- Updated unit coverage for tool activity labels, summaries, and progress rendering behavior
- Not run (not requested)