### PR TITLE
[codex] Consolidate desktop settings navigation

### DIFF
--- a/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tile-layout.test.ts
@@ -25,9 +25,10 @@ describe("agent progress tile layout", () => {
   it("wraps the tile footer metadata row and preserves trailing status visibility", () => {
     expect(agentProgressSource).toContain('className="flex items-center justify-between gap-2"')
     expect(agentProgressSource).toContain('className="flex min-w-0 flex-1 items-center gap-x-2"')
-    expect(agentProgressSource).toContain('<SessionModelPicker modelInfo={modelInfo} compact />')
-    expect(agentProgressSource).toContain('<SessionThinkingPicker compact />')
-    expect(agentProgressSource).toContain('<SessionVerbosityPicker compact />')
+    expect(agentProgressSource).toContain("Footer with session status metadata.")
+    expect(agentProgressSource).not.toContain("SessionModelPicker")
+    expect(agentProgressSource).not.toContain("SessionThinkingPicker")
+    expect(agentProgressSource).not.toContain("SessionVerbosityPicker")
     expect(agentProgressSource).toContain('className="shrink-0 whitespace-nowrap">Step')
   })
 
@@ -194,15 +195,13 @@ describe("agent progress tile layout", () => {
     expect(agentProgressSource).not.toContain('{value.expandedText}\n        </pre>')
   })
 
-  it("keeps the session model visible and clickable as a picker", () => {
-    expect(agentProgressSource).toContain('const SessionModelPicker: React.FC')
-    expect(agentProgressSource).toContain('aria-label="Change agent model"')
-    expect(agentProgressSource).toContain('buildAgentModelConfigUpdates(config, providerId, modelId)')
-    expect(agentProgressSource).toContain('Model/provider controls stay available even before live session metadata arrives')
-    expect(agentProgressSource).toContain('<SessionModelPicker modelInfo={modelInfo} />')
-    // Tile footer renders unconditionally so the model/thinking/verbosity controls
-    // stay reachable for inactive (completed) sessions too.
-    expect(agentProgressSource).toContain('always render so model picker, thinking,')
+  it("keeps model configuration controls out of the session view", () => {
+    expect(agentProgressSource).not.toContain('aria-label="Change agent model"')
+    expect(agentProgressSource).not.toContain('aria-label="Change thinking level"')
+    expect(agentProgressSource).not.toContain('aria-label="Change verbosity"')
+    expect(agentProgressSource).not.toContain("buildAgentModelConfigUpdates")
+    expect(agentProgressSource).not.toContain("Model/provider controls stay available")
+    expect(agentProgressSource).not.toContain("always render so model picker, thinking,")
   })
 
   it("keeps inline tool approval cards readable in narrow tiles and under zoom", () => {

--- a/apps/desktop/src/renderer/src/components/agent-progress.tsx
+++ b/apps/desktop/src/renderer/src/components/agent-progress.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { cn } from "@renderer/lib/utils"
-import type { AgentProgressUpdate, ACPDelegationProgress, ACPSubAgentMessage, Config, ModelPreset } from "../../../shared/types"
+import type { AgentProgressUpdate, ACPDelegationProgress, ACPSubAgentMessage } from "../../../shared/types"
 import { INTERNAL_COMPLETION_NUDGE_TEXT, RESPOND_TO_USER_TOOL, MARK_WORK_COMPLETE_TOOL } from "../../../shared/runtime-tool-names"
 import { ChevronDown, ChevronUp, ChevronRight, X, AlertTriangle, Shield, Check, XCircle, Loader2, Clock, Copy, CheckCheck, GripHorizontal, Moon, Maximize2, Bot, OctagonX, MessageSquare, Brain, Volume2, Wrench, Play, Pause, Pin, GitBranch } from "lucide-react"
 import { MarkdownRenderer } from "@renderer/components/markdown-renderer"
@@ -11,7 +11,7 @@ import { tipcClient } from "@renderer/lib/tipc-client"
 import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { useAgentStore, useMessageQueue, useIsQueuePaused } from "@renderer/stores"
 import { AudioPlayer } from "@renderer/components/audio-player"
-import { useAvailableModelsQuery, useConfigQuery, queryClient } from "@renderer/lib/queries"
+import { useConfigQuery, queryClient } from "@renderer/lib/queries"
 import { useTheme } from "@renderer/contexts/theme-context"
 import { logUI, logExpand } from "@renderer/lib/debug"
 import { useNavigate } from "react-router-dom"
@@ -30,8 +30,6 @@ import {
   getToolActivitySummary,
   TOOL_GROUP_MIN_SIZE,
   getToolCallPreview,
-  getBuiltInModelPresets,
-  DEFAULT_MODEL_PRESET_ID,
 } from "@dotagents/shared"
 import { ToolExecutionStats } from "./tool-execution-stats"
 import { ACPSessionBadge } from "./acp-session-badge"
@@ -163,280 +161,6 @@ const getRunningToolCallNames = (item: DisplayItem): string[] => {
   return item.data.calls
     .filter((_, index) => !item.data.results[index])
     .map((call) => call.name)
-}
-
-type ChatProviderId = NonNullable<Config["agentProviderId"]>
-
-type SessionModelInfo = NonNullable<AgentProgressUpdate["modelInfo"]>
-
-const AGENT_MODEL_FALLBACKS: Record<ChatProviderId, string> = {
-  openai: "gpt-4.1-mini",
-  groq: "openai/gpt-oss-120b",
-  gemini: "gemini-2.5-flash",
-  "chatgpt-web": "gpt-5.4-mini",
-}
-
-const getAgentProviderId = (config: Config | undefined): ChatProviderId => (
-  config?.agentProviderId || config?.mcpToolsProviderId || "openai"
-)
-
-const getMergedModelPresets = (config: Config | undefined): ModelPreset[] => {
-  const builtIn = getBuiltInModelPresets()
-  const saved = config?.modelPresets || []
-  const mergedBuiltIn = builtIn.map((preset) => {
-    const savedPreset = saved.find((candidate) => candidate.id === preset.id)
-    if (!savedPreset) {
-      if (preset.id === DEFAULT_MODEL_PRESET_ID && config?.openaiApiKey) {
-        return { ...preset, apiKey: config.openaiApiKey }
-      }
-      return preset
-    }
-    const merged = { ...preset, ...savedPreset }
-    if (preset.id === DEFAULT_MODEL_PRESET_ID && !merged.apiKey && config?.openaiApiKey) {
-      merged.apiKey = config.openaiApiKey
-    }
-    return merged
-  })
-  return [...mergedBuiltIn, ...saved.filter((preset) => !preset.isBuiltIn)]
-}
-
-const getActiveModelPreset = (config: Config | undefined): ModelPreset | undefined => {
-  const currentPresetId = config?.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
-  return getMergedModelPresets(config).find((preset) => preset.id === currentPresetId)
-}
-
-const getConfiguredAgentModel = (config: Config | undefined, providerId: ChatProviderId): string => {
-  if (providerId === "openai") {
-    const activePreset = getActiveModelPreset(config)
-    return config?.agentOpenaiModel || config?.mcpToolsOpenaiModel || activePreset?.agentModel || activePreset?.mcpToolsModel || AGENT_MODEL_FALLBACKS.openai
-  }
-  if (providerId === "groq") return config?.agentGroqModel || config?.mcpToolsGroqModel || AGENT_MODEL_FALLBACKS.groq
-  if (providerId === "gemini") return config?.agentGeminiModel || config?.mcpToolsGeminiModel || AGENT_MODEL_FALLBACKS.gemini
-  return config?.agentChatgptWebModel || config?.mcpToolsChatgptWebModel || AGENT_MODEL_FALLBACKS["chatgpt-web"]
-}
-
-const getModelDisplayName = (model: string): string => model.split("/").pop() || model
-
-const SESSION_CONTROL_SELECT_CLASS =
-  "h-[18px] min-w-0 max-w-full cursor-pointer rounded border-0 bg-transparent py-0 pl-0 pr-4 text-[10px] text-muted-foreground/80 shadow-none outline-none hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-default disabled:opacity-60"
-
-const buildAgentModelConfigUpdates = (config: Config, providerId: ChatProviderId, modelId: string): Partial<Config> => {
-  if (providerId === "openai") {
-    const currentPresetId = config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
-    const existingPresets = config.modelPresets || []
-    const existingPreset = existingPresets.find((preset) => preset.id === currentPresetId)
-    const builtInPreset = getBuiltInModelPresets().find((preset) => preset.id === currentPresetId)
-    const presetBase = existingPreset || builtInPreset
-    const updatedPreset: ModelPreset | undefined = presetBase
-      ? {
-          ...presetBase,
-          apiKey: presetBase.apiKey || (currentPresetId === DEFAULT_MODEL_PRESET_ID ? config.openaiApiKey || "" : ""),
-          agentModel: modelId,
-          mcpToolsModel: modelId,
-          updatedAt: Date.now(),
-        }
-      : undefined
-
-    return {
-      agentOpenaiModel: modelId,
-      mcpToolsOpenaiModel: modelId,
-      ...(updatedPreset
-        ? {
-            modelPresets: existingPreset
-              ? existingPresets.map((preset) => preset.id === currentPresetId ? updatedPreset : preset)
-              : [...existingPresets, updatedPreset],
-          }
-        : {}),
-    }
-  }
-
-  if (providerId === "groq") return { agentGroqModel: modelId, mcpToolsGroqModel: modelId }
-  if (providerId === "gemini") return { agentGeminiModel: modelId, mcpToolsGeminiModel: modelId }
-  return { agentChatgptWebModel: modelId, mcpToolsChatgptWebModel: modelId }
-}
-
-const SessionModelPicker: React.FC<{
-  modelInfo?: SessionModelInfo
-  compact?: boolean
-}> = ({ modelInfo, compact = false }) => {
-  const configQuery = useConfigQuery()
-  const config = configQuery.data
-  const providerId = getAgentProviderId(config)
-  const configuredModel = getConfiguredAgentModel(config, providerId)
-  const sessionModel = modelInfo?.model
-  const currentValue = configuredModel || sessionModel || AGENT_MODEL_FALLBACKS[providerId]
-  const providerLabel = modelInfo?.provider || getActiveModelPreset(config)?.name || providerId
-  const modelsQuery = useAvailableModelsQuery(providerId, !!providerId, providerId === "openai" ? config?.currentModelPresetId || DEFAULT_MODEL_PRESET_ID : undefined)
-  const modelOptions = useMemo(() => {
-    const options = [...(modelsQuery.data || [])]
-    if (currentValue && !options.some((model) => model.id === currentValue)) {
-      options.unshift({ id: currentValue, name: getModelDisplayName(currentValue) })
-    }
-    return options
-  }, [currentValue, modelsQuery.data])
-
-  const handleModelChange = useCallback(async (modelId: string) => {
-    if (!config || modelId === currentValue) return
-    try {
-      await tipcClient.saveConfig({
-        config: {
-          ...config,
-          ...buildAgentModelConfigUpdates(config, providerId, modelId),
-        },
-      })
-      await queryClient.invalidateQueries({ queryKey: ["config"] })
-      await queryClient.invalidateQueries({ queryKey: ["available-models"] })
-      toast.success("Agent model updated")
-    } catch (error) {
-      console.error("Failed to update agent model:", error)
-      toast.error("Failed to update model")
-    }
-  }, [config, currentValue, providerId])
-
-  if (!currentValue) return null
-
-  return (
-    <select
-      value={currentValue}
-      onChange={(event) => void handleModelChange(event.currentTarget.value)}
-      disabled={!config}
-      className={cn(SESSION_CONTROL_SELECT_CLASS, compact ? "max-w-[150px]" : "max-w-[170px]")}
-      title={`Change agent model (${providerLabel}/${currentValue})`}
-      aria-label="Change agent model"
-      onClick={(event) => event.stopPropagation()}
-    >
-      {modelOptions.map((model) => (
-        <option key={model.id} value={model.id}>
-          {providerLabel}/{model.name || getModelDisplayName(model.id)}
-        </option>
-      ))}
-      {modelsQuery.isLoading && modelOptions.length === 0 && (
-        <option value={currentValue}>Loading models...</option>
-      )}
-      {modelOptions.length === 0 && !modelsQuery.isLoading && (
-        <option value={currentValue}>No models available</option>
-      )}
-    </select>
-  )
-}
-
-type ReasoningEffort = NonNullable<Config["openaiReasoningEffort"]>
-type CodexVerbosity = NonNullable<Config["codexTextVerbosity"]>
-
-const REASONING_EFFORT_OPTIONS: Array<{ value: ReasoningEffort; label: string }> = [
-  { value: "none", label: "None" },
-  { value: "minimal", label: "Minimal" },
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-  { value: "xhigh", label: "Extra high" },
-]
-
-const VERBOSITY_OPTIONS: Array<{ value: CodexVerbosity; label: string }> = [
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-]
-
-const providerSupportsThinking = (providerId: ChatProviderId): boolean =>
-  providerId === "openai" || providerId === "chatgpt-web"
-
-const providerSupportsVerbosity = (providerId: ChatProviderId): boolean =>
-  providerId === "chatgpt-web"
-
-const SessionThinkingPicker: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
-  const configQuery = useConfigQuery()
-  const config = configQuery.data
-  const providerId = getAgentProviderId(config)
-
-  const currentValue: ReasoningEffort = (config?.openaiReasoningEffort as ReasoningEffort | undefined) ||
-    (providerId === "chatgpt-web" ? "low" : "medium")
-
-  const handleChange = useCallback(async (value: string) => {
-    if (!config || value === currentValue) return
-    try {
-      await tipcClient.saveConfig({
-        config: { ...config, openaiReasoningEffort: value as ReasoningEffort },
-      })
-      await queryClient.invalidateQueries({ queryKey: ["config"] })
-      toast.success("Thinking level updated")
-    } catch (error) {
-      console.error("Failed to update thinking level:", error)
-      toast.error("Failed to update thinking level")
-    }
-  }, [config, currentValue])
-
-  if (!providerSupportsThinking(providerId)) return null
-
-  const currentLabel = REASONING_EFFORT_OPTIONS.find((o) => o.value === currentValue)?.label || currentValue
-
-  return (
-    <span className="inline-flex min-w-0 items-center gap-1">
-      <Brain className="h-3 w-3 shrink-0 opacity-70" />
-      <select
-        value={currentValue}
-        onChange={(event) => void handleChange(event.currentTarget.value)}
-        disabled={!config}
-        className={cn(SESSION_CONTROL_SELECT_CLASS, compact ? "max-w-[82px]" : "max-w-[105px]")}
-        title={`Thinking level (${currentLabel})`}
-        aria-label="Change thinking level"
-        onClick={(event) => event.stopPropagation()}
-      >
-        {REASONING_EFFORT_OPTIONS.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </span>
-  )
-}
-
-const SessionVerbosityPicker: React.FC<{ compact?: boolean }> = ({ compact = false }) => {
-  const configQuery = useConfigQuery()
-  const config = configQuery.data
-  const providerId = getAgentProviderId(config)
-
-  const currentValue: CodexVerbosity = (config?.codexTextVerbosity as CodexVerbosity | undefined) || "medium"
-
-  const handleChange = useCallback(async (value: string) => {
-    if (!config || value === currentValue) return
-    try {
-      await tipcClient.saveConfig({
-        config: { ...config, codexTextVerbosity: value as CodexVerbosity },
-      })
-      await queryClient.invalidateQueries({ queryKey: ["config"] })
-      toast.success("Verbosity updated")
-    } catch (error) {
-      console.error("Failed to update verbosity:", error)
-      toast.error("Failed to update verbosity")
-    }
-  }, [config, currentValue])
-
-  if (!providerSupportsVerbosity(providerId)) return null
-
-  const currentLabel = VERBOSITY_OPTIONS.find((o) => o.value === currentValue)?.label || currentValue
-
-  return (
-    <span className="inline-flex min-w-0 items-center gap-1">
-      <Volume2 className="h-3 w-3 shrink-0 opacity-70" />
-      <select
-        value={currentValue}
-        onChange={(event) => void handleChange(event.currentTarget.value)}
-        disabled={!config}
-        className={cn(SESSION_CONTROL_SELECT_CLASS, compact ? "max-w-[70px]" : "max-w-[90px]")}
-        title={`Verbosity (${currentLabel})`}
-        aria-label="Change verbosity"
-        onClick={(event) => event.stopPropagation()}
-      >
-        {VERBOSITY_OPTIONS.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </span>
-  )
 }
 
 const COLLAPSIBLE_PAYLOAD_LINE_THRESHOLD = 2
@@ -3951,7 +3675,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
     conversationHistory,
     sessionStartIndex,
     contextInfo,
-    modelInfo,
     profileName,
     acpSessionInfo,
   } = progress
@@ -5405,8 +5128,7 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               </div>
             )}
 
-            {/* Footer with status/model controls — always render so model picker, thinking,
-                and verbosity stay reachable on inactive sessions too. */}
+            {/* Footer with session status metadata. */}
             <div
               className={cn(
                 "border-t bg-muted/20 text-muted-foreground flex-shrink-0",
@@ -5422,9 +5144,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
                     </span>
                   )}
                   {profileName && <span className="text-muted-foreground/50">•</span>}
-                  <SessionModelPicker modelInfo={modelInfo} compact />
-                  <SessionThinkingPicker compact />
-                  <SessionVerbosityPicker compact />
                   {!isComplete && contextInfo && contextInfo.maxTokens > 0 && (
                     <div className="flex shrink-0 items-center gap-1">
                       <div className="w-8 h-1 bg-muted rounded-full overflow-hidden">
@@ -5549,13 +5268,6 @@ export const AgentProgress: React.FC<AgentProgressProps> = ({
               {profileName}
             </span>
           )}
-          {/* Model/provider controls stay available even before live session metadata arrives */}
-          <>
-            {profileName && <span className="text-muted-foreground/50">•</span>}
-            <SessionModelPicker modelInfo={modelInfo} />
-            <SessionThinkingPicker />
-            <SessionVerbosityPicker />
-          </>
           {/* Context fill indicator */}
           {!isComplete && contextInfo && contextInfo.maxTokens > 0 && (
             <div className="flex items-center gap-1.5">

--- a/apps/desktop/src/renderer/src/components/app-bottom-bar.test.ts
+++ b/apps/desktop/src/renderer/src/components/app-bottom-bar.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+const bottomBarSource = readFileSync(
+  new URL("./app-bottom-bar.tsx", import.meta.url),
+  "utf8",
+)
+const appLayoutSource = readFileSync(
+  new URL("./app-layout.tsx", import.meta.url),
+  "utf8",
+)
+
+describe("app bottom bar", () => {
+  it("renders as app chrome instead of sidebar content", () => {
+    expect(appLayoutSource).toContain(
+      'import { AppBottomBar } from "@renderer/components/app-bottom-bar"',
+    )
+    expect(appLayoutSource).toContain('className="flex h-dvh flex-col"')
+    expect(appLayoutSource).toContain("<AppBottomBar />")
+    expect(appLayoutSource).not.toContain("process.env.APP_VERSION")
+    expect(bottomBarSource).toContain("process.env.APP_VERSION")
+  })
+
+  it("exposes repeat tasks and model controls from the footer", () => {
+    expect(bottomBarSource).toContain('navigate("/settings/repeat-tasks")')
+    expect(bottomBarSource).toContain('queryKey: ["loops"]')
+    expect(bottomBarSource).toContain(
+      "rendererHandlers.loopsFolderChanged.listen",
+    )
+    expect(bottomBarSource).toContain("CHAT_PROVIDERS")
+    expect(bottomBarSource).toContain('aria-label="Change agent provider"')
+    expect(bottomBarSource).toContain('aria-label="Change agent model"')
+    expect(bottomBarSource).not.toContain(">Provider<")
+    expect(bottomBarSource).not.toContain(">Model<")
+    expect(bottomBarSource).toContain('aria-label="Change thinking level"')
+    expect(bottomBarSource).toContain('aria-label="Change verbosity"')
+  })
+
+  it("updates the same config fields as settings model controls", () => {
+    expect(bottomBarSource).toContain("agentProviderId")
+    expect(bottomBarSource).toContain("buildAgentModelConfigUpdates")
+    expect(bottomBarSource).toContain("DEFAULT_MODEL_PRESET_ID")
+    expect(bottomBarSource).toContain("useAvailableModelsQuery")
+    expect(bottomBarSource).toContain("openaiReasoningEffort")
+    expect(bottomBarSource).toContain("codexTextVerbosity")
+  })
+})

--- a/apps/desktop/src/renderer/src/components/app-bottom-bar.tsx
+++ b/apps/desktop/src/renderer/src/components/app-bottom-bar.tsx
@@ -1,0 +1,384 @@
+import { useEffect, useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useNavigate } from "react-router-dom"
+import {
+  CHAT_PROVIDERS,
+  DEFAULT_MODEL_PRESET_ID,
+  getBuiltInModelPresets,
+  type CHAT_PROVIDER_ID,
+} from "@dotagents/shared"
+import type { Config, LoopConfig, ModelPreset } from "@shared/types"
+import {
+  queryClient,
+  useAvailableModelsQuery,
+  useConfigQuery,
+  useSaveConfigMutation,
+} from "@renderer/lib/queries"
+import { rendererHandlers, tipcClient } from "@renderer/lib/tipc-client"
+import { cn } from "@renderer/lib/utils"
+
+type ReasoningEffort = NonNullable<Config["openaiReasoningEffort"]>
+type CodexVerbosity = NonNullable<Config["codexTextVerbosity"]>
+
+const BAR_SELECT_CLASS =
+  "h-5 min-w-0 cursor-pointer rounded border-0 bg-transparent py-0 pl-0 pr-5 text-[11px] text-muted-foreground outline-none hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-default disabled:opacity-60"
+
+const AGENT_MODEL_FALLBACKS: Record<CHAT_PROVIDER_ID, string> = {
+  openai: "gpt-5.5",
+  groq: "llama-3.3-70b-versatile",
+  gemini: "gemini-2.5-pro",
+  "chatgpt-web": "gpt-5.5",
+}
+
+const REASONING_EFFORT_OPTIONS: Array<{
+  value: ReasoningEffort
+  label: string
+}> = [
+  { value: "none", label: "None" },
+  { value: "minimal", label: "Minimal" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra high" },
+]
+
+const VERBOSITY_OPTIONS: Array<{ value: CodexVerbosity; label: string }> = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+]
+
+const getAgentProviderId = (config: Config | undefined): CHAT_PROVIDER_ID => {
+  return config?.agentProviderId || config?.mcpToolsProviderId || "openai"
+}
+
+const getMergedModelPresets = (config: Config | undefined): ModelPreset[] => {
+  const builtIn = getBuiltInModelPresets()
+  const saved = config?.modelPresets || []
+  const mergedBuiltIn = builtIn.map((preset) => {
+    const savedPreset = saved.find((candidate) => candidate.id === preset.id)
+    if (!savedPreset) {
+      if (preset.id === DEFAULT_MODEL_PRESET_ID && config?.openaiApiKey) {
+        return { ...preset, apiKey: config.openaiApiKey }
+      }
+      return preset
+    }
+    const merged = { ...preset, ...savedPreset }
+    if (
+      preset.id === DEFAULT_MODEL_PRESET_ID &&
+      !merged.apiKey &&
+      config?.openaiApiKey
+    ) {
+      merged.apiKey = config.openaiApiKey
+    }
+    return merged
+  })
+  return [...mergedBuiltIn, ...saved.filter((preset) => !preset.isBuiltIn)]
+}
+
+const getActiveModelPreset = (
+  config: Config | undefined,
+): ModelPreset | undefined => {
+  const currentPresetId =
+    config?.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
+  return getMergedModelPresets(config).find(
+    (preset) => preset.id === currentPresetId,
+  )
+}
+
+const getConfiguredAgentModel = (
+  config: Config | undefined,
+  providerId: CHAT_PROVIDER_ID,
+): string => {
+  if (providerId === "openai") {
+    const activePreset = getActiveModelPreset(config)
+    return (
+      config?.agentOpenaiModel ||
+      config?.mcpToolsOpenaiModel ||
+      activePreset?.agentModel ||
+      activePreset?.mcpToolsModel ||
+      AGENT_MODEL_FALLBACKS.openai
+    )
+  }
+  if (providerId === "groq") {
+    return (
+      config?.agentGroqModel ||
+      config?.mcpToolsGroqModel ||
+      AGENT_MODEL_FALLBACKS.groq
+    )
+  }
+  if (providerId === "gemini") {
+    return (
+      config?.agentGeminiModel ||
+      config?.mcpToolsGeminiModel ||
+      AGENT_MODEL_FALLBACKS.gemini
+    )
+  }
+  return (
+    config?.agentChatgptWebModel ||
+    config?.mcpToolsChatgptWebModel ||
+    AGENT_MODEL_FALLBACKS["chatgpt-web"]
+  )
+}
+
+const getModelDisplayName = (model: string): string =>
+  model.split("/").pop() || model
+
+const buildAgentModelConfigUpdates = (
+  config: Config,
+  providerId: CHAT_PROVIDER_ID,
+  modelId: string,
+): Partial<Config> => {
+  if (providerId === "openai") {
+    const currentPresetId =
+      config.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
+    const existingPresets = config.modelPresets || []
+    const existingPreset = existingPresets.find(
+      (preset) => preset.id === currentPresetId,
+    )
+    const builtInPreset = getBuiltInModelPresets().find(
+      (preset) => preset.id === currentPresetId,
+    )
+    const presetBase = existingPreset || builtInPreset
+    const updatedPreset: ModelPreset | undefined = presetBase
+      ? {
+          ...presetBase,
+          apiKey:
+            presetBase.apiKey ||
+            (currentPresetId === DEFAULT_MODEL_PRESET_ID
+              ? config.openaiApiKey || ""
+              : ""),
+          agentModel: modelId,
+          mcpToolsModel: modelId,
+          updatedAt: Date.now(),
+        }
+      : undefined
+
+    return {
+      agentOpenaiModel: modelId,
+      mcpToolsOpenaiModel: modelId,
+      ...(updatedPreset
+        ? {
+            modelPresets: existingPreset
+              ? existingPresets.map((preset) =>
+                  preset.id === currentPresetId ? updatedPreset : preset,
+                )
+              : [...existingPresets, updatedPreset],
+          }
+        : {}),
+    }
+  }
+
+  if (providerId === "groq") {
+    return { agentGroqModel: modelId, mcpToolsGroqModel: modelId }
+  }
+  if (providerId === "gemini") {
+    return { agentGeminiModel: modelId, mcpToolsGeminiModel: modelId }
+  }
+  return { agentChatgptWebModel: modelId, mcpToolsChatgptWebModel: modelId }
+}
+
+const providerSupportsThinking = (providerId: CHAT_PROVIDER_ID): boolean =>
+  providerId === "openai" || providerId === "chatgpt-web"
+
+const providerSupportsVerbosity = (providerId: CHAT_PROVIDER_ID): boolean =>
+  providerId === "chatgpt-web"
+
+export function AppBottomBar() {
+  const navigate = useNavigate()
+  const configQuery = useConfigQuery()
+  const saveConfigMutation = useSaveConfigMutation()
+  const config = configQuery.data
+  const providerId = getAgentProviderId(config)
+  const currentModel = getConfiguredAgentModel(config, providerId)
+  const providerLabel =
+    CHAT_PROVIDERS.find((provider) => provider.value === providerId)?.label ||
+    providerId
+  const activePreset = getActiveModelPreset(config)
+  const modelsQuery = useAvailableModelsQuery(
+    providerId,
+    !!providerId,
+    providerId === "openai"
+      ? config?.currentModelPresetId || DEFAULT_MODEL_PRESET_ID
+      : undefined,
+  )
+  const loopsQuery = useQuery({
+    queryKey: ["loops"],
+    queryFn: async () => tipcClient.getLoops(),
+  })
+
+  useEffect(() => {
+    return rendererHandlers.loopsFolderChanged.listen(() => {
+      queryClient.invalidateQueries({ queryKey: ["loops"] })
+    })
+  }, [])
+
+  const modelOptions = useMemo(() => {
+    const options = [...(modelsQuery.data || [])]
+    if (currentModel && !options.some((model) => model.id === currentModel)) {
+      options.unshift({
+        id: currentModel,
+        name: getModelDisplayName(currentModel),
+      })
+    }
+    return options
+  }, [currentModel, modelsQuery.data])
+
+  const loops = (loopsQuery.data || []) as LoopConfig[]
+  const enabledLoopCount = loops.filter((loop) => loop.enabled).length
+  const loopSummary =
+    loops.length > 0 ? `${enabledLoopCount}/${loops.length}` : "0"
+  const reasoningValue: ReasoningEffort =
+    (config?.openaiReasoningEffort as ReasoningEffort | undefined) ||
+    (providerId === "chatgpt-web" ? "low" : "medium")
+  const verbosityValue: CodexVerbosity =
+    (config?.codexTextVerbosity as CodexVerbosity | undefined) || "medium"
+
+  const saveConfig = (updates: Partial<Config>) => {
+    if (!config) return
+    saveConfigMutation.mutate({ config: { ...config, ...updates } })
+  }
+
+  const handleProviderChange = (nextProviderId: string) => {
+    if (!config || nextProviderId === providerId) return
+    saveConfig({ agentProviderId: nextProviderId as CHAT_PROVIDER_ID })
+  }
+
+  const handleModelChange = (modelId: string) => {
+    if (!config || modelId === currentModel) return
+    saveConfig(buildAgentModelConfigUpdates(config, providerId, modelId))
+  }
+
+  return (
+    <footer
+      className="app-bottom-bar bg-background/95 text-muted-foreground flex h-7 shrink-0 items-center justify-between gap-3 border-t px-2 text-[11px] backdrop-blur"
+      aria-label="Application status and controls"
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={() => navigate("/settings/repeat-tasks")}
+          className="hover:bg-accent hover:text-foreground flex h-5 items-center gap-1 rounded px-1.5 transition-colors"
+          title="Open and edit repeat tasks"
+        >
+          <span className="i-mingcute-refresh-3-line h-3.5 w-3.5 shrink-0" />
+          <span className="hidden sm:inline">Repeat Tasks</span>
+          <span className="tabular-nums">{loopSummary}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate("/settings/models")}
+          className="hover:bg-accent hover:text-foreground hidden h-5 items-center gap-1 rounded px-1.5 transition-colors md:flex"
+          title="Open model settings"
+        >
+          <span className="i-mingcute-brain-line h-3.5 w-3.5 shrink-0" />
+          <span>Models</span>
+        </button>
+      </div>
+
+      <div className="flex min-w-0 flex-1 items-center justify-center gap-2 overflow-hidden">
+        <label className="flex min-w-0 items-center gap-1">
+          <select
+            value={providerId}
+            onChange={(event) =>
+              handleProviderChange(event.currentTarget.value)
+            }
+            disabled={!config || saveConfigMutation.isPending}
+            className={cn(BAR_SELECT_CLASS, "max-w-[125px]")}
+            title={`Agent provider (${providerLabel})`}
+            aria-label="Change agent provider"
+          >
+            {CHAT_PROVIDERS.map((provider) => (
+              <option key={provider.value} value={provider.value}>
+                {provider.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex min-w-0 items-center gap-1">
+          <select
+            value={currentModel}
+            onChange={(event) => handleModelChange(event.currentTarget.value)}
+            disabled={!config || saveConfigMutation.isPending}
+            className={cn(BAR_SELECT_CLASS, "max-w-[180px]")}
+            title={`Agent model (${activePreset?.name || providerLabel}/${currentModel})`}
+            aria-label="Change agent model"
+          >
+            {modelOptions.map((model) => (
+              <option key={model.id} value={model.id}>
+                {model.name || getModelDisplayName(model.id)}
+              </option>
+            ))}
+            {modelsQuery.isLoading && modelOptions.length === 0 && (
+              <option value={currentModel}>Loading models...</option>
+            )}
+            {modelOptions.length === 0 && !modelsQuery.isLoading && (
+              <option value={currentModel}>No models available</option>
+            )}
+          </select>
+        </label>
+
+        {providerSupportsThinking(providerId) && (
+          <label className="flex shrink-0 items-center gap-1">
+            <span className="i-mingcute-brain-line h-3.5 w-3.5" />
+            <select
+              value={reasoningValue}
+              onChange={(event) =>
+                saveConfig({
+                  openaiReasoningEffort: event.currentTarget
+                    .value as ReasoningEffort,
+                })
+              }
+              disabled={!config || saveConfigMutation.isPending}
+              className={cn(BAR_SELECT_CLASS, "max-w-[92px]")}
+              title="Change thinking level"
+              aria-label="Change thinking level"
+            >
+              {REASONING_EFFORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {providerSupportsVerbosity(providerId) && (
+          <label className="flex shrink-0 items-center gap-1">
+            <span className="i-mingcute-chat-3-line h-3.5 w-3.5" />
+            <select
+              value={verbosityValue}
+              onChange={(event) =>
+                saveConfig({
+                  codexTextVerbosity: event.currentTarget
+                    .value as CodexVerbosity,
+                })
+              }
+              disabled={!config || saveConfigMutation.isPending}
+              className={cn(BAR_SELECT_CLASS, "max-w-[82px]")}
+              title="Change verbosity"
+              aria-label="Change verbosity"
+            >
+              {VERBOSITY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => navigate("/settings")}
+        className="hover:bg-accent hover:text-foreground flex h-5 shrink-0 items-center gap-1 rounded px-1.5 tabular-nums transition-colors"
+        title="Open settings"
+      >
+        <span className="i-mingcute-settings-3-line h-3.5 w-3.5" />
+        <span>v{process.env.APP_VERSION}</span>
+      </button>
+    </footer>
+  )
+}

--- a/apps/desktop/src/renderer/src/components/app-layout.session-retention.test.ts
+++ b/apps/desktop/src/renderer/src/components/app-layout.session-retention.test.ts
@@ -1,58 +1,104 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
 
-const appLayoutSource = readFileSync(new URL("./app-layout.tsx", import.meta.url), "utf8")
+const appLayoutSource = readFileSync(
+  new URL("./app-layout.tsx", import.meta.url),
+  "utf8",
+)
 
 describe("app layout session retention", () => {
   it("keeps store-backed sessions in the collapsed active preview list", () => {
-    expect(appLayoutSource).toContain("const trackedActiveSessions = sessionData?.activeSessions ?? []")
-    expect(appLayoutSource).toContain("for (const [sessionId, progress] of agentProgressById.entries())")
-    expect(appLayoutSource).toContain('status: progress.isComplete')
-    expect(appLayoutSource).toContain("const isVisiblyActive = isFocused || !isSnoozed")
+    expect(appLayoutSource).toContain(
+      "const trackedActiveSessions = sessionData?.activeSessions ?? []",
+    )
+    expect(appLayoutSource).toContain(
+      "for (const [sessionId, progress] of agentProgressById.entries())",
+    )
+    expect(appLayoutSource).toContain("status: progress.isComplete")
+    expect(appLayoutSource).toContain(
+      "const isVisiblyActive = isFocused || !isSnoozed",
+    )
   })
 
   it("shows compact multi-character labels for collapsed session previews", () => {
-    expect(appLayoutSource).toContain('const collapsedTitle = title.replace(/\\s+/g, " ")')
-    expect(appLayoutSource).toContain('rounded-md px-0.5 transition-all duration-200')
     expect(appLayoutSource).toContain(
-      'max-w-[calc(100%-0.375rem)] line-clamp-2 text-center text-[7px] font-medium leading-[0.55rem] tracking-tight [overflow-wrap:anywhere]',
+      'const collapsedTitle = title.replace(/\\s+/g, " ")',
     )
-    expect(appLayoutSource).toContain("const handleCollapsedSessionsOverviewClick = useCallback(() => {")
+    expect(appLayoutSource).toContain(
+      "rounded-md px-0.5 transition-all duration-200",
+    )
+    expect(appLayoutSource).toContain(
+      "line-clamp-2 max-w-[calc(100%-0.375rem)] text-center text-[7px] font-medium leading-[0.55rem] tracking-tight [overflow-wrap:anywhere]",
+    )
+    expect(appLayoutSource).toContain(
+      "const handleCollapsedSessionsOverviewClick = useCallback(() => {",
+    )
     expect(appLayoutSource).toContain("setSavedConversationsDialogOpen(true)")
     expect(appLayoutSource).toContain("handleCollapsedSessionsOverviewClick()")
-    expect(appLayoutSource).toContain("const handleCollapsedSessionClick = useCallback(")
+    expect(appLayoutSource).toContain(
+      "const handleCollapsedSessionClick = useCallback(",
+    )
     expect(appLayoutSource).toContain("setScrollToSessionId(sessionId)")
-    expect(appLayoutSource).toContain('aria-label={`Open session ${title}`}')
-    expect(appLayoutSource).not.toContain('const initial = title.charAt(0).toUpperCase()')
+    expect(appLayoutSource).toContain("aria-label={`Open session ${title}`}")
+    expect(appLayoutSource).not.toContain(
+      "const initial = title.charAt(0).toUpperCase()",
+    )
   })
 
   it("archives the focused session from Ctrl+W using the backing conversation id", () => {
-    expect(appLayoutSource).toContain("const handleArchiveFocusedSession = useCallback(async () => {")
+    expect(appLayoutSource).toContain(
+      "const handleArchiveFocusedSession = useCallback(async () => {",
+    )
     expect(appLayoutSource).toContain("store.focusedSessionId")
     expect(appLayoutSource).toContain("store.expandedSessionId")
     expect(appLayoutSource).toContain("store.viewedConversationId")
     expect(appLayoutSource).toContain("if (archiveCandidates.length === 0)")
-    expect(appLayoutSource).toContain("const fallbackCandidates = Array.from(new Set([")
+    expect(appLayoutSource).toContain("const fallbackCandidates = Array.from(")
     expect(appLayoutSource).toContain("addSessionCandidate(fallback.sessionId)")
-    expect(appLayoutSource).toContain("progress?.conversationId ?? trackedSession?.conversationId")
-    expect(appLayoutSource).toContain("store.toggleArchiveSession(conversationId)")
-    expect(appLayoutSource).not.toContain('toast.message("No focused session to archive")')
-    expect(appLayoutSource).toContain('if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return')
-    expect(appLayoutSource).toContain('if (event.key.toLowerCase() !== "w") return')
+    expect(appLayoutSource).toContain(
+      "progress?.conversationId ?? trackedSession?.conversationId",
+    )
+    expect(appLayoutSource).toContain(
+      "store.toggleArchiveSession(conversationId)",
+    )
+    expect(appLayoutSource).not.toContain(
+      'toast.message("No focused session to archive")',
+    )
+    expect(appLayoutSource).toContain(
+      "if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)",
+    )
+    expect(appLayoutSource).toContain(
+      'if (event.key.toLowerCase() !== "w") return',
+    )
     expect(appLayoutSource).toContain("void handleArchiveFocusedSession()")
   })
 
   it("opens the archived conversations view from sidebar buttons", () => {
     expect(appLayoutSource).toContain("savedConversationsArchivedOnOpen")
-    expect(appLayoutSource).toContain("initialArchivedOnly={savedConversationsArchivedOnOpen}")
-    expect(appLayoutSource).toContain("const handleOpenArchivedConversationsDialog = useCallback(() => {")
-    expect(appLayoutSource).toContain("openSavedConversationsDialog({ archivedOnly: true })")
+    expect(appLayoutSource).toContain(
+      "initialArchivedOnly={savedConversationsArchivedOnOpen}",
+    )
+    expect(appLayoutSource).toContain(
+      "const handleOpenArchivedConversationsDialog = useCallback(() => {",
+    )
+    expect(appLayoutSource).toContain(
+      "openSavedConversationsDialog({ archivedOnly: true })",
+    )
     expect(appLayoutSource).toContain('title="Archived sessions"')
   })
 
-  it("lets settings move up when the expanded session list shrinks", () => {
-    expect(appLayoutSource).toContain("sessions and settings scroll together")
-    expect(appLayoutSource).toContain("mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden")
-    expect(appLayoutSource).toContain('className="shrink-0"')
+  it("lets normal sessions fill the sidebar without pinned app navigation", () => {
+    expect(appLayoutSource).toContain(
+      "Normal sidebar: sessions fill the available sidebar height.",
+    )
+    expect(appLayoutSource).not.toContain("Sidebar footer - pinned app navigation")
+    expect(appLayoutSource).not.toContain("const sidebarFooterLinks")
+    expect(appLayoutSource).toContain(
+      "mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden",
+    )
+    expect(appLayoutSource).toContain('className="min-h-full"')
+    expect(appLayoutSource).not.toContain(
+      "sessions and settings scroll together",
+    )
   })
 })

--- a/apps/desktop/src/renderer/src/components/app-layout.tsx
+++ b/apps/desktop/src/renderer/src/components/app-layout.tsx
@@ -4,9 +4,14 @@ import { cn } from "@renderer/lib/utils"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { NavLink, Outlet, useNavigate, useLocation } from "react-router-dom"
 import { Button } from "@renderer/components/ui/button"
+import { AppBottomBar } from "@renderer/components/app-bottom-bar"
 import { ActiveAgentsSidebar } from "@renderer/components/active-agents-sidebar"
 import { SandboxSlotIndicator } from "@renderer/components/sandbox-slot-switcher"
-import { SessionActionDialog, type SessionActionDialogMode } from "@renderer/components/session-action-dialog"
+import {
+  SessionActionDialog,
+  type SessionActionDialogMode,
+} from "@renderer/components/session-action-dialog"
+import { SettingsSidebarNavigation } from "@renderer/components/settings-navigation"
 import { useSelectedAgentId } from "@renderer/components/agent-selector"
 
 import { SavedConversationsDialog } from "@renderer/components/past-sessions-dialog"
@@ -18,6 +23,7 @@ import {
 import { useTTSPlaybackController } from "@renderer/lib/tts-playback-controller"
 import { applySelectedAgentToNextSession as applySelectedAgentForNextSession } from "@renderer/lib/apply-selected-agent"
 import { hasUnreadAgentResponse } from "@renderer/lib/sidebar-sessions"
+import { isConsolidatedSettingsRoute } from "@renderer/lib/settings-navigation"
 import { useAgentStore } from "@renderer/stores"
 import {
   Clock,
@@ -28,17 +34,10 @@ import {
   VolumeX,
   OctagonX,
   Loader2,
-  Plug2,
   Plus,
   Mic,
 } from "lucide-react"
 import { toast } from "sonner"
-
-type NavLinkItem = {
-  text: string
-  href: string
-  icon: string | React.ComponentType<{ className?: string }>
-}
 
 interface AgentSession {
   id: string
@@ -72,12 +71,17 @@ export const Component = () => {
   const navigate = useNavigate()
   const location = useLocation()
   const queryClient = useQueryClient()
-  const [settingsExpanded, setSettingsExpanded] = useState(true)
-  const [savedConversationsDialogOpen, setSavedConversationsDialogOpen] = useState(false)
-  const [savedConversationsHotkeyOpen, setSavedConversationsHotkeyOpen] = useState(false)
-  const [savedConversationsArchivedOnOpen, setSavedConversationsArchivedOnOpen] = useState(false)
+  const [savedConversationsDialogOpen, setSavedConversationsDialogOpen] =
+    useState(false)
+  const [savedConversationsHotkeyOpen, setSavedConversationsHotkeyOpen] =
+    useState(false)
+  const [
+    savedConversationsArchivedOnOpen,
+    setSavedConversationsArchivedOnOpen,
+  ] = useState(false)
   const [isEmergencyStopping, setIsEmergencyStopping] = useState(false)
-  const [sessionActionDialog, setSessionActionDialog] = useState<SessionActionDialogState | null>(null)
+  const [sessionActionDialog, setSessionActionDialog] =
+    useState<SessionActionDialogState | null>(null)
   const [selectedAgentId, setSelectedAgentId] = useSelectedAgentId()
   const { isCollapsed, width, isResizing, toggleCollapse, handleResizeStart } =
     useSidebar()
@@ -110,8 +114,6 @@ export const Component = () => {
     return unlisten
   }, [isCollapsed, refetchSessionData])
 
-  const whatsappEnabled = configQuery.data?.whatsappEnabled ?? false
-  const discordEnabled = configQuery.data?.discordEnabled ?? false
   const isGlobalTTSEnabled = configQuery.data?.ttsEnabled ?? true
   const trackedActiveSessions = sessionData?.activeSessions ?? []
   const collapsedActiveSessions = useMemo(() => {
@@ -122,13 +124,14 @@ export const Component = () => {
     for (const [sessionId, progress] of agentProgressById.entries()) {
       const existingSession = mergedSessions.get(sessionId)
       const firstHistoryTimestamp = progress.conversationHistory?.[0]?.timestamp
-      const lastHistoryTimestamp = progress.conversationHistory?.[
-        progress.conversationHistory.length - 1
-      ]?.timestamp
+      const lastHistoryTimestamp =
+        progress.conversationHistory?.[progress.conversationHistory.length - 1]
+          ?.timestamp
 
       mergedSessions.set(sessionId, {
         id: sessionId,
-        conversationId: progress.conversationId ?? existingSession?.conversationId,
+        conversationId:
+          progress.conversationId ?? existingSession?.conversationId,
         conversationTitle:
           progress.conversationTitle ?? existingSession?.conversationTitle,
         status: progress.isComplete
@@ -139,7 +142,8 @@ export const Component = () => {
           firstHistoryTimestamp ??
           lastHistoryTimestamp ??
           Date.now(),
-        endTime: existingSession?.endTime ??
+        endTime:
+          existingSession?.endTime ??
           (progress.isComplete ? lastHistoryTimestamp : undefined),
         isSnoozed: progress.isSnoozed ?? existingSession?.isSnoozed,
       })
@@ -149,14 +153,16 @@ export const Component = () => {
       const aProgress = agentProgressById.get(a.id)
       const bProgress = agentProgressById.get(b.id)
       const aTimestamp =
-        aProgress?.conversationHistory?.[aProgress.conversationHistory.length - 1]
-          ?.timestamp ??
+        aProgress?.conversationHistory?.[
+          aProgress.conversationHistory.length - 1
+        ]?.timestamp ??
         a.endTime ??
         a.startTime ??
         0
       const bTimestamp =
-        bProgress?.conversationHistory?.[bProgress.conversationHistory.length - 1]
-          ?.timestamp ??
+        bProgress?.conversationHistory?.[
+          bProgress.conversationHistory.length - 1
+        ]?.timestamp ??
         b.endTime ??
         b.startTime ??
         0
@@ -172,20 +178,21 @@ export const Component = () => {
     window.dispatchEvent(new Event("sessions:clear-inactive"))
   }, [navigate])
 
-  const openSavedConversationsDialog = useCallback((options?: {
-    archivedOnly?: boolean
-    focusSearch?: boolean
-  }) => {
-    setSavedConversationsArchivedOnOpen(options?.archivedOnly ?? false)
-    setSavedConversationsHotkeyOpen(options?.focusSearch ?? false)
-    setSavedConversationsDialogOpen(true)
-  }, [])
+  const openSavedConversationsDialog = useCallback(
+    (options?: { archivedOnly?: boolean; focusSearch?: boolean }) => {
+      setSavedConversationsArchivedOnOpen(options?.archivedOnly ?? false)
+      setSavedConversationsHotkeyOpen(options?.focusSearch ?? false)
+      setSavedConversationsDialogOpen(true)
+    },
+    [],
+  )
 
   const handleArchiveFocusedSession = useCallback(async () => {
     const store = useAgentStore.getState()
 
-    let sessionDataSnapshot =
-      queryClient.getQueryData<SessionListResponse>(["agentSessions"])
+    let sessionDataSnapshot = queryClient.getQueryData<SessionListResponse>([
+      "agentSessions",
+    ])
 
     if (!sessionDataSnapshot) {
       try {
@@ -246,33 +253,37 @@ export const Component = () => {
     }
 
     if (archiveCandidates.length === 0) {
-      const fallbackCandidates = Array.from(new Set([
-        ...trackedSessions.map((session) => session.id),
-        ...store.agentProgressById.keys(),
-      ])).map((sessionId) => {
-        const progress = store.agentProgressById.get(sessionId)
-        const trackedSession = sessionById.get(sessionId)
-        const conversationId =
-          progress?.conversationId ?? trackedSession?.conversationId
-        const isActive =
-          progress
+      const fallbackCandidates = Array.from(
+        new Set([
+          ...trackedSessions.map((session) => session.id),
+          ...store.agentProgressById.keys(),
+        ]),
+      )
+        .map((sessionId) => {
+          const progress = store.agentProgressById.get(sessionId)
+          const trackedSession = sessionById.get(sessionId)
+          const conversationId =
+            progress?.conversationId ?? trackedSession?.conversationId
+          const isActive = progress
             ? !progress.isComplete && !progress.isSnoozed
             : trackedSession?.status === "active"
-        return {
-          sessionId,
-          conversationId,
-          isActive,
-          timestamp: getCandidateTimestamp(progress, trackedSession),
-        }
-      }).filter((candidate) => {
-        return (
-          !!candidate.conversationId &&
-          !store.archivedSessionIds.has(candidate.conversationId)
-        )
-      }).sort((a, b) => {
-        if (a.isActive !== b.isActive) return a.isActive ? -1 : 1
-        return b.timestamp - a.timestamp
-      })
+          return {
+            sessionId,
+            conversationId,
+            isActive,
+            timestamp: getCandidateTimestamp(progress, trackedSession),
+          }
+        })
+        .filter((candidate) => {
+          return (
+            !!candidate.conversationId &&
+            !store.archivedSessionIds.has(candidate.conversationId)
+          )
+        })
+        .sort((a, b) => {
+          if (a.isActive !== b.isActive) return a.isActive ? -1 : 1
+          return b.timestamp - a.timestamp
+        })
 
       for (const fallback of fallbackCandidates) {
         addSessionCandidate(fallback.sessionId)
@@ -298,7 +309,8 @@ export const Component = () => {
 
       const canDismiss =
         progress?.isComplete === true ||
-        (trackedSession?.status !== undefined && trackedSession.status !== "active")
+        (trackedSession?.status !== undefined &&
+          trackedSession.status !== "active")
 
       if (sessionId && canDismiss) {
         try {
@@ -349,7 +361,8 @@ export const Component = () => {
         tagName === "select"
 
       if (isEditable) return
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey)
+        return
       if (event.key.toLowerCase() !== "k") return
 
       event.preventDefault()
@@ -372,7 +385,8 @@ export const Component = () => {
         tagName === "select"
 
       if (isEditable) return
-      if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
+      if (!event.ctrlKey || event.metaKey || event.altKey || event.shiftKey)
+        return
       if (event.key.toLowerCase() !== "w") return
 
       event.preventDefault()
@@ -394,18 +408,21 @@ export const Component = () => {
     openSessionActionDialog({ mode: "text" })
   }, [applySelectedAgentToNextSession, openSessionActionDialog])
 
-  const handleStartVoiceSession = useCallback(async (options?: {
-    conversationId?: string
-    continueConversationTitle?: string
-  }) => {
-    const applied = await applySelectedAgentToNextSession()
-    if (!applied) return
-    openSessionActionDialog({
-      mode: "voice",
-      conversationId: options?.conversationId,
-      continueConversationTitle: options?.continueConversationTitle,
-    })
-  }, [applySelectedAgentToNextSession, openSessionActionDialog])
+  const handleStartVoiceSession = useCallback(
+    async (options?: {
+      conversationId?: string
+      continueConversationTitle?: string
+    }) => {
+      const applied = await applySelectedAgentToNextSession()
+      if (!applied) return
+      openSessionActionDialog({
+        mode: "voice",
+        conversationId: options?.conversationId,
+        continueConversationTitle: options?.continueConversationTitle,
+      })
+    },
+    [applySelectedAgentToNextSession, openSessionActionDialog],
+  )
 
   const handleStartPromptSession = useCallback(
     async (content: string) => {
@@ -437,7 +454,10 @@ export const Component = () => {
       const nextEnabled = !(configQuery.data?.ttsEnabled ?? true)
       if (!nextEnabled) {
         try {
-          await tipcClient.controlTTSPlayback({ type: "stop", reason: "collapsed-sidebar-global-tts-disabled" })
+          await tipcClient.controlTTSPlayback({
+            type: "stop",
+            reason: "collapsed-sidebar-global-tts-disabled",
+          })
           await tipcClient.stopAllTts()
         } catch (error) {
           console.error("Failed to stop TTS in all windows:", error)
@@ -455,7 +475,10 @@ export const Component = () => {
 
       setIsEmergencyStopping(true)
       try {
-        await tipcClient.controlTTSPlayback({ type: "stop", reason: "collapsed-sidebar-emergency-stop" })
+        await tipcClient.controlTTSPlayback({
+          type: "stop",
+          reason: "collapsed-sidebar-emergency-stop",
+        })
         await tipcClient.stopAllTts()
       } catch (error) {
         console.error("Failed to stop TTS in all windows:", error)
@@ -486,132 +509,14 @@ export const Component = () => {
     [navigate, setFocusedSessionId, setScrollToSessionId],
   )
 
-  const settingsNavLinks: NavLinkItem[] = [
-    {
-      text: "General",
-      href: "/settings",
-      icon: "i-mingcute-settings-3-line",
-    },
-    {
-      text: "Models",
-      href: "/settings/models",
-      icon: "i-mingcute-brain-line",
-    },
-    {
-      text: "Providers",
-      href: "/settings/providers",
-      icon: Plug2,
-    },
-    {
-      text: "Knowledge",
-      href: "/knowledge",
-      icon: "i-mingcute-book-2-line",
-    },
-    {
-      text: "Agents",
-      href: "/settings/agents",
-      icon: "i-mingcute-group-line",
-    },
-    {
-      text: "Capabilities",
-      href: "/settings/capabilities",
-      icon: "i-mingcute-tool-line",
-    },
-    // Only show WhatsApp settings when enabled
-    ...(whatsappEnabled
-      ? [
-          {
-            text: "WhatsApp",
-            href: "/settings/whatsapp",
-            icon: "i-mingcute-message-4-line",
-          },
-        ]
-      : []),
-    ...(discordEnabled
-      ? [
-          {
-            text: "Discord",
-            href: "/settings/discord",
-            icon: "i-mingcute-discord-line",
-          },
-        ]
-      : []),
-    {
-      text: "Repeat Tasks",
-      href: "/settings/repeat-tasks",
-      icon: "i-mingcute-refresh-3-line",
-    },
-  ]
-
-  // Route aliases that should highlight the same nav item
-  // Maps route paths to their primary nav link href
-  const routeAliases: Record<string, string> = {
-    "/settings/general": "/settings",
-    "/settings/mcp-tools": "/settings/capabilities",
-    "/settings/skills": "/settings/capabilities",
-    "/settings/remote-server": "/settings",
-    "/settings/loops": "/settings/repeat-tasks",
-    "/settings/agents": "/settings/agents",
-  }
-
-  const isAgentsActive =
-    location.pathname === "/settings/agents" ||
-    location.pathname.startsWith("/settings/agents")
-
-  // Check if current path matches the nav link (including aliases)
-  const isNavLinkActive = (linkHref: string): boolean => {
-    const currentPath = location.pathname
-    // Exact match
-    if (currentPath === linkHref) return true
-    // Check if current path is an alias that maps to this link
-    const aliasTarget = routeAliases[currentPath]
-    return aliasTarget === linkHref
-  }
-
   useEffect(() => {
     return rendererHandlers.navigate.listen((url) => {
       navigate(url)
     })
   }, [])
 
-  const renderNavLink = (link: NavLinkItem) => {
-    const isActive = isNavLinkActive(link.href)
-    const icon = typeof link.icon === "string"
-      ? <span className={cn(link.icon, "h-3.5 w-3.5 shrink-0")}></span>
-      : <link.icon className="h-3.5 w-3.5 shrink-0" />
-
-    return (
-      <NavLink
-        key={link.text}
-        to={link.href}
-        role="button"
-        draggable={false}
-        title={isCollapsed ? link.text : undefined}
-        aria-label={isCollapsed ? link.text : undefined}
-        aria-current={isActive ? "page" : undefined}
-        onClick={(e) => {
-          e.preventDefault()
-          navigate(link.href)
-        }}
-        className={() => {
-          return cn(
-            "flex h-6 items-center rounded px-1.5 text-[11px] font-medium transition-all duration-200",
-            isCollapsed ? "justify-center" : "gap-1.5",
-            isActive
-              ? "bg-accent text-accent-foreground"
-              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-          )
-        }}
-      >
-        {icon}
-        {!isCollapsed && (
-          <span className="truncate text-[11px] font-medium leading-4">{link.text}</span>
-        )}
-      </NavLink>
-    )
-  }
-
   const sidebarWidth = isCollapsed ? SIDEBAR_DIMENSIONS.width.collapsed : width
+  const isSettingsSidebarMode = isConsolidatedSettingsRoute(location.pathname)
 
   const isSessionsActive =
     location.pathname === "/" ||
@@ -636,453 +541,400 @@ export const Component = () => {
         }}
       />
 
-      <div className="flex h-dvh">
-        {/* Sidebar with dynamic width */}
-        <div
-          className={cn(
-            "bg-background relative flex shrink-0 flex-col border-r",
-            !isResizing && "transition-all duration-200",
-            isResizing && "select-none",
-          )}
-          style={{ width: sidebarWidth }}
-        >
-          {/* Header with collapse toggle */}
-          <header
+      <div className="flex h-dvh flex-col">
+        <div className="flex min-h-0 flex-1">
+          {/* Sidebar with dynamic width */}
+          <div
             className={cn(
-              "flex shrink-0 items-center",
-              isCollapsed ? "justify-center" : "justify-between",
-              // On macOS, add top padding to clear the traffic-light window controls
-              process.env.IS_MAC ? "pb-1 pt-7 app-drag-region" : "pb-1 pt-2",
-              isCollapsed ? "px-1" : "px-2",
+              "bg-background relative flex shrink-0 flex-col border-r",
+              !isResizing && "transition-all duration-200",
+              isResizing && "select-none",
             )}
+            style={{ width: sidebarWidth }}
           >
-            {!isCollapsed && (
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm-icon"
-                  onClick={handleToggleGlobalTTS}
-                  disabled={!configQuery.data || saveConfigMutation.isPending}
-                  className="app-no-drag-region text-muted-foreground hover:bg-accent/50 hover:text-foreground shrink-0 disabled:opacity-50"
-                  title={
-                    isGlobalTTSEnabled
-                      ? "Disable global TTS"
-                      : "Enable global TTS"
-                  }
-                  aria-label={
-                    isGlobalTTSEnabled
-                      ? "Disable global TTS"
-                      : "Enable global TTS"
-                  }
-                >
-                  {saveConfigMutation.isPending ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : isGlobalTTSEnabled ? (
-                    <Volume2 className="h-3.5 w-3.5" />
-                  ) : (
-                    <VolumeX className="h-3.5 w-3.5" />
-                  )}
-                </Button>
-
-                <Button
-                  variant="ghost"
-                  size="sm-icon"
-                  onClick={handleEmergencyStopAll}
-                  disabled={isEmergencyStopping}
-                  className="app-no-drag-region text-destructive hover:bg-destructive/10 shrink-0 disabled:opacity-50"
-                  title="Emergency stop all agent sessions"
-                  aria-label="Emergency stop all agent sessions"
-                >
-                  {isEmergencyStopping ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <OctagonX className="h-3.5 w-3.5" />
-                  )}
-                </Button>
-              </div>
-            )}
-
-            <Button
-              variant="ghost"
-              size="sm-icon"
-              onClick={toggleCollapse}
+            {/* Header with collapse toggle */}
+            <header
               className={cn(
-                "app-no-drag-region shrink-0",
-                "text-muted-foreground hover:bg-accent hover:text-foreground",
+                "flex shrink-0 items-center",
+                isCollapsed
+                  ? "justify-center"
+                  : isSettingsSidebarMode
+                    ? "justify-end"
+                    : "justify-between",
+                // On macOS, add top padding to clear the traffic-light window controls
+                process.env.IS_MAC ? "app-drag-region pb-1 pt-7" : "pb-1 pt-2",
+                isCollapsed ? "px-1" : "px-2",
               )}
-              title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-              aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
             >
-              {isCollapsed ? (
-                <PanelLeft className="h-3.5 w-3.5" />
-              ) : (
-                <PanelLeftClose className="h-3.5 w-3.5" />
-              )}
-            </Button>
-          </header>
-
-          {/* Scrollable area: Settings + Sessions scroll together */}
-          {isCollapsed ? (
-            /* Collapsed: Sessions quick actions first, then settings shortcuts */
-            <div className="mt-2 px-1">
-              <div className="grid gap-1">
-                <button
-                  type="button"
-                  onClick={handleToggleGlobalTTS}
-                  disabled={!configQuery.data || saveConfigMutation.isPending}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    "text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:opacity-50",
-                  )}
-                  title={
-                    isGlobalTTSEnabled
-                      ? "Disable global TTS"
-                      : "Enable global TTS"
-                  }
-                  aria-label={
-                    isGlobalTTSEnabled
-                      ? "Disable global TTS"
-                      : "Enable global TTS"
-                  }
-                >
-                  {saveConfigMutation.isPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : isGlobalTTSEnabled ? (
-                    <Volume2 className="h-4 w-4" />
-                  ) : (
-                    <VolumeX className="h-4 w-4" />
-                  )}
-                </button>
-
-                <button
-                  type="button"
-                  onClick={handleEmergencyStopAll}
-                  disabled={isEmergencyStopping}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    "text-destructive hover:bg-destructive/10 disabled:opacity-50",
-                  )}
-                  title="Emergency stop all agent sessions"
-                  aria-label="Emergency stop all agent sessions"
-                >
-                  {isEmergencyStopping ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <OctagonX className="h-4 w-4" />
-                  )}
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => openSavedConversationsDialog()}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    savedConversationsDialogOpen && !savedConversationsArchivedOnOpen
-                      ? "bg-accent text-accent-foreground"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Saved conversations"
-                  aria-label="Saved conversations"
-                  aria-pressed={
-                    savedConversationsDialogOpen && !savedConversationsArchivedOnOpen
-                      ? true
-                      : undefined
-                  }
-                >
-                  <Clock className="h-4 w-4" />
-                </button>
-
-                <button
-                  type="button"
-                  onClick={handleOpenArchivedConversationsDialog}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    savedConversationsDialogOpen && savedConversationsArchivedOnOpen
-                      ? "bg-accent text-accent-foreground"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Archived sessions"
-                  aria-label="Archived sessions"
-                  aria-pressed={
-                    savedConversationsDialogOpen && savedConversationsArchivedOnOpen
-                      ? true
-                      : undefined
-                  }
-                >
-                  <Archive className="h-4 w-4" />
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => void handleStartTextSession()}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Start with text"
-                  aria-label="Start with text"
-                >
-                  <Plus className="h-4 w-4" />
-                </button>
-
-                <button
-                  type="button"
-                  onClick={() => void handleStartVoiceSession()}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Start with voice"
-                  aria-label="Start with voice"
-                >
-                  <Mic className="h-4 w-4" />
-                </button>
-
-                <NavLink
-                  to="/"
-                  end
-                  onClick={(e) => {
-                    e.preventDefault()
-                    handleCollapsedSessionsOverviewClick()
-                  }}
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    isSessionsActive
-                      ? "bg-accent text-accent-foreground"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Sessions"
-                  aria-label="Sessions"
-                  aria-current={isSessionsActive ? "page" : undefined}
-                >
-                  <div className="relative flex items-center justify-center">
-                    <span className="i-mingcute-chat-3-line"></span>
-                    {collapsedActiveSessions.length > 0 && (
-                      <span className="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] font-semibold text-white">
-                        {collapsedActiveSessions.length > 9
-                          ? "9+"
-                          : collapsedActiveSessions.length}
-                      </span>
+              {!isCollapsed && !isSettingsSidebarMode && (
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm-icon"
+                    onClick={handleToggleGlobalTTS}
+                    disabled={!configQuery.data || saveConfigMutation.isPending}
+                    className="app-no-drag-region text-muted-foreground hover:bg-accent/50 hover:text-foreground shrink-0 disabled:opacity-50"
+                    title={
+                      isGlobalTTSEnabled
+                        ? "Disable global TTS"
+                        : "Enable global TTS"
+                    }
+                    aria-label={
+                      isGlobalTTSEnabled
+                        ? "Disable global TTS"
+                        : "Enable global TTS"
+                    }
+                  >
+                    {saveConfigMutation.isPending ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : isGlobalTTSEnabled ? (
+                      <Volume2 className="h-3.5 w-3.5" />
+                    ) : (
+                      <VolumeX className="h-3.5 w-3.5" />
                     )}
-                  </div>
-                </NavLink>
+                  </Button>
 
-                <NavLink
-                  to="/settings/agents?view=list"
-                  className={cn(
-                    "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                    isAgentsActive
-                      ? "bg-accent text-accent-foreground"
-                      : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                  title="Agents"
-                  aria-label="Agents"
-                  aria-current={isAgentsActive ? "page" : undefined}
-                >
-                  <span className="i-mingcute-group-line h-4 w-4"></span>
-                </NavLink>
+                  <Button
+                    variant="ghost"
+                    size="sm-icon"
+                    onClick={handleEmergencyStopAll}
+                    disabled={isEmergencyStopping}
+                    className="app-no-drag-region text-destructive hover:bg-destructive/10 shrink-0 disabled:opacity-50"
+                    title="Emergency stop all agent sessions"
+                    aria-label="Emergency stop all agent sessions"
+                  >
+                    {isEmergencyStopping ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <OctagonX className="h-3.5 w-3.5" />
+                    )}
+                  </Button>
+                </div>
+              )}
 
-                {collapsedPreviewSessions.map((session) => {
-                  const isFocused = focusedSessionId === session.id
-                  const sessionProgress = agentProgressById.get(session.id)
-                  const hasPendingApproval =
-                    !!sessionProgress?.pendingToolApproval
-                  const isSnoozed =
-                    sessionProgress?.isSnoozed ?? false
-                  const hasUnreadResponse = hasUnreadAgentResponse(
-                    sessionProgress,
-                    agentResponseReadAtBySessionId.get(session.id),
-                    isFocused,
-                  )
-                  const isVisiblyActive = isFocused || !isSnoozed
-                  const isInProgress =
-                    session.status === "active" && !(sessionProgress?.isComplete ?? false)
-                  const statusDotColor = hasPendingApproval
-                    ? "bg-amber-500"
-                    : hasUnreadResponse
-                      ? "bg-blue-500"
-                      : isInProgress
-                        ? "bg-sky-500"
-                      : !isVisiblyActive
-                        ? "bg-muted-foreground"
-                        : "bg-green-500"
-                  const title =
-                    session.conversationTitle?.trim() || "Untitled conversation"
-                  const collapsedTitle = title.replace(/\s+/g, " ")
+              <Button
+                variant="ghost"
+                size="sm-icon"
+                onClick={toggleCollapse}
+                className={cn(
+                  "app-no-drag-region shrink-0",
+                  "text-muted-foreground hover:bg-accent hover:text-foreground",
+                )}
+                title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+              >
+                {isCollapsed ? (
+                  <PanelLeft className="h-3.5 w-3.5" />
+                ) : (
+                  <PanelLeftClose className="h-3.5 w-3.5" />
+                )}
+              </Button>
+            </header>
 
-                  return (
-                    <button
-                      key={session.id}
-                      type="button"
-                      onClick={() => handleCollapsedSessionClick(session.id)}
-                      className={cn(
-                        "group relative flex h-8 w-full items-center justify-center rounded-md px-0.5 transition-all duration-200",
-                        isFocused
-                          ? "text-foreground bg-blue-500/15"
-                          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                      )}
-                      title={title}
-                      aria-label={`Open session ${title}`}
-                    >
-                      <span className="max-w-[calc(100%-0.375rem)] line-clamp-2 text-center text-[7px] font-medium leading-[0.55rem] tracking-tight [overflow-wrap:anywhere]">
-                        {collapsedTitle}
-                      </span>
-                      <span
-                        className={cn(
-                          "border-background absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border",
-                          statusDotColor,
-                          (isInProgress || isVisiblyActive || hasUnreadResponse) &&
-                            !hasPendingApproval &&
-                            "animate-pulse",
-                        )}
-                      />
-                    </button>
-                  )
-                })}
-
-                {collapsedActiveSessions.length >
-                  collapsedPreviewSessions.length && (
+            {/* Main sidebar body */}
+            {isCollapsed ? (
+              /* Collapsed sidebar: session controls stay above bottom app navigation. */
+              <div className="flex min-h-0 flex-1 flex-col px-1">
+                <div className="mt-2 grid gap-1">
                   <button
                     type="button"
-                    onClick={handleCollapsedSessionsOverviewClick}
+                    onClick={handleToggleGlobalTTS}
+                    disabled={!configQuery.data || saveConfigMutation.isPending}
                     className={cn(
-                      "flex h-8 w-full items-center justify-center rounded-md text-[10px] font-semibold transition-all duration-200",
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                      "text-muted-foreground hover:bg-accent/50 hover:text-foreground disabled:opacity-50",
+                    )}
+                    title={
+                      isGlobalTTSEnabled
+                        ? "Disable global TTS"
+                        : "Enable global TTS"
+                    }
+                    aria-label={
+                      isGlobalTTSEnabled
+                        ? "Disable global TTS"
+                        : "Enable global TTS"
+                    }
+                  >
+                    {saveConfigMutation.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : isGlobalTTSEnabled ? (
+                      <Volume2 className="h-4 w-4" />
+                    ) : (
+                      <VolumeX className="h-4 w-4" />
+                    )}
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleEmergencyStopAll}
+                    disabled={isEmergencyStopping}
+                    className={cn(
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                      "text-destructive hover:bg-destructive/10 disabled:opacity-50",
+                    )}
+                    title="Emergency stop all agent sessions"
+                    aria-label="Emergency stop all agent sessions"
+                  >
+                    {isEmergencyStopping ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <OctagonX className="h-4 w-4" />
+                    )}
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => openSavedConversationsDialog()}
+                    className={cn(
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                      savedConversationsDialogOpen &&
+                        !savedConversationsArchivedOnOpen
+                        ? "bg-accent text-accent-foreground"
+                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    )}
+                    title="Saved conversations"
+                    aria-label="Saved conversations"
+                    aria-pressed={
+                      savedConversationsDialogOpen &&
+                      !savedConversationsArchivedOnOpen
+                        ? true
+                        : undefined
+                    }
+                  >
+                    <Clock className="h-4 w-4" />
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={handleOpenArchivedConversationsDialog}
+                    className={cn(
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                      savedConversationsDialogOpen &&
+                        savedConversationsArchivedOnOpen
+                        ? "bg-accent text-accent-foreground"
+                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    )}
+                    title="Archived sessions"
+                    aria-label="Archived sessions"
+                    aria-pressed={
+                      savedConversationsDialogOpen &&
+                      savedConversationsArchivedOnOpen
+                        ? true
+                        : undefined
+                    }
+                  >
+                    <Archive className="h-4 w-4" />
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => void handleStartTextSession()}
+                    className={cn(
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
                       "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                     )}
-                    title={`View ${collapsedActiveSessions.length - collapsedPreviewSessions.length} more sessions`}
-                    aria-label="View more sessions"
+                    title="Start with text"
+                    aria-label="Start with text"
                   >
-                    +
-                    {collapsedActiveSessions.length -
-                      collapsedPreviewSessions.length}
+                    <Plus className="h-4 w-4" />
                   </button>
-                )}
-              </div>
 
-              {/* Settings Section - collapsed quick navigation */}
-              <div className="mt-2 grid gap-1">
-                {settingsNavLinks.map((link) => {
-                  const isActive = isNavLinkActive(link.href)
-                  const icon = typeof link.icon === "string"
-                    ? <span className={cn(link.icon, "h-4 w-4")}></span>
-                    : <link.icon className="h-4 w-4" />
-
-                  return (
-                    <NavLink
-                      key={link.text}
-                      to={link.href}
-                      onClick={(e) => {
-                        e.preventDefault()
-                        navigate(link.href)
-                      }}
-                      className={cn(
-                        "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
-                        isActive
-                          ? "bg-accent text-accent-foreground"
-                          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                      )}
-                      title={link.text}
-                      aria-label={link.text}
-                      aria-current={isActive ? "page" : undefined}
-                    >
-                      {icon}
-                    </NavLink>
-                  )
-                })}
-              </div>
-            </div>
-          ) : (
-            /* Expanded: sessions and settings scroll together so settings moves up when the session list shrinks. */
-            <div className="mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden scrollbar-none">
-              {/* Sandbox slot indicator */}
-              <div className="mt-1 shrink-0 px-2">
-                <SandboxSlotIndicator />
-              </div>
-
-              {/* Sessions Section - shows sessions list */}
-              <ActiveAgentsSidebar
-                className="shrink-0"
-                onOpenSavedConversationsDialog={() => openSavedConversationsDialog()}
-                onOpenArchivedConversationsDialog={handleOpenArchivedConversationsDialog}
-                selectedAgentId={selectedAgentId}
-                onSelectAgent={setSelectedAgentId}
-                onStartTextSession={handleStartTextSession}
-                onStartVoiceSession={handleStartVoiceSession}
-                onStartPromptSession={handleStartPromptSession}
-                onClearInactiveSessions={isSessionsActive ? clearInactiveSessions : undefined}
-                inactiveSessionCount={0}
-              />
-
-              {/* Settings Section - Collapsible, collapsed by default */}
-              <div className="shrink-0 px-2">
-                <button
-                  onClick={() => setSettingsExpanded(!settingsExpanded)}
-                  className={cn(
-                    "flex w-full items-center gap-1 rounded px-1.5 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide transition-colors",
-                    "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
-                  )}
-                >
-                  <span
+                  <button
+                    type="button"
+                    onClick={() => void handleStartVoiceSession()}
                     className={cn(
-                      "h-3 w-3 shrink-0 transition-transform duration-200",
-                      settingsExpanded
-                        ? "i-mingcute-down-line"
-                        : "i-mingcute-right-line",
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                      "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                     )}
-                  ></span>
-                  <span className="select-none">Settings</span>
-                </button>
+                    title="Start with voice"
+                    aria-label="Start with voice"
+                  >
+                    <Mic className="h-4 w-4" />
+                  </button>
 
-                {settingsExpanded && (
-                  <div className="mt-1 grid gap-0.5 text-xs">
-                    {settingsNavLinks.map(renderNavLink)}
+                  <NavLink
+                    to="/"
+                    end
+                    onClick={(e) => {
+                      e.preventDefault()
+                      handleCollapsedSessionsOverviewClick()
+                    }}
+                    className={cn(
+                      "flex h-8 w-full items-center justify-center rounded-md transition-all duration-200",
+                      isSessionsActive
+                        ? "bg-accent text-accent-foreground"
+                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    )}
+                    title="Sessions"
+                    aria-label="Sessions"
+                    aria-current={isSessionsActive ? "page" : undefined}
+                  >
+                    <div className="relative flex items-center justify-center">
+                      <span className="i-mingcute-chat-3-line"></span>
+                      {collapsedActiveSessions.length > 0 && (
+                        <span className="absolute -right-2 -top-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] font-semibold text-white">
+                          {collapsedActiveSessions.length > 9
+                            ? "9+"
+                            : collapsedActiveSessions.length}
+                        </span>
+                      )}
+                    </div>
+                  </NavLink>
+
+                  {collapsedPreviewSessions.map((session) => {
+                    const isFocused = focusedSessionId === session.id
+                    const sessionProgress = agentProgressById.get(session.id)
+                    const hasPendingApproval =
+                      !!sessionProgress?.pendingToolApproval
+                    const isSnoozed = sessionProgress?.isSnoozed ?? false
+                    const hasUnreadResponse = hasUnreadAgentResponse(
+                      sessionProgress,
+                      agentResponseReadAtBySessionId.get(session.id),
+                      isFocused,
+                    )
+                    const isVisiblyActive = isFocused || !isSnoozed
+                    const isInProgress =
+                      session.status === "active" &&
+                      !(sessionProgress?.isComplete ?? false)
+                    const statusDotColor = hasPendingApproval
+                      ? "bg-amber-500"
+                      : hasUnreadResponse
+                        ? "bg-blue-500"
+                        : isInProgress
+                          ? "bg-sky-500"
+                          : !isVisiblyActive
+                            ? "bg-muted-foreground"
+                            : "bg-green-500"
+                    const title =
+                      session.conversationTitle?.trim() ||
+                      "Untitled conversation"
+                    const collapsedTitle = title.replace(/\s+/g, " ")
+
+                    return (
+                      <button
+                        key={session.id}
+                        type="button"
+                        onClick={() => handleCollapsedSessionClick(session.id)}
+                        className={cn(
+                          "group relative flex h-8 w-full items-center justify-center rounded-md px-0.5 transition-all duration-200",
+                          isFocused
+                            ? "text-foreground bg-blue-500/15"
+                            : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                        )}
+                        title={title}
+                        aria-label={`Open session ${title}`}
+                      >
+                        <span className="line-clamp-2 max-w-[calc(100%-0.375rem)] text-center text-[7px] font-medium leading-[0.55rem] tracking-tight [overflow-wrap:anywhere]">
+                          {collapsedTitle}
+                        </span>
+                        <span
+                          className={cn(
+                            "border-background absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border",
+                            statusDotColor,
+                            (isInProgress ||
+                              isVisiblyActive ||
+                              hasUnreadResponse) &&
+                              !hasPendingApproval &&
+                              "animate-pulse",
+                          )}
+                        />
+                      </button>
+                    )
+                  })}
+
+                  {collapsedActiveSessions.length >
+                    collapsedPreviewSessions.length && (
+                    <button
+                      type="button"
+                      onClick={handleCollapsedSessionsOverviewClick}
+                      className={cn(
+                        "flex h-8 w-full items-center justify-center rounded-md text-[10px] font-semibold transition-all duration-200",
+                        "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                      )}
+                      title={`View ${collapsedActiveSessions.length - collapsedPreviewSessions.length} more sessions`}
+                      aria-label="View more sessions"
+                    >
+                      +
+                      {collapsedActiveSessions.length -
+                        collapsedPreviewSessions.length}
+                    </button>
+                  )}
+                </div>
+
+                <div className="min-h-2 flex-1" />
+              </div>
+            ) : isSettingsSidebarMode ? (
+              <div className="min-h-0 flex-1">
+                <SettingsSidebarNavigation onBackToApp={() => navigate("/")} />
+              </div>
+            ) : (
+              <>
+                {/* Normal sidebar: sessions fill the available sidebar height. */}
+                <div className="scrollbar-none mt-2 min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
+                  {/* Sandbox slot indicator */}
+                  <div className="mt-1 shrink-0 px-2">
+                    <SandboxSlotIndicator />
                   </div>
+
+                  {/* Sessions Section - shows sessions list */}
+                  <ActiveAgentsSidebar
+                    className="min-h-full"
+                    onOpenSavedConversationsDialog={() =>
+                      openSavedConversationsDialog()
+                    }
+                    onOpenArchivedConversationsDialog={
+                      handleOpenArchivedConversationsDialog
+                    }
+                    selectedAgentId={selectedAgentId}
+                    onSelectAgent={setSelectedAgentId}
+                    onStartTextSession={handleStartTextSession}
+                    onStartVoiceSession={handleStartVoiceSession}
+                    onStartPromptSession={handleStartPromptSession}
+                    onClearInactiveSessions={
+                      isSessionsActive ? clearInactiveSessions : undefined
+                    }
+                    inactiveSessionCount={0}
+                  />
+                </div>
+              </>
+            )}
+
+            {/* Resize handle - only visible when not collapsed */}
+            {!isCollapsed && (
+              <div
+                className={cn(
+                  "absolute right-0 top-0 h-full w-1 cursor-col-resize transition-colors",
+                  "hover:bg-primary/20",
+                  isResizing && "bg-primary/30",
                 )}
-              </div>
+                onMouseDown={handleResizeStart}
+                title="Drag to resize sidebar"
+              />
+            )}
+          </div>
 
-              {/* Logo/version pushed down by menu content, scrolls naturally */}
-              <div className="flex shrink-0 flex-col items-center space-y-0.5 pb-4 pt-2 text-muted-foreground">
-                <div className="text-[11px] font-medium">DotAgents</div>
-                <div className="text-[9px]">{process.env.APP_VERSION}</div>
-              </div>
+          {/* Main content area */}
+          <div className="bg-background flex min-w-0 grow flex-col">
+            {/* Scrollable content area */}
+            <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
+              <Outlet
+                context={{
+                  onOpenSavedConversationsDialog: () =>
+                    openSavedConversationsDialog(),
+                  sidebarWidth,
+                  selectedAgentId,
+                  setSelectedAgentId,
+                  onStartTextSession: handleStartTextSession,
+                  onStartVoiceSession: handleStartVoiceSession,
+                  onStartPromptSession: handleStartPromptSession,
+                  openSessionActionDialog,
+                }}
+              />
             </div>
-          )}
-
-          {/* Spacer to push footer down when collapsed */}
-          {isCollapsed && <div className="flex-1" />}
-
-          {/* Resize handle - only visible when not collapsed */}
-          {!isCollapsed && (
-            <div
-              className={cn(
-                "absolute right-0 top-0 h-full w-1 cursor-col-resize transition-colors",
-                "hover:bg-primary/20",
-                isResizing && "bg-primary/30",
-              )}
-              onMouseDown={handleResizeStart}
-              title="Drag to resize sidebar"
-            />
-          )}
-        </div>
-
-        {/* Main content area */}
-        <div className="bg-background flex min-w-0 grow flex-col">
-          {/* Scrollable content area */}
-          <div className="min-w-0 flex-1 overflow-y-auto overflow-x-hidden">
-            <Outlet
-              context={{
-                onOpenSavedConversationsDialog: () => openSavedConversationsDialog(),
-                sidebarWidth,
-                selectedAgentId,
-                setSelectedAgentId,
-                onStartTextSession: handleStartTextSession,
-                onStartVoiceSession: handleStartVoiceSession,
-                onStartPromptSession: handleStartPromptSession,
-                openSessionActionDialog,
-              }}
-            />
           </div>
         </div>
+
+        <AppBottomBar />
       </div>
 
       {sessionActionDialog && (
@@ -1093,7 +945,9 @@ export const Component = () => {
           conversationId={sessionActionDialog.conversationId}
           sessionId={sessionActionDialog.sessionId}
           fromTile={sessionActionDialog.fromTile}
-          continueConversationTitle={sessionActionDialog.continueConversationTitle}
+          continueConversationTitle={
+            sessionActionDialog.continueConversationTitle
+          }
           agentName={sessionActionDialog.agentName}
           selectedAgentId={selectedAgentId}
           onSelectAgent={setSelectedAgentId}

--- a/apps/desktop/src/renderer/src/components/settings-navigation.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-navigation.tsx
@@ -1,0 +1,176 @@
+import { type ReactNode, useMemo, useState } from "react"
+import { useLocation, useNavigate } from "react-router-dom"
+import { useConfigQuery } from "@renderer/lib/query-client"
+import {
+  getSettingsNavigationState,
+  getVisibleSettingsNavGroups,
+  type SettingsNavItem,
+} from "@renderer/lib/settings-navigation"
+import { cn } from "@renderer/lib/utils"
+
+function SettingsIcon({
+  icon,
+  className,
+}: {
+  icon: string
+  className?: string
+}) {
+  return <span className={cn(icon, "shrink-0", className)} />
+}
+
+export function SettingsSidebarNavigation({
+  onBackToApp,
+}: {
+  onBackToApp?: () => void
+}) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [searchQuery, setSearchQuery] = useState("")
+  const configQuery = useConfigQuery()
+  const activeState = getSettingsNavigationState(location.pathname)
+  const groups = getVisibleSettingsNavGroups({
+    discordEnabled: configQuery.data?.discordEnabled ?? false,
+    activeItemHref: activeState.itemHref,
+  })
+  const filteredGroups = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    if (!query) return groups
+
+    return groups
+      .map((group) => {
+        const groupMatches = group.label.toLowerCase().includes(query)
+        const items = groupMatches
+          ? group.items
+          : group.items.filter((item) =>
+              item.label.toLowerCase().includes(query),
+            )
+
+        return {
+          ...group,
+          items,
+        }
+      })
+      .filter((group) => group.items.length > 0)
+  }, [groups, searchQuery])
+
+  const handleBackToApp = () => {
+    if (onBackToApp) {
+      onBackToApp()
+      return
+    }
+
+    navigate("/")
+  }
+
+  const navigateToItem = (item: SettingsNavItem) => {
+    navigate(item.href)
+  }
+
+  return (
+    <nav
+      className="flex h-full min-h-0 flex-col px-2 pb-3"
+      aria-label="Settings"
+    >
+      <div className="shrink-0 px-1 pt-1">
+        <button
+          type="button"
+          onClick={handleBackToApp}
+          className="text-muted-foreground hover:bg-accent/50 hover:text-foreground flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm font-medium transition-colors"
+        >
+          <span className="i-mingcute-left-line h-4 w-4 shrink-0" />
+          <span className="truncate">Back to app</span>
+        </button>
+
+        <label className="relative mt-2 block">
+          <span className="i-mingcute-search-2-line text-muted-foreground pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2" />
+          <input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search settings..."
+            className="border-input bg-background/70 placeholder:text-muted-foreground focus-visible:border-ring h-8 w-full rounded-md border px-8 text-sm outline-none transition-colors"
+            aria-label="Search settings"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery("")}
+              className="text-muted-foreground hover:text-foreground absolute right-2 top-1/2 flex h-5 w-5 -translate-y-1/2 items-center justify-center rounded"
+              aria-label="Clear settings search"
+            >
+              <span className="i-mingcute-close-line h-3.5 w-3.5" />
+            </button>
+          )}
+        </label>
+      </div>
+
+      <div className="scrollbar-none min-h-0 flex-1 overflow-y-auto px-1 py-3">
+        {filteredGroups.length > 0 ? (
+          <div className="space-y-4">
+            {filteredGroups.map((group) => (
+              <section key={group.id} aria-label={group.label}>
+                <div className="text-muted-foreground/80 mb-1 px-2 text-[10px] font-semibold uppercase tracking-wide">
+                  {group.label}
+                </div>
+                <div className="grid gap-0.5">
+                  {group.items.map((item) => {
+                    const active = item.href === activeState.itemHref
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => navigateToItem(item)}
+                        aria-current={active ? "page" : undefined}
+                        className={cn(
+                          "flex h-8 min-w-0 items-center gap-2 rounded-md px-2 text-sm font-medium transition-colors",
+                          active
+                            ? "bg-accent text-accent-foreground"
+                            : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                        )}
+                      >
+                        <SettingsIcon icon={item.icon} className="h-4 w-4" />
+                        <span className="truncate">{item.label}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="text-muted-foreground px-2 py-4 text-sm">
+            No settings found.
+          </div>
+        )}
+      </div>
+    </nav>
+  )
+}
+
+export function SettingsNavigation() {
+  return <SettingsSidebarNavigation />
+}
+
+export function SettingsPageShell({
+  children,
+  contentClassName,
+  innerClassName,
+}: {
+  children: ReactNode
+  contentClassName?: string
+  innerClassName?: string
+}) {
+  return (
+    <div className="modern-panel flex h-full min-w-0 flex-col overflow-hidden">
+      <div
+        className={cn(
+          "min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-5 sm:px-6",
+          contentClassName,
+        )}
+      >
+        <div className={cn("mx-auto w-full max-w-5xl", innerClassName)}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/desktop/src/renderer/src/lib/legacy-settings-redirect.test.ts
+++ b/apps/desktop/src/renderer/src/lib/legacy-settings-redirect.test.ts
@@ -29,4 +29,13 @@ describe("getLegacySettingsRedirectPath", () => {
       )
     ).toBe("/settings/repeat-tasks#scheduled")
   })
+
+  it("can preserve context when moving knowledge under settings", () => {
+    expect(
+      getLegacySettingsRedirectPath(
+        "/settings/knowledge",
+        "http://localhost/knowledge?context=auto#notes"
+      )
+    ).toBe("/settings/knowledge?context=auto#notes")
+  })
 })

--- a/apps/desktop/src/renderer/src/lib/settings-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-navigation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getSettingsNavigationState,
+  getVisibleSettingsNavGroups,
+  isConsolidatedSettingsRoute,
+  normalizeSettingsPath,
+} from "./settings-navigation"
+
+describe("settings navigation", () => {
+  it("maps consolidated settings routes to their internal group and subsection", () => {
+    expect(getSettingsNavigationState("/settings")).toEqual({
+      groupId: "general",
+      itemHref: "/settings",
+    })
+    expect(getSettingsNavigationState("/settings/knowledge")).toEqual({
+      groupId: "general",
+      itemHref: "/settings/knowledge",
+    })
+    expect(getSettingsNavigationState("/settings/models")).toEqual({
+      groupId: "intelligence",
+      itemHref: "/settings/models",
+    })
+    expect(getSettingsNavigationState("/settings/providers")).toEqual({
+      groupId: "intelligence",
+      itemHref: "/settings/providers",
+    })
+    expect(getSettingsNavigationState("/settings/agents")).toEqual({
+      groupId: "agents",
+      itemHref: "/settings/agents",
+    })
+    expect(getSettingsNavigationState("/settings/capabilities")).toEqual({
+      groupId: "agents",
+      itemHref: "/settings/capabilities",
+    })
+    expect(getSettingsNavigationState("/settings/whatsapp")).toEqual({
+      groupId: "integrations",
+      itemHref: "/settings/whatsapp",
+    })
+  })
+
+  it("keeps legacy settings routes attached to the consolidated settings nav", () => {
+    expect(normalizeSettingsPath("/settings/general")).toBe("/settings")
+    expect(normalizeSettingsPath("/settings/remote-server")).toBe("/settings")
+    expect(normalizeSettingsPath("/settings/mcp-tools")).toBe(
+      "/settings/capabilities",
+    )
+    expect(normalizeSettingsPath("/settings/skills")).toBe(
+      "/settings/capabilities",
+    )
+    expect(normalizeSettingsPath("/settings/agent-personas")).toBe(
+      "/settings/agents",
+    )
+  })
+
+  it("excludes repeat tasks from the consolidated settings sidebar target", () => {
+    expect(isConsolidatedSettingsRoute("/settings/models")).toBe(true)
+    expect(isConsolidatedSettingsRoute("/settings/knowledge")).toBe(true)
+    expect(isConsolidatedSettingsRoute("/settings/repeat-tasks")).toBe(false)
+    expect(isConsolidatedSettingsRoute("/settings/loops")).toBe(false)
+  })
+
+  it("shows WhatsApp by default and gates Discord unless it is enabled or active", () => {
+    const disabledGroups = getVisibleSettingsNavGroups({
+      discordEnabled: false,
+    })
+    const disabledIntegrationItems =
+      disabledGroups.find((group) => group.id === "integrations")?.items ?? []
+
+    expect(disabledIntegrationItems.map((item) => item.href)).toEqual([
+      "/settings/whatsapp",
+    ])
+
+    const enabledGroups = getVisibleSettingsNavGroups({ discordEnabled: true })
+    const enabledIntegrationItems =
+      enabledGroups.find((group) => group.id === "integrations")?.items ?? []
+
+    expect(enabledIntegrationItems.map((item) => item.href)).toEqual([
+      "/settings/whatsapp",
+      "/settings/discord",
+    ])
+
+    const activeDiscordGroups = getVisibleSettingsNavGroups({
+      discordEnabled: false,
+      activeItemHref: "/settings/discord",
+    })
+    const activeDiscordItems =
+      activeDiscordGroups.find((group) => group.id === "integrations")?.items ??
+      []
+
+    expect(activeDiscordItems.map((item) => item.href)).toContain(
+      "/settings/discord",
+    )
+  })
+})

--- a/apps/desktop/src/renderer/src/lib/settings-navigation.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-navigation.ts
@@ -1,0 +1,196 @@
+export type SettingsNavGroupId =
+  | "general"
+  | "intelligence"
+  | "agents"
+  | "integrations"
+
+export type SettingsNavIntegrationGate = "discord"
+
+export interface SettingsNavItem {
+  id: string
+  label: string
+  href: string
+  icon: string
+  groupId: SettingsNavGroupId
+  requires?: SettingsNavIntegrationGate
+}
+
+export interface SettingsNavGroup {
+  id: SettingsNavGroupId
+  label: string
+  icon: string
+  items: readonly SettingsNavItem[]
+}
+
+export interface SettingsNavigationState {
+  groupId: SettingsNavGroupId
+  itemHref: string
+}
+
+export interface SettingsNavVisibility {
+  discordEnabled?: boolean
+  activeItemHref?: string
+}
+
+export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
+  {
+    id: "general",
+    label: "General",
+    icon: "i-mingcute-settings-3-line",
+    items: [
+      {
+        id: "general",
+        label: "General",
+        href: "/settings",
+        icon: "i-mingcute-settings-3-line",
+        groupId: "general",
+      },
+      {
+        id: "knowledge",
+        label: "Knowledge",
+        href: "/settings/knowledge",
+        icon: "i-mingcute-book-2-line",
+        groupId: "general",
+      },
+    ],
+  },
+  {
+    id: "intelligence",
+    label: "Intelligence",
+    icon: "i-mingcute-brain-line",
+    items: [
+      {
+        id: "models",
+        label: "Models",
+        href: "/settings/models",
+        icon: "i-mingcute-brain-line",
+        groupId: "intelligence",
+      },
+      {
+        id: "providers",
+        label: "Providers",
+        href: "/settings/providers",
+        icon: "i-mingcute-tool-line",
+        groupId: "intelligence",
+      },
+    ],
+  },
+  {
+    id: "agents",
+    label: "Agents",
+    icon: "i-mingcute-group-line",
+    items: [
+      {
+        id: "agents",
+        label: "Agents",
+        href: "/settings/agents",
+        icon: "i-mingcute-group-line",
+        groupId: "agents",
+      },
+      {
+        id: "capabilities",
+        label: "Capabilities",
+        href: "/settings/capabilities",
+        icon: "i-mingcute-tool-line",
+        groupId: "agents",
+      },
+    ],
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    icon: "i-mingcute-message-4-line",
+    items: [
+      {
+        id: "whatsapp",
+        label: "WhatsApp",
+        href: "/settings/whatsapp",
+        icon: "i-mingcute-message-4-line",
+        groupId: "integrations",
+      },
+      {
+        id: "discord",
+        label: "Discord",
+        href: "/settings/discord",
+        icon: "i-mingcute-discord-line",
+        groupId: "integrations",
+        requires: "discord",
+      },
+    ],
+  },
+]
+
+const SETTINGS_ROUTE_ALIASES: Record<string, string> = {
+  "/settings/general": "/settings",
+  "/settings/langfuse": "/settings",
+  "/settings/remote-server": "/settings",
+  "/settings/mcp-tools": "/settings/capabilities",
+  "/settings/skills": "/settings/capabilities",
+  "/settings/agent-personas": "/settings/agents",
+  "/settings/external-agents": "/settings/agents",
+  "/settings/agent-profiles": "/settings/agents",
+}
+
+const SETTINGS_NAV_EXCLUDED_PREFIXES = [
+  "/settings/repeat-tasks",
+  "/settings/loops",
+] as const
+
+function pathnameOnly(pathname: string): string {
+  return pathname.split(/[?#]/, 1)[0] || "/"
+}
+
+export function isConsolidatedSettingsRoute(pathname: string): boolean {
+  const path = pathnameOnly(pathname)
+  if (path !== "/settings" && !path.startsWith("/settings/")) return false
+  return !SETTINGS_NAV_EXCLUDED_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  )
+}
+
+export function normalizeSettingsPath(pathname: string): string {
+  const path = pathnameOnly(pathname)
+  return SETTINGS_ROUTE_ALIASES[path] ?? path
+}
+
+export function getSettingsNavigationState(
+  pathname: string,
+): SettingsNavigationState {
+  const normalizedPath = normalizeSettingsPath(pathname)
+
+  for (const group of SETTINGS_NAV_GROUPS) {
+    for (const item of group.items) {
+      const isItemRoute =
+        item.href === "/settings"
+          ? normalizedPath === item.href
+          : normalizedPath === item.href ||
+            normalizedPath.startsWith(`${item.href}/`)
+      if (isItemRoute) {
+        return {
+          groupId: group.id,
+          itemHref: item.href,
+        }
+      }
+    }
+  }
+
+  return {
+    groupId: "general",
+    itemHref: "/settings",
+  }
+}
+
+export function getVisibleSettingsNavGroups({
+  discordEnabled = false,
+  activeItemHref,
+}: SettingsNavVisibility = {}): SettingsNavGroup[] {
+  return SETTINGS_NAV_GROUPS.map((group) => ({
+    ...group,
+    items: group.items.filter((item) => {
+      if (item.requires === "discord") {
+        return discordEnabled || activeItemHref === item.href
+      }
+      return true
+    }),
+  })).filter((group) => group.items.length > 0)
+}

--- a/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
+++ b/apps/desktop/src/renderer/src/pages/sessions.in-app-actions.test.ts
@@ -1,11 +1,26 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
 
-const appLayoutSource = readFileSync(new URL("../components/app-layout.tsx", import.meta.url), "utf8")
-const sidebarSource = readFileSync(new URL("../components/active-agents-sidebar.tsx", import.meta.url), "utf8")
-const agentProgressSource = readFileSync(new URL("../components/agent-progress.tsx", import.meta.url), "utf8")
-const sessionsSource = readFileSync(new URL("./sessions.tsx", import.meta.url), "utf8")
-const tileFollowUpSource = readFileSync(new URL("../components/tile-follow-up-input.tsx", import.meta.url), "utf8")
+const appLayoutSource = readFileSync(
+  new URL("../components/app-layout.tsx", import.meta.url),
+  "utf8",
+)
+const sidebarSource = readFileSync(
+  new URL("../components/active-agents-sidebar.tsx", import.meta.url),
+  "utf8",
+)
+const agentProgressSource = readFileSync(
+  new URL("../components/agent-progress.tsx", import.meta.url),
+  "utf8",
+)
+const sessionsSource = readFileSync(
+  new URL("./sessions.tsx", import.meta.url),
+  "utf8",
+)
+const tileFollowUpSource = readFileSync(
+  new URL("../components/tile-follow-up-input.tsx", import.meta.url),
+  "utf8",
+)
 const sessionActionDialogSource = readFileSync(
   new URL("../components/session-action-dialog.tsx", import.meta.url),
   "utf8",
@@ -20,17 +35,31 @@ const compactSource = (source: string) => source.replace(/\s+/g, " ")
 describe("sessions in-app actions", () => {
   it("opens the in-app session action dialog from shared layout handlers instead of the hover panel", () => {
     expect(appLayoutSource).toContain("<SessionActionDialog")
-    expect(appLayoutSource).toContain("const handleStartTextSession = useCallback(async () => {")
-    expect(appLayoutSource).toContain("const handleStartVoiceSession = useCallback(async (options?: {")
-    expect(appLayoutSource).toContain("openSessionActionDialog({ mode: \"text\" })")
+    expect(appLayoutSource).toContain(
+      "const handleStartTextSession = useCallback(async () => {",
+    )
+    expect(compactSource(appLayoutSource)).toContain(
+      "const handleStartVoiceSession = useCallback( async (options?: {",
+    )
+    expect(appLayoutSource).toContain(
+      'openSessionActionDialog({ mode: "text" })',
+    )
     expect(appLayoutSource).toContain('mode: "voice"')
-    expect(appLayoutSource).toContain("continueConversationTitle: options?.continueConversationTitle")
-    expect(appLayoutSource).not.toContain("await tipcClient.showPanelWindowWithTextInput({})")
-    expect(appLayoutSource).not.toContain("await tipcClient.triggerMcpRecording({})")
+    expect(appLayoutSource).toContain(
+      "continueConversationTitle: options?.continueConversationTitle",
+    )
+    expect(appLayoutSource).not.toContain(
+      "await tipcClient.showPanelWindowWithTextInput({})",
+    )
+    expect(appLayoutSource).not.toContain(
+      "await tipcClient.triggerMcpRecording({})",
+    )
   })
 
   it("renders a single full-height session view instead of the old card grid", () => {
-    expect(sessionsSource).toContain("const selectedSessionId = useMemo(() => {")
+    expect(sessionsSource).toContain(
+      "const selectedSessionId = useMemo(() => {",
+    )
     expect(sessionsSource).toContain('className="flex h-full min-h-0 flex-col"')
     expect(sessionsSource).not.toContain("SessionCompactCard")
     expect(sessionsSource).not.toContain("calculateAdaptiveColumns")
@@ -39,29 +68,49 @@ describe("sessions in-app actions", () => {
   it("prefers focused sessions over stale expanded selection and refreshes clear-inactive handlers", () => {
     const compactSessionsSource = compactSource(sessionsSource)
     expect(
-      compactSessionsSource.indexOf("if (focusedSessionId && displayedSessionIds.has(focusedSessionId)) return focusedSessionId")
+      compactSessionsSource.indexOf(
+        "if (focusedSessionId && displayedSessionIds.has(focusedSessionId)) return focusedSessionId",
+      ),
     ).toBeLessThan(
-      compactSessionsSource.indexOf("if (expandedSessionId && displayedSessionIds.has(expandedSessionId)) return expandedSessionId")
+      compactSessionsSource.indexOf(
+        "if (expandedSessionId && displayedSessionIds.has(expandedSessionId)) return expandedSessionId",
+      ),
     )
-    expect(sessionsSource).toContain("const handleClearInactiveSessions = useCallback(async () => {")
-    expect(sessionsSource).toContain("}, [inactiveSessionCount, handleClearInactiveSessions])")
+    expect(sessionsSource).toContain(
+      "const handleClearInactiveSessions = useCallback(async () => {",
+    )
+    expect(sessionsSource).toContain(
+      "}, [inactiveSessionCount, handleClearInactiveSessions])",
+    )
   })
 
   it("keeps sidebar active-session clicks selecting the session while past-session opens clear active focus", () => {
     expect(sidebarSource).toContain("setExpandedSessionId(sessionId)")
-    expect(sidebarSource).toContain('navigate("/", { state: { clearPendingConversation: true } })')
-    expect(sidebarSource).toContain("const focusSidebarSessionComposer = useCallback(() => {")
+    expect(sidebarSource).toContain(
+      'navigate("/", { state: { clearPendingConversation: true } })',
+    )
+    expect(sidebarSource).toContain(
+      "const focusSidebarSessionComposer = useCallback(() => {",
+    )
     expect(sidebarSource).toContain("focusSidebarSessionComposer()")
     expect(sidebarSource).toContain("window.setTimeout(tryFocusComposer, 75)")
-    expect(sidebarSource).toContain('document.querySelector<HTMLTextAreaElement>(\'textarea[data-composer="true"]\')')
+    expect(sidebarSource).toContain(
+      "document.querySelector<HTMLTextAreaElement>('textarea[data-composer=\"true\"]')",
+    )
     expect(sidebarSource).toContain("setExpandedSessionId(null)")
   })
 
   it("clears stale pending past-session state when returning to an active session", () => {
-    expect(appLayoutSource).toContain('navigate("/", { state: { clearPendingConversation: true } })')
-    expect(sessionsSource).toContain("if (!navigationState?.clearPendingConversation) return")
+    expect(appLayoutSource).toContain(
+      'navigate("/", { state: { clearPendingConversation: true } })',
+    )
+    expect(sessionsSource).toContain(
+      "if (!navigationState?.clearPendingConversation) return",
+    )
     const compactSessionsSource = compactSource(sessionsSource)
-    expect(compactSessionsSource).toContain('navigate(`${location.pathname}${location.search}`, {')
+    expect(compactSessionsSource).toContain(
+      "navigate(`${location.pathname}${location.search}`, {",
+    )
     expect(compactSessionsSource).toContain("replace: true")
     expect(compactSessionsSource).toContain("state: null")
   })
@@ -71,7 +120,9 @@ describe("sessions in-app actions", () => {
     expect(sidebarSource).toContain("<PredefinedPromptsMenu")
     expect(sidebarSource).toContain("onStartTextSession")
     expect(sidebarSource).toContain("onStartVoiceSession")
-    expect(sidebarSource).toContain('className="ml-auto flex items-center gap-2"')
+    expect(sidebarSource).toContain(
+      'className="ml-auto flex items-center gap-2"',
+    )
     expect(sidebarSource).toContain('aria-label="Start text session"')
     expect(sidebarSource).toContain('aria-label="Start voice session"')
     expect(sidebarSource).not.toContain('variant="secondary"')
@@ -82,24 +133,43 @@ describe("sessions in-app actions", () => {
     expect(sessionsSource).not.toContain('aria-label="Cycle tile layout"')
   })
 
-  it("keeps expanded sidebar settings headings compact", () => {
+  it("lets sessions fill the sidebar and switches settings routes into settings navigation", () => {
     expect(appLayoutSource).toContain(
-      'flex w-full items-center gap-1 rounded px-1.5 pb-0.5 pt-1 text-[10px] font-semibold uppercase tracking-wide transition-colors',
+      "Normal sidebar: sessions fill the available sidebar height.",
     )
-    expect(appLayoutSource).toContain('<div className="mt-1 grid gap-0.5 text-xs">')
-    expect(appLayoutSource).toContain('flex h-6 items-center rounded px-1.5 text-[11px] font-medium transition-all duration-200')
-    expect(appLayoutSource).toContain('isCollapsed ? "justify-center" : "gap-1.5"')
-    expect(appLayoutSource).toContain('h-3.5 w-3.5 shrink-0')
-    expect(appLayoutSource).toContain('<span className="truncate text-[11px] font-medium leading-4">')
-    expect(appLayoutSource).toContain('<span className="select-none">Settings</span>')
-    expect(appLayoutSource).not.toContain('i-mingcute-settings-3-line"></span>')
+    expect(appLayoutSource).toContain("const isSettingsSidebarMode =")
+    expect(compactSource(appLayoutSource)).toContain(
+      '<SettingsSidebarNavigation onBackToApp={() => navigate("/")} />',
+    )
+    expect(appLayoutSource).not.toContain("Sidebar footer - pinned app navigation")
+    expect(appLayoutSource).not.toContain("const sidebarFooterLinks")
+    expect(appLayoutSource).not.toContain("setSettingsExpanded")
+    expect(appLayoutSource).not.toContain("Settings Section - Collapsible")
+    expect(appLayoutSource).not.toContain(
+      "sessions and settings scroll together",
+    )
+  })
+
+  it("keeps app settings destinations out of the normal sidebar", () => {
+    expect(appLayoutSource).not.toContain("SETTINGS_SIDEBAR_LINK")
+    expect(appLayoutSource).not.toContain('text: "Knowledge"')
+    expect(appLayoutSource).not.toContain('text: "Repeat Tasks"')
+    expect(appLayoutSource).not.toContain('text: "Settings"')
+    expect(appLayoutSource).toContain(
+      "isConsolidatedSettingsRoute(location.pathname)",
+    )
+    expect(appLayoutSource).not.toContain('to="/settings/agents?view=list"')
   })
 
   it("shows sidebar session previews and removes sidebar minimize controls", () => {
     expect(sidebarSource).toContain("getSidebarActivityPresentation")
-    expect(sidebarSource).toContain("const sessionPreview = sidebarActivity.detail")
+    expect(sidebarSource).toContain(
+      "const sessionPreview = sidebarActivity.detail",
+    )
     expect(sidebarSource).toContain("title={sessionPreview}")
-    expect(sidebarSource).toContain('className="shrink-0 text-[10px] tabular-nums text-muted-foreground/80"')
+    expect(sidebarSource).toContain(
+      'className="shrink-0 text-[10px] tabular-nums text-muted-foreground/80"',
+    )
     expect(sidebarSource).not.toContain("Minimize - run in background")
   })
 
@@ -108,40 +178,62 @@ describe("sessions in-app actions", () => {
   })
 
   it("keeps errored resumed sessions visible and focused so their error state is shown", () => {
-    expect(sessionsSource).toContain("Keep errored AND user-stopped sessions visible")
-    expect(sessionsSource).not.toContain('recentStatus === "stopped" || recentStatus === "error"')
-    expect(sessionsSource).toContain("setExpandedSessionId(realEntry.sessionId)")
+    expect(sessionsSource).toContain(
+      "Keep errored AND user-stopped sessions visible",
+    )
+    expect(sessionsSource).not.toContain(
+      'recentStatus === "stopped" || recentStatus === "error"',
+    )
+    expect(sessionsSource).toContain(
+      "setExpandedSessionId(realEntry.sessionId)",
+    )
   })
 
   it("preserves display-only thinking blocks when saved conversations become session history", () => {
-    expect(sessionsSource).toContain("...(m.displayContent ? { displayContent: m.displayContent } : {}),")
-    expect(tipcSource).toContain("...(msg.displayContent ? { displayContent: msg.displayContent } : {}),")
+    expect(sessionsSource).toContain(
+      "...(m.displayContent ? { displayContent: m.displayContent } : {}),",
+    )
+    expect(tipcSource).toContain(
+      "...(msg.displayContent ? { displayContent: msg.displayContent } : {}),",
+    )
   })
 
   it("keeps pinned tiles at the top of the active sessions grid and exposes a tile pin control", () => {
     expect(sessionsSource).toContain("orderActiveSessionsByPinnedFirst(")
-    expect(agentProgressSource).toContain('title={isPinned ? "Unpin session" : "Pin session"}')
+    expect(agentProgressSource).toContain(
+      'title={isPinned ? "Unpin session" : "Pin session"}',
+    )
     expect(agentProgressSource).toContain("togglePinSession(conversationId)")
   })
 
   it("keeps the home recent conversations splash ordered by recent activity, not pin state", () => {
-    expect(sessionsSource).toContain("orderConversationHistoryByRecentActivity(")
-    expect(sessionsSource).not.toContain("orderConversationHistoryByPinnedFirst(")
+    expect(sessionsSource).toContain(
+      "orderConversationHistoryByRecentActivity(",
+    )
+    expect(sessionsSource).not.toContain(
+      "orderConversationHistoryByPinnedFirst(",
+    )
   })
 
   it("lets tile voice continuation use the in-app dialog path while keeping the IPC fallback", () => {
     expect(tileFollowUpSource).toContain("if (onVoiceContinue) {")
-    expect(tileFollowUpSource).toContain("continueConversationTitle: conversationTitle")
+    expect(tileFollowUpSource).toContain(
+      "continueConversationTitle: conversationTitle",
+    )
     const compactTileFollowUpSource = compactSource(tileFollowUpSource)
-    expect(compactTileFollowUpSource).toContain("await tipcClient.triggerMcpRecording({")
+    expect(compactTileFollowUpSource).toContain(
+      "await tipcClient.triggerMcpRecording({",
+    )
     expect(compactTileFollowUpSource).toContain("sessionId: realSessionId")
     expect(compactTileFollowUpSource).toContain("fromTile: true")
   })
 
   it("navigates to a newly branched conversation so it becomes the focused session", () => {
-    expect(agentProgressSource).toContain('const navigate = useNavigate()')
-    expect(agentProgressSource).toContain('navigate(`/${branched.id}`)')
-    expect(agentProgressSource).not.toContain('Conversation branched — find it in Saved Conversations')
+    expect(agentProgressSource).toContain("const navigate = useNavigate()")
+    expect(agentProgressSource).toContain("navigate(`/${branched.id}`)")
+    expect(agentProgressSource).not.toContain(
+      "Conversation branched — find it in Saved Conversations",
+    )
   })
 
   it("keeps SessionActionDialog sessions audible while suppressing hover-panel auto-show", () => {
@@ -149,18 +241,28 @@ describe("sessions in-app actions", () => {
     // but interactive submits should still be foreground/audible for TTS.
     // So both text and voice submit paths should keep fromTile:true while
     // explicitly sending startSnoozed:false.
-    const textSubmitIndex = sessionActionDialogSource.indexOf("const handleTextSubmit")
-    const voiceCreateIndex = sessionActionDialogSource.indexOf("tipcClient.createMcpRecording")
+    const textSubmitIndex = sessionActionDialogSource.indexOf(
+      "const handleTextSubmit",
+    )
+    const voiceCreateIndex = sessionActionDialogSource.indexOf(
+      "tipcClient.createMcpRecording",
+    )
     expect(textSubmitIndex).toBeGreaterThan(-1)
     expect(voiceCreateIndex).toBeGreaterThan(-1)
 
-    const textSubmitBlock = sessionActionDialogSource.slice(textSubmitIndex, textSubmitIndex + 800)
+    const textSubmitBlock = sessionActionDialogSource.slice(
+      textSubmitIndex,
+      textSubmitIndex + 800,
+    )
     expect(textSubmitBlock).toContain("tipcClient.createMcpTextInput")
     expect(textSubmitBlock).toContain("fromTile: true")
     expect(textSubmitBlock).toContain("startSnoozed: false")
     expect(textSubmitBlock).toContain("preserveMainWindowFocus: true")
 
-    const voiceSubmitBlock = sessionActionDialogSource.slice(voiceCreateIndex, voiceCreateIndex + 600)
+    const voiceSubmitBlock = sessionActionDialogSource.slice(
+      voiceCreateIndex,
+      voiceCreateIndex + 600,
+    )
     expect(voiceSubmitBlock).toContain("fromTile: true")
     expect(voiceSubmitBlock).toContain("startSnoozed: false")
     expect(voiceSubmitBlock).toContain("preserveMainWindowFocus: true")
@@ -180,12 +282,20 @@ describe("sessions in-app actions", () => {
     expect(compactTileFollowUpSource).toContain("startSnoozed: false")
     expect(compactTileFollowUpSource).toContain("preserveMainWindowFocus: true")
     expect(tipcSource).toContain("fromTile?: boolean // Origin hint")
-    expect(tipcSource).toContain("startSnoozed?: boolean // True background mode")
+    expect(tipcSource).toContain(
+      "startSnoozed?: boolean // True background mode",
+    )
     expect(tipcSource).toContain("preserveMainWindowFocus?: boolean")
-    expect(tipcSource).toContain("startSnoozed || input.suppressPanelAutoShow === true || input.fromTile === true")
-    expect(tipcSource).toContain("suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow")
+    expect(tipcSource).toContain(
+      "startSnoozed || input.suppressPanelAutoShow === true || input.fromTile === true",
+    )
+    expect(tipcSource).toContain(
+      "suppressPanelAutoShow: launchState.shouldSuppressPanelAutoShow",
+    )
     expect(tipcSource).toContain("createMainWindowForegroundPreserver(")
-    expect(tipcSource).toContain("processWithAgentMode(agentInputText, conversationId, existingSessionId, launchState)")
+    expect(tipcSource).toContain(
+      "processWithAgentMode(agentInputText, conversationId, existingSessionId, launchState)",
+    )
   })
 
   it("time-suppresses panel auto-show from explicit launch state without forcing snooze", () => {
@@ -196,29 +306,55 @@ describe("sessions in-app actions", () => {
     expect(textInputIndex).toBeGreaterThan(-1)
     expect(recordingIndex).toBeGreaterThan(-1)
 
-    const textInputBlock = tipcSource.slice(textInputIndex, textInputIndex + 2000)
-    const recordingBlock = tipcSource.slice(recordingIndex, recordingIndex + 2000)
+    const textInputBlock = tipcSource.slice(
+      textInputIndex,
+      textInputIndex + 2000,
+    )
+    const recordingBlock = tipcSource.slice(
+      recordingIndex,
+      recordingIndex + 2000,
+    )
 
-    expect(textInputBlock).toContain("const launchState = resolveAgentLaunchState(input)")
-    expect(textInputBlock).toContain("if (launchState.shouldSuppressPanelAutoShow) {")
+    expect(textInputBlock).toContain(
+      "const launchState = resolveAgentLaunchState(input)",
+    )
+    expect(textInputBlock).toContain(
+      "if (launchState.shouldSuppressPanelAutoShow) {",
+    )
     expect(textInputBlock).toContain("suppressPanelAutoShow(2000)")
-    expect(recordingBlock).toContain("const launchState = resolveAgentLaunchState(input)")
-    expect(recordingBlock).toContain("if (launchState.shouldSuppressPanelAutoShow) {")
+    expect(recordingBlock).toContain(
+      "const launchState = resolveAgentLaunchState(input)",
+    )
+    expect(recordingBlock).toContain(
+      "if (launchState.shouldSuppressPanelAutoShow) {",
+    )
     expect(recordingBlock).toContain("suppressPanelAutoShow(2000)")
   })
 
   it("reports centralized TTS IPC delivery only when handlers are available", () => {
-    expect(tipcSource).toContain("const handler = getRendererHandlers<RendererHandlers>(win.webContents).ttsPlaybackStateChanged")
+    expect(tipcSource).toContain(
+      "const handler = getRendererHandlers<RendererHandlers>(win.webContents).ttsPlaybackStateChanged",
+    )
     expect(tipcSource).toContain("handler.send(state)")
     expect(tipcSource).toContain("windowsNotified += 1")
-    expect(tipcSource).toContain("const handler = getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackCommand")
-    expect(tipcSource).toContain("Main renderer has no TTS playback command handler")
-    expect(tipcSource).toContain("Main renderer has no TTS playback request handler")
+    expect(tipcSource).toContain(
+      "const handler = getRendererHandlers<RendererHandlers>(main.webContents).ttsPlaybackCommand",
+    )
+    expect(tipcSource).toContain(
+      "Main renderer has no TTS playback command handler",
+    )
+    expect(tipcSource).toContain(
+      "Main renderer has no TTS playback request handler",
+    )
   })
 
   it("derives the active session tile's isFocused from the focusedSessionId store rather than hardcoding true", () => {
-    expect(sessionsSource).toContain("const focusedSessionId = useAgentStore((state) => state.focusedSessionId)")
-    expect(sessionsSource).toContain("const isFocused = focusedSessionId === sessionId")
+    expect(sessionsSource).toContain(
+      "const focusedSessionId = useAgentStore((state) => state.focusedSessionId)",
+    )
+    expect(sessionsSource).toContain(
+      "const isFocused = focusedSessionId === sessionId",
+    )
     expect(sessionsSource).toContain("isFocused={isFocused}")
     expect(sessionsSource).not.toContain("isFocused={true}")
   })
@@ -231,36 +367,61 @@ describe("sessions in-app actions", () => {
   })
 
   it("wires lazy earlier-history loading for active session tiles", () => {
-    expect(sessionsSource).toContain("const [activeHistoryMessageLimit, setActiveHistoryMessageLimit]")
-    expect(sessionsSource).toContain("const progressForExpandedHistoryDecision = useMemo")
-    expect(sessionsSource).toContain("const shouldLoadExpandedConversationHistory =")
-    expect(sessionsSource.indexOf("const progressForExpandedHistoryDecision = useMemo")).toBeLessThan(
+    expect(sessionsSource).toContain(
+      "const [activeHistoryMessageLimit, setActiveHistoryMessageLimit]",
+    )
+    expect(sessionsSource).toContain(
+      "const progressForExpandedHistoryDecision = useMemo",
+    )
+    expect(sessionsSource).toContain(
+      "const shouldLoadExpandedConversationHistory =",
+    )
+    expect(
+      sessionsSource.indexOf(
+        "const progressForExpandedHistoryDecision = useMemo",
+      ),
+    ).toBeLessThan(
       sessionsSource.indexOf("const shouldLoadExpandedConversationHistory ="),
     )
     expect(sessionsSource).toContain("messageLimit: activeHistoryMessageLimit")
     expect(sessionsSource).toContain("replaceExistingHistory:")
-    expect(sessionsSource).toContain("activeHistoryMessageLimit > baseConversationHistoryCount")
-    expect(sessionsSource).toContain("onLoadEarlierConversationHistory={handleLoadEarlierConversationHistory}")
+    expect(sessionsSource).toContain(
+      "activeHistoryMessageLimit > baseConversationHistoryCount",
+    )
+    expect(sessionsSource).toContain(
+      "onLoadEarlierConversationHistory={handleLoadEarlierConversationHistory}",
+    )
     expect(sessionsSource).toContain("isLoadingEarlierConversationHistory={")
   })
 
   it("hands pending saved-conversation history to the real session before removing the pending tile", () => {
     expect(sessionsSource).toContain("getConversationHydrationQueryKey")
     expect(sessionsSource).toContain("const hydrationConversationQuery")
-    expect(sessionsSource).toContain('queryKey: hydrationQueryKey ?? ["conversation", "__missing__", "hydrate"]')
+    expect(sessionsSource).toContain(
+      'queryKey: hydrationQueryKey ?? ["conversation", "__missing__", "hydrate"]',
+    )
     expect(sessionsSource).toContain("const cachedHydrationConversation")
     expect(sessionsSource).toContain("!!cachedHydrationConversation")
     expect(sessionsSource).not.toContain("hasLiveSessionForPendingResume")
     expect(sessionsSource).toContain("queryClient.setQueryData(")
-    expect(sessionsSource).toContain("if (!pendingResumeConversationQuery.data) return")
-    expect(
-      sessionsSource.indexOf("queryClient.setQueryData(")
-    ).toBeLessThan(
-      sessionsSource.indexOf("setPendingResumeConversationId(null)", sessionsSource.indexOf("if (realEntry) {")),
+    expect(sessionsSource).toContain(
+      "if (!pendingResumeConversationQuery.data) return",
     )
-    expect(sessionsSource).toContain("onFollowUpSubmitStarted={handlePendingContinuationStarted}")
-    expect(sessionsSource).toContain("onFollowUpSubmitFailed={handlePendingContinuationFailed}")
-    expect(agentProgressSource).toContain("onMessageSubmitStarted={handleFollowUpSubmitStarted}")
+    expect(sessionsSource.indexOf("queryClient.setQueryData(")).toBeLessThan(
+      sessionsSource.indexOf(
+        "setPendingResumeConversationId(null)",
+        sessionsSource.indexOf("if (realEntry) {"),
+      ),
+    )
+    expect(sessionsSource).toContain(
+      "onFollowUpSubmitStarted={handlePendingContinuationStarted}",
+    )
+    expect(sessionsSource).toContain(
+      "onFollowUpSubmitFailed={handlePendingContinuationFailed}",
+    )
+    expect(agentProgressSource).toContain(
+      "onMessageSubmitStarted={handleFollowUpSubmitStarted}",
+    )
     expect(tileFollowUpSource).toContain("onMessageSubmitStarted?.()")
     expect(tileFollowUpSource).toContain("onMessageSubmitFailed?.()")
   })

--- a/apps/desktop/src/renderer/src/pages/settings-agents.install-handoff.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.install-handoff.test.tsx
@@ -1,48 +1,124 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-type EffectRecord = { callback?: () => void | (() => void); deps?: any[]; nextDeps?: any[]; cleanup?: void | (() => void); hasRun: boolean }
+type EffectRecord = {
+  callback?: () => void | (() => void)
+  deps?: any[]
+  nextDeps?: any[]
+  cleanup?: void | (() => void)
+  hasRun: boolean
+}
 
 function createHookRuntime() {
   const states: any[] = []
   const refs: Array<{ current: any }> = []
   const effects: EffectRecord[] = []
-  let stateIndex = 0, refIndex = 0, effectIndex = 0
-  const depsChanged = (prev?: any[], next?: any[]) => !prev || !next || prev.length !== next.length || prev.some((v, i) => !Object.is(v, next[i]))
+  let stateIndex = 0,
+    refIndex = 0,
+    effectIndex = 0
+  const depsChanged = (prev?: any[], next?: any[]) =>
+    !prev ||
+    !next ||
+    prev.length !== next.length ||
+    prev.some((v, i) => !Object.is(v, next[i]))
   const useState = <T,>(initial: T | (() => T)) => {
     const idx = stateIndex++
-    if (states[idx] === undefined) states[idx] = typeof initial === "function" ? (initial as () => T)() : initial
-    return [states[idx] as T, (update: T | ((prev: T) => T)) => { states[idx] = typeof update === "function" ? (update as (prev: T) => T)(states[idx]) : update }] as const
+    if (states[idx] === undefined)
+      states[idx] =
+        typeof initial === "function" ? (initial as () => T)() : initial
+    return [
+      states[idx] as T,
+      (update: T | ((prev: T) => T)) => {
+        states[idx] =
+          typeof update === "function"
+            ? (update as (prev: T) => T)(states[idx])
+            : update
+      },
+    ] as const
   }
   const useMemo = <T,>(factory: () => T) => factory()
-  const forwardRef = <P,>(renderFn: (props: P, ref: unknown) => any) => (props: P) => renderFn(props, null)
-  const useRef = <T,>(initial: T) => (refs[refIndex] ??= { current: initial }) as { current: T }
-  const useEffect = (callback: EffectRecord["callback"], deps?: any[]) => { effects[effectIndex] = { ...(effects[effectIndex] ?? { hasRun: false }), callback, nextDeps: deps }; effectIndex += 1 }
-  const render = <P,>(Component: (props: P) => any, props: P) => { stateIndex = 0; refIndex = 0; effectIndex = 0; return Component(props) }
-  const commitEffects = () => { for (const effect of effects) { if (!effect?.callback) continue; if (!effect.hasRun || depsChanged(effect.deps, effect.nextDeps)) { if (typeof effect.cleanup === "function") effect.cleanup(); effect.cleanup = effect.callback(); effect.deps = effect.nextDeps; effect.hasRun = true } } }
-  const invoke = (type: any, props: any) => typeof type === "function" ? type(props) : null
+  const forwardRef =
+    <P,>(renderFn: (props: P, ref: unknown) => any) =>
+    (props: P) =>
+      renderFn(props, null)
+  const useRef = <T,>(initial: T) =>
+    (refs[refIndex] ??= { current: initial }) as { current: T }
+  const useEffect = (callback: EffectRecord["callback"], deps?: any[]) => {
+    effects[effectIndex] = {
+      ...(effects[effectIndex] ?? { hasRun: false }),
+      callback,
+      nextDeps: deps,
+    }
+    effectIndex += 1
+  }
+  const render = <P,>(Component: (props: P) => any, props: P) => {
+    stateIndex = 0
+    refIndex = 0
+    effectIndex = 0
+    return Component(props)
+  }
+  const commitEffects = () => {
+    for (const effect of effects) {
+      if (!effect?.callback) continue
+      if (!effect.hasRun || depsChanged(effect.deps, effect.nextDeps)) {
+        if (typeof effect.cleanup === "function") effect.cleanup()
+        effect.cleanup = effect.callback()
+        effect.deps = effect.nextDeps
+        effect.hasRun = true
+      }
+    }
+  }
+  const invoke = (type: any, props: any) =>
+    typeof type === "function" ? type(props) : null
   return {
     render,
     commitEffects,
-    reactMock: { __esModule: true, default: {} as any, useState, useMemo, useRef: <T,>(initial: T) => { const ref = useRef(initial); refIndex += 1; return ref }, useEffect, forwardRef },
-    jsxRuntimeMock: { __esModule: true, jsx: invoke, jsxs: invoke, jsxDEV: invoke, Fragment: Symbol.for("react.fragment") },
+    reactMock: {
+      __esModule: true,
+      default: {} as any,
+      useState,
+      useMemo,
+      useRef: <T,>(initial: T) => {
+        const ref = useRef(initial)
+        refIndex += 1
+        return ref
+      },
+      useEffect,
+      forwardRef,
+    },
+    jsxRuntimeMock: {
+      __esModule: true,
+      jsx: invoke,
+      jsxs: invoke,
+      jsxDEV: invoke,
+      Fragment: Symbol.for("react.fragment"),
+    },
   }
 }
 
-async function flushPromises() { await Promise.resolve(); await Promise.resolve() }
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
 
-async function loadSettingsAgents(runtime: ReturnType<typeof createHookRuntime>, installBundlePath: string) {
+async function loadSettingsAgents(
+  runtime: ReturnType<typeof createHookRuntime>,
+  installBundlePath: string,
+) {
   vi.resetModules()
   const Null = () => null
   let currentSearchParams = installBundlePath
     ? new URLSearchParams([["installBundle", installBundlePath]])
     : new URLSearchParams()
-  const setSearchParams = vi.fn((next: URLSearchParams) => { currentSearchParams = new URLSearchParams(next) })
+  const setSearchParams = vi.fn((next: URLSearchParams) => {
+    currentSearchParams = new URLSearchParams(next)
+  })
   const dialogProps = { current: null as any }
   const exportDialogProps = { current: null as any }
   const publishDialogProps = { current: null as any }
   const buttonProps = new Map<string, any>()
   const collectText = (children: any): string => {
-    if (typeof children === "string" || typeof children === "number") return String(children)
+    if (typeof children === "string" || typeof children === "number")
+      return String(children)
     if (Array.isArray(children)) return children.map(collectText).join("")
     return ""
   }
@@ -50,33 +126,131 @@ async function loadSettingsAgents(runtime: ReturnType<typeof createHookRuntime>,
   vi.doMock("react", () => runtime.reactMock)
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
-  vi.doMock("react-router-dom", () => ({ useNavigate: () => vi.fn(), useSearchParams: () => [currentSearchParams, setSearchParams] }))
-  vi.doMock("@tanstack/react-query", () => ({ useQueryClient: () => ({ invalidateQueries: vi.fn() }) }))
-  const settingsTipcMock = { tipcClient: { getAgentProfiles: vi.fn(async () => []), getDefaultSystemPrompt: vi.fn(async () => "") } }
+  vi.doMock("react-router-dom", () => ({
+    useNavigate: () => vi.fn(),
+    useSearchParams: () => [currentSearchParams, setSearchParams],
+  }))
+  vi.doMock("@tanstack/react-query", () => ({
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  }))
+  vi.doMock("@renderer/components/settings-navigation", () => ({
+    SettingsPageShell: (props: any) => props?.children ?? null,
+    SettingsNavigation: Null,
+  }))
+  vi.doMock("../components/settings-navigation", () => ({
+    SettingsPageShell: (props: any) => props?.children ?? null,
+    SettingsNavigation: Null,
+  }))
+  const settingsTipcMock = {
+    tipcClient: {
+      getAgentProfiles: vi.fn(async () => []),
+      getDefaultSystemPrompt: vi.fn(async () => ""),
+    },
+  }
   vi.doMock("../lib/tipc-client", () => settingsTipcMock)
   vi.doMock("@renderer/lib/tipc-client", () => settingsTipcMock)
-  vi.doMock("../components/bundle-import-dialog", () => ({ BundleImportDialog: (props: any) => { dialogProps.current = props; return null } }))
-  vi.doMock("../components/bundle-export-dialog", () => ({ BundleExportDialog: (props: any) => { exportDialogProps.current = props; return null } }))
-  vi.doMock("@renderer/components/bundle-export-dialog", () => ({ BundleExportDialog: (props: any) => { exportDialogProps.current = props; return null } }))
-  vi.doMock("../components/bundle-publish-dialog", () => ({ BundlePublishDialog: (props: any) => { publishDialogProps.current = props; return null } }))
-  vi.doMock("@renderer/components/bundle-publish-dialog", () => ({ BundlePublishDialog: (props: any) => { publishDialogProps.current = props; return null } }))
-  vi.doMock("../components/sandbox-slot-switcher", () => ({ SandboxSlotSwitcher: Null }))
-  vi.doMock("@renderer/components/sandbox-slot-switcher", () => ({ SandboxSlotSwitcher: Null }))
+  vi.doMock("../components/bundle-import-dialog", () => ({
+    BundleImportDialog: (props: any) => {
+      dialogProps.current = props
+      return null
+    },
+  }))
+  vi.doMock("../components/bundle-export-dialog", () => ({
+    BundleExportDialog: (props: any) => {
+      exportDialogProps.current = props
+      return null
+    },
+  }))
+  vi.doMock("@renderer/components/bundle-export-dialog", () => ({
+    BundleExportDialog: (props: any) => {
+      exportDialogProps.current = props
+      return null
+    },
+  }))
+  vi.doMock("../components/bundle-publish-dialog", () => ({
+    BundlePublishDialog: (props: any) => {
+      publishDialogProps.current = props
+      return null
+    },
+  }))
+  vi.doMock("@renderer/components/bundle-publish-dialog", () => ({
+    BundlePublishDialog: (props: any) => {
+      publishDialogProps.current = props
+      return null
+    },
+  }))
+  vi.doMock("../components/sandbox-slot-switcher", () => ({
+    SandboxSlotSwitcher: Null,
+  }))
+  vi.doMock("@renderer/components/sandbox-slot-switcher", () => ({
+    SandboxSlotSwitcher: Null,
+  }))
   vi.doMock("../components/model-selector", () => ({ ModelSelector: Null }))
-  vi.doMock("../components/ui/button", () => ({ Button: (props: any) => { const label = collectText(props.children).trim(); if (label) buttonProps.set(label, props); return null } }))
+  vi.doMock("../components/ui/button", () => ({
+    Button: (props: any) => {
+      const label = collectText(props.children).trim()
+      if (label) buttonProps.set(label, props)
+      return null
+    },
+  }))
   vi.doMock("../components/ui/input", () => ({ Input: Null }))
   vi.doMock("../components/ui/label", () => ({ Label: Null }))
   vi.doMock("../components/ui/textarea", () => ({ Textarea: Null }))
   vi.doMock("../components/ui/switch", () => ({ Switch: Null }))
-  vi.doMock("../components/ui/select", () => ({ Select: Null, SelectContent: Null, SelectItem: Null, SelectTrigger: Null, SelectValue: Null }))
-  vi.doMock("../components/ui/card", () => ({ Card: Null, CardContent: Null, CardDescription: Null, CardHeader: Null, CardTitle: Null }))
+  vi.doMock("../components/ui/select", () => ({
+    Select: Null,
+    SelectContent: Null,
+    SelectItem: Null,
+    SelectTrigger: Null,
+    SelectValue: Null,
+  }))
+  vi.doMock("../components/ui/card", () => ({
+    Card: Null,
+    CardContent: Null,
+    CardDescription: Null,
+    CardHeader: Null,
+    CardTitle: Null,
+  }))
   vi.doMock("../components/ui/badge", () => ({ Badge: Null }))
-  vi.doMock("../components/ui/tabs", () => ({ Tabs: Null, TabsList: Null, TabsTrigger: Null, TabsContent: Null }))
+  vi.doMock("../components/ui/tabs", () => ({
+    Tabs: Null,
+    TabsList: Null,
+    TabsTrigger: Null,
+    TabsContent: Null,
+  }))
   vi.doMock("facehash", () => ({ Facehash: Null }))
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-  vi.doMock("lucide-react", () => { const Icon = () => null; return { Trash2: Icon, Plus: Icon, Edit2: Icon, Save: Icon, X: Icon, Server: Icon, Sparkles: Icon, Brain: Icon, Settings2: Icon, ChevronDown: Icon, ChevronRight: Icon, Wrench: Icon, RefreshCw: Icon, ExternalLink: Icon, Download: Icon, Upload: Icon, Globe: Icon } })
+  vi.doMock("lucide-react", () => {
+    const Icon = () => null
+    return {
+      Trash2: Icon,
+      Plus: Icon,
+      Edit2: Icon,
+      Save: Icon,
+      X: Icon,
+      Server: Icon,
+      Sparkles: Icon,
+      Brain: Icon,
+      Settings2: Icon,
+      ChevronDown: Icon,
+      ChevronRight: Icon,
+      Wrench: Icon,
+      RefreshCw: Icon,
+      ExternalLink: Icon,
+      Download: Icon,
+      Upload: Icon,
+      Globe: Icon,
+    }
+  })
   const mod = await import("./settings-agents")
-  return { SettingsAgents: mod.SettingsAgents, dialogProps, exportDialogProps, publishDialogProps, buttonProps, setSearchParams }
+  return {
+    SettingsAgents: mod.SettingsAgents,
+    dialogProps,
+    exportDialogProps,
+    publishDialogProps,
+    buttonProps,
+    setSearchParams,
+  }
 }
 
 async function loadBundleImportDialogHelper() {
@@ -86,29 +260,92 @@ async function loadBundleImportDialogHelper() {
   vi.doUnmock("react/jsx-runtime")
   vi.doUnmock("react/jsx-dev-runtime")
   const Null = () => null
-  const previewBundleWithConflicts = vi.fn(async ({ filePath }: { filePath: string }) => ({ filePath, bundle: null, manifest: { version: 1, name: "Hub Bundle", createdAt: "", exportedFrom: "", components: { agentProfiles: 1, mcpServers: 0, skills: 0, repeatTasks: 0, knowledgeNotes: 0 } }, conflicts: { agentProfiles: [], mcpServers: [], skills: [], repeatTasks: [], knowledgeNotes: [] } }))
-  const bundleTipcMock = { tipcClient: { previewBundleWithConflicts, previewBundleFromDialog: vi.fn(), importBundle: vi.fn() } }
+  const previewBundleWithConflicts = vi.fn(
+    async ({ filePath }: { filePath: string }) => ({
+      filePath,
+      bundle: null,
+      manifest: {
+        version: 1,
+        name: "Hub Bundle",
+        createdAt: "",
+        exportedFrom: "",
+        components: {
+          agentProfiles: 1,
+          mcpServers: 0,
+          skills: 0,
+          repeatTasks: 0,
+          knowledgeNotes: 0,
+        },
+      },
+      conflicts: {
+        agentProfiles: [],
+        mcpServers: [],
+        skills: [],
+        repeatTasks: [],
+        knowledgeNotes: [],
+      },
+    }),
+  )
+  const bundleTipcMock = {
+    tipcClient: {
+      previewBundleWithConflicts,
+      previewBundleFromDialog: vi.fn(),
+      importBundle: vi.fn(),
+    },
+  }
   vi.doMock("../lib/tipc-client", () => bundleTipcMock)
   vi.doMock("@renderer/lib/tipc-client", () => bundleTipcMock)
-  vi.doMock("../components/ui/dialog", () => ({ Dialog: Null, DialogContent: Null, DialogDescription: Null, DialogFooter: Null, DialogHeader: Null, DialogTitle: Null }))
+  vi.doMock("../components/ui/dialog", () => ({
+    Dialog: Null,
+    DialogContent: Null,
+    DialogDescription: Null,
+    DialogFooter: Null,
+    DialogHeader: Null,
+    DialogTitle: Null,
+  }))
   vi.doMock("../components/ui/button", () => ({ Button: Null }))
   vi.doMock("../components/ui/label", () => ({ Label: Null }))
   vi.doMock("../components/ui/switch", () => ({ Switch: Null }))
   vi.doMock("../components/ui/badge", () => ({ Badge: Null }))
-  vi.doMock("../components/ui/select", () => ({ Select: Null, SelectContent: Null, SelectItem: Null, SelectTrigger: Null, SelectValue: Null }))
+  vi.doMock("../components/ui/select", () => ({
+    Select: Null,
+    SelectContent: Null,
+    SelectItem: Null,
+    SelectTrigger: Null,
+    SelectValue: Null,
+  }))
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-  vi.doMock("lucide-react", () => { const Icon = () => null; return { Loader2: Icon, AlertTriangle: Icon, Package: Icon, Bot: Icon, Server: Icon, Sparkles: Icon, Clock: Icon, Brain: Icon } })
+  vi.doMock("lucide-react", () => {
+    const Icon = () => null
+    return {
+      Loader2: Icon,
+      AlertTriangle: Icon,
+      Package: Icon,
+      Bot: Icon,
+      Server: Icon,
+      Sparkles: Icon,
+      Clock: Icon,
+      Brain: Icon,
+    }
+  })
   const mod = await import("../components/bundle-import-dialog")
-  return { previewProvidedBundleFile: mod.previewProvidedBundleFile, previewBundleWithConflicts }
+  return {
+    previewProvidedBundleFile: mod.previewProvidedBundleFile,
+    previewBundleWithConflicts,
+  }
 }
 
-afterEach(() => { vi.restoreAllMocks(); vi.resetModules() })
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
 
 describe("settings-agents Hub install handoff", () => {
   it("opens the existing bundle import dialog from the installBundle query param", async () => {
     const runtime = createHookRuntime()
     const bundlePath = "/tmp/from-hub.dotagents"
-    const { SettingsAgents, dialogProps, setSearchParams } = await loadSettingsAgents(runtime, bundlePath)
+    const { SettingsAgents, dialogProps, setSearchParams } =
+      await loadSettingsAgents(runtime, bundlePath)
     runtime.render(SettingsAgents, {})
     runtime.commitEffects()
     await flushPromises()
@@ -150,9 +387,12 @@ describe("settings-agents Hub install handoff", () => {
 
   it("previews a provided Hub bundle path through the existing conflict-aware dialog flow", async () => {
     const bundlePath = "/tmp/from-hub.dotagents"
-    const { previewProvidedBundleFile, previewBundleWithConflicts } = await loadBundleImportDialogHelper()
+    const { previewProvidedBundleFile, previewBundleWithConflicts } =
+      await loadBundleImportDialogHelper()
     await previewProvidedBundleFile(bundlePath)
 
-    expect(previewBundleWithConflicts).toHaveBeenCalledWith({ filePath: bundlePath })
+    expect(previewBundleWithConflicts).toHaveBeenCalledWith({
+      filePath: bundlePath,
+    })
   })
 })

--- a/apps/desktop/src/renderer/src/pages/settings-agents.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-agents.tsx
@@ -6,26 +6,84 @@ import { Input } from "@renderer/components/ui/input"
 import { Label } from "@renderer/components/ui/label"
 import { Textarea } from "@renderer/components/ui/textarea"
 import { Switch } from "@renderer/components/ui/switch"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@renderer/components/ui/select"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@renderer/components/ui/card"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@renderer/components/ui/card"
 import { Badge } from "@renderer/components/ui/badge"
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "@renderer/components/ui/tabs"
-import { Trash2, Plus, Edit2, Save, X, Server, Sparkles, Brain, Settings2, ChevronDown, ChevronRight, Wrench, RefreshCw, ExternalLink, Download, Upload, Globe, AlertTriangle } from "lucide-react"
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+} from "@renderer/components/ui/tabs"
+import {
+  Trash2,
+  Plus,
+  Edit2,
+  Save,
+  X,
+  Server,
+  Sparkles,
+  Brain,
+  Settings2,
+  ChevronDown,
+  ChevronRight,
+  Wrench,
+  RefreshCw,
+  ExternalLink,
+  Download,
+  Upload,
+  Globe,
+  AlertTriangle,
+} from "lucide-react"
 import { Facehash } from "facehash"
 import { toast } from "sonner"
-import { DEFAULT_AGENT_RUNTIME_TOOL_NAMES, MARK_WORK_COMPLETE_TOOL } from "@shared/runtime-tool-names"
+import {
+  DEFAULT_AGENT_RUNTIME_TOOL_NAMES,
+  MARK_WORK_COMPLETE_TOOL,
+} from "@shared/runtime-tool-names"
 
 // Curated palette of vivid colors to pick from deterministically
 const AVATAR_PALETTE = [
-  "#ef4444","#f97316","#eab308","#22c55e","#14b8a6",
-  "#3b82f6","#8b5cf6","#ec4899","#06b6d4","#84cc16",
-  "#f43f5e","#a855f7","#0ea5e9","#10b981","#f59e0b",
-  "#e11d48","#7c3aed","#0891b2","#059669","#d97706",
+  "#ef4444",
+  "#f97316",
+  "#eab308",
+  "#22c55e",
+  "#14b8a6",
+  "#3b82f6",
+  "#8b5cf6",
+  "#ec4899",
+  "#06b6d4",
+  "#84cc16",
+  "#f43f5e",
+  "#a855f7",
+  "#0ea5e9",
+  "#10b981",
+  "#f59e0b",
+  "#e11d48",
+  "#7c3aed",
+  "#0891b2",
+  "#059669",
+  "#d97706",
 ]
 function agentColors(seed: string): string[] {
   let h = 5381
-  for (let i = 0; i < seed.length; i++) h = ((h * 33) ^ seed.charCodeAt(i)) >>> 0
-  return [0, 7, 13].map(offset => AVATAR_PALETTE[(h + offset) % AVATAR_PALETTE.length])
+  for (let i = 0; i < seed.length; i++)
+    h = ((h * 33) ^ seed.charCodeAt(i)) >>> 0
+  return [0, 7, 13].map(
+    (offset) => AVATAR_PALETTE[(h + offset) % AVATAR_PALETTE.length],
+  )
 }
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { sortAgentsWithDefaultFirst } from "@renderer/lib/agent-order"
@@ -33,11 +91,18 @@ import { ModelSelector } from "@renderer/components/model-selector"
 import { BundleImportDialog } from "@renderer/components/bundle-import-dialog"
 import { BundleExportDialog } from "@renderer/components/bundle-export-dialog"
 import { BundlePublishDialog } from "@renderer/components/bundle-publish-dialog"
+import { SettingsPageShell } from "@renderer/components/settings-navigation"
 import { invalidateAgentProfileQueries } from "@renderer/lib/invalidate-agent-profile-queries"
 import { SandboxSlotSwitcher } from "@renderer/components/sandbox-slot-switcher"
 import {
-  AgentProfile, AgentProfileConnectionType, AgentProfileConnection,
-  ProfileModelConfig, AgentProfileToolConfig, ProfileSkillsConfig, AgentSkill, DetailedToolInfo,
+  AgentProfile,
+  AgentProfileConnectionType,
+  AgentProfileConnection,
+  ProfileModelConfig,
+  AgentProfileToolConfig,
+  ProfileSkillsConfig,
+  AgentSkill,
+  DetailedToolInfo,
 } from "../../../shared/types"
 
 type ConnectionType = AgentProfileConnectionType
@@ -83,57 +148,102 @@ interface ExternalAgentCommandVerificationResult {
   warnings?: string[]
 }
 
-type ServerInfo = { connected: boolean; toolCount: number; runtimeEnabled?: boolean; configDisabled?: boolean }
+type ServerInfo = {
+  connected: boolean
+  toolCount: number
+  runtimeEnabled?: boolean
+  configDisabled?: boolean
+}
 
 const AGENT_PRESETS: Record<AgentPresetKey, AgentPresetDefinition> = {
   auggie: {
     displayName: "Auggie (Augment Code)",
     description: "Augment Code's AI coding assistant with native ACP support",
-    connectionType: 'acpx', connectionCommand: 'auggie', connectionArgs: '--acp', enabled: true,
+    connectionType: "acpx",
+    connectionCommand: "auggie",
+    connectionArgs: "--acp",
+    enabled: true,
     docsUrl: "https://www.augmentcode.com/",
-    cwdHint: "Point the working directory at the repo you want Auggie to operate in.",
+    cwdHint:
+      "Point the working directory at the repo you want Auggie to operate in.",
     verifyArgs: ["--help"],
   },
   "claude-code": {
     displayName: "Claude Code",
     description: "Anthropic's Claude for coding tasks via ACP adapter",
-    connectionType: 'acpx', connectionCommand: 'claude-code-acp', connectionArgs: '', enabled: true,
+    connectionType: "acpx",
+    connectionCommand: "claude-code-acp",
+    connectionArgs: "",
+    enabled: true,
     docsUrl: "https://github.com/zed-industries/claude-code-acp",
     installCommand: "npm install -g @zed-industries/claude-code-acp",
-    authHint: "Sign in to Claude Code in your terminal before verifying if this is your first run.",
-    cwdHint: "Use your repo root so Claude Code inherits the right project context.",
+    authHint:
+      "Sign in to Claude Code in your terminal before verifying if this is your first run.",
+    cwdHint:
+      "Use your repo root so Claude Code inherits the right project context.",
     verifyArgs: ["--help"],
   },
   codex: {
     displayName: "Codex",
     description: "OpenAI Codex via the official ACP adapter",
-    connectionType: 'acpx', connectionCommand: 'codex-acp', connectionArgs: '', enabled: true,
+    connectionType: "acpx",
+    connectionCommand: "codex-acp",
+    connectionArgs: "",
+    enabled: true,
     docsUrl: "https://github.com/zed-industries/codex-acp",
     installCommand: "npm install -g @zed-industries/codex-acp",
-    authHint: "Run codex login first, or set CODEX_API_KEY / OPENAI_API_KEY before verifying.",
-    cwdHint: "Set the working directory to the project Codex should inspect and edit.",
+    authHint:
+      "Run codex login first, or set CODEX_API_KEY / OPENAI_API_KEY before verifying.",
+    cwdHint:
+      "Set the working directory to the project Codex should inspect and edit.",
     verifyArgs: ["--help"],
   },
   opencode: {
     displayName: "OpenCode",
-    description: "OpenCode's native ACP server for terminal-first agent workflows",
-    connectionType: 'acpx', connectionCommand: 'opencode', connectionArgs: 'acp', enabled: true,
+    description:
+      "OpenCode's native ACP server for terminal-first agent workflows",
+    connectionType: "acpx",
+    connectionCommand: "opencode",
+    connectionArgs: "acp",
+    enabled: true,
     docsUrl: "https://opencode.ai/docs/acp/",
     installCommand: "npm install -g opencode-ai",
-    authHint: "OpenCode stores provider auth after you run opencode and complete /connect in the TUI.",
-    cwdHint: "Use your workspace root so opencode acp can load the right project and config.",
+    authHint:
+      "OpenCode stores provider auth after you run opencode and complete /connect in the TUI.",
+    cwdHint:
+      "Use your workspace root so opencode acp can load the right project and config.",
     verifyArgs: ["--help"],
   },
 }
 
-function detectPresetKey(agent?: Partial<EditingAgent> | null): AgentPresetKey | undefined {
+function detectPresetKey(
+  agent?: Partial<EditingAgent> | null,
+): AgentPresetKey | undefined {
   if (!agent) return undefined
   const args = (agent.connectionArgs || "").trim()
 
-  if (agent.connectionType === 'acpx' && agent.connectionCommand === 'auggie' && args === '--acp') return 'auggie'
-  if (agent.connectionType === 'acpx' && agent.connectionCommand === 'claude-code-acp') return 'claude-code'
-  if (agent.connectionType === 'acpx' && agent.connectionCommand === 'codex-acp') return 'codex'
-  if (agent.connectionType === 'acpx' && agent.connectionCommand === 'opencode' && args === 'acp') return 'opencode'
+  if (
+    agent.connectionType === "acpx" &&
+    agent.connectionCommand === "auggie" &&
+    args === "--acp"
+  )
+    return "auggie"
+  if (
+    agent.connectionType === "acpx" &&
+    agent.connectionCommand === "claude-code-acp"
+  )
+    return "claude-code"
+  if (
+    agent.connectionType === "acpx" &&
+    agent.connectionCommand === "codex-acp"
+  )
+    return "codex"
+  if (
+    agent.connectionType === "acpx" &&
+    agent.connectionCommand === "opencode" &&
+    args === "acp"
+  )
+    return "opencode"
 
   return undefined
 }
@@ -144,10 +254,16 @@ function buildCommandPreview(command?: string, args?: string): string {
 
 function emptyAgent(): EditingAgent {
   return {
-    displayName: "", description: "", systemPrompt: "", guidelines: "",
-    connectionType: "internal", enabled: true,
-    modelConfig: undefined, toolConfig: undefined,
-    skillsConfig: undefined, properties: {},
+    displayName: "",
+    description: "",
+    systemPrompt: "",
+    guidelines: "",
+    connectionType: "internal",
+    enabled: true,
+    modelConfig: undefined,
+    toolConfig: undefined,
+    skillsConfig: undefined,
+    properties: {},
   }
 }
 
@@ -155,35 +271,50 @@ function hasCustomSystemPrompt(systemPrompt?: string | null): boolean {
   return Boolean(systemPrompt?.trim())
 }
 
-function getAgentCardSummaryItems(agent: AgentProfile, availableSkillCount: number, availableRuntimeToolCount: number): string[] {
+function getAgentCardSummaryItems(
+  agent: AgentProfile,
+  availableSkillCount: number,
+  availableRuntimeToolCount: number,
+): string[] {
   const items: string[] = [agent.connection.type]
 
-  const agentProviderId = agent.modelConfig?.agentProviderId || agent.modelConfig?.mcpToolsProviderId
+  const agentProviderId =
+    agent.modelConfig?.agentProviderId || agent.modelConfig?.mcpToolsProviderId
   if (agentProviderId) {
     items.push(agentProviderId)
   }
 
   const enabledServerCount = agent.toolConfig?.enabledServers?.length ?? 0
   if (enabledServerCount > 0) {
-    items.push(`${enabledServerCount} server${enabledServerCount === 1 ? "" : "s"}`)
+    items.push(
+      `${enabledServerCount} server${enabledServerCount === 1 ? "" : "s"}`,
+    )
   }
 
   if (availableSkillCount > 0) {
-    const enabledSkillCount = (!agent.skillsConfig || !agent.skillsConfig.allSkillsDisabledByDefault)
-      ? availableSkillCount
-      : (agent.skillsConfig.enabledSkillIds?.length ?? 0)
-    items.push(`${enabledSkillCount} skill${enabledSkillCount === 1 ? "" : "s"}`)
+    const enabledSkillCount =
+      !agent.skillsConfig || !agent.skillsConfig.allSkillsDisabledByDefault
+        ? availableSkillCount
+        : (agent.skillsConfig.enabledSkillIds?.length ?? 0)
+    items.push(
+      `${enabledSkillCount} skill${enabledSkillCount === 1 ? "" : "s"}`,
+    )
   }
 
   if (availableRuntimeToolCount > 0) {
     const runtimeList = agent.toolConfig?.enabledRuntimeTools
-    const enabledRuntimeCount = (!runtimeList || runtimeList.length === 0)
-      ? availableRuntimeToolCount
-      : runtimeList.length
-    items.push(`${enabledRuntimeCount} runtime tool${enabledRuntimeCount === 1 ? "" : "s"}`)
+    const enabledRuntimeCount =
+      !runtimeList || runtimeList.length === 0
+        ? availableRuntimeToolCount
+        : runtimeList.length
+    items.push(
+      `${enabledRuntimeCount} runtime tool${enabledRuntimeCount === 1 ? "" : "s"}`,
+    )
   }
 
-  const propertyCount = agent.properties ? Object.keys(agent.properties).length : 0
+  const propertyCount = agent.properties
+    ? Object.keys(agent.properties).length
+    : 0
   if (propertyCount > 0) {
     items.push(`${propertyCount} prop${propertyCount === 1 ? "" : "s"}`)
   }
@@ -198,31 +329,52 @@ export function SettingsAgents() {
   const [agents, setAgents] = useState<AgentProfile[]>([])
   const [editing, setEditing] = useState<EditingAgent | null>(null)
   const [isCreating, setIsCreating] = useState(false)
-  const [serverStatus, setServerStatus] = useState<Record<string, ServerInfo>>({})
-  const [allTools, setAllTools] = useState<{name: string, description: string, serverName: string}[]>([])
+  const [serverStatus, setServerStatus] = useState<Record<string, ServerInfo>>(
+    {},
+  )
+  const [allTools, setAllTools] = useState<
+    { name: string; description: string; serverName: string }[]
+  >([])
   const [skills, setSkills] = useState<AgentSkill[]>([])
   const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set())
-  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
+    new Set(),
+  )
   const [newPropKey, setNewPropKey] = useState("")
   const [newPropValue, setNewPropValue] = useState("")
   const [showSystemPrompt, setShowSystemPrompt] = useState(false)
   const [defaultSystemPrompt, setDefaultSystemPrompt] = useState("")
   const [isImportDialogOpen, setIsImportDialogOpen] = useState(false)
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false)
-  const [prefilledImportFilePath, setPrefilledImportFilePath] = useState<string | null>(null)
+  const [prefilledImportFilePath, setPrefilledImportFilePath] = useState<
+    string | null
+  >(null)
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false)
   const avatarFileInputRef = useRef<HTMLInputElement>(null)
-  const [commandVerification, setCommandVerification] = useState<ExternalAgentCommandVerificationResult | null>(null)
+  const [commandVerification, setCommandVerification] =
+    useState<ExternalAgentCommandVerificationResult | null>(null)
   const [isVerifyingCommand, setIsVerifyingCommand] = useState(false)
-  const sortedAgents = useMemo(() => sortAgentsWithDefaultFirst(agents), [agents])
+  const sortedAgents = useMemo(
+    () => sortAgentsWithDefaultFirst(agents),
+    [agents],
+  )
 
   useEffect(() => {
     loadAgents()
     loadSkills()
     loadAllTools()
-    tipcClient.getDefaultSystemPrompt().then(setDefaultSystemPrompt).catch(console.error)
+    tipcClient
+      .getDefaultSystemPrompt()
+      .then(setDefaultSystemPrompt)
+      .catch(console.error)
   }, [])
-  useEffect(() => { if (editing) { loadServers(); loadSkills(); loadAllTools() } }, [!!editing])
+  useEffect(() => {
+    if (editing) {
+      loadServers()
+      loadSkills()
+      loadAllTools()
+    }
+  }, [!!editing])
 
   useEffect(() => {
     const installBundlePath = searchParams.get("installBundle")
@@ -240,7 +392,13 @@ export function SettingsAgents() {
 
   useEffect(() => {
     setCommandVerification(null)
-  }, [editing?.presetKey, editing?.connectionType, editing?.connectionCommand, editing?.connectionArgs, editing?.connectionCwd])
+  }, [
+    editing?.presetKey,
+    editing?.connectionType,
+    editing?.connectionCommand,
+    editing?.connectionArgs,
+    editing?.connectionCwd,
+  ])
 
   // Handle URL-driven navigation: ?edit=<agentId> opens edit, ?create=1 opens
   // the create form, ?view=list returns to list
@@ -265,7 +423,7 @@ export function SettingsAgents() {
     }
 
     if (editId && agents.length > 0 && editing?.id !== editId) {
-      const agent = agents.find(a => a.id === editId)
+      const agent = agents.find((a) => a.id === editId)
       if (agent) {
         handleEdit(agent)
         // Clear the param so refreshing doesn't re-trigger
@@ -279,7 +437,10 @@ export function SettingsAgents() {
     setAgents(all)
   }
   const loadServers = async () => {
-    try { const s = await tipcClient.getMcpServerStatus(); setServerStatus(s as Record<string, ServerInfo>) } catch {}
+    try {
+      const s = await tipcClient.getMcpServerStatus()
+      setServerStatus(s as Record<string, ServerInfo>)
+    } catch {}
   }
   const loadAllTools = async () => {
     try {
@@ -288,12 +449,20 @@ export function SettingsAgents() {
     } catch {}
   }
   const loadSkills = async () => {
-    try { const s = await tipcClient.getSkills(); setSkills(s) } catch {}
+    try {
+      const s = await tipcClient.getSkills()
+      setSkills(s)
+    } catch {}
   }
 
-  const handleCreate = () => { setIsCreating(true); setEditing(emptyAgent()); setCommandVerification(null) }
+  const handleCreate = () => {
+    setIsCreating(true)
+    setEditing(emptyAgent())
+    setCommandVerification(null)
+  }
 
-  const refreshAgentProfileQueries = () => invalidateAgentProfileQueries(queryClient)
+  const refreshAgentProfileQueries = () =>
+    invalidateAgentProfileQueries(queryClient)
 
   const applyPreset = (presetKey: AgentPresetKey) => {
     const preset = AGENT_PRESETS[presetKey]
@@ -305,14 +474,18 @@ export function SettingsAgents() {
     setIsCreating(false)
     const connectionArgs = agent.connection.args?.join(" ")
     setEditing({
-      id: agent.id, displayName: agent.displayName,
-      description: agent.description ?? "", systemPrompt: agent.systemPrompt ?? "",
-      guidelines: agent.guidelines ?? "", connectionType: agent.connection.type,
+      id: agent.id,
+      displayName: agent.displayName,
+      description: agent.description ?? "",
+      systemPrompt: agent.systemPrompt ?? "",
+      guidelines: agent.guidelines ?? "",
+      connectionType: agent.connection.type,
       connectionCommand: agent.connection.command,
       connectionArgs,
       connectionBaseUrl: agent.connection.baseUrl,
       connectionCwd: agent.connection.cwd,
-      enabled: agent.enabled, autoSpawn: agent.autoSpawn,
+      enabled: agent.enabled,
+      autoSpawn: agent.autoSpawn,
       modelConfig: agent.modelConfig ? { ...agent.modelConfig } : undefined,
       toolConfig: agent.toolConfig ? { ...agent.toolConfig } : undefined,
       skillsConfig: agent.skillsConfig ? { ...agent.skillsConfig } : undefined,
@@ -328,16 +501,23 @@ export function SettingsAgents() {
 
   const handleSave = async () => {
     if (!editing) return
-    if (editing.connectionType === 'acpx' && !editing.connectionCommand?.trim()) {
-      toast.error('Add a command for acpx agents before saving.')
+    if (
+      editing.connectionType === "acpx" &&
+      !editing.connectionCommand?.trim()
+    ) {
+      toast.error("Add a command for acpx agents before saving.")
       return
     }
-    if (editing.connectionType === "remote" && !editing.connectionBaseUrl?.trim()) {
+    if (
+      editing.connectionType === "remote" &&
+      !editing.connectionBaseUrl?.trim()
+    ) {
       toast.error("Add a base URL before saving a remote agent.")
       return
     }
     const connection: AgentProfileConnection = {
-      type: editing.connectionType, command: editing.connectionCommand,
+      type: editing.connectionType,
+      command: editing.connectionCommand,
       args: editing.connectionArgs?.split(" ").filter(Boolean),
       baseUrl: editing.connectionBaseUrl,
       cwd: editing.connectionCwd,
@@ -347,35 +527,54 @@ export function SettingsAgents() {
       description: editing.description || undefined,
       systemPrompt: editing.systemPrompt || undefined,
       guidelines: editing.guidelines || undefined,
-      connection, enabled: editing.enabled,
-      isUserProfile: false, isAgentTarget: true,
+      connection,
+      enabled: editing.enabled,
+      isUserProfile: false,
+      isAgentTarget: true,
       autoSpawn: editing.autoSpawn,
       modelConfig: editing.modelConfig,
       toolConfig: editing.toolConfig,
       skillsConfig: editing.skillsConfig,
-      properties: editing.properties && Object.keys(editing.properties).length > 0 ? editing.properties : undefined,
+      properties:
+        editing.properties && Object.keys(editing.properties).length > 0
+          ? editing.properties
+          : undefined,
       avatarDataUrl: editing.avatarDataUrl ?? null,
     }
     if (isCreating) await tipcClient.createAgentProfile({ profile: data })
-    else if (editing.id) await tipcClient.updateAgentProfile({ id: editing.id, updates: data })
-    setEditing(null); setIsCreating(false); setNewPropKey(""); setNewPropValue(""); setCommandVerification(null); loadAgents()
+    else if (editing.id)
+      await tipcClient.updateAgentProfile({ id: editing.id, updates: data })
+    setEditing(null)
+    setIsCreating(false)
+    setNewPropKey("")
+    setNewPropValue("")
+    setCommandVerification(null)
+    loadAgents()
     refreshAgentProfileQueries()
   }
 
   const handleDelete = async (id: string) => {
     if (!confirm("Are you sure you want to delete this agent?")) return
-    await tipcClient.deleteAgentProfile({ id }); loadAgents()
+    await tipcClient.deleteAgentProfile({ id })
+    loadAgents()
     refreshAgentProfileQueries()
   }
 
-  const handleCancel = () => { setEditing(null); setIsCreating(false); setNewPropKey(""); setNewPropValue(""); setCommandVerification(null) }
+  const handleCancel = () => {
+    setEditing(null)
+    setIsCreating(false)
+    setNewPropKey("")
+    setNewPropValue("")
+    setCommandVerification(null)
+  }
 
   // Derived tool data
   const typedTools = allTools as DetailedToolInfo[]
-  const runtimeTools = typedTools.filter(t => t.sourceKind === "runtime")
-  const externalTools = typedTools.filter(t => t.sourceKind === "mcp")
+  const runtimeTools = typedTools.filter((t) => t.sourceKind === "runtime")
+  const externalTools = typedTools.filter((t) => t.sourceKind === "mcp")
   const serverNames = Object.keys(serverStatus)
-  const toolsByServer = (serverName: string) => externalTools.filter(t => t.sourceName === serverName)
+  const toolsByServer = (serverName: string) =>
+    externalTools.filter((t) => t.sourceName === serverName)
 
   // Tool config helpers
   const isServerEnabled = (serverName: string): boolean => {
@@ -392,13 +591,20 @@ export function SettingsAgents() {
 
   const isRuntimeToolEnabled = (toolName: string): boolean => {
     const list = editing?.toolConfig?.enabledRuntimeTools
-    if (!list || list.length === 0) return DEFAULT_AGENT_RUNTIME_TOOL_NAMES.includes(toolName as typeof DEFAULT_AGENT_RUNTIME_TOOL_NAMES[number])
+    if (!list || list.length === 0)
+      return DEFAULT_AGENT_RUNTIME_TOOL_NAMES.includes(
+        toolName as (typeof DEFAULT_AGENT_RUNTIME_TOOL_NAMES)[number],
+      )
     return list.includes(toolName)
   }
 
   const isSkillEnabled = (skillId: string): boolean => {
     // When skillsConfig is undefined or allSkillsDisabledByDefault is false, all skills are enabled
-    if (!editing?.skillsConfig || !editing.skillsConfig.allSkillsDisabledByDefault) return true
+    if (
+      !editing?.skillsConfig ||
+      !editing.skillsConfig.allSkillsDisabledByDefault
+    )
+      return true
     return (editing.skillsConfig.enabledSkillIds || []).includes(skillId)
   }
 
@@ -408,13 +614,18 @@ export function SettingsAgents() {
     if (tc.allServersDisabledByDefault) {
       const enabled = [...(tc.enabledServers || [])]
       const idx = enabled.indexOf(serverName)
-      if (idx >= 0) enabled.splice(idx, 1); else enabled.push(serverName)
+      if (idx >= 0) enabled.splice(idx, 1)
+      else enabled.push(serverName)
       setEditing({ ...editing, toolConfig: { ...tc, enabledServers: enabled } })
     } else {
       const disabled = [...(tc.disabledServers || [])]
       const idx = disabled.indexOf(serverName)
-      if (idx >= 0) disabled.splice(idx, 1); else disabled.push(serverName)
-      setEditing({ ...editing, toolConfig: { ...tc, disabledServers: disabled } })
+      if (idx >= 0) disabled.splice(idx, 1)
+      else disabled.push(serverName)
+      setEditing({
+        ...editing,
+        toolConfig: { ...tc, disabledServers: disabled },
+      })
     }
   }
 
@@ -423,7 +634,8 @@ export function SettingsAgents() {
     const tc = { ...(editing.toolConfig || {}) } as AgentProfileToolConfig
     const disabled = [...(tc.disabledTools || [])]
     const idx = disabled.indexOf(toolName)
-    if (idx >= 0) disabled.splice(idx, 1); else disabled.push(toolName)
+    if (idx >= 0) disabled.splice(idx, 1)
+    else disabled.push(toolName)
     setEditing({ ...editing, toolConfig: { ...tc, disabledTools: disabled } })
   }
 
@@ -433,7 +645,11 @@ export function SettingsAgents() {
     const defaultList = DEFAULT_AGENT_RUNTIME_TOOL_NAMES.filter((name) =>
       runtimeTools.some((tool) => tool.name === name),
     )
-    let currentList = [...(tc.enabledRuntimeTools && tc.enabledRuntimeTools.length > 0 ? tc.enabledRuntimeTools : defaultList)]
+    let currentList = [
+      ...(tc.enabledRuntimeTools && tc.enabledRuntimeTools.length > 0
+        ? tc.enabledRuntimeTools
+        : defaultList),
+    ]
     const idx = currentList.indexOf(toolName)
     if (idx >= 0) {
       currentList.splice(idx, 1)
@@ -441,77 +657,153 @@ export function SettingsAgents() {
       currentList.push(toolName)
     }
     currentList = Array.from(new Set(currentList))
-    const matchesDefault = currentList.length === defaultList.length && defaultList.every((name) => currentList.includes(name))
-    setEditing({ ...editing, toolConfig: { ...tc, enabledRuntimeTools: matchesDefault ? undefined : currentList } })
+    const matchesDefault =
+      currentList.length === defaultList.length &&
+      defaultList.every((name) => currentList.includes(name))
+    setEditing({
+      ...editing,
+      toolConfig: {
+        ...tc,
+        enabledRuntimeTools: matchesDefault ? undefined : currentList,
+      },
+    })
   }
 
   const toggleSkill = (skillId: string) => {
     if (!editing) return
     // Transitioning from "all enabled by default" to explicit opt-in mode
-    if (!editing.skillsConfig || !editing.skillsConfig.allSkillsDisabledByDefault) {
-      const allExcept = skills.map(s => s.id).filter(id => id !== skillId)
-      setEditing({ ...editing, skillsConfig: { enabledSkillIds: allExcept, allSkillsDisabledByDefault: true } })
+    if (
+      !editing.skillsConfig ||
+      !editing.skillsConfig.allSkillsDisabledByDefault
+    ) {
+      const allExcept = skills.map((s) => s.id).filter((id) => id !== skillId)
+      setEditing({
+        ...editing,
+        skillsConfig: {
+          enabledSkillIds: allExcept,
+          allSkillsDisabledByDefault: true,
+        },
+      })
       return
     }
     const ids = [...(editing.skillsConfig.enabledSkillIds || [])]
     const idx = ids.indexOf(skillId)
-    if (idx >= 0) ids.splice(idx, 1); else ids.push(skillId)
+    if (idx >= 0) ids.splice(idx, 1)
+    else ids.push(skillId)
     // If all skills are re-enabled, reset to default state
     if (ids.length === skills.length) {
-      setEditing({ ...editing, skillsConfig: { enabledSkillIds: [], allSkillsDisabledByDefault: false } })
+      setEditing({
+        ...editing,
+        skillsConfig: {
+          enabledSkillIds: [],
+          allSkillsDisabledByDefault: false,
+        },
+      })
     } else {
-      setEditing({ ...editing, skillsConfig: { ...editing.skillsConfig, enabledSkillIds: ids } })
+      setEditing({
+        ...editing,
+        skillsConfig: { ...editing.skillsConfig, enabledSkillIds: ids },
+      })
     }
   }
 
   // Bulk toggle helpers
   const enableAllSkills = () => {
     if (!editing) return
-    setEditing({ ...editing, skillsConfig: { enabledSkillIds: [], allSkillsDisabledByDefault: false } })
+    setEditing({
+      ...editing,
+      skillsConfig: { enabledSkillIds: [], allSkillsDisabledByDefault: false },
+    })
   }
   const disableAllSkills = () => {
     if (!editing) return
-    setEditing({ ...editing, skillsConfig: { enabledSkillIds: [], allSkillsDisabledByDefault: true } })
+    setEditing({
+      ...editing,
+      skillsConfig: { enabledSkillIds: [], allSkillsDisabledByDefault: true },
+    })
   }
-  const allSkillsEnabled = !editing?.skillsConfig?.allSkillsDisabledByDefault || (editing?.skillsConfig?.enabledSkillIds?.length === skills.length)
-  const allSkillsDisabled = !!editing?.skillsConfig?.allSkillsDisabledByDefault && (editing?.skillsConfig?.enabledSkillIds?.length ?? 0) === 0
+  const allSkillsEnabled =
+    !editing?.skillsConfig?.allSkillsDisabledByDefault ||
+    editing?.skillsConfig?.enabledSkillIds?.length === skills.length
+  const allSkillsDisabled =
+    !!editing?.skillsConfig?.allSkillsDisabledByDefault &&
+    (editing?.skillsConfig?.enabledSkillIds?.length ?? 0) === 0
 
   const enableAllServers = () => {
     if (!editing) return
-    setEditing({ ...editing, toolConfig: { ...(editing.toolConfig || {}), allServersDisabledByDefault: false, enabledServers: undefined, disabledServers: [] } })
+    setEditing({
+      ...editing,
+      toolConfig: {
+        ...(editing.toolConfig || {}),
+        allServersDisabledByDefault: false,
+        enabledServers: undefined,
+        disabledServers: [],
+      },
+    })
   }
   const disableAllServers = () => {
     if (!editing) return
-    setEditing({ ...editing, toolConfig: { ...(editing.toolConfig || {}), allServersDisabledByDefault: true, enabledServers: [], disabledServers: undefined } })
+    setEditing({
+      ...editing,
+      toolConfig: {
+        ...(editing.toolConfig || {}),
+        allServersDisabledByDefault: true,
+        enabledServers: [],
+        disabledServers: undefined,
+      },
+    })
   }
-  const allServersEnabled = serverNames.length > 0 && serverNames.every(n => isServerEnabled(n))
-  const allServersDisabled = serverNames.length > 0 && serverNames.every(n => !isServerEnabled(n))
+  const allServersEnabled =
+    serverNames.length > 0 && serverNames.every((n) => isServerEnabled(n))
+  const allServersDisabled =
+    serverNames.length > 0 && serverNames.every((n) => !isServerEnabled(n))
 
   const enableAllRuntimeTools = () => {
     if (!editing) return
-    setEditing({ ...editing, toolConfig: { ...(editing.toolConfig || {}), enabledRuntimeTools: runtimeTools.map(t => t.name) } })
+    setEditing({
+      ...editing,
+      toolConfig: {
+        ...(editing.toolConfig || {}),
+        enabledRuntimeTools: runtimeTools.map((t) => t.name),
+      },
+    })
   }
   const disableAllRuntimeTools = () => {
     if (!editing) return
     // Keep only essential tools enabled
-    setEditing({ ...editing, toolConfig: { ...(editing.toolConfig || {}), enabledRuntimeTools: [MARK_WORK_COMPLETE_TOOL] } })
+    setEditing({
+      ...editing,
+      toolConfig: {
+        ...(editing.toolConfig || {}),
+        enabledRuntimeTools: [MARK_WORK_COMPLETE_TOOL],
+      },
+    })
   }
-  const allRuntimeEnabled = runtimeTools.length > 0 && runtimeTools.every(t => isRuntimeToolEnabled(t.name))
-  const allRuntimeDisabled = runtimeTools.length > 0 && runtimeTools.every(t => t.name === MARK_WORK_COMPLETE_TOOL || !isRuntimeToolEnabled(t.name))
+  const allRuntimeEnabled =
+    runtimeTools.length > 0 &&
+    runtimeTools.every((t) => isRuntimeToolEnabled(t.name))
+  const allRuntimeDisabled =
+    runtimeTools.length > 0 &&
+    runtimeTools.every(
+      (t) =>
+        t.name === MARK_WORK_COMPLETE_TOOL || !isRuntimeToolEnabled(t.name),
+    )
 
   // Section collapse helpers
   const isSectionCollapsed = (section: string) => collapsedSections.has(section)
   const toggleSection = (section: string) => {
-    setCollapsedSections(prev => {
+    setCollapsedSections((prev) => {
       const next = new Set(prev)
-      if (next.has(section)) next.delete(section); else next.add(section)
+      if (next.has(section)) next.delete(section)
+      else next.add(section)
       return next
     })
   }
   const toggleExpandServer = (serverName: string) => {
-    setExpandedServers(prev => {
+    setExpandedServers((prev) => {
       const next = new Set(prev)
-      if (next.has(serverName)) next.delete(serverName); else next.add(serverName)
+      if (next.has(serverName)) next.delete(serverName)
+      else next.add(serverName)
       return next
     })
   }
@@ -519,8 +811,12 @@ export function SettingsAgents() {
   // Property helpers
   const addProperty = () => {
     if (!editing || !newPropKey.trim()) return
-    setEditing({ ...editing, properties: { ...editing.properties, [newPropKey.trim()]: newPropValue } })
-    setNewPropKey(""); setNewPropValue("")
+    setEditing({
+      ...editing,
+      properties: { ...editing.properties, [newPropKey.trim()]: newPropValue },
+    })
+    setNewPropKey("")
+    setNewPropValue("")
   }
   const removeProperty = (key: string) => {
     if (!editing?.properties) return
@@ -531,7 +827,10 @@ export function SettingsAgents() {
   // Model config helper
   const updateModelConfig = (updates: Partial<ProfileModelConfig>) => {
     if (!editing) return
-    setEditing({ ...editing, modelConfig: { ...editing.modelConfig, ...updates } })
+    setEditing({
+      ...editing,
+      modelConfig: { ...editing.modelConfig, ...updates },
+    })
   }
 
   // Avatar upload helper
@@ -539,7 +838,8 @@ export function SettingsAgents() {
     const file = e.target.files?.[0]
     if (!file || !editing) return
     const reader = new FileReader()
-    reader.onload = () => setEditing({ ...editing, avatarDataUrl: reader.result as string })
+    reader.onload = () =>
+      setEditing({ ...editing, avatarDataUrl: reader.result as string })
     reader.readAsDataURL(file)
     // Reset so the same file can be re-selected
     e.target.value = ""
@@ -570,11 +870,15 @@ export function SettingsAgents() {
     }
   }
 
-  const selectedPresetKey = editing ? editing.presetKey || detectPresetKey(editing) : undefined
-  const selectedPreset = selectedPresetKey ? AGENT_PRESETS[selectedPresetKey] : undefined
+  const selectedPresetKey = editing
+    ? editing.presetKey || detectPresetKey(editing)
+    : undefined
+  const selectedPreset = selectedPresetKey
+    ? AGENT_PRESETS[selectedPresetKey]
+    : undefined
 
   const handleVerifyExternalAgent = async () => {
-    if (!editing || editing.connectionType !== 'acpx') return
+    if (!editing || editing.connectionType !== "acpx") return
 
     setIsVerifyingCommand(true)
     try {
@@ -586,7 +890,8 @@ export function SettingsAgents() {
       })
       setCommandVerification(result)
 
-      if (result.ok) toast.success(result.details || "External agent command looks ready.")
+      if (result.ok)
+        toast.success(result.details || "External agent command looks ready.")
       else toast.error(result.error || "External agent verification failed.")
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -598,22 +903,57 @@ export function SettingsAgents() {
   }
 
   return (
-    <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-6 py-4">
+    <SettingsPageShell innerClassName="max-w-6xl">
       {!editing && (
         <div className="mb-3 flex flex-wrap items-center justify-end gap-1.5">
-          <Button size="sm" variant="outline" className="h-8 gap-1.5 whitespace-nowrap px-2.5" onClick={() => handleImportDialogOpenChange(true)}>
-            <Upload className="h-4 w-4" />Import Bundle
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 whitespace-nowrap px-2.5"
+            onClick={() => handleImportDialogOpenChange(true)}
+          >
+            <Upload className="h-4 w-4" />
+            Import Bundle
           </Button>
-          <Button size="sm" variant="outline" className="h-8 gap-1.5 whitespace-nowrap px-2.5" onClick={() => setIsExportDialogOpen(true)}>
-            <Download className="h-4 w-4" />Export Bundle
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 whitespace-nowrap px-2.5"
+            onClick={() => setIsExportDialogOpen(true)}
+          >
+            <Download className="h-4 w-4" />
+            Export Bundle
           </Button>
-          <Button size="sm" variant="outline" className="h-8 gap-1.5 whitespace-nowrap px-2.5" onClick={() => setIsPublishDialogOpen(true)}>
-            <Globe className="h-4 w-4" />Export for Hub
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 whitespace-nowrap px-2.5"
+            onClick={() => setIsPublishDialogOpen(true)}
+          >
+            <Globe className="h-4 w-4" />
+            Export for Hub
           </Button>
-          <Button size="sm" variant="outline" className="h-8 gap-1.5 whitespace-nowrap px-2.5" onClick={async () => { await tipcClient.reloadAgentProfiles(); loadAgents(); refreshAgentProfileQueries() }}>
-            <RefreshCw className="h-4 w-4" />Rescan Files
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 gap-1.5 whitespace-nowrap px-2.5"
+            onClick={async () => {
+              await tipcClient.reloadAgentProfiles()
+              loadAgents()
+              refreshAgentProfileQueries()
+            }}
+          >
+            <RefreshCw className="h-4 w-4" />
+            Rescan Files
           </Button>
-          <Button size="sm" className="h-8 gap-1.5 whitespace-nowrap px-2.5" onClick={handleCreate}><Plus className="h-4 w-4" />Add Agent</Button>
+          <Button
+            size="sm"
+            className="h-8 gap-1.5 whitespace-nowrap px-2.5"
+            onClick={handleCreate}
+          >
+            <Plus className="h-4 w-4" />
+            Add Agent
+          </Button>
         </div>
       )}
       {!editing && (
@@ -628,9 +968,11 @@ export function SettingsAgents() {
         onImportComplete={handleImportComplete}
         initialFilePath={prefilledImportFilePath || undefined}
         title={prefilledImportFilePath ? "Install Hub Bundle" : undefined}
-        description={prefilledImportFilePath
-          ? "Preview and import the downloaded Hub .dotagents bundle using the existing conflict-aware flow."
-          : undefined}
+        description={
+          prefilledImportFilePath
+            ? "Preview and import the downloaded Hub .dotagents bundle using the existing conflict-aware flow."
+            : undefined
+        }
       />
       <BundleExportDialog
         open={isExportDialogOpen}
@@ -640,57 +982,118 @@ export function SettingsAgents() {
         open={isPublishDialogOpen}
         onOpenChange={setIsPublishDialogOpen}
       />
-    </div>
+    </SettingsPageShell>
   )
 
   function renderAgentList() {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-3 pb-12">
-        {sortedAgents.map(agent => {
-          const summaryItems = getAgentCardSummaryItems(agent, skills.length, runtimeTools.length)
-          const customSystemPromptActive = hasCustomSystemPrompt(agent.systemPrompt)
+      <div className="grid grid-cols-1 gap-3 pb-12 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+        {sortedAgents.map((agent) => {
+          const summaryItems = getAgentCardSummaryItems(
+            agent,
+            skills.length,
+            runtimeTools.length,
+          )
+          const customSystemPromptActive = hasCustomSystemPrompt(
+            agent.systemPrompt,
+          )
 
           return (
-            <Card key={agent.id} className={`overflow-hidden flex flex-col transition-all hover:shadow-md ${!agent.enabled ? "opacity-60 grayscale-[0.5]" : ""}`}>
-              <CardHeader className="p-3 pb-2 flex flex-row items-start gap-3 flex-none">
-                <div className="w-10 h-10 rounded-md shadow-sm flex items-center justify-center overflow-hidden shrink-0 bg-muted">
-                  {agent.avatarDataUrl
-                    ? <img src={agent.avatarDataUrl} alt={agent.displayName} className="w-full h-full object-cover" />
-                    : <Facehash name={agent.id} size={40} colors={agentColors(agent.id)} />
-                  }
+            <Card
+              key={agent.id}
+              className={`flex flex-col overflow-hidden transition-all hover:shadow-md ${!agent.enabled ? "opacity-60 grayscale-[0.5]" : ""}`}
+            >
+              <CardHeader className="flex flex-none flex-row items-start gap-3 p-3 pb-2">
+                <div className="bg-muted flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md shadow-sm">
+                  {agent.avatarDataUrl ? (
+                    <img
+                      src={agent.avatarDataUrl}
+                      alt={agent.displayName}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <Facehash
+                      name={agent.id}
+                      size={40}
+                      colors={agentColors(agent.id)}
+                    />
+                  )}
                 </div>
-                <div className="flex flex-col min-w-0 flex-1">
-                  <CardTitle className="text-sm font-semibold truncate leading-none mt-0.5">
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <CardTitle className="mt-0.5 truncate text-sm font-semibold leading-none">
                     {agent.displayName}
                   </CardTitle>
-                  <CardDescription className="line-clamp-2 mt-1 text-[11px] leading-tight min-h-[1.75rem]">
-                    {agent.description || agent.guidelines?.slice(0, 100) || "No description provided."}
+                  <CardDescription className="mt-1 line-clamp-2 min-h-[1.75rem] text-[11px] leading-tight">
+                    {agent.description ||
+                      agent.guidelines?.slice(0, 100) ||
+                      "No description provided."}
                   </CardDescription>
                 </div>
               </CardHeader>
-              <CardContent className="flex-grow flex flex-col justify-end pt-1 pb-2 px-3">
-                <div className="space-y-1.5 mb-2">
-                  {(agent.isBuiltIn || agent.isDefault || !agent.enabled || customSystemPromptActive) && (
-                    <div className="flex gap-1 flex-wrap">
-                      {agent.isBuiltIn && <Badge variant="secondary" className="text-[10px] px-1 py-0 h-3.5 shadow-sm font-medium">Built-in</Badge>}
-                      {agent.isDefault && <Badge variant="secondary" className="text-[10px] px-1 py-0 h-3.5 shadow-sm font-medium">Default</Badge>}
-                      {!agent.enabled && <Badge variant="outline" className="text-[10px] px-1 py-0 h-3.5 bg-background/50 shadow-sm font-medium">Disabled</Badge>}
-                      {customSystemPromptActive && <Badge variant="outline" className="h-3.5 border-amber-500/50 bg-amber-500/10 px-1 py-0 text-[10px] font-medium text-amber-700 shadow-sm dark:text-amber-300">Custom prompt</Badge>}
+              <CardContent className="flex flex-grow flex-col justify-end px-3 pb-2 pt-1">
+                <div className="mb-2 space-y-1.5">
+                  {(agent.isBuiltIn ||
+                    agent.isDefault ||
+                    !agent.enabled ||
+                    customSystemPromptActive) && (
+                    <div className="flex flex-wrap gap-1">
+                      {agent.isBuiltIn && (
+                        <Badge
+                          variant="secondary"
+                          className="h-3.5 px-1 py-0 text-[10px] font-medium shadow-sm"
+                        >
+                          Built-in
+                        </Badge>
+                      )}
+                      {agent.isDefault && (
+                        <Badge
+                          variant="secondary"
+                          className="h-3.5 px-1 py-0 text-[10px] font-medium shadow-sm"
+                        >
+                          Default
+                        </Badge>
+                      )}
+                      {!agent.enabled && (
+                        <Badge
+                          variant="outline"
+                          className="bg-background/50 h-3.5 px-1 py-0 text-[10px] font-medium shadow-sm"
+                        >
+                          Disabled
+                        </Badge>
+                      )}
+                      {customSystemPromptActive && (
+                        <Badge
+                          variant="outline"
+                          className="h-3.5 border-amber-500/50 bg-amber-500/10 px-1 py-0 text-[10px] font-medium text-amber-700 shadow-sm dark:text-amber-300"
+                        >
+                          Custom prompt
+                        </Badge>
+                      )}
                     </div>
                   )}
-                  <p className="text-[11px] leading-tight text-muted-foreground">
+                  <p className="text-muted-foreground text-[11px] leading-tight">
                     {summaryItems.join(" • ")}
                   </p>
                 </div>
-                <div className="flex items-center gap-1 pt-2 border-t mt-auto">
-                  <Button variant="ghost" size="sm" className="flex-1 h-6 text-[11px] text-muted-foreground hover:text-foreground px-0" onClick={() => handleEdit(agent)}>
-                    <Edit2 className="h-3 w-3 mr-1" /> Edit
+                <div className="mt-auto flex items-center gap-1 border-t pt-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-foreground h-6 flex-1 px-0 text-[11px]"
+                    onClick={() => handleEdit(agent)}
+                  >
+                    <Edit2 className="mr-1 h-3 w-3" /> Edit
                   </Button>
                   {!agent.isBuiltIn && !agent.isDefault && (
                     <>
-                      <div className="w-[1px] h-3 bg-border"></div>
-                      <Button variant="ghost" size="sm" className="flex-1 h-6 text-[11px] text-destructive/80 hover:text-destructive hover:bg-destructive/10 px-0" onClick={() => handleDelete(agent.id)}>
-                        <Trash2 className="h-3 w-3 mr-1" /> Delete
+                      <div className="bg-border h-3 w-[1px]"></div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive/80 hover:text-destructive hover:bg-destructive/10 h-6 flex-1 px-0 text-[11px]"
+                        onClick={() => handleDelete(agent.id)}
+                      >
+                        <Trash2 className="mr-1 h-3 w-3" /> Delete
                       </Button>
                     </>
                   )}
@@ -700,9 +1103,13 @@ export function SettingsAgents() {
           )
         })}
         {sortedAgents.length === 0 && (
-          <div className="col-span-full rounded-lg border border-dashed bg-muted/20 px-4 py-7 text-center">
-            <p className="text-sm font-medium text-foreground">No agents yet.</p>
-            <p className="mt-1 text-sm text-muted-foreground">Create one with Add Agent or import an existing bundle.</p>
+          <div className="bg-muted/20 col-span-full rounded-lg border border-dashed px-4 py-7 text-center">
+            <p className="text-foreground text-sm font-medium">
+              No agents yet.
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Create one with Add Agent or import an existing bundle.
+            </p>
           </div>
         )}
       </div>
@@ -712,22 +1119,42 @@ export function SettingsAgents() {
   function renderEditForm() {
     if (!editing) return null
     const isInternal = editing.connectionType === "internal"
-    const externalCommandPreview = buildCommandPreview(editing.connectionCommand, editing.connectionArgs)
+    const externalCommandPreview = buildCommandPreview(
+      editing.connectionCommand,
+      editing.connectionArgs,
+    )
     const customSystemPromptActive = hasCustomSystemPrompt(editing.systemPrompt)
 
     return (
       <Card className="max-w-5xl">
         <CardHeader className="pb-3">
-          <CardTitle className="text-lg">{isCreating ? "Create Agent" : `Edit: ${editing.displayName}`}</CardTitle>
-          <CardDescription>Configure agent identity, behavior, model, and capabilities.</CardDescription>
+          <CardTitle className="text-lg">
+            {isCreating ? "Create Agent" : `Edit: ${editing.displayName}`}
+          </CardTitle>
+          <CardDescription>
+            Configure agent identity, behavior, model, and capabilities.
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <Tabs defaultValue="general" className="w-full">
             <TabsList className="mb-3 h-auto flex-wrap gap-1">
-              <TabsTrigger value="general" className="gap-1.5"><Settings2 className="h-3.5 w-3.5" />General</TabsTrigger>
-              {isInternal && <TabsTrigger value="model" className="gap-1.5"><Brain className="h-3.5 w-3.5" />Model</TabsTrigger>}
-              <TabsTrigger value="capabilities" className="gap-1.5"><Wrench className="h-3.5 w-3.5" />Capabilities</TabsTrigger>
-              <TabsTrigger value="properties" className="gap-1.5">Properties</TabsTrigger>
+              <TabsTrigger value="general" className="gap-1.5">
+                <Settings2 className="h-3.5 w-3.5" />
+                General
+              </TabsTrigger>
+              {isInternal && (
+                <TabsTrigger value="model" className="gap-1.5">
+                  <Brain className="h-3.5 w-3.5" />
+                  Model
+                </TabsTrigger>
+              )}
+              <TabsTrigger value="capabilities" className="gap-1.5">
+                <Wrench className="h-3.5 w-3.5" />
+                Capabilities
+              </TabsTrigger>
+              <TabsTrigger value="properties" className="gap-1.5">
+                Properties
+              </TabsTrigger>
             </TabsList>
 
             {/* ── General Tab ── */}
@@ -736,20 +1163,47 @@ export function SettingsAgents() {
               <div className="space-y-2">
                 <Label>Avatar</Label>
                 <div className="flex items-center gap-4">
-                  <div className="w-16 h-16 rounded-xl border-2 border-border overflow-hidden flex items-center justify-center bg-muted/40 flex-shrink-0">
-                    {editing.avatarDataUrl
-                      ? <img src={editing.avatarDataUrl} alt="avatar" className="w-full h-full object-cover" />
-                      : <Facehash name={editing.id || "new"} size={64} colors={agentColors(editing.id || "new")} />
-                    }
+                  <div className="border-border bg-muted/40 flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden rounded-xl border-2">
+                    {editing.avatarDataUrl ? (
+                      <img
+                        src={editing.avatarDataUrl}
+                        alt="avatar"
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <Facehash
+                        name={editing.id || "new"}
+                        size={64}
+                        colors={agentColors(editing.id || "new")}
+                      />
+                    )}
                   </div>
                   <div className="flex flex-col gap-2">
-                    <input ref={avatarFileInputRef} type="file" accept="image/*" className="hidden" onChange={handleAvatarFileChange} />
-                    <Button type="button" variant="outline" size="sm" onClick={() => avatarFileInputRef.current?.click()}>
+                    <input
+                      ref={avatarFileInputRef}
+                      type="file"
+                      accept="image/*"
+                      className="hidden"
+                      onChange={handleAvatarFileChange}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => avatarFileInputRef.current?.click()}
+                    >
                       Upload photo
                     </Button>
                     {editing.avatarDataUrl && (
-                      <Button type="button" variant="ghost" size="sm" className="text-destructive/80 hover:text-destructive hover:bg-destructive/10"
-                        onClick={() => setEditing({ ...editing, avatarDataUrl: null })}>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-destructive/80 hover:text-destructive hover:bg-destructive/10"
+                        onClick={() =>
+                          setEditing({ ...editing, avatarDataUrl: null })
+                        }
+                      >
                         Remove photo
                       </Button>
                     )}
@@ -757,41 +1211,77 @@ export function SettingsAgents() {
                 </div>
               </div>
               {isCreating && (
-                <div className="space-y-2 rounded-lg border border-dashed bg-muted/20 p-3">
+                <div className="bg-muted/20 space-y-2 rounded-lg border border-dashed p-3">
                   <div className="flex flex-wrap items-center justify-between gap-1.5">
                     <Label>Quick Setup</Label>
-                    <p className="text-[11px] text-muted-foreground">Start with a preset, or configure manually below.</p>
+                    <p className="text-muted-foreground text-[11px]">
+                      Start with a preset, or configure manually below.
+                    </p>
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {Object.entries(AGENT_PRESETS).map(([key, preset]) => (
-                      <Button key={key} type="button" variant="outline" size="sm" className="h-8 px-2.5 text-xs"
+                      <Button
+                        key={key}
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 px-2.5 text-xs"
                         onClick={() => applyPreset(key as AgentPresetKey)}
-                      >{preset.displayName}</Button>
+                      >
+                        {preset.displayName}
+                      </Button>
                     ))}
                   </div>
                 </div>
               )}
               <div className="space-y-2">
                 <Label htmlFor="displayName">Name</Label>
-                <Input id="displayName" value={editing.displayName} onChange={e => setEditing({ ...editing, displayName: e.target.value })} placeholder="My Agent" />
+                <Input
+                  id="displayName"
+                  value={editing.displayName}
+                  onChange={(e) =>
+                    setEditing({ ...editing, displayName: e.target.value })
+                  }
+                  placeholder="My Agent"
+                />
               </div>
               <div className="space-y-2">
                 <Label htmlFor="description">Description</Label>
-                <Input id="description" value={editing.description} onChange={e => setEditing({ ...editing, description: e.target.value })} placeholder="What this agent does..." />
-                <p className="text-[11px] text-muted-foreground">Shown only in the UI. Not visible to the agent—use Guidelines for instructions.</p>
+                <Input
+                  id="description"
+                  value={editing.description}
+                  onChange={(e) =>
+                    setEditing({ ...editing, description: e.target.value })
+                  }
+                  placeholder="What this agent does..."
+                />
+                <p className="text-muted-foreground text-[11px]">
+                  Shown only in the UI. Not visible to the agent—use Guidelines
+                  for instructions.
+                </p>
               </div>
               {customSystemPromptActive && (
                 <div className="flex flex-wrap items-start justify-between gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3">
                   <div className="flex min-w-0 gap-2">
                     <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
                     <div className="min-w-0 space-y-1">
-                      <p className="text-sm font-medium text-amber-700 dark:text-amber-300">Custom base system prompt active</p>
-                      <p className="text-xs leading-5 text-muted-foreground">
-                        This agent is using a saved system prompt snapshot, so it will not receive DotAgents default system prompt updates until you reset it.
+                      <p className="text-sm font-medium text-amber-700 dark:text-amber-300">
+                        Custom base system prompt active
+                      </p>
+                      <p className="text-muted-foreground text-xs leading-5">
+                        This agent is using a saved system prompt snapshot, so
+                        it will not receive DotAgents default system prompt
+                        updates until you reset it.
                       </p>
                     </div>
                   </div>
-                  <Button type="button" variant="outline" size="sm" className="h-7 border-amber-500/50 bg-background/70 px-2 text-xs" onClick={() => setEditing({ ...editing, systemPrompt: "" })}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="bg-background/70 h-7 border-amber-500/50 px-2 text-xs"
+                    onClick={() => setEditing({ ...editing, systemPrompt: "" })}
+                  >
                     Reset to Default
                   </Button>
                 </div>
@@ -800,36 +1290,75 @@ export function SettingsAgents() {
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="guidelines">Guidelines</Label>
-                    <Textarea id="guidelines" value={editing.guidelines} onChange={e => setEditing({ ...editing, guidelines: e.target.value })} rows={4} placeholder="e.g. You are an expert in React. Always check types before writing code..." className="font-mono text-sm" />
-                    <p className="text-xs text-muted-foreground">
-                      Additional instructions for this agent. These are appended to the core tool-calling system prompt.
+                    <Textarea
+                      id="guidelines"
+                      value={editing.guidelines}
+                      onChange={(e) =>
+                        setEditing({ ...editing, guidelines: e.target.value })
+                      }
+                      rows={4}
+                      placeholder="e.g. You are an expert in React. Always check types before writing code..."
+                      className="font-mono text-sm"
+                    />
+                    <p className="text-muted-foreground text-xs">
+                      Additional instructions for this agent. These are appended
+                      to the core tool-calling system prompt.
                     </p>
                   </div>
-                  <div className="space-y-2 pt-2 border-t">
+                  <div className="space-y-2 border-t pt-2">
                     <div
-                      className="flex flex-wrap items-center gap-2 cursor-pointer select-none"
+                      className="flex cursor-pointer select-none flex-wrap items-center gap-2"
                       onClick={() => setShowSystemPrompt(!showSystemPrompt)}
                     >
-                      {showSystemPrompt ? <ChevronDown className="h-4 w-4 text-muted-foreground" /> : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
-                      <Label className="cursor-pointer font-semibold">Base System Prompt (Advanced)</Label>
-                      {customSystemPromptActive && <Badge variant="outline" className="border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300">Custom prompt active</Badge>}
+                      {showSystemPrompt ? (
+                        <ChevronDown className="text-muted-foreground h-4 w-4" />
+                      ) : (
+                        <ChevronRight className="text-muted-foreground h-4 w-4" />
+                      )}
+                      <Label className="cursor-pointer font-semibold">
+                        Base System Prompt (Advanced)
+                      </Label>
+                      {customSystemPromptActive && (
+                        <Badge
+                          variant="outline"
+                          className="border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                        >
+                          Custom prompt active
+                        </Badge>
+                      )}
                     </div>
                     {showSystemPrompt && (
                       <div className="space-y-3 pt-2">
                         <div className="flex flex-wrap items-start justify-between gap-2">
-                          <p className="text-xs text-muted-foreground text-amber-600 dark:text-amber-500">
-                            Not recommended to change. A custom base prompt replaces core tool-calling instructions and blocks future default prompt updates. Leave empty to use the default.
+                          <p className="text-muted-foreground text-xs text-amber-600 dark:text-amber-500">
+                            Not recommended to change. A custom base prompt
+                            replaces core tool-calling instructions and blocks
+                            future default prompt updates. Leave empty to use
+                            the default.
                           </p>
-                          <Button variant="ghost" size="sm" className="h-6 text-xs px-2" onClick={() => setEditing({ ...editing, systemPrompt: "" })} disabled={!editing.systemPrompt}>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-6 px-2 text-xs"
+                            onClick={() =>
+                              setEditing({ ...editing, systemPrompt: "" })
+                            }
+                            disabled={!editing.systemPrompt}
+                          >
                             Reset to Default
                           </Button>
                         </div>
                         <Textarea
                           id="systemPrompt"
                           value={editing.systemPrompt || defaultSystemPrompt}
-                          onChange={e => setEditing({ ...editing, systemPrompt: e.target.value })}
+                          onChange={(e) =>
+                            setEditing({
+                              ...editing,
+                              systemPrompt: e.target.value,
+                            })
+                          }
                           rows={8}
-                          className={`font-mono text-xs resize-y min-h-[120px] max-h-[400px] ${!editing.systemPrompt ? "text-muted-foreground" : ""}`}
+                          className={`max-h-[400px] min-h-[120px] resize-y font-mono text-xs ${!editing.systemPrompt ? "text-muted-foreground" : ""}`}
                         />
                       </div>
                     )}
@@ -838,73 +1367,161 @@ export function SettingsAgents() {
               )}
               <div className="space-y-2">
                 <Label htmlFor="connectionType">Connection Type</Label>
-                <Select value={editing.connectionType} onValueChange={(v: ConnectionType) => setEditing({ ...editing, connectionType: v })}>
-                  <SelectTrigger><SelectValue /></SelectTrigger>
+                <Select
+                  value={editing.connectionType}
+                  onValueChange={(v: ConnectionType) =>
+                    setEditing({ ...editing, connectionType: v })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="internal">Internal (built-in agent)</SelectItem>
+                    <SelectItem value="internal">
+                      Internal (built-in agent)
+                    </SelectItem>
                     <SelectItem value="acpx">acpx (external agent)</SelectItem>
-                    <SelectItem value="remote">Remote (HTTP endpoint)</SelectItem>
+                    <SelectItem value="remote">
+                      Remote (HTTP endpoint)
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>
-              {editing.connectionType === 'acpx' && (
+              {editing.connectionType === "acpx" && (
                 <>
                   <div className="space-y-2">
                     <Label htmlFor="command">Command</Label>
-                    <Input id="command" value={editing.connectionCommand ?? ""} onChange={e => setEditing({ ...editing, connectionCommand: e.target.value })} placeholder="e.g., claude-code-acp" />
+                    <Input
+                      id="command"
+                      value={editing.connectionCommand ?? ""}
+                      onChange={(e) =>
+                        setEditing({
+                          ...editing,
+                          connectionCommand: e.target.value,
+                        })
+                      }
+                      placeholder="e.g., claude-code-acp"
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="args">Arguments (space-separated)</Label>
-                    <Input id="args" value={editing.connectionArgs ?? ""} onChange={e => setEditing({ ...editing, connectionArgs: e.target.value })} placeholder="e.g., --acp" />
+                    <Input
+                      id="args"
+                      value={editing.connectionArgs ?? ""}
+                      onChange={(e) =>
+                        setEditing({
+                          ...editing,
+                          connectionArgs: e.target.value,
+                        })
+                      }
+                      placeholder="e.g., --acp"
+                    />
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="cwd">Working Directory (optional)</Label>
-                    <Input id="cwd" value={editing.connectionCwd ?? ""} onChange={e => setEditing({ ...editing, connectionCwd: e.target.value })} placeholder="e.g., /path/to/project or leave empty" />
+                    <Input
+                      id="cwd"
+                      value={editing.connectionCwd ?? ""}
+                      onChange={(e) =>
+                        setEditing({
+                          ...editing,
+                          connectionCwd: e.target.value,
+                        })
+                      }
+                      placeholder="e.g., /path/to/project or leave empty"
+                    />
                   </div>
-                  <div className="space-y-3 rounded-lg border bg-muted/20 p-3">
+                  <div className="bg-muted/20 space-y-3 rounded-lg border p-3">
                     <div className="flex flex-wrap items-start justify-between gap-2">
                       <div className="space-y-1">
                         <div className="flex flex-wrap items-center gap-2">
-                          <Label>{selectedPreset ? `${selectedPreset.displayName} Setup` : "External Agent Setup"}</Label>
-                          {selectedPresetKey && <Badge variant="secondary" className="text-[10px] uppercase">Preset</Badge>}
+                          <Label>
+                            {selectedPreset
+                              ? `${selectedPreset.displayName} Setup`
+                              : "External Agent Setup"}
+                          </Label>
+                          {selectedPresetKey && (
+                            <Badge
+                              variant="secondary"
+                              className="text-[10px] uppercase"
+                            >
+                              Preset
+                            </Badge>
+                          )}
                         </div>
-                        <p className="text-[11px] text-muted-foreground">
-                          {selectedPreset?.description || "Verify that DotAgents can resolve your command and working directory before saving."}
+                        <p className="text-muted-foreground text-[11px]">
+                          {selectedPreset?.description ||
+                            "Verify that DotAgents can resolve your command and working directory before saving."}
                         </p>
                       </div>
                       {selectedPreset?.docsUrl && (
-                        <Button type="button" variant="ghost" size="sm" className="h-7 gap-1.5 px-2 text-xs" onClick={() => window.open(selectedPreset.docsUrl, "_blank")}>Open docs<ExternalLink className="h-3.5 w-3.5" /></Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1.5 px-2 text-xs"
+                          onClick={() =>
+                            window.open(selectedPreset.docsUrl, "_blank")
+                          }
+                        >
+                          Open docs
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </Button>
                       )}
                     </div>
 
-                    {(selectedPreset?.installCommand || selectedPreset?.authHint || selectedPreset?.cwdHint) && (
+                    {(selectedPreset?.installCommand ||
+                      selectedPreset?.authHint ||
+                      selectedPreset?.cwdHint) && (
                       <div className="grid gap-2 sm:grid-cols-3">
                         {selectedPreset?.installCommand && (
-                          <div className="space-y-1 rounded-md border bg-background/80 px-2.5 py-2">
-                            <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Install</p>
-                            <p className="font-mono text-[11px] leading-relaxed">{selectedPreset.installCommand}</p>
+                          <div className="bg-background/80 space-y-1 rounded-md border px-2.5 py-2">
+                            <p className="text-muted-foreground text-[10px] font-medium uppercase tracking-wide">
+                              Install
+                            </p>
+                            <p className="font-mono text-[11px] leading-relaxed">
+                              {selectedPreset.installCommand}
+                            </p>
                           </div>
                         )}
                         {selectedPreset?.authHint && (
-                          <div className="space-y-1 rounded-md border bg-background/80 px-2.5 py-2">
-                            <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Auth</p>
-                            <p className="text-[11px] leading-relaxed text-muted-foreground">{selectedPreset.authHint}</p>
+                          <div className="bg-background/80 space-y-1 rounded-md border px-2.5 py-2">
+                            <p className="text-muted-foreground text-[10px] font-medium uppercase tracking-wide">
+                              Auth
+                            </p>
+                            <p className="text-muted-foreground text-[11px] leading-relaxed">
+                              {selectedPreset.authHint}
+                            </p>
                           </div>
                         )}
                         {selectedPreset?.cwdHint && (
-                          <div className="space-y-1 rounded-md border bg-background/80 px-2.5 py-2">
-                            <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Working Directory</p>
-                            <p className="text-[11px] leading-relaxed text-muted-foreground">{selectedPreset.cwdHint}</p>
+                          <div className="bg-background/80 space-y-1 rounded-md border px-2.5 py-2">
+                            <p className="text-muted-foreground text-[10px] font-medium uppercase tracking-wide">
+                              Working Directory
+                            </p>
+                            <p className="text-muted-foreground text-[11px] leading-relaxed">
+                              {selectedPreset.cwdHint}
+                            </p>
                           </div>
                         )}
                       </div>
                     )}
 
                     <div className="flex flex-wrap items-center gap-2">
-                      <Button type="button" variant="outline" size="sm" className="h-8 gap-1.5 px-2.5 text-xs" disabled={isVerifyingCommand} onClick={handleVerifyExternalAgent}>
-                        <RefreshCw className={`h-3.5 w-3.5 ${isVerifyingCommand ? "animate-spin" : ""}`} />Verify Setup
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="h-8 gap-1.5 px-2.5 text-xs"
+                        disabled={isVerifyingCommand}
+                        onClick={handleVerifyExternalAgent}
+                      >
+                        <RefreshCw
+                          className={`h-3.5 w-3.5 ${isVerifyingCommand ? "animate-spin" : ""}`}
+                        />
+                        Verify Setup
                       </Button>
-                      <p className="text-[11px] text-muted-foreground">
+                      <p className="text-muted-foreground text-[11px]">
                         {selectedPreset?.verifyArgs?.length
                           ? `Runs ${buildCommandPreview(editing.connectionCommand, `${editing.connectionArgs || ""} ${selectedPreset.verifyArgs.join(" ")}`)} to confirm the command is runnable.`
                           : "Checks the command path and working directory before you save."}
@@ -912,17 +1529,36 @@ export function SettingsAgents() {
                     </div>
 
                     {commandVerification && (
-                      <div className={`space-y-1 rounded-md border px-2.5 py-2 text-[11px] ${commandVerification.ok ? "border-emerald-500/40 bg-emerald-500/5" : "border-amber-500/40 bg-amber-500/5"}`}>
-                        <p className="font-medium">{commandVerification.ok ? "Verification passed" : "Verification needs attention"}</p>
-                        <p className="text-muted-foreground">{commandVerification.details || commandVerification.error}</p>
+                      <div
+                        className={`space-y-1 rounded-md border px-2.5 py-2 text-[11px] ${commandVerification.ok ? "border-emerald-500/40 bg-emerald-500/5" : "border-amber-500/40 bg-amber-500/5"}`}
+                      >
+                        <p className="font-medium">
+                          {commandVerification.ok
+                            ? "Verification passed"
+                            : "Verification needs attention"}
+                        </p>
+                        <p className="text-muted-foreground">
+                          {commandVerification.details ||
+                            commandVerification.error}
+                        </p>
                         {commandVerification.resolvedCommand && (
-                          <p className="font-mono text-[10px] text-muted-foreground">Resolved command: {commandVerification.resolvedCommand}</p>
+                          <p className="text-muted-foreground font-mono text-[10px]">
+                            Resolved command:{" "}
+                            {commandVerification.resolvedCommand}
+                          </p>
                         )}
                         {externalCommandPreview && (
-                          <p className="font-mono text-[10px] text-muted-foreground">Configured command: {externalCommandPreview}</p>
+                          <p className="text-muted-foreground font-mono text-[10px]">
+                            Configured command: {externalCommandPreview}
+                          </p>
                         )}
                         {commandVerification.warnings?.map((warning, index) => (
-                          <p key={`${warning}-${index}`} className="text-[10px] text-muted-foreground">{warning}</p>
+                          <p
+                            key={`${warning}-${index}`}
+                            className="text-muted-foreground text-[10px]"
+                          >
+                            {warning}
+                          </p>
                         ))}
                       </div>
                     )}
@@ -932,45 +1568,81 @@ export function SettingsAgents() {
               {editing.connectionType === "remote" && (
                 <div className="space-y-2">
                   <Label htmlFor="baseUrl">Base URL</Label>
-                  <Input id="baseUrl" value={editing.connectionBaseUrl ?? ""} onChange={e => setEditing({ ...editing, connectionBaseUrl: e.target.value })} placeholder="e.g., http://localhost:8000" />
+                  <Input
+                    id="baseUrl"
+                    value={editing.connectionBaseUrl ?? ""}
+                    onChange={(e) =>
+                      setEditing({
+                        ...editing,
+                        connectionBaseUrl: e.target.value,
+                      })
+                    }
+                    placeholder="e.g., http://localhost:8000"
+                  />
                 </div>
               )}
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pt-1">
                 <div className="flex items-center space-x-2">
-                  <Switch id="enabled" checked={editing.enabled} onCheckedChange={v => setEditing({ ...editing, enabled: v })} />
+                  <Switch
+                    id="enabled"
+                    checked={editing.enabled}
+                    onCheckedChange={(v) =>
+                      setEditing({ ...editing, enabled: v })
+                    }
+                  />
                   <Label htmlFor="enabled">Enabled</Label>
                 </div>
-                {editing.connectionType === 'acpx' && (
+                {editing.connectionType === "acpx" && (
                   <div className="flex items-center space-x-2">
-                    <Switch id="autoSpawn" checked={editing.autoSpawn ?? false} onCheckedChange={v => setEditing({ ...editing, autoSpawn: v })} />
+                    <Switch
+                      id="autoSpawn"
+                      checked={editing.autoSpawn ?? false}
+                      onCheckedChange={(v) =>
+                        setEditing({ ...editing, autoSpawn: v })
+                      }
+                    />
                     <Label htmlFor="autoSpawn">Auto-spawn on startup</Label>
                   </div>
                 )}
               </div>
             </TabsContent>
 
-
             {/* ── Model Tab (internal only) ── */}
             {isInternal && (
               <TabsContent value="model" className="space-y-4">
-                <p className="text-sm text-muted-foreground">
-                  Choose which LLM provider and model this agent uses. Leave unset to use global defaults.
+                <p className="text-muted-foreground text-sm">
+                  Choose which LLM provider and model this agent uses. Leave
+                  unset to use global defaults.
                 </p>
                 <div className="space-y-2">
                   <Label>LLM Provider</Label>
                   <Select
-                    value={editing.modelConfig?.agentProviderId ?? editing.modelConfig?.mcpToolsProviderId ?? "__global__"}
-                    onValueChange={v => {
+                    value={
+                      editing.modelConfig?.agentProviderId ??
+                      editing.modelConfig?.mcpToolsProviderId ??
+                      "__global__"
+                    }
+                    onValueChange={(v) => {
                       if (v === "__global__") {
                         setEditing({ ...editing, modelConfig: undefined })
                       } else {
-                        updateModelConfig({ agentProviderId: v as "openai" | "groq" | "gemini" | "chatgpt-web" })
+                        updateModelConfig({
+                          agentProviderId: v as
+                            | "openai"
+                            | "groq"
+                            | "gemini"
+                            | "chatgpt-web",
+                        })
                       }
                     }}
                   >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="__global__">Use global default</SelectItem>
+                      <SelectItem value="__global__">
+                        Use global default
+                      </SelectItem>
                       <SelectItem value="openai">OpenAI</SelectItem>
                       <SelectItem value="groq">Groq</SelectItem>
                       <SelectItem value="gemini">Gemini</SelectItem>
@@ -978,21 +1650,42 @@ export function SettingsAgents() {
                     </SelectContent>
                   </Select>
                 </div>
-                {(editing.modelConfig?.agentProviderId || editing.modelConfig?.mcpToolsProviderId) && (
+                {(editing.modelConfig?.agentProviderId ||
+                  editing.modelConfig?.mcpToolsProviderId) && (
                   <ModelSelector
-                    providerId={editing.modelConfig.agentProviderId || editing.modelConfig.mcpToolsProviderId}
-                    value={
-                      (editing.modelConfig.agentProviderId || editing.modelConfig.mcpToolsProviderId) === "openai" ? editing.modelConfig.agentOpenaiModel || editing.modelConfig.mcpToolsOpenaiModel :
-                      (editing.modelConfig.agentProviderId || editing.modelConfig.mcpToolsProviderId) === "groq" ? editing.modelConfig.agentGroqModel || editing.modelConfig.mcpToolsGroqModel :
-                      (editing.modelConfig.agentProviderId || editing.modelConfig.mcpToolsProviderId) === "gemini" ? editing.modelConfig.agentGeminiModel || editing.modelConfig.mcpToolsGeminiModel :
-                      editing.modelConfig.agentChatgptWebModel || editing.modelConfig.mcpToolsChatgptWebModel
+                    providerId={
+                      editing.modelConfig.agentProviderId ||
+                      editing.modelConfig.mcpToolsProviderId
                     }
-                    onValueChange={model => {
-                      const p = editing.modelConfig?.agentProviderId || editing.modelConfig?.mcpToolsProviderId
-                      if (p === "openai") updateModelConfig({ agentOpenaiModel: model })
-                      else if (p === "groq") updateModelConfig({ agentGroqModel: model })
-                      else if (p === "gemini") updateModelConfig({ agentGeminiModel: model })
-                      else if (p === "chatgpt-web") updateModelConfig({ agentChatgptWebModel: model })
+                    value={
+                      (editing.modelConfig.agentProviderId ||
+                        editing.modelConfig.mcpToolsProviderId) === "openai"
+                        ? editing.modelConfig.agentOpenaiModel ||
+                          editing.modelConfig.mcpToolsOpenaiModel
+                        : (editing.modelConfig.agentProviderId ||
+                              editing.modelConfig.mcpToolsProviderId) === "groq"
+                          ? editing.modelConfig.agentGroqModel ||
+                            editing.modelConfig.mcpToolsGroqModel
+                          : (editing.modelConfig.agentProviderId ||
+                                editing.modelConfig.mcpToolsProviderId) ===
+                              "gemini"
+                            ? editing.modelConfig.agentGeminiModel ||
+                              editing.modelConfig.mcpToolsGeminiModel
+                            : editing.modelConfig.agentChatgptWebModel ||
+                              editing.modelConfig.mcpToolsChatgptWebModel
+                    }
+                    onValueChange={(model) => {
+                      const p =
+                        editing.modelConfig?.agentProviderId ||
+                        editing.modelConfig?.mcpToolsProviderId
+                      if (p === "openai")
+                        updateModelConfig({ agentOpenaiModel: model })
+                      else if (p === "groq")
+                        updateModelConfig({ agentGroqModel: model })
+                      else if (p === "gemini")
+                        updateModelConfig({ agentGeminiModel: model })
+                      else if (p === "chatgpt-web")
+                        updateModelConfig({ agentChatgptWebModel: model })
                     }}
                     label="Agent Model"
                     placeholder="Select model for this agent"
@@ -1005,153 +1698,370 @@ export function SettingsAgents() {
             <TabsContent value="capabilities" className="space-y-4">
               {/* ── Skills Section ── */}
               <div className="rounded-lg border">
-                <div className="flex items-center justify-between w-full px-4 py-3">
-                  <button type="button" className="flex items-center gap-2 hover:bg-muted/50 transition-colors rounded-md px-1 py-0.5 -mx-1" onClick={() => toggleSection("skills")}>
-                    {isSectionCollapsed("skills") ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                    <Sparkles className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-semibold text-sm">Skills</span>
+                <div className="flex w-full items-center justify-between px-4 py-3">
+                  <button
+                    type="button"
+                    className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+                    onClick={() => toggleSection("skills")}
+                  >
+                    {isSectionCollapsed("skills") ? (
+                      <ChevronRight className="h-4 w-4" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4" />
+                    )}
+                    <Sparkles className="text-muted-foreground h-4 w-4" />
+                    <span className="text-sm font-semibold">Skills</span>
                   </button>
                   <div className="flex items-center gap-2">
                     {skills.length > 0 && (
                       <div className="flex items-center gap-1">
-                        <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-[11px]" disabled={allSkillsEnabled} onClick={(e) => { e.stopPropagation(); enableAllSkills() }}>Enable All</Button>
-                        <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-[11px]" disabled={allSkillsDisabled} onClick={(e) => { e.stopPropagation(); disableAllSkills() }}>Disable All</Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          disabled={allSkillsEnabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            enableAllSkills()
+                          }}
+                        >
+                          Enable All
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          disabled={allSkillsDisabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            disableAllSkills()
+                          }}
+                        >
+                          Disable All
+                        </Button>
                       </div>
                     )}
-                    <Badge variant="secondary" className="text-xs">{skills.filter(s => isSkillEnabled(s.id)).length} of {skills.length} enabled</Badge>
+                    <Badge variant="secondary" className="text-xs">
+                      {skills.filter((s) => isSkillEnabled(s.id)).length} of{" "}
+                      {skills.length} enabled
+                    </Badge>
                   </div>
                 </div>
                 {!isSectionCollapsed("skills") && (
-                  <div className="border-t px-2 py-2 space-y-0.5">
+                  <div className="space-y-0.5 border-t px-2 py-2">
                     {skills.length === 0 ? (
-                      <p className="text-sm text-muted-foreground py-3 text-center">No skills available.</p>
-                    ) : skills.map(skill => (
-                      <div key={skill.id} className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted/30">
-                        <Switch checked={isSkillEnabled(skill.id)} onCheckedChange={() => toggleSkill(skill.id)} />
-                        <div className="min-w-0 flex-1">
-                          <span className="text-sm truncate block">{skill.name}</span>
-                          {skill.description && <span className="text-xs text-muted-foreground truncate block">{skill.description}</span>}
+                      <p className="text-muted-foreground py-3 text-center text-sm">
+                        No skills available.
+                      </p>
+                    ) : (
+                      skills.map((skill) => (
+                        <div
+                          key={skill.id}
+                          className="hover:bg-muted/30 flex items-center gap-3 rounded-md px-3 py-2"
+                        >
+                          <Switch
+                            checked={isSkillEnabled(skill.id)}
+                            onCheckedChange={() => toggleSkill(skill.id)}
+                          />
+                          <div className="min-w-0 flex-1">
+                            <span className="block truncate text-sm">
+                              {skill.name}
+                            </span>
+                            {skill.description && (
+                              <span className="text-muted-foreground block truncate text-xs">
+                                {skill.description}
+                              </span>
+                            )}
+                          </div>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 shrink-0"
+                            title="Edit skill"
+                            onClick={() => navigate("/settings/capabilities")}
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </Button>
                         </div>
-                        <Button type="button" variant="ghost" size="icon" className="h-7 w-7 shrink-0" title="Edit skill" onClick={() => navigate("/settings/capabilities")}>
-                          <ExternalLink className="h-3.5 w-3.5" />
-                        </Button>
-                      </div>
-                    ))}
+                      ))
+                    )}
                   </div>
                 )}
               </div>
 
               {/* ── MCP Servers Section ── */}
               <div className="rounded-lg border">
-                <div className="flex items-center justify-between w-full px-4 py-3">
-                  <button type="button" className="flex items-center gap-2 hover:bg-muted/50 transition-colors rounded-md px-1 py-0.5 -mx-1" onClick={() => toggleSection("mcp-servers")}>
-                    {isSectionCollapsed("mcp-servers") ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                    <Server className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-semibold text-sm">MCP Servers</span>
+                <div className="flex w-full items-center justify-between px-4 py-3">
+                  <button
+                    type="button"
+                    className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+                    onClick={() => toggleSection("mcp-servers")}
+                  >
+                    {isSectionCollapsed("mcp-servers") ? (
+                      <ChevronRight className="h-4 w-4" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4" />
+                    )}
+                    <Server className="text-muted-foreground h-4 w-4" />
+                    <span className="text-sm font-semibold">MCP Servers</span>
                   </button>
                   <div className="flex items-center gap-2">
                     {serverNames.length > 0 && (
                       <div className="flex items-center gap-1">
-                        <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-[11px]" disabled={allServersEnabled} onClick={(e) => { e.stopPropagation(); enableAllServers() }}>Enable All</Button>
-                        <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-[11px]" disabled={allServersDisabled} onClick={(e) => { e.stopPropagation(); disableAllServers() }}>Disable All</Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          disabled={allServersEnabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            enableAllServers()
+                          }}
+                        >
+                          Enable All
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          disabled={allServersDisabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            disableAllServers()
+                          }}
+                        >
+                          Disable All
+                        </Button>
                       </div>
                     )}
-                    <Badge variant="secondary" className="text-xs">{serverNames.filter(n => isServerEnabled(n)).length} of {serverNames.length} enabled</Badge>
+                    <Badge variant="secondary" className="text-xs">
+                      {serverNames.filter((n) => isServerEnabled(n)).length} of{" "}
+                      {serverNames.length} enabled
+                    </Badge>
                   </div>
                 </div>
                 {!isSectionCollapsed("mcp-servers") && (
-                  <div className="border-t px-2 py-2 space-y-1">
+                  <div className="space-y-1 border-t px-2 py-2">
                     {serverNames.length === 0 ? (
-                      <p className="text-sm text-muted-foreground py-3 text-center">No MCP servers configured.</p>
-                    ) : serverNames.map(name => {
-                      const info = serverStatus[name]
-                      const serverToolList = toolsByServer(name)
-                      const isExpanded = expandedServers.has(name)
-                      const enabled = isServerEnabled(name)
-                      return (
-                        <div key={name} className="rounded-md border bg-card">
-                          <div className="flex items-center justify-between px-3 py-2">
-                            <div className="flex items-center gap-3 min-w-0">
-                              <Switch checked={enabled} onCheckedChange={() => toggleServer(name)} />
-                              <div className="flex items-center gap-2 min-w-0">
-                                <span className={`font-medium text-sm truncate ${!enabled ? "text-muted-foreground" : ""}`}>{name}</span>
-                                {info?.connected
-                                  ? <Badge variant="secondary" className="text-[10px] px-1.5">connected</Badge>
-                                  : <Badge variant="outline" className="text-[10px] px-1.5">offline</Badge>
-                                }
+                      <p className="text-muted-foreground py-3 text-center text-sm">
+                        No MCP servers configured.
+                      </p>
+                    ) : (
+                      serverNames.map((name) => {
+                        const info = serverStatus[name]
+                        const serverToolList = toolsByServer(name)
+                        const isExpanded = expandedServers.has(name)
+                        const enabled = isServerEnabled(name)
+                        return (
+                          <div key={name} className="bg-card rounded-md border">
+                            <div className="flex items-center justify-between px-3 py-2">
+                              <div className="flex min-w-0 items-center gap-3">
+                                <Switch
+                                  checked={enabled}
+                                  onCheckedChange={() => toggleServer(name)}
+                                />
+                                <div className="flex min-w-0 items-center gap-2">
+                                  <span
+                                    className={`truncate text-sm font-medium ${!enabled ? "text-muted-foreground" : ""}`}
+                                  >
+                                    {name}
+                                  </span>
+                                  {info?.connected ? (
+                                    <Badge
+                                      variant="secondary"
+                                      className="px-1.5 text-[10px]"
+                                    >
+                                      connected
+                                    </Badge>
+                                  ) : (
+                                    <Badge
+                                      variant="outline"
+                                      className="px-1.5 text-[10px]"
+                                    >
+                                      offline
+                                    </Badge>
+                                  )}
+                                </div>
+                              </div>
+                              <div className="flex items-center gap-1">
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-7 w-7 shrink-0"
+                                  title="Edit server"
+                                  onClick={() =>
+                                    navigate("/settings/capabilities")
+                                  }
+                                >
+                                  <ExternalLink className="h-3.5 w-3.5" />
+                                </Button>
+                                <button
+                                  type="button"
+                                  className="text-muted-foreground hover:text-foreground flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors"
+                                  onClick={() => toggleExpandServer(name)}
+                                >
+                                  <span>{serverToolList.length} tools</span>
+                                  {isExpanded ? (
+                                    <ChevronDown className="h-3.5 w-3.5" />
+                                  ) : (
+                                    <ChevronRight className="h-3.5 w-3.5" />
+                                  )}
+                                </button>
                               </div>
                             </div>
-                            <div className="flex items-center gap-1">
-                              <Button type="button" variant="ghost" size="icon" className="h-7 w-7 shrink-0" title="Edit server" onClick={() => navigate("/settings/capabilities")}>
-                                <ExternalLink className="h-3.5 w-3.5" />
-                              </Button>
-                              <button type="button" className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded" onClick={() => toggleExpandServer(name)}>
-                                <span>{serverToolList.length} tools</span>
-                                {isExpanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-                              </button>
-                            </div>
-                          </div>
-                          {isExpanded && serverToolList.length > 0 && (
-                            <div className="border-t mx-3 mb-2 pt-1 space-y-0.5">
-                              {serverToolList.map(tool => {
-                                const toolEnabled = enabled && !isToolDisabled(tool.name)
-                                return (
-                                  <div key={tool.name} className="flex items-center gap-3 px-2 py-1.5 rounded hover:bg-muted/30">
-                                    <Switch checked={toolEnabled} disabled={!enabled} onCheckedChange={() => toggleTool(tool.name)} />
-                                    <div className="min-w-0">
-                                      <span className={`text-sm truncate block ${!toolEnabled ? "text-muted-foreground" : ""}`}>{tool.name.replace(`${name}:`, "")}</span>
-                                      {tool.description && <span className="text-xs text-muted-foreground truncate block">{tool.description}</span>}
+                            {isExpanded && serverToolList.length > 0 && (
+                              <div className="mx-3 mb-2 space-y-0.5 border-t pt-1">
+                                {serverToolList.map((tool) => {
+                                  const toolEnabled =
+                                    enabled && !isToolDisabled(tool.name)
+                                  return (
+                                    <div
+                                      key={tool.name}
+                                      className="hover:bg-muted/30 flex items-center gap-3 rounded px-2 py-1.5"
+                                    >
+                                      <Switch
+                                        checked={toolEnabled}
+                                        disabled={!enabled}
+                                        onCheckedChange={() =>
+                                          toggleTool(tool.name)
+                                        }
+                                      />
+                                      <div className="min-w-0">
+                                        <span
+                                          className={`block truncate text-sm ${!toolEnabled ? "text-muted-foreground" : ""}`}
+                                        >
+                                          {tool.name.replace(`${name}:`, "")}
+                                        </span>
+                                        {tool.description && (
+                                          <span className="text-muted-foreground block truncate text-xs">
+                                            {tool.description}
+                                          </span>
+                                        )}
+                                      </div>
                                     </div>
-                                  </div>
-                                )
-                              })}
-                            </div>
-                          )}
-                        </div>
-                      )
-                    })}
+                                  )
+                                })}
+                              </div>
+                            )}
+                          </div>
+                        )
+                      })
+                    )}
                   </div>
                 )}
               </div>
 
               {/* ── DotAgents Runtime Tools Section ── */}
               <div className="rounded-lg border">
-                <div className="flex items-center justify-between w-full px-4 py-3">
-                  <button type="button" className="flex items-center gap-2 hover:bg-muted/50 transition-colors rounded-md px-1 py-0.5 -mx-1" onClick={() => toggleSection("runtime-tools")}>
-                    {isSectionCollapsed("runtime-tools") ? <ChevronRight className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
-                    <Wrench className="h-4 w-4 text-muted-foreground" />
-                    <span className="font-semibold text-sm">DotAgents Runtime Tools</span>
+                <div className="flex w-full items-center justify-between px-4 py-3">
+                  <button
+                    type="button"
+                    className="hover:bg-muted/50 -mx-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+                    onClick={() => toggleSection("runtime-tools")}
+                  >
+                    {isSectionCollapsed("runtime-tools") ? (
+                      <ChevronRight className="h-4 w-4" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4" />
+                    )}
+                    <Wrench className="text-muted-foreground h-4 w-4" />
+                    <span className="text-sm font-semibold">
+                      DotAgents Runtime Tools
+                    </span>
                   </button>
                   <div className="flex items-center gap-2">
                     {runtimeTools.length > 0 && (
                       <div className="flex items-center gap-1">
-                        <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-[11px]" disabled={allRuntimeEnabled} onClick={(e) => { e.stopPropagation(); enableAllRuntimeTools() }}>Enable All</Button>
-                        <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-[11px]" disabled={allRuntimeDisabled} onClick={(e) => { e.stopPropagation(); disableAllRuntimeTools() }}>Disable All</Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          disabled={allRuntimeEnabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            enableAllRuntimeTools()
+                          }}
+                        >
+                          Enable All
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 px-2 text-[11px]"
+                          disabled={allRuntimeDisabled}
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            disableAllRuntimeTools()
+                          }}
+                        >
+                          Disable All
+                        </Button>
                       </div>
                     )}
-                    <Badge variant="secondary" className="text-xs">{runtimeTools.filter(t => isRuntimeToolEnabled(t.name)).length} of {runtimeTools.length} enabled</Badge>
+                    <Badge variant="secondary" className="text-xs">
+                      {
+                        runtimeTools.filter((t) => isRuntimeToolEnabled(t.name))
+                          .length
+                      }{" "}
+                      of {runtimeTools.length} enabled
+                    </Badge>
                   </div>
                 </div>
                 {!isSectionCollapsed("runtime-tools") && (
-                  <div className="border-t px-2 py-2 space-y-0.5">
+                  <div className="space-y-0.5 border-t px-2 py-2">
                     {runtimeTools.length === 0 ? (
-                      <p className="text-sm text-muted-foreground py-3 text-center">No DotAgents runtime tools available.</p>
-                    ) : runtimeTools.map(tool => {
-                      const isEssential = tool.name === "mark_work_complete"
-                      const enabled = isEssential || isRuntimeToolEnabled(tool.name)
-                      return (
-                        <div key={tool.name} className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-muted/30">
-                          <Switch checked={enabled} disabled={isEssential} onCheckedChange={() => toggleRuntimeTool(tool.name)} />
-                          <div className="min-w-0">
-                            <span className={`text-sm truncate flex items-center gap-2 ${!enabled ? "text-muted-foreground" : ""}`}>
-                              {tool.name}
-                              {isEssential && <Badge variant="outline" className="text-[10px] px-1.5">essential</Badge>}
-                            </span>
-                            {tool.description && <span className="text-xs text-muted-foreground truncate block">{tool.description}</span>}
+                      <p className="text-muted-foreground py-3 text-center text-sm">
+                        No DotAgents runtime tools available.
+                      </p>
+                    ) : (
+                      runtimeTools.map((tool) => {
+                        const isEssential = tool.name === "mark_work_complete"
+                        const enabled =
+                          isEssential || isRuntimeToolEnabled(tool.name)
+                        return (
+                          <div
+                            key={tool.name}
+                            className="hover:bg-muted/30 flex items-center gap-3 rounded-md px-3 py-2"
+                          >
+                            <Switch
+                              checked={enabled}
+                              disabled={isEssential}
+                              onCheckedChange={() =>
+                                toggleRuntimeTool(tool.name)
+                              }
+                            />
+                            <div className="min-w-0">
+                              <span
+                                className={`flex items-center gap-2 truncate text-sm ${!enabled ? "text-muted-foreground" : ""}`}
+                              >
+                                {tool.name}
+                                {isEssential && (
+                                  <Badge
+                                    variant="outline"
+                                    className="px-1.5 text-[10px]"
+                                  >
+                                    essential
+                                  </Badge>
+                                )}
+                              </span>
+                              {tool.description && (
+                                <span className="text-muted-foreground block truncate text-xs">
+                                  {tool.description}
+                                </span>
+                              )}
+                            </div>
                           </div>
-                        </div>
-                      )
-                    })}
+                        )
+                      })
+                    )}
                   </div>
                 )}
               </div>
@@ -1159,43 +2069,81 @@ export function SettingsAgents() {
 
             {/* ── Properties Tab ── */}
             <TabsContent value="properties" className="space-y-4">
-              <p className="text-sm text-muted-foreground">
-                Dynamic key-value properties that are exposed in the agent&apos;s system prompt as variables.
+              <p className="text-muted-foreground text-sm">
+                Dynamic key-value properties that are exposed in the
+                agent&apos;s system prompt as variables.
               </p>
-              {editing.properties && Object.keys(editing.properties).length > 0 && (
-                <div className="space-y-1">
-                  {Object.entries(editing.properties).map(([key, val]) => (
-                    <div key={key} className="flex items-center gap-2 px-3 py-2 rounded-lg border bg-card">
-                      <code className="text-sm font-mono bg-muted px-1.5 py-0.5 rounded">{key}</code>
-                      <span className="text-sm flex-1 truncate">{String(val)}</span>
-                      <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0" onClick={() => removeProperty(key)}>
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  ))}
-                </div>
-              )}
-              <div className="flex gap-2 items-end">
-                <div className="space-y-1 flex-1">
+              {editing.properties &&
+                Object.keys(editing.properties).length > 0 && (
+                  <div className="space-y-1">
+                    {Object.entries(editing.properties).map(([key, val]) => (
+                      <div
+                        key={key}
+                        className="bg-card flex items-center gap-2 rounded-lg border px-3 py-2"
+                      >
+                        <code className="bg-muted rounded px-1.5 py-0.5 font-mono text-sm">
+                          {key}
+                        </code>
+                        <span className="flex-1 truncate text-sm">
+                          {String(val)}
+                        </span>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-7 w-7 shrink-0"
+                          onClick={() => removeProperty(key)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              <div className="flex items-end gap-2">
+                <div className="flex-1 space-y-1">
                   <Label className="text-xs">Key</Label>
-                  <Input value={newPropKey} onChange={e => setNewPropKey(e.target.value)} placeholder="e.g., language" className="h-8 text-sm" />
-                </div>
-                <div className="space-y-1 flex-1">
-                  <Label className="text-xs">Value</Label>
-                  <Input value={newPropValue} onChange={e => setNewPropValue(e.target.value)} placeholder="e.g., TypeScript" className="h-8 text-sm"
-                    onKeyDown={e => { if (e.key === "Enter") addProperty() }}
+                  <Input
+                    value={newPropKey}
+                    onChange={(e) => setNewPropKey(e.target.value)}
+                    placeholder="e.g., language"
+                    className="h-8 text-sm"
                   />
                 </div>
-                <Button size="sm" variant="outline" className="h-8 gap-1" onClick={addProperty} disabled={!newPropKey.trim()}>
-                  <Plus className="h-3.5 w-3.5" />Add
+                <div className="flex-1 space-y-1">
+                  <Label className="text-xs">Value</Label>
+                  <Input
+                    value={newPropValue}
+                    onChange={(e) => setNewPropValue(e.target.value)}
+                    placeholder="e.g., TypeScript"
+                    className="h-8 text-sm"
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") addProperty()
+                    }}
+                  />
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-8 gap-1"
+                  onClick={addProperty}
+                  disabled={!newPropKey.trim()}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add
                 </Button>
               </div>
             </TabsContent>
           </Tabs>
 
-          <div className="flex justify-end gap-2 pt-4 border-t mt-4">
-            <Button variant="outline" className="gap-2" onClick={handleCancel}><X className="h-4 w-4" />Cancel</Button>
-            <Button className="gap-2" onClick={handleSave}><Save className="h-4 w-4" />Save</Button>
+          <div className="mt-4 flex justify-end gap-2 border-t pt-4">
+            <Button variant="outline" className="gap-2" onClick={handleCancel}>
+              <X className="h-4 w-4" />
+              Cancel
+            </Button>
+            <Button className="gap-2" onClick={handleSave}>
+              <Save className="h-4 w-4" />
+              Save
+            </Button>
           </div>
         </CardContent>
       </Card>

--- a/apps/desktop/src/renderer/src/pages/settings-capabilities.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-capabilities.tsx
@@ -14,19 +14,19 @@ export function Component() {
   const [activeTab, setActiveTab] = useState<TabId>("skills")
 
   return (
-    <div className="h-full flex flex-col overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       {/* Tab bar */}
-      <div className="flex items-center gap-1 px-6 pt-4 pb-2 shrink-0 border-b bg-background">
-        {tabs.map(tab => (
+      <div className="bg-background flex shrink-0 items-center gap-1 border-b px-6 pb-2 pt-4">
+        {tabs.map((tab) => (
           <button
             key={tab.id}
             type="button"
             onClick={() => setActiveTab(tab.id)}
             className={cn(
-              "flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+              "flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
               activeTab === tab.id
                 ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
             )}
           >
             <span className={cn(tab.icon, "shrink-0")} />
@@ -36,11 +36,10 @@ export function Component() {
       </div>
 
       {/* Tab content — each page provides its own scroll container */}
-      <div className="flex-1 min-h-0">
+      <div className="min-h-0 flex-1">
         {activeTab === "skills" && <SkillsPage />}
         {activeTab === "mcp-servers" && <McpToolsPage />}
       </div>
     </div>
   )
 }
-

--- a/apps/desktop/src/renderer/src/pages/settings-discord.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-discord.tsx
@@ -1,12 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { AlertTriangle, CheckCircle2, RefreshCw, Trash2, XCircle } from "lucide-react"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  RefreshCw,
+  Trash2,
+  XCircle,
+} from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
 import { Control, ControlGroup } from "@renderer/components/ui/control"
 import { Input } from "@renderer/components/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@renderer/components/ui/select"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@renderer/components/ui/select"
+import { SettingsPageShell } from "@renderer/components/settings-navigation"
 import { Switch } from "@renderer/components/ui/switch"
 import { Textarea } from "@renderer/components/ui/textarea"
-import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
+import {
+  useConfigQuery,
+  useSaveConfigMutation,
+} from "@renderer/lib/query-client"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import type { AgentProfile, Config } from "@shared/types"
 
@@ -62,7 +78,12 @@ export function Component() {
     setUserAllowlistDraft(formatIdList(cfg?.discordAllowUserIds))
     setGuildAllowlistDraft(formatIdList(cfg?.discordAllowGuildIds))
     setChannelAllowlistDraft(formatIdList(cfg?.discordAllowChannelIds))
-  }, [cfg?.discordBotToken, cfg?.discordAllowUserIds, cfg?.discordAllowGuildIds, cfg?.discordAllowChannelIds])
+  }, [
+    cfg?.discordBotToken,
+    cfg?.discordAllowUserIds,
+    cfg?.discordAllowGuildIds,
+    cfg?.discordAllowChannelIds,
+  ])
 
   // Pure: returns the merged config without touching `cfgRef.current`. The
   // ref is only advanced AFTER the save mutation actually succeeds, so an
@@ -76,27 +97,33 @@ export function Component() {
     return { ...cfgRef.current, ...partial }
   }, [])
 
-  const saveConfig = useCallback((partial: Partial<Config>) => {
-    const nextConfig = mergeConfig(partial)
-    if (!nextConfig) return
-    saveConfigMutation.mutate(
-      { config: nextConfig },
-      {
-        onSuccess: () => {
-          cfgRef.current = nextConfig
+  const saveConfig = useCallback(
+    (partial: Partial<Config>) => {
+      const nextConfig = mergeConfig(partial)
+      if (!nextConfig) return
+      saveConfigMutation.mutate(
+        { config: nextConfig },
+        {
+          onSuccess: () => {
+            cfgRef.current = nextConfig
+          },
         },
-      },
-    )
-  }, [mergeConfig, saveConfigMutation])
+      )
+    },
+    [mergeConfig, saveConfigMutation],
+  )
 
-  const saveConfigAsync = useCallback(async (partial: Partial<Config>) => {
-    const nextConfig = mergeConfig(partial)
-    if (!nextConfig) return
-    await saveConfigMutation.mutateAsync({ config: nextConfig })
-    // Only advance the ref after the mutation resolves successfully. If the
-    // mutation throws, the await above re-throws and we never reach here.
-    cfgRef.current = nextConfig
-  }, [mergeConfig, saveConfigMutation])
+  const saveConfigAsync = useCallback(
+    async (partial: Partial<Config>) => {
+      const nextConfig = mergeConfig(partial)
+      if (!nextConfig) return
+      await saveConfigMutation.mutateAsync({ config: nextConfig })
+      // Only advance the ref after the mutation resolves successfully. If the
+      // mutation throws, the await above re-throws and we never reach here.
+      cfgRef.current = nextConfig
+    },
+    [mergeConfig, saveConfigMutation],
+  )
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -107,7 +134,15 @@ export function Component() {
       ])
       setStatus(nextStatus as DiscordStatus)
       setLogs((nextLogs as DiscordLogEntry[]).slice().reverse())
-      setProfiles((nextProfiles as AgentProfile[]).filter((profile) => profile.enabled !== false && (profile.role === "chat-agent" || profile.role === "user-profile" || profile.isUserProfile)))
+      setProfiles(
+        (nextProfiles as AgentProfile[]).filter(
+          (profile) =>
+            profile.enabled !== false &&
+            (profile.role === "chat-agent" ||
+              profile.role === "user-profile" ||
+              profile.isUserProfile),
+        ),
+      )
       setStatusError(null)
     } catch (error) {
       setStatusError(error instanceof Error ? error.message : String(error))
@@ -159,15 +194,16 @@ export function Component() {
   const statusMessage = statusError || status?.lastError
 
   return (
-    <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-6 py-4">
+    <SettingsPageShell>
       <div className="grid gap-4">
         <ControlGroup
           title="Discord Integration"
-          endDescription={(
-            <div className="break-words whitespace-normal">
-              Connect a Discord bot so DMs, mentions, and threads can talk to a selected DotAgents profile.
+          endDescription={
+            <div className="whitespace-normal break-words">
+              Connect a Discord bot so DMs, mentions, and threads can talk to a
+              selected DotAgents profile.
             </div>
-          )}
+          }
         >
           <Control label="Enable Discord" className="px-3">
             <Switch
@@ -184,12 +220,15 @@ export function Component() {
               value={botTokenDraft}
               placeholder="Paste your Discord bot token"
               onChange={(event) => setBotTokenDraft(event.target.value)}
-              onBlur={() => saveConfig({ discordBotToken: botTokenDraft.trim() })}
+              onBlur={() =>
+                saveConfig({ discordBotToken: botTokenDraft.trim() })
+              }
             />
           </Control>
 
-          <div className="px-3 py-1 text-sm text-muted-foreground">
-            Discord needs the bot token plus the Message Content intent enabled in the Discord developer portal.
+          <div className="text-muted-foreground px-3 py-1 text-sm">
+            Discord needs the bot token plus the Message Content intent enabled
+            in the Discord developer portal.
           </div>
 
           <div className="px-3 pb-3">
@@ -197,23 +236,26 @@ export function Component() {
               {unavailable ? (
                 <>
                   <AlertTriangle className="h-4 w-4 text-amber-500" />
-                  <span className="text-amber-600 dark:text-amber-400">Discord support unavailable</span>
+                  <span className="text-amber-600 dark:text-amber-400">
+                    Discord support unavailable
+                  </span>
                 </>
               ) : status?.connected ? (
                 <>
                   <CheckCircle2 className="h-4 w-4 text-green-500" />
                   <span className="text-green-600 dark:text-green-400">
-                    Connected as {status.botUsername || "unknown bot"}{status.botId ? ` (${status.botId})` : ""}
+                    Connected as {status.botUsername || "unknown bot"}
+                    {status.botId ? ` (${status.botId})` : ""}
                   </span>
                 </>
               ) : status?.connecting ? (
                 <>
-                  <RefreshCw className="h-4 w-4 animate-spin text-muted-foreground" />
+                  <RefreshCw className="text-muted-foreground h-4 w-4 animate-spin" />
                   <span>Connecting…</span>
                 </>
               ) : (
                 <>
-                  <XCircle className="h-4 w-4 text-muted-foreground" />
+                  <XCircle className="text-muted-foreground h-4 w-4" />
                   <span className="text-muted-foreground">Not connected</span>
                 </>
               )}
@@ -227,9 +269,25 @@ export function Component() {
             )}
 
             <div className="flex flex-wrap gap-2">
-              <Button onClick={() => void handleConnect()} disabled={!enabled || unavailable}>Connect</Button>
-              <Button variant="outline" onClick={() => void handleDisconnect()} disabled={!enabled || unavailable}>Disconnect</Button>
-              <Button variant="ghost" size="icon" onClick={() => void fetchStatus()} aria-label="Refresh Discord status">
+              <Button
+                onClick={() => void handleConnect()}
+                disabled={!enabled || unavailable}
+              >
+                Connect
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => void handleDisconnect()}
+                disabled={!enabled || unavailable}
+              >
+                Disconnect
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => void fetchStatus()}
+                aria-label="Refresh Discord status"
+              >
                 <RefreshCw className="h-4 w-4" />
               </Button>
             </div>
@@ -240,7 +298,12 @@ export function Component() {
           <Control label="Default profile" className="px-3">
             <Select
               value={cfg.discordDefaultProfileId || "__none__"}
-              onValueChange={(value) => saveConfig({ discordDefaultProfileId: value === "__none__" ? undefined : value })}
+              onValueChange={(value) =>
+                saveConfig({
+                  discordDefaultProfileId:
+                    value === "__none__" ? undefined : value,
+                })
+              }
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select a profile" />
@@ -248,7 +311,9 @@ export function Component() {
               <SelectContent>
                 <SelectItem value="__none__">No profile selected</SelectItem>
                 {profiles.map((profile) => (
-                  <SelectItem key={profile.id} value={profile.id}>{profile.displayName}</SelectItem>
+                  <SelectItem key={profile.id} value={profile.id}>
+                    {profile.displayName}
+                  </SelectItem>
                 ))}
               </SelectContent>
             </Select>
@@ -257,27 +322,37 @@ export function Component() {
           <Control label="Allow direct messages" className="px-3">
             <Switch
               checked={cfg.discordDmEnabled ?? true}
-              onCheckedChange={(value) => saveConfig({ discordDmEnabled: value })}
+              onCheckedChange={(value) =>
+                saveConfig({ discordDmEnabled: value })
+              }
             />
           </Control>
 
           <Control label="Require mention in servers" className="px-3">
             <Switch
               checked={cfg.discordRequireMention ?? true}
-              onCheckedChange={(value) => saveConfig({ discordRequireMention: value })}
+              onCheckedChange={(value) =>
+                saveConfig({ discordRequireMention: value })
+              }
             />
           </Control>
 
-          <div className="mx-3 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2 text-xs text-muted-foreground">
-            💡 <span className="font-medium">You usually don't need to fill these in.</span> The Discord
-            bot's <span className="font-medium">application owner</span> (or Team members, for
-            Team‑owned apps) is automatically trusted — no IDs required. To grant a friend read‑only
-            access, DM the bot <code className="rounded bg-muted px-1">/dm allow @user</code> — it uses
-            Discord's native user picker. Any user can also run{" "}
-            <code className="rounded bg-muted px-1">/whoami</code> in Discord to see their own ID if
-            you prefer to paste it here manually. Mutating commands like{" "}
-            <code className="rounded bg-muted px-1">/dm allow</code> remain restricted to the
-            application owner.
+          <div className="text-muted-foreground mx-3 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2 text-xs">
+            💡{" "}
+            <span className="font-medium">
+              You usually don't need to fill these in.
+            </span>{" "}
+            The Discord bot's{" "}
+            <span className="font-medium">application owner</span> (or Team
+            members, for Team‑owned apps) is automatically trusted — no IDs
+            required. To grant a friend read‑only access, DM the bot{" "}
+            <code className="bg-muted rounded px-1">/dm allow @user</code> — it
+            uses Discord's native user picker. Any user can also run{" "}
+            <code className="bg-muted rounded px-1">/whoami</code> in Discord to
+            see their own ID if you prefer to paste it here manually. Mutating
+            commands like{" "}
+            <code className="bg-muted rounded px-1">/dm allow</code> remain
+            restricted to the application owner.
           </div>
 
           <Control label="Allowed user IDs" className="px-3">
@@ -286,7 +361,11 @@ export function Component() {
               value={userAllowlistDraft}
               placeholder="One Discord user ID per line"
               onChange={(event) => setUserAllowlistDraft(event.target.value)}
-              onBlur={() => saveConfig({ discordAllowUserIds: parseIdList(userAllowlistDraft) })}
+              onBlur={() =>
+                saveConfig({
+                  discordAllowUserIds: parseIdList(userAllowlistDraft),
+                })
+              }
             />
           </Control>
 
@@ -296,7 +375,11 @@ export function Component() {
               value={guildAllowlistDraft}
               placeholder="One Discord server ID per line"
               onChange={(event) => setGuildAllowlistDraft(event.target.value)}
-              onBlur={() => saveConfig({ discordAllowGuildIds: parseIdList(guildAllowlistDraft) })}
+              onBlur={() =>
+                saveConfig({
+                  discordAllowGuildIds: parseIdList(guildAllowlistDraft),
+                })
+              }
             />
           </Control>
 
@@ -306,22 +389,36 @@ export function Component() {
               value={channelAllowlistDraft}
               placeholder="One Discord channel or thread ID per line"
               onChange={(event) => setChannelAllowlistDraft(event.target.value)}
-              onBlur={() => saveConfig({ discordAllowChannelIds: parseIdList(channelAllowlistDraft) })}
+              onBlur={() =>
+                saveConfig({
+                  discordAllowChannelIds: parseIdList(channelAllowlistDraft),
+                })
+              }
             />
           </Control>
 
           <Control label="Log message content" className="px-3">
             <Switch
               checked={cfg.discordLogMessages ?? false}
-              onCheckedChange={(value) => saveConfig({ discordLogMessages: value })}
+              onCheckedChange={(value) =>
+                saveConfig({ discordLogMessages: value })
+              }
             />
           </Control>
         </ControlGroup>
 
         <ControlGroup title="Recent Logs">
           <div className="flex items-center justify-between px-3 pt-2">
-            <div className="text-sm text-muted-foreground">Most recent Discord events and errors.</div>
-            <Button variant="ghost" size="sm" onClick={() => void tipcClient.discordClearLogs().then(() => fetchStatus())}>
+            <div className="text-muted-foreground text-sm">
+              Most recent Discord events and errors.
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                void tipcClient.discordClearLogs().then(() => fetchStatus())
+              }
+            >
               <Trash2 className="mr-2 h-4 w-4" />
               Clear logs
             </Button>
@@ -329,19 +426,29 @@ export function Component() {
 
           <div className="space-y-2 px-3 pb-3">
             {logs.length === 0 ? (
-              <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">No Discord logs yet.</div>
-            ) : logs.map((entry) => (
-              <div key={entry.id} className="rounded-md border p-3 text-sm">
-                <div className="mb-1 flex items-center justify-between gap-3">
-                  <span className="font-medium uppercase text-muted-foreground">{entry.level}</span>
-                  <span className="text-xs text-muted-foreground">{new Date(entry.timestamp).toLocaleString()}</span>
-                </div>
-                <div className="break-words whitespace-pre-wrap">{entry.message}</div>
+              <div className="text-muted-foreground rounded-md border border-dashed p-3 text-sm">
+                No Discord logs yet.
               </div>
-            ))}
+            ) : (
+              logs.map((entry) => (
+                <div key={entry.id} className="rounded-md border p-3 text-sm">
+                  <div className="mb-1 flex items-center justify-between gap-3">
+                    <span className="text-muted-foreground font-medium uppercase">
+                      {entry.level}
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {new Date(entry.timestamp).toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="whitespace-pre-wrap break-words">
+                    {entry.message}
+                  </div>
+                </div>
+              ))
+            )}
           </div>
         </ControlGroup>
       </div>
-    </div>
+    </SettingsPageShell>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.langfuse-draft.test.tsx
@@ -16,13 +16,25 @@ function createHookRuntime() {
   let refIndex = 0
   let effectIndex = 0
 
-  const depsChanged = (prev?: any[], next?: any[]) => !prev || !next || prev.length !== next.length || prev.some((value, index) => !Object.is(value, next[index]))
+  const depsChanged = (prev?: any[], next?: any[]) =>
+    !prev ||
+    !next ||
+    prev.length !== next.length ||
+    prev.some((value, index) => !Object.is(value, next[index]))
   const useState = <T,>(initial: T | (() => T)) => {
     const idx = stateIndex++
-    if (states[idx] === undefined) states[idx] = typeof initial === "function" ? (initial as () => T)() : initial
-    return [states[idx] as T, (update: T | ((prev: T) => T)) => {
-      states[idx] = typeof update === "function" ? (update as (prev: T) => T)(states[idx]) : update
-    }] as const
+    if (states[idx] === undefined)
+      states[idx] =
+        typeof initial === "function" ? (initial as () => T)() : initial
+    return [
+      states[idx] as T,
+      (update: T | ((prev: T) => T)) => {
+        states[idx] =
+          typeof update === "function"
+            ? (update as (prev: T) => T)(states[idx])
+            : update
+      },
+    ] as const
   }
   const useRef = <T,>(initial: T) => {
     const idx = refIndex++
@@ -46,7 +58,8 @@ function createHookRuntime() {
     useCallback: (fn: any) => fn,
     forwardRef: (render: any) => {
       const ForwardRefComponent = (props: any) => render(props, null)
-      ForwardRefComponent.displayName = render.displayName || render.name || "ForwardRef"
+      ForwardRefComponent.displayName =
+        render.displayName || render.name || "ForwardRef"
       return ForwardRefComponent
     },
   }
@@ -55,11 +68,13 @@ function createHookRuntime() {
   const Fragment = Symbol.for("react.fragment")
   const invoke = (type: any, props: any) => {
     if (type === Fragment) return props?.children ?? null
-    return typeof type === "function" ? type(props ?? {}) : { type, props: props ?? {} }
+    return typeof type === "function"
+      ? type(props ?? {})
+      : { type, props: props ?? {} }
   }
 
   return {
-    render<P,>(Component: (props: P) => any, props: P) {
+    render<P>(Component: (props: P) => any, props: P) {
       stateIndex = 0
       refIndex = 0
       effectIndex = 0
@@ -68,7 +83,8 @@ function createHookRuntime() {
     commitEffects() {
       for (const record of effects) {
         if (!record?.callback) continue
-        const shouldRun = !record.hasRun || depsChanged(record.deps, record.nextDeps)
+        const shouldRun =
+          !record.hasRun || depsChanged(record.deps, record.nextDeps)
         if (!shouldRun) continue
         if (typeof record.cleanup === "function") record.cleanup()
         record.cleanup = record.callback()
@@ -77,7 +93,13 @@ function createHookRuntime() {
       }
     },
     reactMock,
-    jsxRuntimeMock: { __esModule: true, Fragment, jsx: invoke, jsxs: invoke, jsxDEV: invoke },
+    jsxRuntimeMock: {
+      __esModule: true,
+      Fragment,
+      jsx: invoke,
+      jsxs: invoke,
+      jsxDEV: invoke,
+    },
   }
 }
 
@@ -100,7 +122,7 @@ function findNode(node: any, predicate: (node: any) => boolean): any {
 function findInputByPlaceholder(node: any, placeholder: string) {
   return findNode(
     node,
-    candidate =>
+    (candidate) =>
       (candidate.type === "Input" || candidate.type === "input") &&
       candidate.props?.placeholder === placeholder,
   )
@@ -109,7 +131,7 @@ function findInputByPlaceholder(node: any, placeholder: string) {
 function findTextareaByPlaceholder(node: any, placeholder: string) {
   return findNode(
     node,
-    candidate =>
+    (candidate) =>
       (candidate.type === "Textarea" || candidate.type === "textarea") &&
       candidate.props?.placeholder === placeholder,
   )
@@ -118,7 +140,7 @@ function findTextareaByPlaceholder(node: any, placeholder: string) {
 function findMaxIterationsInput(node: any) {
   return findNode(
     node,
-    candidate =>
+    (candidate) =>
       (candidate.type === "Input" || candidate.type === "input") &&
       candidate.props?.type === "number" &&
       candidate.props?.placeholder === "10",
@@ -128,18 +150,22 @@ function findMaxIterationsInput(node: any) {
 function findControlByLabel(node: any, label: string) {
   return findNode(
     node,
-    candidate => candidate.type === "Control" && candidate.props?.label === label,
+    (candidate) =>
+      candidate.type === "Control" && candidate.props?.label === label,
   )
 }
 
-const GROQ_STT_PROMPT_PLACEHOLDER = "Optional prompt to guide the model's style or specify how to spell unfamiliar words (limited to 224 tokens)"
+const GROQ_STT_PROMPT_PLACEHOLDER =
+  "Optional prompt to guide the model's style or specify how to spell unfamiliar words (limited to 224 tokens)"
 
 async function flushPromises() {
   await Promise.resolve()
   await Promise.resolve()
 }
 
-async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>) {
+async function loadSettingsGeneral(
+  runtime: ReturnType<typeof createHookRuntime>,
+) {
   vi.resetModules()
 
   const Null = () => null
@@ -169,14 +195,37 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
     ControlLabel: (props: any) => props.label,
     SettingsSearchContext: { Provider: PassThrough },
   }
+  const settingsNavigationMock = {
+    SettingsPageShell: PassThrough,
+    SettingsNavigation: Null,
+  }
   const inputMock = { Input: (props: any) => ({ type: "Input", props }) }
   const switchMock = { Switch: (props: any) => ({ type: "Switch", props }) }
   const buttonMock = { Button: (props: any) => ({ type: "Button", props }) }
-  const selectMock = { Select: Null, SelectContent: Null, SelectItem: Null, SelectTrigger: Null, SelectValue: Null }
-  const textareaMock = { Textarea: (props: any) => ({ type: "Textarea", props }) }
-  const dialogMock = { Dialog: PassThrough, DialogContent: PassThrough, DialogHeader: PassThrough, DialogTitle: PassThrough, DialogTrigger: PassThrough }
+  const selectMock = {
+    Select: Null,
+    SelectContent: Null,
+    SelectItem: Null,
+    SelectTrigger: Null,
+    SelectValue: Null,
+  }
+  const textareaMock = {
+    Textarea: (props: any) => ({ type: "Textarea", props }),
+  }
+  const dialogMock = {
+    Dialog: PassThrough,
+    DialogContent: PassThrough,
+    DialogHeader: PassThrough,
+    DialogTitle: PassThrough,
+    DialogTrigger: PassThrough,
+  }
   const ttsManagerMock = { ttsManager: { stopAll: vi.fn() } }
-  const tipcClientMock = { tipcClient: { getAgentsFolders: vi.fn(async () => ({})), getExternalAgents: vi.fn(async () => []) } }
+  const tipcClientMock = {
+    tipcClient: {
+      getAgentsFolders: vi.fn(async () => ({})),
+      getExternalAgents: vi.fn(async () => []),
+    },
+  }
 
   vi.doMock("react", () => runtime.reactMock)
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
@@ -190,7 +239,14 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
     useQuery: ({ queryKey }: any) => {
       const key = Array.isArray(queryKey) ? queryKey[0] : queryKey
       if (key === "langfuseInstalled") return { data: true, isLoading: false }
-      if (key === "agentsFolders") return { data: { global: { agentsDir: "/tmp/global/.agents" }, workspace: null }, isLoading: false }
+      if (key === "agentsFolders")
+        return {
+          data: {
+            global: { agentsDir: "/tmp/global/.agents" },
+            workspace: null,
+          },
+          isLoading: false,
+        }
       if (key === "externalAgents") return { data: [], isLoading: false }
       return { data: undefined, isLoading: false }
     },
@@ -199,24 +255,58 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   }))
   vi.doMock("@renderer/lib/query-client", () => queryClientMock)
   vi.doMock("../lib/query-client", () => queryClientMock)
-  vi.doMock("./settings-general-main-agent-options", () => ({ getSelectableMainAcpAgents: () => [] }))
+  vi.doMock("./settings-general-main-agent-options", () => ({
+    getSelectableMainAcpAgents: () => [],
+  }))
   vi.doMock("@renderer/lib/tts-manager", () => ttsManagerMock)
   vi.doMock("../lib/tts-manager", () => ttsManagerMock)
   vi.doMock("@renderer/lib/tipc-client", () => tipcClientMock)
   vi.doMock("../lib/tipc-client", () => tipcClientMock)
   vi.doMock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
-  vi.doMock("lucide-react", () => ({ ExternalLink: Null, AlertCircle: Null, FolderOpen: Null, FolderUp: Null, FileText: Null, Search: Null }))
-  vi.doMock("@dotagents/shared", () => ({ __esModule: true, STT_PROVIDER_ID: {}, SUPPORTED_LANGUAGES: [] }))
-  vi.doMock("@shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))
-  vi.doMock("../shared/key-utils", () => ({ getEffectiveShortcut: () => "", formatKeyComboForDisplay: () => "" }))
+  vi.doMock("lucide-react", () => ({
+    ExternalLink: Null,
+    AlertCircle: Null,
+    FolderOpen: Null,
+    FolderUp: Null,
+    FileText: Null,
+    Search: Null,
+  }))
+  vi.doMock("@dotagents/shared", () => ({
+    __esModule: true,
+    STT_PROVIDER_ID: {},
+    SUPPORTED_LANGUAGES: [],
+  }))
+  vi.doMock("@shared/key-utils", () => ({
+    getEffectiveShortcut: () => "",
+    formatKeyComboForDisplay: () => "",
+  }))
+  vi.doMock("../shared/key-utils", () => ({
+    getEffectiveShortcut: () => "",
+    formatKeyComboForDisplay: () => "",
+  }))
   vi.doMock("@renderer/hooks/use-audio-devices", () => ({
-    useAudioDevices: () => ({ inputDevices: [], outputDevices: [], error: null, refresh: vi.fn() }),
+    useAudioDevices: () => ({
+      inputDevices: [],
+      outputDevices: [],
+      error: null,
+      refresh: vi.fn(),
+    }),
   }))
   vi.doMock("../hooks/use-audio-devices", () => ({
-    useAudioDevices: () => ({ inputDevices: [], outputDevices: [], error: null, refresh: vi.fn() }),
+    useAudioDevices: () => ({
+      inputDevices: [],
+      outputDevices: [],
+      error: null,
+      refresh: vi.fn(),
+    }),
   }))
   vi.doMock("@renderer/components/ui/control", () => controlMock)
   vi.doMock("../components/ui/control", () => controlMock)
+  vi.doMock(
+    "@renderer/components/settings-navigation",
+    () => settingsNavigationMock,
+  )
+  vi.doMock("../components/settings-navigation", () => settingsNavigationMock)
   vi.doMock("@renderer/components/ui/input", () => inputMock)
   vi.doMock("../components/ui/input", () => inputMock)
   vi.doMock("@renderer/components/ui/switch", () => switchMock)
@@ -225,16 +315,25 @@ async function loadSettingsGeneral(runtime: ReturnType<typeof createHookRuntime>
   vi.doMock("../components/ui/button", () => buttonMock)
   vi.doMock("@renderer/components/ui/select", () => selectMock)
   vi.doMock("../components/ui/select", () => selectMock)
-  vi.doMock("@renderer/components/ui/tooltip", () => ({ Tooltip: Null, TooltipContent: Null, TooltipProvider: Null, TooltipTrigger: Null }))
+  vi.doMock("@renderer/components/ui/tooltip", () => ({
+    Tooltip: Null,
+    TooltipContent: Null,
+    TooltipProvider: Null,
+    TooltipTrigger: Null,
+  }))
   vi.doMock("@renderer/components/ui/textarea", () => textareaMock)
   vi.doMock("../components/ui/textarea", () => textareaMock)
   vi.doMock("@renderer/components/ui/dialog", () => dialogMock)
   vi.doMock("../components/ui/dialog", () => dialogMock)
-  vi.doMock("@renderer/components/model-selector", () => ({ ModelSelector: Null }))
+  vi.doMock("@renderer/components/model-selector", () => ({
+    ModelSelector: Null,
+  }))
   vi.doMock("../components/model-selector", () => ({ ModelSelector: Null }))
   vi.doMock("@renderer/components/key-recorder", () => ({ KeyRecorder: Null }))
   vi.doMock("../components/key-recorder", () => ({ KeyRecorder: Null }))
-  vi.doMock("./settings-remote-server", () => ({ RemoteServerSettingsGroups: Null }))
+  vi.doMock("./settings-remote-server", () => ({
+    RemoteServerSettingsGroups: Null,
+  }))
 
   const mod = await import("./settings-general")
   return {
@@ -275,15 +374,22 @@ afterEach(() => {
 describe("desktop general settings draft behavior", () => {
   it("saves the local trace logging toggle from general settings", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     const tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
     await flushPromises()
 
-    const localTraceLoggingControl = findControlByLabel(tree, "Local trace logging")
+    const localTraceLoggingControl = findControlByLabel(
+      tree,
+      "Local trace logging",
+    )
     expect(localTraceLoggingControl).toBeTruthy()
-    const toggle = findNode(localTraceLoggingControl, candidate => candidate.type === "Switch")
+    const toggle = findNode(
+      localTraceLoggingControl,
+      (candidate) => candidate.type === "Switch",
+    )
     expect(toggle.props.checked).toBe(false)
 
     toggle.props.onCheckedChange(true)
@@ -298,7 +404,8 @@ describe("desktop general settings draft behavior", () => {
 
   it("keeps the public key draft local, debounces saves, and merges with the latest config", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, setConfig, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, setConfig, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     let tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -333,7 +440,8 @@ describe("desktop general settings draft behavior", () => {
 
   it("flushes the latest secret key on blur without waiting for a rerender", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     const tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -354,7 +462,8 @@ describe("desktop general settings draft behavior", () => {
 
   it("resyncs the displayed drafts from saved config updates", async () => {
     const runtime = createHookRuntime()
-    const { Component, setConfig, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, setConfig, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     let tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -370,13 +479,19 @@ describe("desktop general settings draft behavior", () => {
     runtime.commitEffects()
     tree = runtime.render(Component, {} as any)
 
-    expect(findInputByPlaceholder(tree, "pk-lf-...").props.value).toBe("pk-lf-synced")
-    expect(findInputByPlaceholder(tree, "https://cloud.langfuse.com (default)").props.value).toBe("https://langfuse.example")
+    expect(findInputByPlaceholder(tree, "pk-lf-...").props.value).toBe(
+      "pk-lf-synced",
+    )
+    expect(
+      findInputByPlaceholder(tree, "https://cloud.langfuse.com (default)").props
+        .value,
+    ).toBe("https://langfuse.example")
   })
 
   it("keeps the max-iterations draft local, allows temporary empty input, and debounces valid saves", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, setConfig, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, setConfig, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     let tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -419,7 +534,8 @@ describe("desktop general settings draft behavior", () => {
 
   it("flushes the latest valid max-iterations draft on blur without waiting for a rerender", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     const tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -486,20 +602,29 @@ describe("desktop general settings draft behavior", () => {
 
   it("keeps the Groq STT prompt draft local, debounces saves, and merges with the latest config", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, setConfig, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, setConfig, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     let tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
     await flushPromises()
 
-    let groqPromptTextarea = findTextareaByPlaceholder(tree, GROQ_STT_PROMPT_PLACEHOLDER)
+    let groqPromptTextarea = findTextareaByPlaceholder(
+      tree,
+      GROQ_STT_PROMPT_PLACEHOLDER,
+    )
     expect(groqPromptTextarea.props.value).toBe("Spell DotAgents correctly")
 
-    groqPromptTextarea.props.onChange({ currentTarget: { value: "Spell DotAgents as two words" } })
+    groqPromptTextarea.props.onChange({
+      currentTarget: { value: "Spell DotAgents as two words" },
+    })
 
     tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
-    groqPromptTextarea = findTextareaByPlaceholder(tree, GROQ_STT_PROMPT_PLACEHOLDER)
+    groqPromptTextarea = findTextareaByPlaceholder(
+      tree,
+      GROQ_STT_PROMPT_PLACEHOLDER,
+    )
     expect(groqPromptTextarea.props.value).toBe("Spell DotAgents as two words")
     expect(mutate).not.toHaveBeenCalled()
 
@@ -521,15 +646,23 @@ describe("desktop general settings draft behavior", () => {
 
   it("flushes the latest Groq STT prompt on blur without waiting for a rerender", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, mutate, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     const tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
     await flushPromises()
 
-    const groqPromptTextarea = findTextareaByPlaceholder(tree, GROQ_STT_PROMPT_PLACEHOLDER)
-    groqPromptTextarea.props.onChange({ currentTarget: { value: "Prefer agent names verbatim" } })
-    groqPromptTextarea.props.onBlur({ currentTarget: { value: "Prefer agent names verbatim" } })
+    const groqPromptTextarea = findTextareaByPlaceholder(
+      tree,
+      GROQ_STT_PROMPT_PLACEHOLDER,
+    )
+    groqPromptTextarea.props.onChange({
+      currentTarget: { value: "Prefer agent names verbatim" },
+    })
+    groqPromptTextarea.props.onBlur({
+      currentTarget: { value: "Prefer agent names verbatim" },
+    })
 
     expect(mutate).toHaveBeenCalledTimes(1)
     expect(mutate).toHaveBeenCalledWith({
@@ -542,7 +675,8 @@ describe("desktop general settings draft behavior", () => {
 
   it("resyncs the Groq STT prompt draft from saved config updates", async () => {
     const runtime = createHookRuntime()
-    const { Component, setConfig, getCurrentConfig } = await loadSettingsGeneral(runtime)
+    const { Component, setConfig, getCurrentConfig } =
+      await loadSettingsGeneral(runtime)
 
     let tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -557,9 +691,8 @@ describe("desktop general settings draft behavior", () => {
     runtime.commitEffects()
     tree = runtime.render(Component, {} as any)
 
-    expect(findTextareaByPlaceholder(tree, GROQ_STT_PROMPT_PLACEHOLDER).props.value).toBe(
-      "Use product names exactly as written",
-    )
+    expect(
+      findTextareaByPlaceholder(tree, GROQ_STT_PROMPT_PLACEHOLDER).props.value,
+    ).toBe("Use product names exactly as written")
   })
-
 })

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -1,4 +1,9 @@
-import { Control, ControlGroup, ControlLabel, SettingsSearchContext } from "@renderer/components/ui/control"
+import {
+  Control,
+  ControlGroup,
+  ControlLabel,
+  SettingsSearchContext,
+} from "@renderer/components/ui/control"
 import {
   Select,
   SelectContent,
@@ -18,13 +23,22 @@ import {
 } from "@renderer/lib/query-client"
 import { getSelectableMainAcpAgents } from "./settings-general-main-agent-options"
 import { tipcClient } from "@renderer/lib/tipc-client"
-import { AlertTriangle, ExternalLink, FolderOpen, FolderUp, FileText, Search, X } from "lucide-react"
+import {
+  AlertTriangle,
+  ExternalLink,
+  FolderOpen,
+  FolderUp,
+  FileText,
+  Search,
+  X,
+} from "lucide-react"
 import { toast } from "sonner"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "react-router-dom"
 import { Config } from "@shared/types"
 import { KeyRecorder } from "@renderer/components/key-recorder"
+import { SettingsPageShell } from "@renderer/components/settings-navigation"
 import {
   getEffectiveShortcut,
   formatKeyComboForDisplay,
@@ -38,7 +52,10 @@ const MCP_MAX_ITERATIONS_MIN = 1
 const MCP_MAX_ITERATIONS_MAX = 50
 const MCP_MAX_ITERATIONS_DEFAULT = 10
 
-type LangfuseDraftKey = "langfusePublicKey" | "langfuseSecretKey" | "langfuseBaseUrl"
+type LangfuseDraftKey =
+  | "langfusePublicKey"
+  | "langfuseSecretKey"
+  | "langfuseBaseUrl"
 
 function getLangfuseDrafts(config: Config | undefined) {
   return {
@@ -51,7 +68,11 @@ function getLangfuseDrafts(config: Config | undefined) {
 function parseMcpMaxIterationsDraft(value: string) {
   const parsedValue = Number.parseInt(value, 10)
   if (Number.isNaN(parsedValue)) return null
-  if (parsedValue < MCP_MAX_ITERATIONS_MIN || parsedValue > MCP_MAX_ITERATIONS_MAX) return null
+  if (
+    parsedValue < MCP_MAX_ITERATIONS_MIN ||
+    parsedValue > MCP_MAX_ITERATIONS_MAX
+  )
+    return null
   return parsedValue
 }
 
@@ -63,14 +84,24 @@ export function Component() {
 
   const saveConfigMutation = useSaveConfigMutation()
   const cfgRef = useRef<Config | undefined>(cfg)
-  const [langfuseDrafts, setLangfuseDrafts] = useState(() => getLangfuseDrafts(cfg))
-  const langfuseSaveTimeoutsRef = useRef<Partial<Record<LangfuseDraftKey, ReturnType<typeof setTimeout>>>>({})
-  const [groqSttPromptDraft, setGroqSttPromptDraft] = useState(() => cfg?.groqSttPrompt ?? "")
-  const groqSttPromptSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [mcpMaxIterationsDraft, setMcpMaxIterationsDraft] = useState(
-    () => String(cfg?.mcpMaxIterations ?? MCP_MAX_ITERATIONS_DEFAULT),
+  const [langfuseDrafts, setLangfuseDrafts] = useState(() =>
+    getLangfuseDrafts(cfg),
   )
-  const mcpMaxIterationsSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const langfuseSaveTimeoutsRef = useRef<
+    Partial<Record<LangfuseDraftKey, ReturnType<typeof setTimeout>>>
+  >({})
+  const [groqSttPromptDraft, setGroqSttPromptDraft] = useState(
+    () => cfg?.groqSttPrompt ?? "",
+  )
+  const groqSttPromptSaveTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const [mcpMaxIterationsDraft, setMcpMaxIterationsDraft] = useState(() =>
+    String(cfg?.mcpMaxIterations ?? MCP_MAX_ITERATIONS_DEFAULT),
+  )
+  const mcpMaxIterationsSaveTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
 
   // Settings search
   const [searchQuery, setSearchQuery] = useState("")
@@ -78,7 +109,8 @@ export function Component() {
 
   // Defer audio device enumeration until the user expands the Audio Devices section
   const [audioSectionOpen, setAudioSectionOpen] = useState(false)
-  const { inputDevices: audioInputDevices, outputDevices: audioOutputDevices } = useAudioDevices(audioSectionOpen || searchQuery.length > 0)
+  const { inputDevices: audioInputDevices, outputDevices: audioOutputDevices } =
+    useAudioDevices(audioSectionOpen || searchQuery.length > 0)
 
   // Check if langfuse package is installed
   const langfuseInstalledQuery = useQuery({
@@ -105,7 +137,8 @@ export function Component() {
   })
 
   const isLangfuseInstalled = langfuseInstalledQuery.data ?? true // Default to true while loading
-  const systemPromptOverrideScope = agentsFoldersQuery.data?.workspace?.systemPromptExists
+  const systemPromptOverrideScope = agentsFoldersQuery.data?.workspace
+    ?.systemPromptExists
     ? "Workspace"
     : agentsFoldersQuery.data?.global?.systemPromptExists
       ? "Global"
@@ -115,7 +148,7 @@ export function Component() {
   const systemPromptOverrideActive = Boolean(systemPromptOverrideScope)
   const selectableMainAcpAgents = getSelectableMainAcpAgents(
     externalAgentsQuery.data,
-    []
+    [],
   )
 
   const openGlobalAgentsFolder = useCallback(async () => {
@@ -221,12 +254,16 @@ export function Component() {
   }, [cfg?.groqSttPrompt])
 
   useEffect(() => {
-    setMcpMaxIterationsDraft(String(cfg?.mcpMaxIterations ?? MCP_MAX_ITERATIONS_DEFAULT))
+    setMcpMaxIterationsDraft(
+      String(cfg?.mcpMaxIterations ?? MCP_MAX_ITERATIONS_DEFAULT),
+    )
   }, [cfg?.mcpMaxIterations])
 
   useEffect(() => {
     return () => {
-      for (const timeout of Object.values(langfuseSaveTimeoutsRef.current) as Array<ReturnType<typeof setTimeout> | undefined>) {
+      for (const timeout of Object.values(
+        langfuseSaveTimeoutsRef.current,
+      ) as Array<ReturnType<typeof setTimeout> | undefined>) {
         if (timeout) clearTimeout(timeout)
       }
 
@@ -240,100 +277,134 @@ export function Component() {
     }
   }, [])
 
-  const flushLangfuseSave = useCallback((key: LangfuseDraftKey, value: string) => {
-    const pendingSave = langfuseSaveTimeoutsRef.current[key]
-    if (pendingSave) {
-      clearTimeout(pendingSave)
-      delete langfuseSaveTimeoutsRef.current[key]
-    }
+  const flushLangfuseSave = useCallback(
+    (key: LangfuseDraftKey, value: string) => {
+      const pendingSave = langfuseSaveTimeoutsRef.current[key]
+      if (pendingSave) {
+        clearTimeout(pendingSave)
+        delete langfuseSaveTimeoutsRef.current[key]
+      }
 
-    saveConfig({ [key]: value || undefined } as Partial<Config>)
-  }, [saveConfig])
-
-  const scheduleLangfuseSave = useCallback((key: LangfuseDraftKey, value: string) => {
-    const pendingSave = langfuseSaveTimeoutsRef.current[key]
-    if (pendingSave) {
-      clearTimeout(pendingSave)
-    }
-
-    langfuseSaveTimeoutsRef.current[key] = setTimeout(() => {
-      delete langfuseSaveTimeoutsRef.current[key]
       saveConfig({ [key]: value || undefined } as Partial<Config>)
-    }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
-  }, [saveConfig])
+    },
+    [saveConfig],
+  )
 
-  const updateLangfuseDraft = useCallback((key: LangfuseDraftKey, value: string) => {
-    setLangfuseDrafts((currentDrafts) => ({
-      ...currentDrafts,
-      [key]: value,
-    }))
-    scheduleLangfuseSave(key, value)
-  }, [scheduleLangfuseSave])
+  const scheduleLangfuseSave = useCallback(
+    (key: LangfuseDraftKey, value: string) => {
+      const pendingSave = langfuseSaveTimeoutsRef.current[key]
+      if (pendingSave) {
+        clearTimeout(pendingSave)
+      }
 
-  const flushGroqSttPromptSave = useCallback((value: string) => {
-    if (groqSttPromptSaveTimeoutRef.current) {
-      clearTimeout(groqSttPromptSaveTimeoutRef.current)
-      groqSttPromptSaveTimeoutRef.current = null
-    }
+      langfuseSaveTimeoutsRef.current[key] = setTimeout(() => {
+        delete langfuseSaveTimeoutsRef.current[key]
+        saveConfig({ [key]: value || undefined } as Partial<Config>)
+      }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
 
-    saveConfig({ groqSttPrompt: value || undefined })
-  }, [saveConfig])
+  const updateLangfuseDraft = useCallback(
+    (key: LangfuseDraftKey, value: string) => {
+      setLangfuseDrafts((currentDrafts) => ({
+        ...currentDrafts,
+        [key]: value,
+      }))
+      scheduleLangfuseSave(key, value)
+    },
+    [scheduleLangfuseSave],
+  )
 
-  const scheduleGroqSttPromptSave = useCallback((value: string) => {
-    if (groqSttPromptSaveTimeoutRef.current) {
-      clearTimeout(groqSttPromptSaveTimeoutRef.current)
-    }
+  const flushGroqSttPromptSave = useCallback(
+    (value: string) => {
+      if (groqSttPromptSaveTimeoutRef.current) {
+        clearTimeout(groqSttPromptSaveTimeoutRef.current)
+        groqSttPromptSaveTimeoutRef.current = null
+      }
 
-    groqSttPromptSaveTimeoutRef.current = setTimeout(() => {
-      groqSttPromptSaveTimeoutRef.current = null
       saveConfig({ groqSttPrompt: value || undefined })
-    }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
-  }, [saveConfig])
+    },
+    [saveConfig],
+  )
 
-  const updateGroqSttPromptDraft = useCallback((value: string) => {
-    setGroqSttPromptDraft(value)
-    scheduleGroqSttPromptSave(value)
-  }, [scheduleGroqSttPromptSave])
+  const scheduleGroqSttPromptSave = useCallback(
+    (value: string) => {
+      if (groqSttPromptSaveTimeoutRef.current) {
+        clearTimeout(groqSttPromptSaveTimeoutRef.current)
+      }
 
-  const flushMcpMaxIterationsSave = useCallback((value: string) => {
-    if (mcpMaxIterationsSaveTimeoutRef.current) {
-      clearTimeout(mcpMaxIterationsSaveTimeoutRef.current)
-      mcpMaxIterationsSaveTimeoutRef.current = null
-    }
+      groqSttPromptSaveTimeoutRef.current = setTimeout(() => {
+        groqSttPromptSaveTimeoutRef.current = null
+        saveConfig({ groqSttPrompt: value || undefined })
+      }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
 
-    const parsedValue = parseMcpMaxIterationsDraft(value)
-    if (parsedValue === null) {
-      setMcpMaxIterationsDraft(String(cfgRef.current?.mcpMaxIterations ?? MCP_MAX_ITERATIONS_DEFAULT))
-      return
-    }
+  const updateGroqSttPromptDraft = useCallback(
+    (value: string) => {
+      setGroqSttPromptDraft(value)
+      scheduleGroqSttPromptSave(value)
+    },
+    [scheduleGroqSttPromptSave],
+  )
 
-    saveConfig({ mcpMaxIterations: parsedValue })
-  }, [saveConfig])
+  const flushMcpMaxIterationsSave = useCallback(
+    (value: string) => {
+      if (mcpMaxIterationsSaveTimeoutRef.current) {
+        clearTimeout(mcpMaxIterationsSaveTimeoutRef.current)
+        mcpMaxIterationsSaveTimeoutRef.current = null
+      }
 
-  const scheduleMcpMaxIterationsSave = useCallback((value: string) => {
-    if (mcpMaxIterationsSaveTimeoutRef.current) {
-      clearTimeout(mcpMaxIterationsSaveTimeoutRef.current)
-      mcpMaxIterationsSaveTimeoutRef.current = null
-    }
+      const parsedValue = parseMcpMaxIterationsDraft(value)
+      if (parsedValue === null) {
+        setMcpMaxIterationsDraft(
+          String(
+            cfgRef.current?.mcpMaxIterations ?? MCP_MAX_ITERATIONS_DEFAULT,
+          ),
+        )
+        return
+      }
 
-    const parsedValue = parseMcpMaxIterationsDraft(value)
-    if (parsedValue === null) return
-
-    mcpMaxIterationsSaveTimeoutRef.current = setTimeout(() => {
-      mcpMaxIterationsSaveTimeoutRef.current = null
       saveConfig({ mcpMaxIterations: parsedValue })
-    }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
-  }, [saveConfig])
+    },
+    [saveConfig],
+  )
 
-  const updateMcpMaxIterationsDraft = useCallback((value: string) => {
-    setMcpMaxIterationsDraft(value)
-    scheduleMcpMaxIterationsSave(value)
-  }, [scheduleMcpMaxIterationsSave])
+  const scheduleMcpMaxIterationsSave = useCallback(
+    (value: string) => {
+      if (mcpMaxIterationsSaveTimeoutRef.current) {
+        clearTimeout(mcpMaxIterationsSaveTimeoutRef.current)
+        mcpMaxIterationsSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseMcpMaxIterationsDraft(value)
+      if (parsedValue === null) return
+
+      mcpMaxIterationsSaveTimeoutRef.current = setTimeout(() => {
+        mcpMaxIterationsSaveTimeoutRef.current = null
+        saveConfig({ mcpMaxIterations: parsedValue })
+      }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
+
+  const updateMcpMaxIterationsDraft = useCallback(
+    (value: string) => {
+      setMcpMaxIterationsDraft(value)
+      scheduleMcpMaxIterationsSave(value)
+    },
+    [scheduleMcpMaxIterationsSave],
+  )
 
   // Sync theme preference from config to localStorage when config loads
   useEffect(() => {
     if ((configQuery.data as any)?.themePreference) {
-      localStorage.setItem("theme-preference", (configQuery.data as any).themePreference)
+      localStorage.setItem(
+        "theme-preference",
+        (configQuery.data as any).themePreference,
+      )
       window.dispatchEvent(
         new CustomEvent("theme-preference-changed", {
           detail: (configQuery.data as any).themePreference,
@@ -345,19 +416,24 @@ export function Component() {
   const sttProviderId: STT_PROVIDER_ID =
     (configQuery.data as any)?.sttProviderId || "openai"
   const shortcut = (configQuery.data as any)?.shortcut || "hold-ctrl"
-  const textInputShortcut = (configQuery.data as any)?.textInputShortcut || "ctrl-t"
+  const textInputShortcut =
+    (configQuery.data as any)?.textInputShortcut || "ctrl-t"
   const recordingShortcutMode = cfg?.customShortcutMode || "hold"
-  const effectiveRecordingShortcut = getEffectiveShortcut(shortcut, cfg?.customShortcut)
+  const effectiveRecordingShortcut = getEffectiveShortcut(
+    shortcut,
+    cfg?.customShortcut,
+  )
   const customRecordingShortcutDisplay = effectiveRecordingShortcut
     ? formatKeyComboForDisplay(effectiveRecordingShortcut)
     : "your custom shortcut"
-  const recordingShortcutHelperText = shortcut === "hold-ctrl"
-    ? "Hold Ctrl to record, release it to finish, and press any other key to cancel."
-    : shortcut === "custom"
-      ? recordingShortcutMode === "toggle"
-        ? `Press ${customRecordingShortcutDisplay} to start and finish recording. Press Esc to cancel.`
-        : `Hold ${customRecordingShortcutDisplay} to record, release it to finish, and press any other key to cancel.`
-      : "Press Ctrl+/ to start and finish recording. Press Esc to cancel."
+  const recordingShortcutHelperText =
+    shortcut === "hold-ctrl"
+      ? "Hold Ctrl to record, release it to finish, and press any other key to cancel."
+      : shortcut === "custom"
+        ? recordingShortcutMode === "toggle"
+          ? `Press ${customRecordingShortcutDisplay} to start and finish recording. Press Esc to cancel.`
+          : `Hold ${customRecordingShortcutDisplay} to record, release it to finish, and press any other key to cancel.`
+        : "Press Ctrl+/ to start and finish recording. Press Esc to cancel."
 
   const agentShortcut = cfg?.agentShortcut || cfg?.mcpToolsShortcut
   const customAgentShortcutMode = cfg?.customAgentShortcutMode || "hold"
@@ -368,15 +444,16 @@ export function Component() {
   const customAgentShortcutDisplay = effectiveAgentShortcut
     ? formatKeyComboForDisplay(effectiveAgentShortcut)
     : "your custom shortcut"
-  const agentShortcutHelperText = agentShortcut === "toggle-ctrl-alt"
-    ? "Press Ctrl+Alt to start agent mode, press again to send. Press Esc to cancel."
-    : agentShortcut === "ctrl-alt-slash"
-      ? "Press Ctrl+Alt+/ to start agent mode, press again to send. Press Esc to cancel."
-      : agentShortcut === "custom"
-        ? customAgentShortcutMode === "toggle"
-          ? `Press ${customAgentShortcutDisplay} to start agent mode, press again to send. Press Esc to cancel.`
-          : `Hold ${customAgentShortcutDisplay} to record an agent prompt, release to send.`
-        : "Hold Ctrl+Alt to record an agent prompt, release to send."
+  const agentShortcutHelperText =
+    agentShortcut === "toggle-ctrl-alt"
+      ? "Press Ctrl+Alt to start agent mode, press again to send. Press Esc to cancel."
+      : agentShortcut === "ctrl-alt-slash"
+        ? "Press Ctrl+Alt+/ to start agent mode, press again to send. Press Esc to cancel."
+        : agentShortcut === "custom"
+          ? customAgentShortcutMode === "toggle"
+            ? `Press ${customAgentShortcutDisplay} to start agent mode, press again to send. Press Esc to cancel.`
+            : `Hold ${customAgentShortcutDisplay} to record an agent prompt, release to send.`
+          : "Hold Ctrl+Alt to record an agent prompt, release to send."
 
   const toggleVoiceDictationHotkey = cfg?.toggleVoiceDictationHotkey || "fn"
   const effectiveToggleVoiceDictationShortcut = getEffectiveShortcut(
@@ -386,20 +463,17 @@ export function Component() {
   const toggleVoiceDictationDisplay = effectiveToggleVoiceDictationShortcut
     ? formatKeyComboForDisplay(effectiveToggleVoiceDictationShortcut)
     : "your custom shortcut"
-  const toggleVoiceDictationHelperText =
-    `Press ${toggleVoiceDictationDisplay} to start dictation, press again to stop. Press Esc to cancel.`
-
+  const toggleVoiceDictationHelperText = `Press ${toggleVoiceDictationDisplay} to start dictation, press again to stop. Press Esc to cancel.`
 
   const isSearching = searchQuery.length > 0
 
   if (!configQuery.data) return null
 
   return (
-    <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-4 py-4 sm:px-6">
-
+    <SettingsPageShell>
       {/* Search input */}
       <div className="relative mb-4">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+        <Search className="text-muted-foreground pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
         <Input
           ref={searchInputRef}
           type="text"
@@ -415,1194 +489,1744 @@ export function Component() {
               setSearchQuery("")
               searchInputRef.current?.focus()
             }}
-            className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded-sm hover:bg-muted transition-colors cursor-pointer"
+            className="hover:bg-muted absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer rounded-sm p-0.5 transition-colors"
           >
-            <X className="h-4 w-4 text-muted-foreground" />
+            <X className="text-muted-foreground h-4 w-4" />
           </button>
         )}
       </div>
 
       <SettingsSearchContext.Provider value={searchQuery}>
-      <div className="grid gap-4">
-        {/* Agent Settings */}
-        <ControlGroup collapsible defaultCollapsed title="Agent Settings" forceOpen={isSearching}>
-          {/* Main Agent Mode Selection */}
-          <Control label={<ControlLabel label="Main Agent Mode" tooltip="Choose how the main agent processes your requests. API mode uses external LLM APIs (OpenAI, Groq, Gemini). acpx mode routes prompts to a configured acpx agent profile like Codex or Claude." />} className="px-3">
-            <Select
-              value={configQuery.data?.mainAgentMode || "api"}
-              onValueChange={(value: "api" | "acpx") => {
-                saveConfig({ mainAgentMode: value })
-              }}
-            >
-              <SelectTrigger className="w-full sm:w-[200px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="api">API (OpenAI, Groq, Gemini)</SelectItem>
-                <SelectItem value="acpx">acpx Agent</SelectItem>
-              </SelectContent>
-            </Select>
-          </Control>
-
-          {configQuery.data?.mainAgentMode === "acpx" && (
-            <>
-              <Control label={<ControlLabel label="acpx Agent" tooltip="Select which configured acpx agent profile to use as the main agent. The agent must be configured in the Agents settings page." />} className="px-3">
-                <Select
-                  value={configQuery.data?.mainAgentName || ""}
-                  onValueChange={(value: string) => {
-                    saveConfig({ mainAgentName: value })
-                  }}
-                >
-                  <SelectTrigger className="w-full sm:w-[200px]">
-                    <SelectValue placeholder="Select an agent..." />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {selectableMainAcpAgents.map(agent => (
-                      <SelectItem key={agent.name} value={agent.name}>
-                        {agent.displayName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Control>
-
-              {configQuery.data?.mainAgentName && (
-                <div className="px-3 py-2 text-sm text-muted-foreground bg-muted/30 rounded-md mx-3 mb-2">
-                  <span className="font-medium">Note:</span> When using acpx mode, the agent will use its own runtime/tooling stack via acpx instead of DotAgents directly speaking ACP.
-                </div>
-              )}
-            </>
-          )}
-
-          <Control label={<ControlLabel label="Message Queuing" tooltip="Allow queueing messages while the agent is processing. Messages will be processed in order after the current task completes." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.mcpMessageQueueEnabled ?? true}
-              onCheckedChange={(value) => saveConfig({ mcpMessageQueueEnabled: value })}
-            />
-          </Control>
-          <Control label={<ControlLabel label="Require Tool Approval" tooltip="Adds a confirmation dialog before any tool executes. Recommended for safety." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.mcpRequireApprovalBeforeToolCall ?? false}
-              onCheckedChange={(value) => saveConfig({ mcpRequireApprovalBeforeToolCall: value })}
-            />
-          </Control>
-
-          <Control label={<ControlLabel label="Verify Task Completion" tooltip="When enabled, the agent will verify whether the user's task has been completed before finishing. Disable for faster responses without verification." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.mcpVerifyCompletionEnabled ?? true}
-              onCheckedChange={(value) => saveConfig({ mcpVerifyCompletionEnabled: value })}
-            />
-          </Control>
-
-          <Control label={<ControlLabel label="Final Summary" tooltip="When enabled, the agent will generate a concise final summary after completing a task. Disable for faster responses without the summary step." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.mcpFinalSummaryEnabled ?? false}
-              onCheckedChange={(value) => saveConfig({ mcpFinalSummaryEnabled: value })}
-            />
-          </Control>
-
-          <Control label={<ControlLabel label="Unlimited Iterations" tooltip="Allow the agent to run indefinitely without an iteration limit. Use with caution as it may run for a long time." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.mcpUnlimitedIterations ?? true}
-              onCheckedChange={(checked) => saveConfig({ mcpUnlimitedIterations: checked })}
-            />
-          </Control>
-
-          {!(configQuery.data?.mcpUnlimitedIterations ?? true) && (
-            <Control label={<ControlLabel label="Max Iterations" tooltip="Maximum number of iterations the agent can perform before stopping. Higher values allow more complex tasks but may take longer." />} className="px-3">
-              <Input
-                type="number"
-                min={String(MCP_MAX_ITERATIONS_MIN)}
-                max={String(MCP_MAX_ITERATIONS_MAX)}
-                step="1"
-                value={mcpMaxIterationsDraft}
-                onChange={(e) => updateMcpMaxIterationsDraft(e.currentTarget.value)}
-                onBlur={(e) => flushMcpMaxIterationsSave(e.currentTarget.value)}
-                placeholder={String(MCP_MAX_ITERATIONS_DEFAULT)}
-                className="w-32"
-              />
-            </Control>
-          )}
-
-          <Control label={<ControlLabel label="Emergency Kill Switch" tooltip="Provides a global hotkey to immediately stop agent mode and kill all agent-created processes" />} className="px-3">
-            <div className="space-y-3">
-              <div className="flex items-center gap-2">
-                <Switch
-                  checked={configQuery.data?.agentKillSwitchEnabled !== false}
-                  onCheckedChange={(checked) => saveConfig({ agentKillSwitchEnabled: checked })}
-                />
-                <span className="text-sm text-muted-foreground">Enable kill switch</span>
-              </div>
-
-              {configQuery.data?.agentKillSwitchEnabled !== false && (
-                <>
-                  <Select
-                    value={configQuery.data?.agentKillSwitchHotkey || "ctrl-shift-escape"}
-                    onValueChange={(value: "ctrl-shift-escape" | "ctrl-alt-q" | "ctrl-shift-q" | "custom") => {
-                      saveConfig({ agentKillSwitchHotkey: value })
-                    }}
-                  >
-                    <SelectTrigger className="w-48">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="ctrl-shift-escape">Ctrl + Shift + Escape</SelectItem>
-                      <SelectItem value="ctrl-alt-q">Ctrl + Alt + Q</SelectItem>
-                      <SelectItem value="ctrl-shift-q">Ctrl + Shift + Q</SelectItem>
-                      <SelectItem value="custom">Custom</SelectItem>
-                    </SelectContent>
-                  </Select>
-
-                  {configQuery.data?.agentKillSwitchHotkey === "custom" && (
-                    <KeyRecorder
-                      value={configQuery.data?.customAgentKillSwitchHotkey || ""}
-                      onChange={(keyCombo) => saveConfig({ customAgentKillSwitchHotkey: keyCombo })}
-                      placeholder="Click to record custom kill switch hotkey"
-                    />
-                  )}
-                </>
-              )}
-            </div>
-          </Control>
-        </ControlGroup>
-
-        <ControlGroup collapsible defaultCollapsed title="General" forceOpen={isSearching}>
-          {process.env.IS_MAC && (
-            <Control label="Hide Dock Icon" className="px-3">
-              <Switch
-                defaultChecked={configQuery.data.hideDockIcon}
-                onCheckedChange={(value) => {
-                  saveConfig({
-                    hideDockIcon: value,
-                  })
-                }}
-              />
-            </Control>
-          )}
-          <Control label="Launch at Login" className="px-3">
-            <Switch
-              defaultChecked={configQuery.data.launchAtLogin ?? false}
-              onCheckedChange={(value) => {
-                saveConfig({
-                  launchAtLogin: value,
-                })
-              }}
-            />
-          </Control>
-
-          <Control label={<ControlLabel label="Streamer Mode" tooltip="Hide sensitive information (phone numbers, QR codes, API keys) when streaming or sharing your screen" />} className="px-3">
-            <Switch
-              defaultChecked={configQuery.data.streamerModeEnabled ?? false}
-              onCheckedChange={(value) => {
-                saveConfig({
-                  streamerModeEnabled: value,
-                })
-              }}
-            />
-          </Control>
-          {configQuery.data.streamerModeEnabled && (
-            <div className="px-3 py-2 text-xs text-amber-600 dark:text-amber-400 flex items-center gap-2">
-              <span className="i-mingcute-eye-off-line h-4 w-4" />
-              <span>Streamer Mode is active - sensitive information is hidden</span>
-            </div>
-          )}
-          <Control label="Theme" className="px-3">
-            <Select
-              value={configQuery.data.themePreference || "system"}
-              onValueChange={(value: "system" | "light" | "dark") => {
-                saveConfig({
-                  themePreference: value,
-                })
-                // Update localStorage immediately to sync with ThemeProvider
-                localStorage.setItem("theme-preference", value)
-                // Apply theme immediately
-                window.dispatchEvent(
-                  new CustomEvent("theme-preference-changed", {
-                    detail: value,
-                  }),
-                )
-              }}
-            >
-              <SelectTrigger className="w-full sm:w-[140px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="system">System</SelectItem>
-                <SelectItem value="light">Light</SelectItem>
-                <SelectItem value="dark">Dark</SelectItem>
-              </SelectContent>
-            </Select>
-          </Control>
-        </ControlGroup>
-
-        <RemoteServerSettingsGroups collapsible defaultCollapsed forceOpen={isSearching} />
-
-        <ControlGroup
-          collapsible
-          defaultCollapsed
-          title={
-            <span className="flex flex-wrap items-center gap-2">
-              <span>Modular config (.agents)</span>
-              {systemPromptOverrideActive && (
-                <Badge variant="outline" className="border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300">
-                  System prompt override active
-                </Badge>
-              )}
-            </span>
-          }
-          forceOpen={isSearching}
-        >
-          {systemPromptOverrideActive && (
-            <div className="mx-3 mt-2 flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-              <div className="min-w-0 space-y-1">
-                <p className="font-medium text-amber-700 dark:text-amber-300">{systemPromptOverrideScope} system prompt override active</p>
-                <p className="text-xs leading-5 text-muted-foreground">
-                  A saved system prompt replaces the DotAgents default prompt, so this install will not receive default system prompt updates until the override is removed or reset.
-                </p>
-              </div>
-            </div>
-          )}
-          <div className="px-3 py-2 text-sm leading-5 text-muted-foreground">
-            Advanced configuration can live in <span className="font-mono">.agents</span>. Global{" "}
-            <span className="font-mono">~/.agents</span> is the default layer. Workspace{" "}
-            <span className="font-mono">.agents</span> is only used when{" "}
-            <span className="font-mono">DOTAGENTS_WORKSPACE_DIR</span> is set, and then it overrides the global layer. Skills live in{" "}
-            <span className="font-mono">skills/&lt;id&gt;/skill.md</span> and knowledge notes live in configured knowledge roots as{" "}
-            <span className="font-mono">&lt;slug&gt;/&lt;slug&gt;.md</span>. Frontmatter uses simple{" "}
-            <span className="font-mono">key: value</span> lines (not YAML).
-          </div>
-          <Control label="Global folder" className="px-3">
-            <div className="text-right font-mono text-xs text-muted-foreground break-all">
-              {agentsFoldersQuery.data?.global?.agentsDir ?? "Loading..."}
-            </div>
-          </Control>
-          <Control
-            label={
-              <ControlLabel
-                label="Workspace folder"
-                tooltip="Optional overlay layer enabled by DOTAGENTS_WORKSPACE_DIR. When configured, it overrides the global .agents layer."
-              />
-            }
-            className="px-3"
+        <div className="grid gap-4">
+          {/* Agent Settings */}
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Agent Settings"
+            forceOpen={isSearching}
           >
-            <div className="text-right font-mono text-xs text-muted-foreground break-all">
-              {agentsFoldersQuery.isLoading
-                ? "Loading..."
-                : agentsFoldersQuery.data?.workspace?.agentsDir ?? "Not configured"}
-              {agentsFoldersQuery.data?.workspace?.agentsDir && agentsFoldersQuery.data?.workspaceSource
-                ? ` (${agentsFoldersQuery.data.workspaceSource})`
-                : ""}
-            </div>
-          </Control>
-          <Control label="Open folders & files" className="px-3">
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button variant="outline" size="sm" className="gap-1.5" onClick={openGlobalAgentsFolder}>
-                <FolderOpen className="h-3 w-3" />
-                Global Folder
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={openWorkspaceAgentsFolder}
-                disabled={!agentsFoldersQuery.data?.workspace?.agentsDir}
-              >
-                <FolderUp className="h-3 w-3" />
-                Workspace Folder
-              </Button>
-              <Button variant="outline" size="sm" className="gap-1.5" onClick={openSystemPromptFile}>
-                <FileText className="h-3 w-3" />
-                System Prompt
-              </Button>
-              <Button variant="outline" size="sm" className="gap-1.5" onClick={openAgentsGuidelinesFile}>
-                <FileText className="h-3 w-3" />
-                Guidelines
-              </Button>
-            </div>
-          </Control>
-        </ControlGroup>
-
-        <ControlGroup
-          collapsible
-          defaultCollapsed
-          title="Shortcuts"
-          forceOpen={isSearching}
-        >
-          <Control label="Recording" className="px-3">
-            <div className="space-y-2">
+            {/* Main Agent Mode Selection */}
+            <Control
+              label={
+                <ControlLabel
+                  label="Main Agent Mode"
+                  tooltip="Choose how the main agent processes your requests. API mode uses external LLM APIs (OpenAI, Groq, Gemini). acpx mode routes prompts to a configured acpx agent profile like Codex or Claude."
+                />
+              }
+              className="px-3"
+            >
               <Select
-                defaultValue={shortcut}
-                onValueChange={(value) => {
-                  saveConfig({
-                    shortcut: value as typeof configQuery.data.shortcut,
-                  })
+                value={configQuery.data?.mainAgentMode || "api"}
+                onValueChange={(value: "api" | "acpx") => {
+                  saveConfig({ mainAgentMode: value })
                 }}
               >
-                <SelectTrigger>
+                <SelectTrigger className="w-full sm:w-[200px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="hold-ctrl">Hold Ctrl</SelectItem>
-                  <SelectItem value="ctrl-slash">Ctrl+{"/"}</SelectItem>
-                  <SelectItem value="custom">Custom</SelectItem>
+                  <SelectItem value="api">
+                    API (OpenAI, Groq, Gemini)
+                  </SelectItem>
+                  <SelectItem value="acpx">acpx Agent</SelectItem>
                 </SelectContent>
               </Select>
+            </Control>
 
-              {shortcut === "custom" && (
-                <>
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium">Mode</label>
+            {configQuery.data?.mainAgentMode === "acpx" && (
+              <>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="acpx Agent"
+                      tooltip="Select which configured acpx agent profile to use as the main agent. The agent must be configured in the Agents settings page."
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Select
+                    value={configQuery.data?.mainAgentName || ""}
+                    onValueChange={(value: string) => {
+                      saveConfig({ mainAgentName: value })
+                    }}
+                  >
+                    <SelectTrigger className="w-full sm:w-[200px]">
+                      <SelectValue placeholder="Select an agent..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {selectableMainAcpAgents.map((agent) => (
+                        <SelectItem key={agent.name} value={agent.name}>
+                          {agent.displayName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Control>
+
+                {configQuery.data?.mainAgentName && (
+                  <div className="text-muted-foreground bg-muted/30 mx-3 mb-2 rounded-md px-3 py-2 text-sm">
+                    <span className="font-medium">Note:</span> When using acpx
+                    mode, the agent will use its own runtime/tooling stack via
+                    acpx instead of DotAgents directly speaking ACP.
+                  </div>
+                )}
+              </>
+            )}
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Message Queuing"
+                  tooltip="Allow queueing messages while the agent is processing. Messages will be processed in order after the current task completes."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.mcpMessageQueueEnabled ?? true}
+                onCheckedChange={(value) =>
+                  saveConfig({ mcpMessageQueueEnabled: value })
+                }
+              />
+            </Control>
+            <Control
+              label={
+                <ControlLabel
+                  label="Require Tool Approval"
+                  tooltip="Adds a confirmation dialog before any tool executes. Recommended for safety."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={
+                  configQuery.data?.mcpRequireApprovalBeforeToolCall ?? false
+                }
+                onCheckedChange={(value) =>
+                  saveConfig({ mcpRequireApprovalBeforeToolCall: value })
+                }
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Verify Task Completion"
+                  tooltip="When enabled, the agent will verify whether the user's task has been completed before finishing. Disable for faster responses without verification."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.mcpVerifyCompletionEnabled ?? true}
+                onCheckedChange={(value) =>
+                  saveConfig({ mcpVerifyCompletionEnabled: value })
+                }
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Final Summary"
+                  tooltip="When enabled, the agent will generate a concise final summary after completing a task. Disable for faster responses without the summary step."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.mcpFinalSummaryEnabled ?? false}
+                onCheckedChange={(value) =>
+                  saveConfig({ mcpFinalSummaryEnabled: value })
+                }
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Unlimited Iterations"
+                  tooltip="Allow the agent to run indefinitely without an iteration limit. Use with caution as it may run for a long time."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.mcpUnlimitedIterations ?? true}
+                onCheckedChange={(checked) =>
+                  saveConfig({ mcpUnlimitedIterations: checked })
+                }
+              />
+            </Control>
+
+            {!(configQuery.data?.mcpUnlimitedIterations ?? true) && (
+              <Control
+                label={
+                  <ControlLabel
+                    label="Max Iterations"
+                    tooltip="Maximum number of iterations the agent can perform before stopping. Higher values allow more complex tasks but may take longer."
+                  />
+                }
+                className="px-3"
+              >
+                <Input
+                  type="number"
+                  min={String(MCP_MAX_ITERATIONS_MIN)}
+                  max={String(MCP_MAX_ITERATIONS_MAX)}
+                  step="1"
+                  value={mcpMaxIterationsDraft}
+                  onChange={(e) =>
+                    updateMcpMaxIterationsDraft(e.currentTarget.value)
+                  }
+                  onBlur={(e) =>
+                    flushMcpMaxIterationsSave(e.currentTarget.value)
+                  }
+                  placeholder={String(MCP_MAX_ITERATIONS_DEFAULT)}
+                  className="w-32"
+                />
+              </Control>
+            )}
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Emergency Kill Switch"
+                  tooltip="Provides a global hotkey to immediately stop agent mode and kill all agent-created processes"
+                />
+              }
+              className="px-3"
+            >
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={configQuery.data?.agentKillSwitchEnabled !== false}
+                    onCheckedChange={(checked) =>
+                      saveConfig({ agentKillSwitchEnabled: checked })
+                    }
+                  />
+                  <span className="text-muted-foreground text-sm">
+                    Enable kill switch
+                  </span>
+                </div>
+
+                {configQuery.data?.agentKillSwitchEnabled !== false && (
+                  <>
                     <Select
-                      value={configQuery.data?.customShortcutMode || "hold"}
-                      onValueChange={(value: "hold" | "toggle") => {
-                        saveConfig({
-                          customShortcutMode: value,
-                        })
+                      value={
+                        configQuery.data?.agentKillSwitchHotkey ||
+                        "ctrl-shift-escape"
+                      }
+                      onValueChange={(
+                        value:
+                          | "ctrl-shift-escape"
+                          | "ctrl-alt-q"
+                          | "ctrl-shift-q"
+                          | "custom",
+                      ) => {
+                        saveConfig({ agentKillSwitchHotkey: value })
                       }}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger className="w-48">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="hold">Hold (Press and hold to record)</SelectItem>
-                        <SelectItem value="toggle">Toggle (Press once to start, again to stop)</SelectItem>
+                        <SelectItem value="ctrl-shift-escape">
+                          Ctrl + Shift + Escape
+                        </SelectItem>
+                        <SelectItem value="ctrl-alt-q">
+                          Ctrl + Alt + Q
+                        </SelectItem>
+                        <SelectItem value="ctrl-shift-q">
+                          Ctrl + Shift + Q
+                        </SelectItem>
+                        <SelectItem value="custom">Custom</SelectItem>
                       </SelectContent>
                     </Select>
-                  </div>
-                  <KeyRecorder
-                    value={configQuery.data?.customShortcut || ""}
-                    onChange={(keyCombo) => {
-                      saveConfig({
-                        customShortcut: keyCombo,
-                      })
-                    }}
-                    placeholder="Click to record custom shortcut"
-                  />
-                </>
-              )}
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                {recordingShortcutHelperText}
-              </p>
-            </div>
-          </Control>
 
-          <Control label="Toggle Voice Dictation" className="px-3">
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
+                    {configQuery.data?.agentKillSwitchHotkey === "custom" && (
+                      <KeyRecorder
+                        value={
+                          configQuery.data?.customAgentKillSwitchHotkey || ""
+                        }
+                        onChange={(keyCombo) =>
+                          saveConfig({ customAgentKillSwitchHotkey: keyCombo })
+                        }
+                        placeholder="Click to record custom kill switch hotkey"
+                      />
+                    )}
+                  </>
+                )}
+              </div>
+            </Control>
+          </ControlGroup>
+
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="General"
+            forceOpen={isSearching}
+          >
+            {process.env.IS_MAC && (
+              <Control label="Hide Dock Icon" className="px-3">
                 <Switch
-                  checked={configQuery.data?.toggleVoiceDictationEnabled || false}
-                  onCheckedChange={(checked) => {
+                  defaultChecked={configQuery.data.hideDockIcon}
+                  onCheckedChange={(value) => {
                     saveConfig({
-                      toggleVoiceDictationEnabled: checked,
+                      hideDockIcon: value,
                     })
                   }}
                 />
-                <span className="text-sm text-muted-foreground">
-                  Enable toggle mode (press once to start, press again to stop)
+              </Control>
+            )}
+            <Control label="Launch at Login" className="px-3">
+              <Switch
+                defaultChecked={configQuery.data.launchAtLogin ?? false}
+                onCheckedChange={(value) => {
+                  saveConfig({
+                    launchAtLogin: value,
+                  })
+                }}
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Streamer Mode"
+                  tooltip="Hide sensitive information (phone numbers, QR codes, API keys) when streaming or sharing your screen"
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                defaultChecked={configQuery.data.streamerModeEnabled ?? false}
+                onCheckedChange={(value) => {
+                  saveConfig({
+                    streamerModeEnabled: value,
+                  })
+                }}
+              />
+            </Control>
+            {configQuery.data.streamerModeEnabled && (
+              <div className="flex items-center gap-2 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+                <span className="i-mingcute-eye-off-line h-4 w-4" />
+                <span>
+                  Streamer Mode is active - sensitive information is hidden
                 </span>
               </div>
+            )}
+            <Control label="Theme" className="px-3">
+              <Select
+                value={configQuery.data.themePreference || "system"}
+                onValueChange={(value: "system" | "light" | "dark") => {
+                  saveConfig({
+                    themePreference: value,
+                  })
+                  // Update localStorage immediately to sync with ThemeProvider
+                  localStorage.setItem("theme-preference", value)
+                  // Apply theme immediately
+                  window.dispatchEvent(
+                    new CustomEvent("theme-preference-changed", {
+                      detail: value,
+                    }),
+                  )
+                }}
+              >
+                <SelectTrigger className="w-full sm:w-[140px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="system">System</SelectItem>
+                  <SelectItem value="light">Light</SelectItem>
+                  <SelectItem value="dark">Dark</SelectItem>
+                </SelectContent>
+              </Select>
+            </Control>
+          </ControlGroup>
 
-              {configQuery.data?.toggleVoiceDictationEnabled && (
-                <>
-                  <Select
-                    defaultValue={configQuery.data?.toggleVoiceDictationHotkey || "fn"}
-                    onValueChange={(value) => {
+          <RemoteServerSettingsGroups
+            collapsible
+            defaultCollapsed
+            forceOpen={isSearching}
+          />
+
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title={
+              <span className="flex flex-wrap items-center gap-2">
+                <span>Modular config (.agents)</span>
+                {systemPromptOverrideActive && (
+                  <Badge
+                    variant="outline"
+                    className="border-amber-500/50 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                  >
+                    System prompt override active
+                  </Badge>
+                )}
+              </span>
+            }
+            forceOpen={isSearching}
+          >
+            {systemPromptOverrideActive && (
+              <div className="mx-3 mt-2 flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <div className="min-w-0 space-y-1">
+                  <p className="font-medium text-amber-700 dark:text-amber-300">
+                    {systemPromptOverrideScope} system prompt override active
+                  </p>
+                  <p className="text-muted-foreground text-xs leading-5">
+                    A saved system prompt replaces the DotAgents default prompt,
+                    so this install will not receive default system prompt
+                    updates until the override is removed or reset.
+                  </p>
+                </div>
+              </div>
+            )}
+            <div className="text-muted-foreground px-3 py-2 text-sm leading-5">
+              Advanced configuration can live in{" "}
+              <span className="font-mono">.agents</span>. Global{" "}
+              <span className="font-mono">~/.agents</span> is the default layer.
+              Workspace <span className="font-mono">.agents</span> is only used
+              when <span className="font-mono">DOTAGENTS_WORKSPACE_DIR</span> is
+              set, and then it overrides the global layer. Skills live in{" "}
+              <span className="font-mono">skills/&lt;id&gt;/skill.md</span> and
+              knowledge notes live in configured knowledge roots as{" "}
+              <span className="font-mono">&lt;slug&gt;/&lt;slug&gt;.md</span>.
+              Frontmatter uses simple{" "}
+              <span className="font-mono">key: value</span> lines (not YAML).
+            </div>
+            <Control label="Global folder" className="px-3">
+              <div className="text-muted-foreground break-all text-right font-mono text-xs">
+                {agentsFoldersQuery.data?.global?.agentsDir ?? "Loading..."}
+              </div>
+            </Control>
+            <Control
+              label={
+                <ControlLabel
+                  label="Workspace folder"
+                  tooltip="Optional overlay layer enabled by DOTAGENTS_WORKSPACE_DIR. When configured, it overrides the global .agents layer."
+                />
+              }
+              className="px-3"
+            >
+              <div className="text-muted-foreground break-all text-right font-mono text-xs">
+                {agentsFoldersQuery.isLoading
+                  ? "Loading..."
+                  : (agentsFoldersQuery.data?.workspace?.agentsDir ??
+                    "Not configured")}
+                {agentsFoldersQuery.data?.workspace?.agentsDir &&
+                agentsFoldersQuery.data?.workspaceSource
+                  ? ` (${agentsFoldersQuery.data.workspaceSource})`
+                  : ""}
+              </div>
+            </Control>
+            <Control label="Open folders & files" className="px-3">
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={openGlobalAgentsFolder}
+                >
+                  <FolderOpen className="h-3 w-3" />
+                  Global Folder
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={openWorkspaceAgentsFolder}
+                  disabled={!agentsFoldersQuery.data?.workspace?.agentsDir}
+                >
+                  <FolderUp className="h-3 w-3" />
+                  Workspace Folder
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={openSystemPromptFile}
+                >
+                  <FileText className="h-3 w-3" />
+                  System Prompt
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={openAgentsGuidelinesFile}
+                >
+                  <FileText className="h-3 w-3" />
+                  Guidelines
+                </Button>
+              </div>
+            </Control>
+          </ControlGroup>
+
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Shortcuts"
+            forceOpen={isSearching}
+          >
+            <Control label="Recording" className="px-3">
+              <div className="space-y-2">
+                <Select
+                  defaultValue={shortcut}
+                  onValueChange={(value) => {
+                    saveConfig({
+                      shortcut: value as typeof configQuery.data.shortcut,
+                    })
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hold-ctrl">Hold Ctrl</SelectItem>
+                    <SelectItem value="ctrl-slash">Ctrl+{"/"}</SelectItem>
+                    <SelectItem value="custom">Custom</SelectItem>
+                  </SelectContent>
+                </Select>
+
+                {shortcut === "custom" && (
+                  <>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">Mode</label>
+                      <Select
+                        value={configQuery.data?.customShortcutMode || "hold"}
+                        onValueChange={(value: "hold" | "toggle") => {
+                          saveConfig({
+                            customShortcutMode: value,
+                          })
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="hold">
+                            Hold (Press and hold to record)
+                          </SelectItem>
+                          <SelectItem value="toggle">
+                            Toggle (Press once to start, again to stop)
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <KeyRecorder
+                      value={configQuery.data?.customShortcut || ""}
+                      onChange={(keyCombo) => {
+                        saveConfig({
+                          customShortcut: keyCombo,
+                        })
+                      }}
+                      placeholder="Click to record custom shortcut"
+                    />
+                  </>
+                )}
+                <p className="text-muted-foreground text-xs leading-relaxed">
+                  {recordingShortcutHelperText}
+                </p>
+              </div>
+            </Control>
+
+            <Control label="Toggle Voice Dictation" className="px-3">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={
+                      configQuery.data?.toggleVoiceDictationEnabled || false
+                    }
+                    onCheckedChange={(checked) => {
                       saveConfig({
-                        toggleVoiceDictationHotkey: value as typeof configQuery.data.toggleVoiceDictationHotkey,
+                        toggleVoiceDictationEnabled: checked,
                       })
                     }}
+                  />
+                  <span className="text-muted-foreground text-sm">
+                    Enable toggle mode (press once to start, press again to
+                    stop)
+                  </span>
+                </div>
+
+                {configQuery.data?.toggleVoiceDictationEnabled && (
+                  <>
+                    <Select
+                      defaultValue={
+                        configQuery.data?.toggleVoiceDictationHotkey || "fn"
+                      }
+                      onValueChange={(value) => {
+                        saveConfig({
+                          toggleVoiceDictationHotkey:
+                            value as typeof configQuery.data.toggleVoiceDictationHotkey,
+                        })
+                      }}
+                    >
+                      <SelectTrigger className="w-40">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="fn">Fn</SelectItem>
+                        <SelectItem value="f1">F1</SelectItem>
+                        <SelectItem value="f2">F2</SelectItem>
+                        <SelectItem value="f3">F3</SelectItem>
+                        <SelectItem value="f4">F4</SelectItem>
+                        <SelectItem value="f5">F5</SelectItem>
+                        <SelectItem value="f6">F6</SelectItem>
+                        <SelectItem value="f7">F7</SelectItem>
+                        <SelectItem value="f8">F8</SelectItem>
+                        <SelectItem value="f9">F9</SelectItem>
+                        <SelectItem value="f10">F10</SelectItem>
+                        <SelectItem value="f11">F11</SelectItem>
+                        <SelectItem value="f12">F12</SelectItem>
+                        <SelectItem value="custom">Custom</SelectItem>
+                      </SelectContent>
+                    </Select>
+
+                    {configQuery.data?.toggleVoiceDictationHotkey ===
+                      "custom" && (
+                      <KeyRecorder
+                        value={
+                          configQuery.data?.customToggleVoiceDictationHotkey ||
+                          ""
+                        }
+                        onChange={(keyCombo) => {
+                          saveConfig({
+                            customToggleVoiceDictationHotkey: keyCombo,
+                          })
+                        }}
+                        placeholder="Click to record custom toggle shortcut"
+                      />
+                    )}
+                    <p className="text-muted-foreground text-xs leading-relaxed">
+                      {toggleVoiceDictationHelperText}
+                    </p>
+                  </>
+                )}
+              </div>
+            </Control>
+
+            <Control label="Text Input" className="px-3">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={configQuery.data?.textInputEnabled ?? true}
+                    onCheckedChange={(checked) => {
+                      saveConfig({
+                        textInputEnabled: checked,
+                      })
+                    }}
+                  />
+                  <Select
+                    value={textInputShortcut}
+                    onValueChange={(value) => {
+                      saveConfig({
+                        textInputShortcut:
+                          value as typeof configQuery.data.textInputShortcut,
+                      })
+                    }}
+                    disabled={!configQuery.data?.textInputEnabled}
                   >
                     <SelectTrigger className="w-40">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="fn">Fn</SelectItem>
-                      <SelectItem value="f1">F1</SelectItem>
-                      <SelectItem value="f2">F2</SelectItem>
-                      <SelectItem value="f3">F3</SelectItem>
-                      <SelectItem value="f4">F4</SelectItem>
-                      <SelectItem value="f5">F5</SelectItem>
-                      <SelectItem value="f6">F6</SelectItem>
-                      <SelectItem value="f7">F7</SelectItem>
-                      <SelectItem value="f8">F8</SelectItem>
-                      <SelectItem value="f9">F9</SelectItem>
-                      <SelectItem value="f10">F10</SelectItem>
-                      <SelectItem value="f11">F11</SelectItem>
-                      <SelectItem value="f12">F12</SelectItem>
+                      <SelectItem value="ctrl-t">Ctrl+T</SelectItem>
+                      <SelectItem value="ctrl-shift-t">Ctrl+Shift+T</SelectItem>
+                      <SelectItem value="alt-t">Alt+T</SelectItem>
                       <SelectItem value="custom">Custom</SelectItem>
                     </SelectContent>
                   </Select>
+                </div>
 
-                  {configQuery.data?.toggleVoiceDictationHotkey === "custom" && (
+                {textInputShortcut === "custom" &&
+                  configQuery.data?.textInputEnabled && (
                     <KeyRecorder
-                      value={configQuery.data?.customToggleVoiceDictationHotkey || ""}
+                      value={configQuery.data?.customTextInputShortcut || ""}
                       onChange={(keyCombo) => {
                         saveConfig({
-                          customToggleVoiceDictationHotkey: keyCombo,
+                          customTextInputShortcut: keyCombo,
                         })
                       }}
-                      placeholder="Click to record custom toggle shortcut"
+                      placeholder="Click to record custom text input shortcut"
                     />
                   )}
-                  <p className="text-xs leading-relaxed text-muted-foreground">
-                    {toggleVoiceDictationHelperText}
-                  </p>
-                </>
-              )}
-            </div>
-          </Control>
-
-          <Control label="Text Input" className="px-3">
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Switch
-                  checked={configQuery.data?.textInputEnabled ?? true}
-                  onCheckedChange={(checked) => {
-                    saveConfig({
-                      textInputEnabled: checked,
-                    })
-                  }}
-                />
-                <Select
-                  value={textInputShortcut}
-                  onValueChange={(value) => {
-                    saveConfig({
-                      textInputShortcut:
-                        value as typeof configQuery.data.textInputShortcut,
-                    })
-                  }}
-                  disabled={!configQuery.data?.textInputEnabled}
-                >
-                  <SelectTrigger className="w-40">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ctrl-t">Ctrl+T</SelectItem>
-                    <SelectItem value="ctrl-shift-t">Ctrl+Shift+T</SelectItem>
-                    <SelectItem value="alt-t">Alt+T</SelectItem>
-                    <SelectItem value="custom">Custom</SelectItem>
-                  </SelectContent>
-                </Select>
               </div>
+            </Control>
 
-              {textInputShortcut === "custom" &&
-                configQuery.data?.textInputEnabled && (
-                  <KeyRecorder
-                    value={configQuery.data?.customTextInputShortcut || ""}
-                    onChange={(keyCombo) => {
+            <Control label="Show Main Window" className="px-3">
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={configQuery.data?.settingsHotkeyEnabled ?? true}
+                    onCheckedChange={(checked) => {
                       saveConfig({
-                        customTextInputShortcut: keyCombo,
+                        settingsHotkeyEnabled: checked,
                       })
                     }}
-                    placeholder="Click to record custom text input shortcut"
                   />
-                )}
-            </div>
-          </Control>
-
-          <Control label="Show Main Window" className="px-3">
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Switch
-                  checked={configQuery.data?.settingsHotkeyEnabled ?? true}
-                  onCheckedChange={(checked) => {
-                    saveConfig({
-                      settingsHotkeyEnabled: checked,
-                    })
-                  }}
-                />
-                <Select
-                  value={configQuery.data?.settingsHotkey || "ctrl-shift-s"}
-                  onValueChange={(value) => {
-                    saveConfig({
-                      settingsHotkey:
-                        value as typeof configQuery.data.settingsHotkey,
-                    })
-                  }}
-                  disabled={!configQuery.data?.settingsHotkeyEnabled}
-                >
-                  <SelectTrigger className="w-40">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="ctrl-shift-s">Ctrl+Shift+S</SelectItem>
-                    <SelectItem value="ctrl-comma">Ctrl+,</SelectItem>
-                    <SelectItem value="ctrl-shift-comma">Ctrl+Shift+,</SelectItem>
-                    <SelectItem value="custom">Custom</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {configQuery.data?.settingsHotkey === "custom" &&
-                configQuery.data?.settingsHotkeyEnabled && (
-                  <KeyRecorder
-                    value={configQuery.data?.customSettingsHotkey || ""}
-                    onChange={(keyCombo) => {
+                  <Select
+                    value={configQuery.data?.settingsHotkey || "ctrl-shift-s"}
+                    onValueChange={(value) => {
                       saveConfig({
-                        customSettingsHotkey: keyCombo,
+                        settingsHotkey:
+                          value as typeof configQuery.data.settingsHotkey,
                       })
                     }}
-                    placeholder="Click to record custom hotkey"
-                  />
-                )}
-            </div>
-          </Control>
+                    disabled={!configQuery.data?.settingsHotkeyEnabled}
+                  >
+                    <SelectTrigger className="w-40">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ctrl-shift-s">Ctrl+Shift+S</SelectItem>
+                      <SelectItem value="ctrl-comma">Ctrl+,</SelectItem>
+                      <SelectItem value="ctrl-shift-comma">
+                        Ctrl+Shift+,
+                      </SelectItem>
+                      <SelectItem value="custom">Custom</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
 
-          <Control label={<ControlLabel label="Agent Mode" tooltip="Choose how to activate agent mode for skills, tools, and delegation" />} className="px-3">
-            <div className="space-y-2">
-              <Select
-                value={configQuery.data?.agentShortcut || configQuery.data?.mcpToolsShortcut || "hold-ctrl-alt"}
-                onValueChange={(value: "hold-ctrl-alt" | "toggle-ctrl-alt" | "ctrl-alt-slash" | "custom") => {
-                  saveConfig({ agentShortcut: value })
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="hold-ctrl-alt">Hold Ctrl+Alt</SelectItem>
-                  <SelectItem value="toggle-ctrl-alt">Toggle Ctrl+Alt</SelectItem>
-                  <SelectItem value="ctrl-alt-slash">Ctrl+Alt+/</SelectItem>
-                  <SelectItem value="custom">Custom</SelectItem>
-                </SelectContent>
-              </Select>
-
-              {(configQuery.data?.agentShortcut || configQuery.data?.mcpToolsShortcut) === "custom" && (
-                <>
-                  <div className="space-y-2">
-                    <label className="text-sm font-medium">Mode</label>
-                    <Select
-                      value={configQuery.data?.customAgentShortcutMode || configQuery.data?.customMcpToolsShortcutMode || "hold"}
-                      onValueChange={(value: "hold" | "toggle") => {
-                        saveConfig({ customAgentShortcutMode: value })
+                {configQuery.data?.settingsHotkey === "custom" &&
+                  configQuery.data?.settingsHotkeyEnabled && (
+                    <KeyRecorder
+                      value={configQuery.data?.customSettingsHotkey || ""}
+                      onChange={(keyCombo) => {
+                        saveConfig({
+                          customSettingsHotkey: keyCombo,
+                        })
                       }}
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="hold">Hold (Press and hold to record)</SelectItem>
-                        <SelectItem value="toggle">Toggle (Press once to start, again to send)</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <KeyRecorder
-                    value={configQuery.data?.customAgentShortcut || configQuery.data?.customMcpToolsShortcut || ""}
-                    onChange={(keyCombo) => {
-                      saveConfig({ customAgentShortcut: keyCombo })
-                    }}
-                    placeholder="Click to record custom agent mode shortcut"
-                  />
-                </>
-              )}
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                {agentShortcutHelperText}
-              </p>
-            </div>
-          </Control>
-        </ControlGroup>
-
-        <ControlGroup collapsible defaultCollapsed title="Audio Devices" forceOpen={isSearching} onOpenChange={setAudioSectionOpen}>
-          <Control label={<ControlLabel label="Microphone" tooltip="Select which microphone to use for speech recognition. 'System Default' uses your OS default input device." />} className="px-3">
-            <Select
-              value={configQuery.data.audioInputDeviceId || "default"}
-              onValueChange={(value) => {
-                const selectedInputDevice = audioInputDevices.find((device) => device.deviceId === value)
-                const selectedInputDeviceLabel = hasResolvedAudioInputDeviceLabel(selectedInputDevice?.label)
-                  ? selectedInputDevice?.label
-                  : undefined
-
-                saveConfig({
-                  audioInputDeviceId: value === "default" ? undefined : value,
-                  audioInputDeviceLabel: value === "default" ? undefined : selectedInputDeviceLabel,
-                })
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="System Default" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="default">System Default</SelectItem>
-                {audioInputDevices.map((device) => (
-                  device.deviceId !== "default" && (
-                    <SelectItem key={device.deviceId} value={device.deviceId}>
-                      {device.label}
-                    </SelectItem>
-                  )
-                ))}
-              </SelectContent>
-            </Select>
-          </Control>
-
-          <Control label={<ControlLabel label="Speaker" tooltip="Select which speaker/output device to use for text-to-speech audio playback. 'System Default' uses your OS default output device." />} className="px-3">
-            <Select
-              value={configQuery.data.audioOutputDeviceId || "default"}
-              onValueChange={(value) => {
-                saveConfig({
-                  audioOutputDeviceId: value === "default" ? undefined : value,
-                })
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="System Default" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="default">System Default</SelectItem>
-                {audioOutputDevices.map((device) => (
-                  device.deviceId !== "default" && (
-                    <SelectItem key={device.deviceId} value={device.deviceId}>
-                      {device.label}
-                    </SelectItem>
-                  )
-                ))}
-              </SelectContent>
-            </Select>
-          </Control>
-        </ControlGroup>
-
-        <ControlGroup collapsible defaultCollapsed title="Speech-to-Text" forceOpen={isSearching}>
-          <Control label={<ControlLabel label="Model Selection" tooltip="Manage STT models from the Models page so speech-to-text choices stay with the rest of your provider model settings." />} className="px-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <Button variant="outline" size="sm" onClick={() => navigate("/settings/models")}>
-                Open Models page
-              </Button>
-              <p className="text-sm text-muted-foreground">
-                {sttProviderId === "parakeet"
-                  ? "Parakeet uses its local downloaded model bundle."
-                  : `Choose your ${sttProviderId === "openai" ? "OpenAI" : "Groq"} STT model from the Models page.`}
-              </p>
-            </div>
-          </Control>
-
-          <Control label={<ControlLabel label="Transcript Processing" tooltip="Clean up punctuation, capitalization, or obvious speech-to-text mistakes after dictation." />} className="px-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <Switch
-                checked={configQuery.data.transcriptPostProcessingEnabled ?? false}
-                onCheckedChange={(value) => {
-                  saveConfig({ transcriptPostProcessingEnabled: value })
-                }}
-              />
-              <Button variant="outline" size="sm" onClick={() => navigate("/settings/models")}>
-                Configure
-              </Button>
-              <p className="text-sm text-muted-foreground">
-                Prompt, provider, and model live on the Models page.
-              </p>
-            </div>
-          </Control>
-
-          <Control label={<ControlLabel label="Language" tooltip="Select the language for speech transcription. 'Auto-detect' lets the model determine the language automatically based on your speech." />} className="px-3">
-            <Select
-              value={configQuery.data.sttLanguage || "auto"}
-              onValueChange={(value) => {
-                saveConfig({
-                  sttLanguage: value,
-                })
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {SUPPORTED_LANGUAGES.map((language) => (
-                  <SelectItem key={language.code} value={language.code}>
-                    {language.nativeName} ({language.name})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </Control>
-
-          {sttProviderId === "openai" && configQuery.data.openaiSttLanguage && configQuery.data.openaiSttLanguage !== configQuery.data.sttLanguage && (
-            <Control label={<ControlLabel label="OpenAI Language Override" tooltip="Override the global language setting specifically for OpenAI's Whisper transcription service." />} className="px-3">
-              <Select
-                value={configQuery.data.openaiSttLanguage || "auto"}
-                onValueChange={(value) => {
-                  saveConfig({
-                    openaiSttLanguage: value,
-                  })
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {SUPPORTED_LANGUAGES.map((language) => (
-                    <SelectItem key={language.code} value={language.code}>
-                      {language.nativeName} ({language.name})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                      placeholder="Click to record custom hotkey"
+                    />
+                  )}
+              </div>
             </Control>
-          )}
 
-          {sttProviderId === "groq" && configQuery.data.groqSttLanguage && configQuery.data.groqSttLanguage !== configQuery.data.sttLanguage && (
-            <Control label={<ControlLabel label="Groq Language Override" tooltip="Override the global language setting specifically for Groq's Whisper transcription service." />} className="px-3">
-              <Select
-                value={configQuery.data.groqSttLanguage || "auto"}
-                onValueChange={(value) => {
-                  saveConfig({
-                    groqSttLanguage: value,
-                  })
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {SUPPORTED_LANGUAGES.map((language) => (
-                    <SelectItem key={language.code} value={language.code}>
-                      {language.nativeName} ({language.name})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Control>
-          )}
-
-          {sttProviderId === "groq" && (
-            <Control label={<ControlLabel label="Prompt" tooltip="Optional prompt to guide the model's style or specify how to spell unfamiliar words. Limited to 224 tokens." />} className="px-3">
-              <Textarea
-                placeholder="Optional prompt to guide the model's style or specify how to spell unfamiliar words (limited to 224 tokens)"
-                value={groqSttPromptDraft}
-                onChange={(e) => {
-                  updateGroqSttPromptDraft(e.currentTarget.value)
-                }}
-                onBlur={(e) => {
-                  flushGroqSttPromptSave(e.currentTarget.value)
-                }}
-                className="min-h-[80px]"
-              />
-            </Control>
-          )}
-
-          <Control label={<ControlLabel label="Transcription Preview" tooltip="Show a live transcription preview while recording. Audio is sent to your STT provider every ~10 seconds to display partial results. Note: this increases API usage — each chunk is billed separately (Groq has a 10-second minimum billing per request)." />} className="px-3">
-            <Switch
-              defaultChecked={configQuery.data.transcriptionPreviewEnabled}
-              onCheckedChange={(value) => {
-                saveConfig({
-                  transcriptionPreviewEnabled: value,
-                })
-              }}
-            />
-          </Control>
-
-        </ControlGroup>
-
-        <ControlGroup collapsible defaultCollapsed title="Text to Speech" forceOpen={isSearching}>
-          <Control label="Enabled" className="px-3">
-            <Switch
-              defaultChecked={configQuery.data.ttsEnabled ?? false}
-              onCheckedChange={async (value) => {
-                if (!value) {
-                  try {
-                    await tipcClient.controlTTSPlayback({ type: "stop", reason: "settings-global-tts-disabled" })
-                    await tipcClient.stopAllTts()
-                  } catch (error) {
-                    console.error("Failed to stop TTS in all windows:", error)
+            <Control
+              label={
+                <ControlLabel
+                  label="Agent Mode"
+                  tooltip="Choose how to activate agent mode for skills, tools, and delegation"
+                />
+              }
+              className="px-3"
+            >
+              <div className="space-y-2">
+                <Select
+                  value={
+                    configQuery.data?.agentShortcut ||
+                    configQuery.data?.mcpToolsShortcut ||
+                    "hold-ctrl-alt"
                   }
-                }
+                  onValueChange={(
+                    value:
+                      | "hold-ctrl-alt"
+                      | "toggle-ctrl-alt"
+                      | "ctrl-alt-slash"
+                      | "custom",
+                  ) => {
+                    saveConfig({ agentShortcut: value })
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="hold-ctrl-alt">Hold Ctrl+Alt</SelectItem>
+                    <SelectItem value="toggle-ctrl-alt">
+                      Toggle Ctrl+Alt
+                    </SelectItem>
+                    <SelectItem value="ctrl-alt-slash">Ctrl+Alt+/</SelectItem>
+                    <SelectItem value="custom">Custom</SelectItem>
+                  </SelectContent>
+                </Select>
 
-                saveConfig({
-                  ttsEnabled: value,
-                })
-              }}
-            />
-          </Control>
+                {(configQuery.data?.agentShortcut ||
+                  configQuery.data?.mcpToolsShortcut) === "custom" && (
+                  <>
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">Mode</label>
+                      <Select
+                        value={
+                          configQuery.data?.customAgentShortcutMode ||
+                          configQuery.data?.customMcpToolsShortcutMode ||
+                          "hold"
+                        }
+                        onValueChange={(value: "hold" | "toggle") => {
+                          saveConfig({ customAgentShortcutMode: value })
+                        }}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="hold">
+                            Hold (Press and hold to record)
+                          </SelectItem>
+                          <SelectItem value="toggle">
+                            Toggle (Press once to start, again to send)
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <KeyRecorder
+                      value={
+                        configQuery.data?.customAgentShortcut ||
+                        configQuery.data?.customMcpToolsShortcut ||
+                        ""
+                      }
+                      onChange={(keyCombo) => {
+                        saveConfig({ customAgentShortcut: keyCombo })
+                      }}
+                      placeholder="Click to record custom agent mode shortcut"
+                    />
+                  </>
+                )}
+                <p className="text-muted-foreground text-xs leading-relaxed">
+                  {agentShortcutHelperText}
+                </p>
+              </div>
+            </Control>
+          </ControlGroup>
 
-          {configQuery.data.ttsEnabled && (
-            <Control label={<ControlLabel label="Auto-play" tooltip="Automatically play TTS audio when assistant responses complete" />} className="px-3">
-              <Switch
-                defaultChecked={configQuery.data.ttsAutoPlay ?? true}
-                onCheckedChange={(value) => {
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Audio Devices"
+            forceOpen={isSearching}
+            onOpenChange={setAudioSectionOpen}
+          >
+            <Control
+              label={
+                <ControlLabel
+                  label="Microphone"
+                  tooltip="Select which microphone to use for speech recognition. 'System Default' uses your OS default input device."
+                />
+              }
+              className="px-3"
+            >
+              <Select
+                value={configQuery.data.audioInputDeviceId || "default"}
+                onValueChange={(value) => {
+                  const selectedInputDevice = audioInputDevices.find(
+                    (device) => device.deviceId === value,
+                  )
+                  const selectedInputDeviceLabel =
+                    hasResolvedAudioInputDeviceLabel(selectedInputDevice?.label)
+                      ? selectedInputDevice?.label
+                      : undefined
+
                   saveConfig({
-                    ttsAutoPlay: value,
+                    audioInputDeviceId: value === "default" ? undefined : value,
+                    audioInputDeviceLabel:
+                      value === "default"
+                        ? undefined
+                        : selectedInputDeviceLabel,
                   })
                 }}
-              />
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="System Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">System Default</SelectItem>
+                  {audioInputDevices.map(
+                    (device) =>
+                      device.deviceId !== "default" && (
+                        <SelectItem
+                          key={device.deviceId}
+                          value={device.deviceId}
+                        >
+                          {device.label}
+                        </SelectItem>
+                      ),
+                  )}
+                </SelectContent>
+              </Select>
             </Control>
-          )}
 
-          {configQuery.data.ttsEnabled && (
-            <div className="px-3 py-1.5">
-              <button
-                type="button"
-                onClick={() => navigate("/settings/models")}
-                className="text-xs text-primary hover:underline"
-              >
-                Configure TTS voice &amp; model →
-              </button>
-            </div>
-          )}
-
-          {configQuery.data.ttsEnabled && (
-            <>
-              <Control label={<ControlLabel label="Text Preprocessing" tooltip="Enable preprocessing to make text more speech-friendly by removing code blocks, URLs, and converting markdown" />} className="px-3">
-                <Switch
-                  defaultChecked={configQuery.data.ttsPreprocessingEnabled ?? true}
-                  onCheckedChange={(value) => {
-                    saveConfig({
-                      ttsPreprocessingEnabled: value,
-                    })
-                  }}
+            <Control
+              label={
+                <ControlLabel
+                  label="Speaker"
+                  tooltip="Select which speaker/output device to use for text-to-speech audio playback. 'System Default' uses your OS default output device."
                 />
-              </Control>
-
-              {configQuery.data.ttsPreprocessingEnabled !== false && (
-                <>
-                  <Control label={<ControlLabel label="Remove Code Blocks" tooltip="Remove code blocks and replace with descriptive text" />} className="px-3">
-                    <Switch
-                      defaultChecked={configQuery.data.ttsRemoveCodeBlocks ?? true}
-                      onCheckedChange={(value) => {
-                        saveConfig({
-                          ttsRemoveCodeBlocks: value,
-                        })
-                      }}
-                    />
-                  </Control>
-
-                  <Control label={<ControlLabel label="Remove URLs" tooltip="Remove URLs and replace with descriptive text" />} className="px-3">
-                    <Switch
-                      defaultChecked={configQuery.data.ttsRemoveUrls ?? true}
-                      onCheckedChange={(value) => {
-                        saveConfig({
-                          ttsRemoveUrls: value,
-                        })
-                      }}
-                    />
-                  </Control>
-
-                  <Control label={<ControlLabel label="Convert Markdown" tooltip="Convert markdown formatting to speech-friendly text" />} className="px-3">
-                    <Switch
-                      defaultChecked={configQuery.data.ttsConvertMarkdown ?? true}
-                      onCheckedChange={(value) => {
-                        saveConfig({
-                          ttsConvertMarkdown: value,
-                        })
-                      }}
-                    />
-                  </Control>
-
-                  <Control label={<ControlLabel label="Use AI for TTS Preprocessing" tooltip="Use an LLM to intelligently convert text to natural speech. More robust handling of abbreviations, acronyms, and context-dependent pronunciation. Adds ~1-2 seconds latency. Falls back to regex if disabled or unavailable." />} className="px-3">
-                    <Switch
-                      defaultChecked={configQuery.data.ttsUseLLMPreprocessing ?? false}
-                      onCheckedChange={(value) => {
-                        saveConfig({
-                          ttsUseLLMPreprocessing: value,
-                        })
-                      }}
-                    />
-                  </Control>
-                </>
-              )}
-            </>
-          )}
-        </ControlGroup>
-
-        {/* Panel Position Settings */}
-        <ControlGroup collapsible defaultCollapsed title="Panel Position" forceOpen={isSearching}>
-          <Control label={<ControlLabel label="Default Position" tooltip="Choose where the floating panel appears on your screen. Custom position: Panel can be dragged to any location and will remember its position." />} className="px-3">
-            <Select
-              value={configQuery.data?.panelPosition || "top-right"}
-              onValueChange={(
-                value:
-                  | "top-left"
-                  | "top-center"
-                  | "top-right"
-                  | "bottom-left"
-                  | "bottom-center"
-                  | "bottom-right"
-                  | "custom",
-              ) => {
-                saveConfig({
-                  panelPosition: value,
-                })
-                // Update panel position immediately if it's visible
-                tipcClient.setPanelPosition({ position: value })
-              }}
+              }
+              className="px-3"
             >
-              <SelectTrigger className="w-full sm:w-[180px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="top-left">Top Left</SelectItem>
-                <SelectItem value="top-center">Top Center</SelectItem>
-                <SelectItem value="top-right">Top Right</SelectItem>
-                <SelectItem value="bottom-left">Bottom Left</SelectItem>
-                <SelectItem value="bottom-center">Bottom Center</SelectItem>
-                <SelectItem value="bottom-right">Bottom Right</SelectItem>
-                <SelectItem value="custom">Custom (Draggable)</SelectItem>
-              </SelectContent>
-            </Select>
-          </Control>
-
-          <Control label={<ControlLabel label="Enable Dragging" tooltip="Enable dragging to move the panel by holding the top bar." />} className="px-3">
-            <Switch
-              defaultChecked={configQuery.data?.panelDragEnabled ?? true}
-              onCheckedChange={(value) => {
-                saveConfig({
-                  panelDragEnabled: value,
-                })
-              }}
-            />
-          </Control>
-
-          <Control label={<ControlLabel label="Auto-Show Floating Panel" tooltip="When enabled, the floating panel automatically appears during agent sessions. When disabled, the panel only appears when manually triggered via hotkeys or menu. You can still access agent progress in the main window." />} className="px-3">
-            <div className="space-y-2">
-              <div className="flex justify-start sm:justify-end">
-                <Switch
-                  checked={configQuery.data?.floatingPanelAutoShow !== false}
-                  onCheckedChange={(value) => {
-                    saveConfig({
-                      floatingPanelAutoShow: value,
-                    })
-                  }}
-                />
-              </div>
-              {configQuery.data?.floatingPanelAutoShow === false && (
-                <div className="text-xs text-muted-foreground sm:text-right">
-                  Auto-show is off. Use the quick actions below or the tray menu to bring the floating panel back anytime.
-                </div>
-              )}
-            </div>
-          </Control>
-
-          <Control label={<ControlLabel label="Agent Progress in Floating Panel" tooltip="When enabled, agent progress can appear in the floating panel. When disabled, agent progress stays in the main app; the voice waveform still uses the floating panel." />} className="px-3">
-            <div className="space-y-2">
-              <div className="flex justify-start sm:justify-end">
-                <Switch
-                  checked={configQuery.data?.floatingPanelAgentProgressEnabled !== false}
-                  onCheckedChange={(value) => {
-                    saveConfig({
-                      floatingPanelAgentProgressEnabled: value,
-                    })
-                  }}
-                />
-              </div>
-              {configQuery.data?.floatingPanelAgentProgressEnabled === false && (
-                <div className="text-xs text-muted-foreground sm:text-right">
-                  Agent progress stays in the main app. Voice waveform recording still uses the floating panel.
-                </div>
-              )}
-            </div>
-          </Control>
-
-          <Control label={<ControlLabel label="Hide Panel When Main App Focused" tooltip="When enabled, the floating panel automatically hides when the main DotAgents window is focused. The panel reappears when the main window loses focus." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.hidePanelWhenMainFocused !== false}
-              onCheckedChange={(value) => {
-                saveConfig({
-                  hidePanelWhenMainFocused: value,
-                })
-              }}
-            />
-          </Control>
-
-          <Control label={<ControlLabel label="Quick Actions" tooltip="Useful recovery actions if the floating panel is hidden, off-screen, or just hard to find." />} className="px-3">
-            <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
-              <Button variant="outline" size="sm" onClick={() => void showFloatingPanelNow()}>
-                Show Now
-              </Button>
-              <Button variant="outline" size="sm" onClick={() => void resetFloatingPanel()}>
-                Reset Position & Size
-              </Button>
-            </div>
-          </Control>
-
-        </ControlGroup>
-
-        {/* WhatsApp Integration */}
-        <ControlGroup
-          collapsible
-          defaultCollapsed
-          title="WhatsApp Integration"
-          forceOpen={isSearching}
-          endDescription={(
-            <div className="break-words whitespace-normal">
-              Enable WhatsApp messaging through DotAgents.{" "}
-              <a href="/settings/whatsapp" className="underline">Configure WhatsApp settings</a>.
-            </div>
-          )}
-        >
-          <Control label={<ControlLabel label="Enable WhatsApp" tooltip="When enabled, allows sending and receiving WhatsApp messages through DotAgents" />} className="px-3">
-            <Switch
-              checked={configQuery.data?.whatsappEnabled ?? false}
-              onCheckedChange={(value) => saveConfig({ whatsappEnabled: value })}
-            />
-          </Control>
-        </ControlGroup>
-
-        {/* Discord Integration */}
-        <ControlGroup
-          collapsible
-          defaultCollapsed
-          title="Discord Integration"
-          // Auto-open when the user is searching or when Discord is currently
-          // disabled. The Discord settings page is hidden from the sidebar
-          // while disabled, so this section is the only place to turn it on
-          // — surface it by default until the user enables it.
-          forceOpen={isSearching || !(configQuery.data?.discordEnabled ?? false)}
-          endDescription={(
-            <div className="break-words whitespace-normal">
-              Enable a Discord bot for DMs, mentions, and threads. {" "}
-              <a href="/settings/discord" className="underline">Configure Discord settings</a>.
-            </div>
-          )}
-        >
-          <Control label={<ControlLabel label="Enable Discord" tooltip="When enabled, DotAgents can receive Discord DMs and server mentions using your configured bot token. The Discord settings page only appears in the sidebar while this is on." />} className="px-3">
-            <Switch
-              checked={configQuery.data?.discordEnabled ?? false}
-              onCheckedChange={(value) => saveConfig({ discordEnabled: value })}
-            />
-          </Control>
-        </ControlGroup>
-
-        {/* Observability */}
-        <ControlGroup
-          collapsible
-          defaultCollapsed
-          title="Observability"
-          forceOpen={isSearching}
-          endDescription={(
-            <div className="break-words whitespace-normal">
-              Optional tracing for LLM calls, agent sessions, and tools. Send traces to Langfuse or keep them local as JSONL logs.{" "}
-              <a
-                href="https://langfuse.com"
-                target="_blank"
-                rel="noreferrer noopener"
-                className="underline inline-flex items-center gap-1"
+              <Select
+                value={configQuery.data.audioOutputDeviceId || "default"}
+                onValueChange={(value) => {
+                  saveConfig({
+                    audioOutputDeviceId:
+                      value === "default" ? undefined : value,
+                  })
+                }}
               >
-                Docs
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            </div>
-          )}
-        >
-          <Control
-            label={(
-              <ControlLabel
-                label="Local trace logging"
-                tooltip="Write each agent session trace to its own local JSONL file on this device. Independent of Langfuse Cloud."
-              />
-            )}
-            className="px-3"
+                <SelectTrigger>
+                  <SelectValue placeholder="System Default" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">System Default</SelectItem>
+                  {audioOutputDevices.map(
+                    (device) =>
+                      device.deviceId !== "default" && (
+                        <SelectItem
+                          key={device.deviceId}
+                          value={device.deviceId}
+                        >
+                          {device.label}
+                        </SelectItem>
+                      ),
+                  )}
+                </SelectContent>
+              </Select>
+            </Control>
+          </ControlGroup>
+
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Speech-to-Text"
+            forceOpen={isSearching}
           >
-            <Switch
-              checked={configQuery.data?.localTraceLoggingEnabled ?? false}
-              onCheckedChange={(value) => {
-                saveConfig({ localTraceLoggingEnabled: value })
-              }}
-            />
-          </Control>
-
-          <Control
-            label={(
-              <ControlLabel
-                label="Langfuse tracing"
-                tooltip="Send traces to Langfuse Cloud or a self-hosted Langfuse instance."
-              />
-            )}
-            className="px-3"
-          >
-            <Switch
-              checked={configQuery.data?.langfuseEnabled ?? false}
-              disabled={!isLangfuseInstalled}
-              onCheckedChange={(value) => {
-                saveConfig({ langfuseEnabled: value })
-              }}
-            />
-          </Control>
-
-          {!isLangfuseInstalled && (
-            <div className="mx-3 mb-3 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-700 dark:text-amber-300">
-              Install the optional <span className="font-mono">langfuse</span> package with <span className="font-mono">pnpm add langfuse</span>, then restart DotAgents to enable tracing.
-            </div>
-          )}
-
-          {configQuery.data?.langfuseEnabled && (
-            <>
-              <Control label={<ControlLabel label="Public Key" tooltip="Your Langfuse project's public key" />} className="px-3">
-                <Input
-                  type="text"
-                  value={langfuseDrafts.langfusePublicKey}
-                  onChange={(e) => updateLangfuseDraft("langfusePublicKey", e.currentTarget.value)}
-                  onBlur={(e) => flushLangfuseSave("langfusePublicKey", e.currentTarget.value)}
-                  placeholder="pk-lf-..."
-                  className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
+            <Control
+              label={
+                <ControlLabel
+                  label="Model Selection"
+                  tooltip="Manage STT models in Models so speech-to-text choices stay with the rest of your provider model settings."
                 />
-              </Control>
+              }
+              className="px-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => navigate("/settings/models")}
+                >
+                  Open Models
+                </Button>
+                <p className="text-muted-foreground text-sm">
+                  {sttProviderId === "parakeet"
+                    ? "Parakeet uses its local downloaded model bundle."
+                    : `Choose your ${sttProviderId === "openai" ? "OpenAI" : "Groq"} STT model in Models.`}
+                </p>
+              </div>
+            </Control>
 
-              <Control label={<ControlLabel label="Secret Key" tooltip="Your Langfuse project's secret key" />} className="px-3">
-                <Input
-                  type="password"
-                  value={langfuseDrafts.langfuseSecretKey}
-                  onChange={(e) => updateLangfuseDraft("langfuseSecretKey", e.currentTarget.value)}
-                  onBlur={(e) => flushLangfuseSave("langfuseSecretKey", e.currentTarget.value)}
-                  placeholder="sk-lf-..."
-                  className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
+            <Control
+              label={
+                <ControlLabel
+                  label="Transcript Processing"
+                  tooltip="Clean up punctuation, capitalization, or obvious speech-to-text mistakes after dictation."
                 />
-              </Control>
-
-              <Control label={<ControlLabel label="Base URL" tooltip="Langfuse API endpoint. Leave empty for Langfuse Cloud (cloud.langfuse.com)" />} className="px-3">
-                <Input
-                  type="text"
-                  value={langfuseDrafts.langfuseBaseUrl}
-                  onChange={(e) => updateLangfuseDraft("langfuseBaseUrl", e.currentTarget.value)}
-                  onBlur={(e) => flushLangfuseSave("langfuseBaseUrl", e.currentTarget.value)}
-                  placeholder="https://cloud.langfuse.com (default)"
-                  className="w-full sm:w-[360px] max-w-full min-w-0"
+              }
+              className="px-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Switch
+                  checked={
+                    configQuery.data.transcriptPostProcessingEnabled ?? false
+                  }
+                  onCheckedChange={(value) => {
+                    saveConfig({ transcriptPostProcessingEnabled: value })
+                  }}
                 />
-                <div className="mt-1 text-xs text-muted-foreground">
-                  Use this for self-hosted Langfuse instances. Leave empty for Langfuse Cloud.
-                </div>
-              </Control>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => navigate("/settings/models")}
+                >
+                  Configure
+                </Button>
+                <p className="text-muted-foreground text-sm">
+                  Prompt, provider, and model live in Models.
+                </p>
+              </div>
+            </Control>
 
-              {/* Status indicator */}
-              {configQuery.data?.langfusePublicKey && configQuery.data?.langfuseSecretKey && (
-                <Control label="Status" className="px-3">
-                  <div className="flex items-center gap-2">
-                    <span className="inline-block w-2 h-2 rounded-full bg-green-500" />
-                    <span className="text-sm text-green-600 dark:text-green-400">Configured</span>
-                  </div>
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    Traces will be sent to Langfuse for each agent session.
-                  </div>
+            <Control
+              label={
+                <ControlLabel
+                  label="Language"
+                  tooltip="Select the language for speech transcription. 'Auto-detect' lets the model determine the language automatically based on your speech."
+                />
+              }
+              className="px-3"
+            >
+              <Select
+                value={configQuery.data.sttLanguage || "auto"}
+                onValueChange={(value) => {
+                  saveConfig({
+                    sttLanguage: value,
+                  })
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SUPPORTED_LANGUAGES.map((language) => (
+                    <SelectItem key={language.code} value={language.code}>
+                      {language.nativeName} ({language.name})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Control>
+
+            {sttProviderId === "openai" &&
+              configQuery.data.openaiSttLanguage &&
+              configQuery.data.openaiSttLanguage !==
+                configQuery.data.sttLanguage && (
+                <Control
+                  label={
+                    <ControlLabel
+                      label="OpenAI Language Override"
+                      tooltip="Override the global language setting specifically for OpenAI's Whisper transcription service."
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Select
+                    value={configQuery.data.openaiSttLanguage || "auto"}
+                    onValueChange={(value) => {
+                      saveConfig({
+                        openaiSttLanguage: value,
+                      })
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SUPPORTED_LANGUAGES.map((language) => (
+                        <SelectItem key={language.code} value={language.code}>
+                          {language.nativeName} ({language.name})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </Control>
               )}
 
-              {(!configQuery.data?.langfusePublicKey || !configQuery.data?.langfuseSecretKey) && (
-                <div className="px-3 py-2">
-                  <div className="text-sm text-amber-600 dark:text-amber-400">
-                    Enter both Public Key and Secret Key to enable tracing.
-                  </div>
-                </div>
+            {sttProviderId === "groq" &&
+              configQuery.data.groqSttLanguage &&
+              configQuery.data.groqSttLanguage !==
+                configQuery.data.sttLanguage && (
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Groq Language Override"
+                      tooltip="Override the global language setting specifically for Groq's Whisper transcription service."
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Select
+                    value={configQuery.data.groqSttLanguage || "auto"}
+                    onValueChange={(value) => {
+                      saveConfig({
+                        groqSttLanguage: value,
+                      })
+                    }}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {SUPPORTED_LANGUAGES.map((language) => (
+                        <SelectItem key={language.code} value={language.code}>
+                          {language.nativeName} ({language.name})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Control>
               )}
-            </>
-          )}
-        </ControlGroup>
 
-        {/* About Section */}
-        <ControlGroup title="About">
-          <Control label="Version" className="px-3">
-            <div className="text-sm">{process.env.APP_VERSION}</div>
-          </Control>
-          <Control label="Onboarding" className="px-3">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                saveConfig({ onboardingCompleted: false })
-                navigate("/onboarding")
-              }}
+            {sttProviderId === "groq" && (
+              <Control
+                label={
+                  <ControlLabel
+                    label="Prompt"
+                    tooltip="Optional prompt to guide the model's style or specify how to spell unfamiliar words. Limited to 224 tokens."
+                  />
+                }
+                className="px-3"
+              >
+                <Textarea
+                  placeholder="Optional prompt to guide the model's style or specify how to spell unfamiliar words (limited to 224 tokens)"
+                  value={groqSttPromptDraft}
+                  onChange={(e) => {
+                    updateGroqSttPromptDraft(e.currentTarget.value)
+                  }}
+                  onBlur={(e) => {
+                    flushGroqSttPromptSave(e.currentTarget.value)
+                  }}
+                  className="min-h-[80px]"
+                />
+              </Control>
+            )}
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Transcription Preview"
+                  tooltip="Show a live transcription preview while recording. Audio is sent to your STT provider every ~10 seconds to display partial results. Note: this increases API usage — each chunk is billed separately (Groq has a 10-second minimum billing per request)."
+                />
+              }
+              className="px-3"
             >
-              Re-run Onboarding
-            </Button>
-          </Control>
-        </ControlGroup>
-      </div>
+              <Switch
+                defaultChecked={configQuery.data.transcriptionPreviewEnabled}
+                onCheckedChange={(value) => {
+                  saveConfig({
+                    transcriptionPreviewEnabled: value,
+                  })
+                }}
+              />
+            </Control>
+          </ControlGroup>
+
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Text to Speech"
+            forceOpen={isSearching}
+          >
+            <Control label="Enabled" className="px-3">
+              <Switch
+                defaultChecked={configQuery.data.ttsEnabled ?? false}
+                onCheckedChange={async (value) => {
+                  if (!value) {
+                    try {
+                      await tipcClient.controlTTSPlayback({
+                        type: "stop",
+                        reason: "settings-global-tts-disabled",
+                      })
+                      await tipcClient.stopAllTts()
+                    } catch (error) {
+                      console.error("Failed to stop TTS in all windows:", error)
+                    }
+                  }
+
+                  saveConfig({
+                    ttsEnabled: value,
+                  })
+                }}
+              />
+            </Control>
+
+            {configQuery.data.ttsEnabled && (
+              <Control
+                label={
+                  <ControlLabel
+                    label="Auto-play"
+                    tooltip="Automatically play TTS audio when assistant responses complete"
+                  />
+                }
+                className="px-3"
+              >
+                <Switch
+                  defaultChecked={configQuery.data.ttsAutoPlay ?? true}
+                  onCheckedChange={(value) => {
+                    saveConfig({
+                      ttsAutoPlay: value,
+                    })
+                  }}
+                />
+              </Control>
+            )}
+
+            {configQuery.data.ttsEnabled && (
+              <div className="px-3 py-1.5">
+                <button
+                  type="button"
+                  onClick={() => navigate("/settings/models")}
+                  className="text-primary text-xs hover:underline"
+                >
+                  Configure TTS voice &amp; model →
+                </button>
+              </div>
+            )}
+
+            {configQuery.data.ttsEnabled && (
+              <>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text Preprocessing"
+                      tooltip="Enable preprocessing to make text more speech-friendly by removing code blocks, URLs, and converting markdown"
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Switch
+                    defaultChecked={
+                      configQuery.data.ttsPreprocessingEnabled ?? true
+                    }
+                    onCheckedChange={(value) => {
+                      saveConfig({
+                        ttsPreprocessingEnabled: value,
+                      })
+                    }}
+                  />
+                </Control>
+
+                {configQuery.data.ttsPreprocessingEnabled !== false && (
+                  <>
+                    <Control
+                      label={
+                        <ControlLabel
+                          label="Remove Code Blocks"
+                          tooltip="Remove code blocks and replace with descriptive text"
+                        />
+                      }
+                      className="px-3"
+                    >
+                      <Switch
+                        defaultChecked={
+                          configQuery.data.ttsRemoveCodeBlocks ?? true
+                        }
+                        onCheckedChange={(value) => {
+                          saveConfig({
+                            ttsRemoveCodeBlocks: value,
+                          })
+                        }}
+                      />
+                    </Control>
+
+                    <Control
+                      label={
+                        <ControlLabel
+                          label="Remove URLs"
+                          tooltip="Remove URLs and replace with descriptive text"
+                        />
+                      }
+                      className="px-3"
+                    >
+                      <Switch
+                        defaultChecked={configQuery.data.ttsRemoveUrls ?? true}
+                        onCheckedChange={(value) => {
+                          saveConfig({
+                            ttsRemoveUrls: value,
+                          })
+                        }}
+                      />
+                    </Control>
+
+                    <Control
+                      label={
+                        <ControlLabel
+                          label="Convert Markdown"
+                          tooltip="Convert markdown formatting to speech-friendly text"
+                        />
+                      }
+                      className="px-3"
+                    >
+                      <Switch
+                        defaultChecked={
+                          configQuery.data.ttsConvertMarkdown ?? true
+                        }
+                        onCheckedChange={(value) => {
+                          saveConfig({
+                            ttsConvertMarkdown: value,
+                          })
+                        }}
+                      />
+                    </Control>
+
+                    <Control
+                      label={
+                        <ControlLabel
+                          label="Use AI for TTS Preprocessing"
+                          tooltip="Use an LLM to intelligently convert text to natural speech. More robust handling of abbreviations, acronyms, and context-dependent pronunciation. Adds ~1-2 seconds latency. Falls back to regex if disabled or unavailable."
+                        />
+                      }
+                      className="px-3"
+                    >
+                      <Switch
+                        defaultChecked={
+                          configQuery.data.ttsUseLLMPreprocessing ?? false
+                        }
+                        onCheckedChange={(value) => {
+                          saveConfig({
+                            ttsUseLLMPreprocessing: value,
+                          })
+                        }}
+                      />
+                    </Control>
+                  </>
+                )}
+              </>
+            )}
+          </ControlGroup>
+
+          {/* Panel Position Settings */}
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Panel Position"
+            forceOpen={isSearching}
+          >
+            <Control
+              label={
+                <ControlLabel
+                  label="Default Position"
+                  tooltip="Choose where the floating panel appears on your screen. Custom position: Panel can be dragged to any location and will remember its position."
+                />
+              }
+              className="px-3"
+            >
+              <Select
+                value={configQuery.data?.panelPosition || "top-right"}
+                onValueChange={(
+                  value:
+                    | "top-left"
+                    | "top-center"
+                    | "top-right"
+                    | "bottom-left"
+                    | "bottom-center"
+                    | "bottom-right"
+                    | "custom",
+                ) => {
+                  saveConfig({
+                    panelPosition: value,
+                  })
+                  // Update panel position immediately if it's visible
+                  tipcClient.setPanelPosition({ position: value })
+                }}
+              >
+                <SelectTrigger className="w-full sm:w-[180px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="top-left">Top Left</SelectItem>
+                  <SelectItem value="top-center">Top Center</SelectItem>
+                  <SelectItem value="top-right">Top Right</SelectItem>
+                  <SelectItem value="bottom-left">Bottom Left</SelectItem>
+                  <SelectItem value="bottom-center">Bottom Center</SelectItem>
+                  <SelectItem value="bottom-right">Bottom Right</SelectItem>
+                  <SelectItem value="custom">Custom (Draggable)</SelectItem>
+                </SelectContent>
+              </Select>
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Enable Dragging"
+                  tooltip="Enable dragging to move the panel by holding the top bar."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                defaultChecked={configQuery.data?.panelDragEnabled ?? true}
+                onCheckedChange={(value) => {
+                  saveConfig({
+                    panelDragEnabled: value,
+                  })
+                }}
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Auto-Show Floating Panel"
+                  tooltip="When enabled, the floating panel automatically appears during agent sessions. When disabled, the panel only appears when manually triggered via hotkeys or menu. You can still access agent progress in the main window."
+                />
+              }
+              className="px-3"
+            >
+              <div className="space-y-2">
+                <div className="flex justify-start sm:justify-end">
+                  <Switch
+                    checked={configQuery.data?.floatingPanelAutoShow !== false}
+                    onCheckedChange={(value) => {
+                      saveConfig({
+                        floatingPanelAutoShow: value,
+                      })
+                    }}
+                  />
+                </div>
+                {configQuery.data?.floatingPanelAutoShow === false && (
+                  <div className="text-muted-foreground text-xs sm:text-right">
+                    Auto-show is off. Use the quick actions below or the tray
+                    menu to bring the floating panel back anytime.
+                  </div>
+                )}
+              </div>
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Agent Progress in Floating Panel"
+                  tooltip="When enabled, agent progress can appear in the floating panel. When disabled, agent progress stays in the main app; the voice waveform still uses the floating panel."
+                />
+              }
+              className="px-3"
+            >
+              <div className="space-y-2">
+                <div className="flex justify-start sm:justify-end">
+                  <Switch
+                    checked={
+                      configQuery.data?.floatingPanelAgentProgressEnabled !==
+                      false
+                    }
+                    onCheckedChange={(value) => {
+                      saveConfig({
+                        floatingPanelAgentProgressEnabled: value,
+                      })
+                    }}
+                  />
+                </div>
+                {configQuery.data?.floatingPanelAgentProgressEnabled ===
+                  false && (
+                  <div className="text-muted-foreground text-xs sm:text-right">
+                    Agent progress stays in the main app. Voice waveform
+                    recording still uses the floating panel.
+                  </div>
+                )}
+              </div>
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Hide Panel When Main App Focused"
+                  tooltip="When enabled, the floating panel automatically hides when the main DotAgents window is focused. The panel reappears when the main window loses focus."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.hidePanelWhenMainFocused !== false}
+                onCheckedChange={(value) => {
+                  saveConfig({
+                    hidePanelWhenMainFocused: value,
+                  })
+                }}
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Quick Actions"
+                  tooltip="Useful recovery actions if the floating panel is hidden, off-screen, or just hard to find."
+                />
+              }
+              className="px-3"
+            >
+              <div className="flex flex-wrap justify-start gap-2 sm:justify-end">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void showFloatingPanelNow()}
+                >
+                  Show Now
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void resetFloatingPanel()}
+                >
+                  Reset Position & Size
+                </Button>
+              </div>
+            </Control>
+          </ControlGroup>
+
+          {/* WhatsApp Integration */}
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="WhatsApp Integration"
+            forceOpen={isSearching}
+            endDescription={
+              <div className="whitespace-normal break-words">
+                Enable WhatsApp messaging through DotAgents.{" "}
+                <a href="/settings/whatsapp" className="underline">
+                  Configure WhatsApp settings
+                </a>
+                .
+              </div>
+            }
+          >
+            <Control
+              label={
+                <ControlLabel
+                  label="Enable WhatsApp"
+                  tooltip="When enabled, allows sending and receiving WhatsApp messages through DotAgents"
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.whatsappEnabled ?? false}
+                onCheckedChange={(value) =>
+                  saveConfig({ whatsappEnabled: value })
+                }
+              />
+            </Control>
+          </ControlGroup>
+
+          {/* Discord Integration */}
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Discord Integration"
+            // Auto-open when the user is searching or when Discord is currently
+            // disabled. The Discord settings page is hidden from the sidebar
+            // while disabled, so this section is the only place to turn it on
+            // — surface it by default until the user enables it.
+            forceOpen={
+              isSearching || !(configQuery.data?.discordEnabled ?? false)
+            }
+            endDescription={
+              <div className="whitespace-normal break-words">
+                Enable a Discord bot for DMs, mentions, and threads.{" "}
+                <a href="/settings/discord" className="underline">
+                  Configure Discord settings
+                </a>
+                .
+              </div>
+            }
+          >
+            <Control
+              label={
+                <ControlLabel
+                  label="Enable Discord"
+                  tooltip="When enabled, DotAgents can receive Discord DMs and server mentions using your configured bot token. The Discord settings page only appears in the sidebar while this is on."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.discordEnabled ?? false}
+                onCheckedChange={(value) =>
+                  saveConfig({ discordEnabled: value })
+                }
+              />
+            </Control>
+          </ControlGroup>
+
+          {/* Observability */}
+          <ControlGroup
+            collapsible
+            defaultCollapsed
+            title="Observability"
+            forceOpen={isSearching}
+            endDescription={
+              <div className="whitespace-normal break-words">
+                Optional tracing for LLM calls, agent sessions, and tools. Send
+                traces to Langfuse or keep them local as JSONL logs.{" "}
+                <a
+                  href="https://langfuse.com"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  className="inline-flex items-center gap-1 underline"
+                >
+                  Docs
+                  <ExternalLink className="h-3 w-3" />
+                </a>
+              </div>
+            }
+          >
+            <Control
+              label={
+                <ControlLabel
+                  label="Local trace logging"
+                  tooltip="Write each agent session trace to its own local JSONL file on this device. Independent of Langfuse Cloud."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.localTraceLoggingEnabled ?? false}
+                onCheckedChange={(value) => {
+                  saveConfig({ localTraceLoggingEnabled: value })
+                }}
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Langfuse tracing"
+                  tooltip="Send traces to Langfuse Cloud or a self-hosted Langfuse instance."
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={configQuery.data?.langfuseEnabled ?? false}
+                disabled={!isLangfuseInstalled}
+                onCheckedChange={(value) => {
+                  saveConfig({ langfuseEnabled: value })
+                }}
+              />
+            </Control>
+
+            {!isLangfuseInstalled && (
+              <div className="mx-3 mb-3 rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-700 dark:text-amber-300">
+                Install the optional <span className="font-mono">langfuse</span>{" "}
+                package with{" "}
+                <span className="font-mono">pnpm add langfuse</span>, then
+                restart DotAgents to enable tracing.
+              </div>
+            )}
+
+            {configQuery.data?.langfuseEnabled && (
+              <>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Public Key"
+                      tooltip="Your Langfuse project's public key"
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Input
+                    type="text"
+                    value={langfuseDrafts.langfusePublicKey}
+                    onChange={(e) =>
+                      updateLangfuseDraft(
+                        "langfusePublicKey",
+                        e.currentTarget.value,
+                      )
+                    }
+                    onBlur={(e) =>
+                      flushLangfuseSave(
+                        "langfusePublicKey",
+                        e.currentTarget.value,
+                      )
+                    }
+                    placeholder="pk-lf-..."
+                    className="w-full min-w-0 max-w-full font-mono text-xs sm:w-[360px]"
+                  />
+                </Control>
+
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Secret Key"
+                      tooltip="Your Langfuse project's secret key"
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Input
+                    type="password"
+                    value={langfuseDrafts.langfuseSecretKey}
+                    onChange={(e) =>
+                      updateLangfuseDraft(
+                        "langfuseSecretKey",
+                        e.currentTarget.value,
+                      )
+                    }
+                    onBlur={(e) =>
+                      flushLangfuseSave(
+                        "langfuseSecretKey",
+                        e.currentTarget.value,
+                      )
+                    }
+                    placeholder="sk-lf-..."
+                    className="w-full min-w-0 max-w-full font-mono text-xs sm:w-[360px]"
+                  />
+                </Control>
+
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Base URL"
+                      tooltip="Langfuse API endpoint. Leave empty for Langfuse Cloud (cloud.langfuse.com)"
+                    />
+                  }
+                  className="px-3"
+                >
+                  <Input
+                    type="text"
+                    value={langfuseDrafts.langfuseBaseUrl}
+                    onChange={(e) =>
+                      updateLangfuseDraft(
+                        "langfuseBaseUrl",
+                        e.currentTarget.value,
+                      )
+                    }
+                    onBlur={(e) =>
+                      flushLangfuseSave(
+                        "langfuseBaseUrl",
+                        e.currentTarget.value,
+                      )
+                    }
+                    placeholder="https://cloud.langfuse.com (default)"
+                    className="w-full min-w-0 max-w-full sm:w-[360px]"
+                  />
+                  <div className="text-muted-foreground mt-1 text-xs">
+                    Use this for self-hosted Langfuse instances. Leave empty for
+                    Langfuse Cloud.
+                  </div>
+                </Control>
+
+                {/* Status indicator */}
+                {configQuery.data?.langfusePublicKey &&
+                  configQuery.data?.langfuseSecretKey && (
+                    <Control label="Status" className="px-3">
+                      <div className="flex items-center gap-2">
+                        <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                        <span className="text-sm text-green-600 dark:text-green-400">
+                          Configured
+                        </span>
+                      </div>
+                      <div className="text-muted-foreground mt-1 text-xs">
+                        Traces will be sent to Langfuse for each agent session.
+                      </div>
+                    </Control>
+                  )}
+
+                {(!configQuery.data?.langfusePublicKey ||
+                  !configQuery.data?.langfuseSecretKey) && (
+                  <div className="px-3 py-2">
+                    <div className="text-sm text-amber-600 dark:text-amber-400">
+                      Enter both Public Key and Secret Key to enable tracing.
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </ControlGroup>
+
+          {/* About Section */}
+          <ControlGroup title="About">
+            <Control label="Version" className="px-3">
+              <div className="text-sm">{process.env.APP_VERSION}</div>
+            </Control>
+            <Control label="Onboarding" className="px-3">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  saveConfig({ onboardingCompleted: false })
+                  navigate("/onboarding")
+                }}
+              >
+                Re-run Onboarding
+              </Button>
+            </Control>
+          </ControlGroup>
+        </div>
       </SettingsSearchContext.Provider>
-    </div>
+    </SettingsPageShell>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -1,5 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ElementType, type ReactNode } from "react"
-import { Control, ControlGroup, ControlLabel } from "@renderer/components/ui/control"
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ElementType,
+  type ReactNode,
+} from "react"
+import {
+  Control,
+  ControlGroup,
+  ControlLabel,
+} from "@renderer/components/ui/control"
 import { Input } from "@renderer/components/ui/input"
 import { Textarea } from "@renderer/components/ui/textarea"
 import {
@@ -10,10 +22,17 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select"
 import { Switch } from "@renderer/components/ui/switch"
-import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
+import {
+  useConfigQuery,
+  useSaveConfigMutation,
+} from "@renderer/lib/query-client"
 import { ModelPresetManager } from "@renderer/components/model-preset-manager"
-import { ModelSelector, ProviderModelSelector } from "@renderer/components/model-selector"
+import {
+  ModelSelector,
+  ProviderModelSelector,
+} from "@renderer/components/model-selector"
 import { PresetModelSelector } from "@renderer/components/preset-model-selector"
+import { SettingsPageShell } from "@renderer/components/settings-navigation"
 import { Config, ModelPreset } from "@shared/types"
 import {
   STT_PROVIDERS,
@@ -59,7 +78,17 @@ function RoleProviderSelector({
 }) {
   return (
     <Control
-      label={<ControlLabel label={<span className="flex items-center gap-2"><Icon className="h-4 w-4 text-muted-foreground" />{label}</span>} tooltip={tooltip} />}
+      label={
+        <ControlLabel
+          label={
+            <span className="flex items-center gap-2">
+              <Icon className="text-muted-foreground h-4 w-4" />
+              {label}
+            </span>
+          }
+          tooltip={tooltip}
+        />
+      }
       className="px-3"
     >
       <Select value={value} onValueChange={onChange}>
@@ -81,35 +110,49 @@ function RoleProviderSelector({
 export function Component() {
   const configQuery = useConfigQuery()
   const saveConfigMutation = useSaveConfigMutation()
-  const transcriptProcessingPromptSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [transcriptProcessingPromptDraft, setTranscriptProcessingPromptDraft] = useState("")
+  const transcriptProcessingPromptSaveTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const [transcriptProcessingPromptDraft, setTranscriptProcessingPromptDraft] =
+    useState("")
 
-  const saveConfig = useCallback((updates: Partial<Config>) => {
-    if (!configQuery.data) return
-    saveConfigMutation.mutate({ config: { ...configQuery.data, ...updates } })
-  }, [configQuery.data, saveConfigMutation])
+  const saveConfig = useCallback(
+    (updates: Partial<Config>) => {
+      if (!configQuery.data) return
+      saveConfigMutation.mutate({ config: { ...configQuery.data, ...updates } })
+    },
+    [configQuery.data, saveConfigMutation],
+  )
 
-  const flushTranscriptProcessingPromptSave = useCallback((value: string) => {
-    if (transcriptProcessingPromptSaveTimeoutRef.current) {
-      clearTimeout(transcriptProcessingPromptSaveTimeoutRef.current)
-      transcriptProcessingPromptSaveTimeoutRef.current = null
-    }
-    saveConfig({ transcriptPostProcessingPrompt: value })
-  }, [saveConfig])
-
-  const updateTranscriptProcessingPromptDraft = useCallback((value: string) => {
-    setTranscriptProcessingPromptDraft(value)
-    if (transcriptProcessingPromptSaveTimeoutRef.current) {
-      clearTimeout(transcriptProcessingPromptSaveTimeoutRef.current)
-    }
-    transcriptProcessingPromptSaveTimeoutRef.current = setTimeout(() => {
-      transcriptProcessingPromptSaveTimeoutRef.current = null
+  const flushTranscriptProcessingPromptSave = useCallback(
+    (value: string) => {
+      if (transcriptProcessingPromptSaveTimeoutRef.current) {
+        clearTimeout(transcriptProcessingPromptSaveTimeoutRef.current)
+        transcriptProcessingPromptSaveTimeoutRef.current = null
+      }
       saveConfig({ transcriptPostProcessingPrompt: value })
-    }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
-  }, [saveConfig])
+    },
+    [saveConfig],
+  )
+
+  const updateTranscriptProcessingPromptDraft = useCallback(
+    (value: string) => {
+      setTranscriptProcessingPromptDraft(value)
+      if (transcriptProcessingPromptSaveTimeoutRef.current) {
+        clearTimeout(transcriptProcessingPromptSaveTimeoutRef.current)
+      }
+      transcriptProcessingPromptSaveTimeoutRef.current = setTimeout(() => {
+        transcriptProcessingPromptSaveTimeoutRef.current = null
+        saveConfig({ transcriptPostProcessingPrompt: value })
+      }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
 
   useEffect(() => {
-    setTranscriptProcessingPromptDraft(configQuery.data?.transcriptPostProcessingPrompt ?? "")
+    setTranscriptProcessingPromptDraft(
+      configQuery.data?.transcriptPostProcessingPrompt ?? "",
+    )
   }, [configQuery.data?.transcriptPostProcessingPrompt])
 
   useEffect(() => {
@@ -127,12 +170,19 @@ export function Component() {
       const saved = custom.find((candidate) => candidate.id === preset.id)
       if (saved) {
         const merged = { ...preset, ...saved }
-        if (preset.id === DEFAULT_MODEL_PRESET_ID && !merged.apiKey && configQuery.data?.openaiApiKey) {
+        if (
+          preset.id === DEFAULT_MODEL_PRESET_ID &&
+          !merged.apiKey &&
+          configQuery.data?.openaiApiKey
+        ) {
           merged.apiKey = configQuery.data.openaiApiKey
         }
         return merged
       }
-      if (preset.id === DEFAULT_MODEL_PRESET_ID && configQuery.data?.openaiApiKey) {
+      if (
+        preset.id === DEFAULT_MODEL_PRESET_ID &&
+        configQuery.data?.openaiApiKey
+      ) {
         return { ...preset, apiKey: configQuery.data.openaiApiKey }
       }
       return preset
@@ -141,62 +191,78 @@ export function Component() {
     return [...mergedBuiltIn, ...custom.filter((preset) => !preset.isBuiltIn)]
   }, [configQuery.data?.modelPresets, configQuery.data?.openaiApiKey])
 
-  const getPresetById = useCallback((presetId?: string): ModelPreset | undefined => {
-    if (!presetId) return undefined
-    return allPresets.find((preset) => preset.id === presetId)
-  }, [allPresets])
+  const getPresetById = useCallback(
+    (presetId?: string): ModelPreset | undefined => {
+      if (!presetId) return undefined
+      return allPresets.find((preset) => preset.id === presetId)
+    },
+    [allPresets],
+  )
 
   if (!configQuery.data) return null
 
   const config = configQuery.data
   const sttProviderId = config.sttProviderId || "openai"
-  const transcriptProcessingProviderId = config.transcriptPostProcessingProviderId || "openai"
+  const transcriptProcessingProviderId =
+    config.transcriptPostProcessingProviderId || "openai"
   const ttsProviderId = config.ttsProviderId || "openai"
-  const agentProviderId = config.agentProviderId || config.mcpToolsProviderId || "openai"
-  const transcriptProcessingEnabled = config.transcriptPostProcessingEnabled ?? false
+  const agentProviderId =
+    config.agentProviderId || config.mcpToolsProviderId || "openai"
+  const transcriptProcessingEnabled =
+    config.transcriptPostProcessingEnabled ?? false
   const usesOpenAiCompatiblePreset =
     agentProviderId === "openai" ||
     (transcriptProcessingEnabled && transcriptProcessingProviderId === "openai")
-  const transcriptProcessingModel = transcriptProcessingProviderId === "openai"
-    ? config.transcriptPostProcessingOpenaiModel
-    : transcriptProcessingProviderId === "groq"
-      ? config.transcriptPostProcessingGroqModel
-      : transcriptProcessingProviderId === "gemini"
-        ? config.transcriptPostProcessingGeminiModel
-        : config.transcriptPostProcessingChatgptWebModel
+  const transcriptProcessingModel =
+    transcriptProcessingProviderId === "openai"
+      ? config.transcriptPostProcessingOpenaiModel
+      : transcriptProcessingProviderId === "groq"
+        ? config.transcriptPostProcessingGroqModel
+        : transcriptProcessingProviderId === "gemini"
+          ? config.transcriptPostProcessingGeminiModel
+          : config.transcriptPostProcessingChatgptWebModel
 
   return (
-    <div className="mx-auto max-w-4xl px-6 pb-10 pt-8">
-      <div className="space-y-6">
-        <div className="rounded-lg border bg-muted/20 px-4 py-3">
+    <SettingsPageShell>
+      <div className="space-y-4">
+        <div className="bg-muted/20 rounded-lg border px-4 py-3">
           <h2 className="text-sm font-semibold">Model Selection</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Choose which provider powers each job, then pick the model or voice for that job here. API keys, base URLs,
-            and local engine downloads live on the Providers page.
+          <p className="text-muted-foreground mt-1 text-sm">
+            Choose which provider powers each job, then pick the model, voice,
+            or local engine used for that job.
           </p>
         </div>
 
         <ControlGroup title="Agent Models">
-          <div className="mx-3 my-2 rounded-md border border-muted bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-            Choose which model powers the main agent. OpenAI-compatible presets can carry both an agent model and a transcript processing model.
+          <div className="border-muted bg-muted/30 text-muted-foreground mx-3 my-2 rounded-md border px-3 py-2 text-xs">
+            Choose which model powers the main agent. OpenAI-compatible presets
+            can carry both an agent model and a transcript processing model.
           </div>
 
           {usesOpenAiCompatiblePreset && (
-            <div className="px-3 py-2 border-b">
+            <div className="border-b px-3 py-2">
               <div className="pb-3">
-                <span className="text-sm font-medium">OpenAI-Compatible Preset</span>
-                <p className="text-xs text-muted-foreground">
-                  Use this when Agent or Transcript Processing is set to OpenAI-compatible.
+                <span className="text-sm font-medium">
+                  OpenAI-Compatible Preset
+                </span>
+                <p className="text-muted-foreground text-xs">
+                  Use this when Agent or Transcript Processing is set to
+                  OpenAI-compatible.
                 </p>
               </div>
               <ModelPresetManager
                 showAgentModel={agentProviderId === "openai"}
-                showTranscriptCleanupModel={transcriptProcessingEnabled && transcriptProcessingProviderId === "openai"}
+                showTranscriptCleanupModel={
+                  transcriptProcessingEnabled &&
+                  transcriptProcessingProviderId === "openai"
+                }
               />
             </div>
           )}
 
-          {(agentProviderId === "groq" || agentProviderId === "gemini" || agentProviderId === "chatgpt-web") && (
+          {(agentProviderId === "groq" ||
+            agentProviderId === "gemini" ||
+            agentProviderId === "chatgpt-web") && (
             <div className="px-3 py-2">
               <ProviderModelSelector
                 providerId={agentProviderId}
@@ -205,7 +271,8 @@ export function Component() {
                     ? config.agentGroqModel || config.mcpToolsGroqModel
                     : agentProviderId === "gemini"
                       ? config.agentGeminiModel || config.mcpToolsGeminiModel
-                      : config.agentChatgptWebModel || config.mcpToolsChatgptWebModel
+                      : config.agentChatgptWebModel ||
+                        config.mcpToolsChatgptWebModel
                 }
                 onMcpModelChange={(value) =>
                   saveConfig(
@@ -226,18 +293,25 @@ export function Component() {
             <div className="border-t px-3 py-2">
               <div className="pb-2">
                 <span className="text-sm font-medium">Codex options</span>
-                <p className="text-xs text-muted-foreground">
-                  Tune how the Codex (ChatGPT Web) model thinks and how verbose its replies are.
+                <p className="text-muted-foreground text-xs">
+                  Tune how the Codex (ChatGPT Web) model thinks and how verbose
+                  its replies are.
                 </p>
               </div>
               <Control
-                label={<ControlLabel label="Thinking level" tooltip="Reasoning effort sent to Codex reasoning models. Defaults to Low when unset. 'None' lets the provider answer with no extra reasoning." />}
+                label={
+                  <ControlLabel
+                    label="Thinking level"
+                    tooltip="Reasoning effort sent to Codex reasoning models. Defaults to Low when unset. 'None' lets the provider answer with no extra reasoning."
+                  />
+                }
               >
                 <Select
                   value={config.openaiReasoningEffort || "low"}
                   onValueChange={(value) =>
                     saveConfig({
-                      openaiReasoningEffort: value as Config["openaiReasoningEffort"],
+                      openaiReasoningEffort:
+                        value as Config["openaiReasoningEffort"],
                     })
                   }
                 >
@@ -255,7 +329,12 @@ export function Component() {
                 </Select>
               </Control>
               <Control
-                label={<ControlLabel label="Verbosity" tooltip="Output verbosity passed as text.verbosity in the Codex responses payload." />}
+                label={
+                  <ControlLabel
+                    label="Verbosity"
+                    tooltip="Output verbosity passed as text.verbosity in the Codex responses payload."
+                  />
+                }
               >
                 <Select
                   value={config.codexTextVerbosity || "medium"}
@@ -279,19 +358,21 @@ export function Component() {
           )}
 
           {!usesOpenAiCompatiblePreset && agentProviderId === "openai" && (
-            <p className="px-3 py-2 text-sm text-muted-foreground">
-              OpenAI-compatible preset controls appear here when Agent or Transcript Processing uses that provider.
+            <p className="text-muted-foreground px-3 py-2 text-sm">
+              OpenAI-compatible preset controls appear here when Agent or
+              Transcript Processing uses that provider.
             </p>
           )}
         </ControlGroup>
-
 
         <ControlGroup title="Choose a Provider for Each Job" collapsible>
           <RoleProviderSelector
             label="Speech-to-Text"
             tooltip="Choose which provider listens to your audio and turns it into text."
             value={sttProviderId}
-            onChange={(value) => saveConfig({ sttProviderId: value as STT_PROVIDER_ID })}
+            onChange={(value) =>
+              saveConfig({ sttProviderId: value as STT_PROVIDER_ID })
+            }
             providers={STT_PROVIDERS}
             icon={Mic}
           />
@@ -300,7 +381,9 @@ export function Component() {
             label="Text-to-Speech"
             tooltip="Choose which provider turns text back into audio."
             value={ttsProviderId}
-            onChange={(value) => saveConfig({ ttsProviderId: value as TTS_PROVIDER_ID })}
+            onChange={(value) =>
+              saveConfig({ ttsProviderId: value as TTS_PROVIDER_ID })
+            }
             providers={TTS_PROVIDERS}
             icon={Volume2}
           />
@@ -309,7 +392,9 @@ export function Component() {
             label="Agent"
             tooltip="Choose which provider powers the main agent model for reasoning, skills, and tools."
             value={agentProviderId}
-            onChange={(value) => saveConfig({ agentProviderId: value as CHAT_PROVIDER_ID })}
+            onChange={(value) =>
+              saveConfig({ agentProviderId: value as CHAT_PROVIDER_ID })
+            }
             providers={CHAT_PROVIDERS}
             icon={Bot}
           />
@@ -317,12 +402,19 @@ export function Component() {
 
         <ControlGroup title="Transcript Processing" collapsible>
           <Control
-            label={<ControlLabel label="Enabled" tooltip="Optionally clean up punctuation, formatting, or wording after transcription and before the transcript is used elsewhere." />}
+            label={
+              <ControlLabel
+                label="Enabled"
+                tooltip="Optionally clean up punctuation, formatting, or wording after transcription and before the transcript is used elsewhere."
+              />
+            }
             className="px-3"
           >
             <Switch
               checked={transcriptProcessingEnabled}
-              onCheckedChange={(checked) => saveConfig({ transcriptPostProcessingEnabled: checked })}
+              onCheckedChange={(checked) =>
+                saveConfig({ transcriptPostProcessingEnabled: checked })
+              }
             />
           </Control>
 
@@ -332,7 +424,12 @@ export function Component() {
                 label="Provider"
                 tooltip="Choose which provider handles transcript processing when it is enabled."
                 value={transcriptProcessingProviderId}
-                onChange={(value) => saveConfig({ transcriptPostProcessingProviderId: value as CHAT_PROVIDER_ID })}
+                onChange={(value) =>
+                  saveConfig({
+                    transcriptPostProcessingProviderId:
+                      value as CHAT_PROVIDER_ID,
+                  })
+                }
                 providers={CHAT_PROVIDERS}
                 icon={FileText}
               />
@@ -340,10 +437,16 @@ export function Component() {
               <div className="border-t px-3 py-2">
                 {transcriptProcessingProviderId === "openai" ? (
                   <Control
-                    label={<ControlLabel label="Transcript Processing model" tooltip="OpenAI-compatible transcript processing is selected through the preset section below." />}
+                    label={
+                      <ControlLabel
+                        label="Transcript Processing model"
+                        tooltip="OpenAI-compatible transcript processing is selected through the preset section below."
+                      />
+                    }
                   >
-                    <p className="text-sm text-muted-foreground">
-                      OpenAI-compatible transcript processing models are selected in the OpenAI-Compatible Preset section below.
+                    <p className="text-muted-foreground text-sm">
+                      OpenAI-compatible transcript processing models are
+                      selected in the OpenAI-Compatible Preset section below.
                     </p>
                   </Control>
                 ) : (
@@ -354,9 +457,13 @@ export function Component() {
                       if (transcriptProcessingProviderId === "groq") {
                         saveConfig({ transcriptPostProcessingGroqModel: value })
                       } else if (transcriptProcessingProviderId === "gemini") {
-                        saveConfig({ transcriptPostProcessingGeminiModel: value })
+                        saveConfig({
+                          transcriptPostProcessingGeminiModel: value,
+                        })
                       } else {
-                        saveConfig({ transcriptPostProcessingChatgptWebModel: value })
+                        saveConfig({
+                          transcriptPostProcessingChatgptWebModel: value,
+                        })
                       }
                     }}
                     label="Transcript Processing model"
@@ -367,20 +474,32 @@ export function Component() {
               </div>
 
               <Control
-                label={<ControlLabel label="Prompt" tooltip="Custom prompt for transcript processing. Use {transcript} to insert the original transcript." />}
+                label={
+                  <ControlLabel
+                    label="Prompt"
+                    tooltip="Custom prompt for transcript processing. Use {transcript} to insert the original transcript."
+                  />
+                }
                 className="border-t px-3 py-2"
               >
                 <div className="w-full space-y-2">
                   <Textarea
                     rows={6}
                     value={transcriptProcessingPromptDraft}
-                    onChange={(e) => updateTranscriptProcessingPromptDraft(e.currentTarget.value)}
-                    onBlur={(e) => flushTranscriptProcessingPromptSave(e.currentTarget.value)}
+                    onChange={(e) =>
+                      updateTranscriptProcessingPromptDraft(
+                        e.currentTarget.value,
+                      )
+                    }
+                    onBlur={(e) =>
+                      flushTranscriptProcessingPromptSave(e.currentTarget.value)
+                    }
                     placeholder="Custom instructions for transcript processing..."
                     className="min-h-[120px]"
                   />
-                  <p className="text-xs text-muted-foreground">
-                    Use <span className="select-text">{"{transcript}"}</span> to insert the original transcript.
+                  <p className="text-muted-foreground text-xs">
+                    Use <span className="select-text">{"{transcript}"}</span> to
+                    insert the original transcript.
                   </p>
                 </div>
               </Control>
@@ -392,17 +511,33 @@ export function Component() {
           <div className="px-3 py-2">
             {sttProviderId === "parakeet" ? (
               <Control
-                label={<ControlLabel label="Speech-to-Text model" tooltip="Parakeet uses the local speech-to-text model bundle managed on the Providers page." />}
+                label={
+                  <ControlLabel
+                    label="Speech-to-Text model"
+                    tooltip="Parakeet uses the local speech-to-text model bundle managed in Providers."
+                  />
+                }
               >
-                <p className="text-sm text-muted-foreground">
-                  Parakeet uses its local downloaded model bundle. Manage installation and runtime settings on Providers.
+                <p className="text-muted-foreground text-sm">
+                  Parakeet uses its local downloaded model bundle. Manage
+                  installation and runtime settings on Providers.
                 </p>
               </Control>
             ) : (
               <ModelSelector
                 providerId={sttProviderId}
-                value={sttProviderId === "openai" ? config.openaiSttModel || getDefaultSttModel("openai") : config.groqSttModel || getDefaultSttModel("groq")}
-                onValueChange={(value) => saveConfig(sttProviderId === "openai" ? { openaiSttModel: value } : { groqSttModel: value })}
+                value={
+                  sttProviderId === "openai"
+                    ? config.openaiSttModel || getDefaultSttModel("openai")
+                    : config.groqSttModel || getDefaultSttModel("groq")
+                }
+                onValueChange={(value) =>
+                  saveConfig(
+                    sttProviderId === "openai"
+                      ? { openaiSttModel: value }
+                      : { groqSttModel: value },
+                  )
+                }
                 label="Speech-to-Text model"
                 placeholder="Select model for speech transcription"
                 onlyTranscriptionModels={true}
@@ -412,33 +547,92 @@ export function Component() {
 
           <div className="border-t px-3 py-2">
             <div className="pb-2">
-              <span className="text-sm font-medium">Text-to-Speech model and voice</span>
-              <p className="text-xs text-muted-foreground">
-                Pick the voice stack for the currently selected text-to-speech provider.
+              <span className="text-sm font-medium">
+                Text-to-Speech model and voice
+              </span>
+              <p className="text-muted-foreground text-xs">
+                Pick the voice stack for the currently selected text-to-speech
+                provider.
               </p>
             </div>
 
             {ttsProviderId === "openai" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the OpenAI TTS model to use." />}>
-                  <Select value={config.openaiTtsModel || "gpt-4o-mini-tts"} onValueChange={(value) => saveConfig({ openaiTtsModel: value as "gpt-4o-mini-tts" | "tts-1" | "tts-1-hd" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech model"
+                      tooltip="Choose the OpenAI TTS model to use."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.openaiTtsModel || "gpt-4o-mini-tts"}
+                    onValueChange={(value) =>
+                      saveConfig({
+                        openaiTtsModel: value as
+                          | "gpt-4o-mini-tts"
+                          | "tts-1"
+                          | "tts-1-hd",
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {OPENAI_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {OPENAI_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>
+                          {model.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for OpenAI TTS." />}>
-                  <Select value={config.openaiTtsVoice || "alloy"} onValueChange={(value) => saveConfig({ openaiTtsVoice: value as "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech voice"
+                      tooltip="Choose the voice for OpenAI TTS."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.openaiTtsVoice || "alloy"}
+                    onValueChange={(value) =>
+                      saveConfig({
+                        openaiTtsVoice: value as
+                          | "alloy"
+                          | "echo"
+                          | "fable"
+                          | "onyx"
+                          | "nova"
+                          | "shimmer",
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {OPENAI_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {OPENAI_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>
+                          {voice.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Text-to-Speech speed" tooltip="Speech speed between 0.25 and 4.0." />}>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech speed"
+                      tooltip="Speech speed between 0.25 and 4.0."
+                    />
+                  }
+                >
                   <Input
                     type="number"
                     min="0.25"
@@ -459,30 +653,75 @@ export function Component() {
 
             {ttsProviderId === "groq" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Groq TTS model to use." />}>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech model"
+                      tooltip="Choose the Groq TTS model to use."
+                    />
+                  }
+                >
                   <Select
-                    value={config.groqTtsModel || "canopylabs/orpheus-v1-english"}
+                    value={
+                      config.groqTtsModel || "canopylabs/orpheus-v1-english"
+                    }
                     onValueChange={(value) => {
-                      const defaultVoice = value === "canopylabs/orpheus-arabic-saudi" ? "fahad" : "troy"
-                      saveConfig({ groqTtsModel: value as "canopylabs/orpheus-v1-english" | "canopylabs/orpheus-arabic-saudi", groqTtsVoice: defaultVoice })
+                      const defaultVoice =
+                        value === "canopylabs/orpheus-arabic-saudi"
+                          ? "fahad"
+                          : "troy"
+                      saveConfig({
+                        groqTtsModel: value as
+                          | "canopylabs/orpheus-v1-english"
+                          | "canopylabs/orpheus-arabic-saudi",
+                        groqTtsVoice: defaultVoice,
+                      })
                     }}
                   >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {GROQ_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {GROQ_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>
+                          {model.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Groq TTS." />}>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech voice"
+                      tooltip="Choose the voice for Groq TTS."
+                    />
+                  }
+                >
                   <Select
-                    value={config.groqTtsVoice || (config.groqTtsModel === "canopylabs/orpheus-arabic-saudi" ? "fahad" : "troy")}
-                    onValueChange={(value) => saveConfig({ groqTtsVoice: value })}
+                    value={
+                      config.groqTtsVoice ||
+                      (config.groqTtsModel === "canopylabs/orpheus-arabic-saudi"
+                        ? "fahad"
+                        : "troy")
+                    }
+                    onValueChange={(value) =>
+                      saveConfig({ groqTtsVoice: value })
+                    }
                   >
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {(config.groqTtsModel === "canopylabs/orpheus-arabic-saudi" ? GROQ_TTS_VOICES_ARABIC : GROQ_TTS_VOICES_ENGLISH).map((voice) => (
-                        <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>
+                      {(config.groqTtsModel ===
+                      "canopylabs/orpheus-arabic-saudi"
+                        ? GROQ_TTS_VOICES_ARABIC
+                        : GROQ_TTS_VOICES_ENGLISH
+                      ).map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>
+                          {voice.label}
+                        </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -492,20 +731,62 @@ export function Component() {
 
             {ttsProviderId === "gemini" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Gemini TTS model to use." />}>
-                  <Select value={config.geminiTtsModel || "gemini-2.5-flash-preview-tts"} onValueChange={(value) => saveConfig({ geminiTtsModel: value as "gemini-2.5-flash-preview-tts" | "gemini-2.5-pro-preview-tts" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech model"
+                      tooltip="Choose the Gemini TTS model to use."
+                    />
+                  }
+                >
+                  <Select
+                    value={
+                      config.geminiTtsModel || "gemini-2.5-flash-preview-tts"
+                    }
+                    onValueChange={(value) =>
+                      saveConfig({
+                        geminiTtsModel: value as
+                          | "gemini-2.5-flash-preview-tts"
+                          | "gemini-2.5-pro-preview-tts",
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {GEMINI_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {GEMINI_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>
+                          {model.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Gemini TTS." />}>
-                  <Select value={config.geminiTtsVoice || "Kore"} onValueChange={(value) => saveConfig({ geminiTtsVoice: value })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech voice"
+                      tooltip="Choose the voice for Gemini TTS."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.geminiTtsVoice || "Kore"}
+                    onValueChange={(value) =>
+                      saveConfig({ geminiTtsVoice: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {GEMINI_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {GEMINI_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>
+                          {voice.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
@@ -514,25 +795,68 @@ export function Component() {
 
             {ttsProviderId === "edge" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech model" tooltip="Choose the Edge TTS model to use." />}>
-                  <Select value={config.edgeTtsModel || "edge-tts"} onValueChange={(value) => saveConfig({ edgeTtsModel: value as "edge-tts" })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech model"
+                      tooltip="Choose the Edge TTS model to use."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.edgeTtsModel || "edge-tts"}
+                    onValueChange={(value) =>
+                      saveConfig({ edgeTtsModel: value as "edge-tts" })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {EDGE_TTS_MODELS.map((model) => <SelectItem key={model.value} value={model.value}>{model.label}</SelectItem>)}
+                      {EDGE_TTS_MODELS.map((model) => (
+                        <SelectItem key={model.value} value={model.value}>
+                          {model.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the voice for Edge TTS." />}>
-                  <Select value={config.edgeTtsVoice || "en-US-AriaNeural"} onValueChange={(value) => saveConfig({ edgeTtsVoice: value })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech voice"
+                      tooltip="Choose the voice for Edge TTS."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.edgeTtsVoice || "en-US-AriaNeural"}
+                    onValueChange={(value) =>
+                      saveConfig({ edgeTtsVoice: value })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {EDGE_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {EDGE_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>
+                          {voice.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Text-to-Speech speed" tooltip="Speech speed between 0.5 and 2.0." />}>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech speed"
+                      tooltip="Speech speed between 0.5 and 2.0."
+                    />
+                  }
+                >
                   <Input
                     type="number"
                     min="0.5"
@@ -548,45 +872,113 @@ export function Component() {
                     }}
                   />
                 </Control>
-                <p className="pb-2 text-xs text-muted-foreground">Edge TTS is cloud-based and does not require an API key.</p>
+                <p className="text-muted-foreground pb-2 text-xs">
+                  Edge TTS is cloud-based and does not require an API key.
+                </p>
               </>
             )}
 
             {ttsProviderId === "kitten" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Choose the local Kitten voice to use." />}>
-                  <Select value={String(config.kittenVoiceId ?? 0)} onValueChange={(value) => saveConfig({ kittenVoiceId: parseInt(value) })}>
-                    <SelectTrigger><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech voice"
+                      tooltip="Choose the local Kitten voice to use."
+                    />
+                  }
+                >
+                  <Select
+                    value={String(config.kittenVoiceId ?? 0)}
+                    onValueChange={(value) =>
+                      saveConfig({ kittenVoiceId: parseInt(value) })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {KITTEN_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={String(voice.value)}>{voice.label}</SelectItem>)}
+                      {KITTEN_TTS_VOICES.map((voice) => (
+                        <SelectItem
+                          key={voice.value}
+                          value={String(voice.value)}
+                        >
+                          {voice.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
-                <p className="pb-2 text-xs text-muted-foreground">Kitten download and voice testing live on Providers.</p>
+                <p className="text-muted-foreground pb-2 text-xs">
+                  Kitten download and voice testing live on Providers.
+                </p>
               </>
             )}
 
             {ttsProviderId === "supertonic" && (
               <>
-                <Control label={<ControlLabel label="Text-to-Speech voice" tooltip="Select the Supertonic voice style." />}>
-                  <Select value={config.supertonicVoice ?? "M1"} onValueChange={(value) => saveConfig({ supertonicVoice: value })}>
-                    <SelectTrigger className="w-full sm:w-[180px]"><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Text-to-Speech voice"
+                      tooltip="Select the Supertonic voice style."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.supertonicVoice ?? "M1"}
+                    onValueChange={(value) =>
+                      saveConfig({ supertonicVoice: value })
+                    }
+                  >
+                    <SelectTrigger className="w-full sm:w-[180px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {SUPERTONIC_TTS_VOICES.map((voice) => <SelectItem key={voice.value} value={voice.value}>{voice.label}</SelectItem>)}
+                      {SUPERTONIC_TTS_VOICES.map((voice) => (
+                        <SelectItem key={voice.value} value={voice.value}>
+                          {voice.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Language" tooltip="Select the language for speech synthesis." />}>
-                  <Select value={config.supertonicLanguage ?? "en"} onValueChange={(value) => saveConfig({ supertonicLanguage: value })}>
-                    <SelectTrigger className="w-full sm:w-[180px]"><SelectValue /></SelectTrigger>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Language"
+                      tooltip="Select the language for speech synthesis."
+                    />
+                  }
+                >
+                  <Select
+                    value={config.supertonicLanguage ?? "en"}
+                    onValueChange={(value) =>
+                      saveConfig({ supertonicLanguage: value })
+                    }
+                  >
+                    <SelectTrigger className="w-full sm:w-[180px]">
+                      <SelectValue />
+                    </SelectTrigger>
                     <SelectContent>
-                      {SUPERTONIC_TTS_LANGUAGES.map((language) => <SelectItem key={language.value} value={language.value}>{language.label}</SelectItem>)}
+                      {SUPERTONIC_TTS_LANGUAGES.map((language) => (
+                        <SelectItem key={language.value} value={language.value}>
+                          {language.label}
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                 </Control>
 
-                <Control label={<ControlLabel label="Speed" tooltip="Speech speed multiplier." />}>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Speed"
+                      tooltip="Speech speed multiplier."
+                    />
+                  }
+                >
                   <Input
                     type="number"
                     min={0.5}
@@ -603,7 +995,14 @@ export function Component() {
                   />
                 </Control>
 
-                <Control label={<ControlLabel label="Quality Steps" tooltip="Higher values improve quality but slow synthesis." />}>
+                <Control
+                  label={
+                    <ControlLabel
+                      label="Quality Steps"
+                      tooltip="Higher values improve quality but slow synthesis."
+                    />
+                  }
+                >
                   <Input
                     type="number"
                     min={2}
@@ -619,13 +1018,14 @@ export function Component() {
                     }}
                   />
                 </Control>
-                <p className="pb-2 text-xs text-muted-foreground">Supertonic downloads and quick voice tests live on Providers.</p>
+                <p className="text-muted-foreground pb-2 text-xs">
+                  Supertonic downloads and quick voice tests live on Providers.
+                </p>
               </>
             )}
           </div>
         </ControlGroup>
-
       </div>
-    </div>
+    </SettingsPageShell>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -14,11 +14,23 @@ import {
   useConfigQuery,
   useSaveConfigMutation,
 } from "@renderer/lib/query-client"
+import { SettingsPageShell } from "@renderer/components/settings-navigation"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { Config } from "@shared/types"
 import { copyTextToClipboard } from "@renderer/lib/clipboard"
 
-import { Mic, Bot, Volume2, FileText, CheckCircle2, ChevronDown, ChevronRight, Cpu, Download, Loader2 } from "lucide-react"
+import {
+  Mic,
+  Bot,
+  Volume2,
+  FileText,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Cpu,
+  Download,
+  Loader2,
+} from "lucide-react"
 
 import { getSelectableMainAcpAgents } from "./settings-general-main-agent-options"
 
@@ -30,7 +42,9 @@ type ProviderDraftKey =
   | "geminiApiKey"
   | "geminiBaseUrl"
 
-function getProviderDrafts(config?: Config | null): Record<ProviderDraftKey, string> {
+function getProviderDrafts(
+  config?: Config | null,
+): Record<ProviderDraftKey, string> {
   return {
     groqApiKey: config?.groqApiKey || "",
     groqBaseUrl: config?.groqBaseUrl || "",
@@ -40,9 +54,15 @@ function getProviderDrafts(config?: Config | null): Record<ProviderDraftKey, str
 }
 
 // Badge component to show which features are using this provider
-function ActiveProviderBadge({ label, icon: Icon }: { label: string; icon: React.ElementType }) {
+function ActiveProviderBadge({
+  label,
+  icon: Icon,
+}: {
+  label: string
+  icon: React.ElementType
+}) {
   return (
-    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20">
+    <span className="bg-primary/10 text-primary border-primary/20 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium">
       <Icon className="h-3 w-3" />
       {label}
     </span>
@@ -61,7 +81,7 @@ function ParakeetModelDownload() {
     // Poll while downloading (either local state or server state) to keep progress updated
     refetchInterval: (query) => {
       const status = query.state.data as { downloading?: boolean } | undefined
-      return (isDownloading || status?.downloading) ? 500 : false
+      return isDownloading || status?.downloading ? 500 : false
     },
   })
 
@@ -79,10 +99,17 @@ function ParakeetModelDownload() {
     }
   }
 
-  const status = modelStatusQuery.data as { downloaded: boolean; downloading: boolean; progress: number; error?: string } | undefined
+  const status = modelStatusQuery.data as
+    | {
+        downloaded: boolean
+        downloading: boolean
+        progress: number
+        error?: string
+      }
+    | undefined
 
   if (modelStatusQuery.isLoading) {
-    return <span className="text-xs text-muted-foreground">Checking...</span>
+    return <span className="text-muted-foreground text-xs">Checking...</span>
   }
 
   if (status?.downloaded) {
@@ -97,16 +124,16 @@ function ParakeetModelDownload() {
   if (status?.downloading || isDownloading) {
     const progress = status?.progress ?? downloadProgress
     return (
-      <div className="flex flex-col gap-1.5 w-full">
+      <div className="flex w-full flex-col gap-1.5">
         <div className="flex items-center gap-2">
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
-          <span className="text-xs text-muted-foreground">
+          <Loader2 className="text-primary h-3.5 w-3.5 animate-spin" />
+          <span className="text-muted-foreground text-xs">
             Downloading... {Math.round(progress * 100)}%
           </span>
         </div>
-        <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
+        <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
           <div
-            className="h-full bg-primary transition-all duration-200"
+            className="bg-primary h-full transition-all duration-200"
             style={{ width: `${progress * 100}%` }}
           />
         </div>
@@ -117,9 +144,9 @@ function ParakeetModelDownload() {
   if (status?.error) {
     return (
       <div className="flex flex-col gap-1.5">
-        <span className="text-xs text-destructive">{status.error}</span>
+        <span className="text-destructive text-xs">{status.error}</span>
         <Button size="sm" variant="outline" onClick={handleDownload}>
-          <Download className="h-3.5 w-3.5 mr-1.5" />
+          <Download className="mr-1.5 h-3.5 w-3.5" />
           Retry
         </Button>
       </div>
@@ -128,7 +155,7 @@ function ParakeetModelDownload() {
 
   return (
     <Button size="sm" variant="outline" onClick={handleDownload}>
-      <Download className="h-3.5 w-3.5 mr-1.5" />
+      <Download className="mr-1.5 h-3.5 w-3.5" />
       Download (~200MB)
     </Button>
   )
@@ -151,37 +178,41 @@ function ParakeetProviderSection({
   onNumThreadsChange: (value: number) => void
 }) {
   return (
-    <div className={`rounded-lg border ${isActive ? 'border-primary/30 bg-primary/5' : ''}`}>
+    <div
+      className={`rounded-lg border ${isActive ? "border-primary/30 bg-primary/5" : ""}`}
+    >
       <button
         type="button"
-        className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
+        className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
         onClick={onToggleCollapse}
         aria-expanded={!isCollapsed}
         aria-controls="parakeet-provider-content"
       >
         <span className="flex items-center gap-2 text-sm font-semibold">
           {isCollapsed ? (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            <ChevronRight className="text-muted-foreground h-4 w-4" />
           ) : (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            <ChevronDown className="text-muted-foreground h-4 w-4" />
           )}
           <Cpu className="h-4 w-4" />
           Parakeet (Local)
-          {isActive && (
-            <CheckCircle2 className="h-4 w-4 text-primary" />
-          )}
+          {isActive && <CheckCircle2 className="text-primary h-4 w-4" />}
         </span>
         {isActive && usageBadges.length > 0 && (
-          <div className="flex gap-1.5 flex-wrap justify-end">
+          <div className="flex flex-wrap justify-end gap-1.5">
             {usageBadges.map((badge) => (
-              <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+              <ActiveProviderBadge
+                key={badge.label}
+                label={badge.label}
+                icon={badge.icon}
+              />
             ))}
           </div>
         )}
       </button>
       {!isCollapsed && (
         <div id="parakeet-provider-content" className="divide-y border-t">
-          <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+          <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
             {isActive
               ? "Local speech-to-text with NVIDIA Parakeet on your device."
               : "Not selected above. You can still configure it here."}
@@ -243,7 +274,7 @@ function KittenModelDownload() {
     // Poll while downloading (either local state or server state) to keep progress updated
     refetchInterval: (query) => {
       const status = query.state.data as { downloading?: boolean } | undefined
-      return (isDownloading || status?.downloading) ? 500 : false
+      return isDownloading || status?.downloading ? 500 : false
     },
   })
 
@@ -261,10 +292,17 @@ function KittenModelDownload() {
     }
   }
 
-  const status = modelStatusQuery.data as { downloaded: boolean; downloading: boolean; progress: number; error?: string } | undefined
+  const status = modelStatusQuery.data as
+    | {
+        downloaded: boolean
+        downloading: boolean
+        progress: number
+        error?: string
+      }
+    | undefined
 
   if (modelStatusQuery.isLoading) {
-    return <span className="text-xs text-muted-foreground">Checking...</span>
+    return <span className="text-muted-foreground text-xs">Checking...</span>
   }
 
   if (status?.downloaded) {
@@ -279,16 +317,16 @@ function KittenModelDownload() {
   if (status?.downloading || isDownloading) {
     const progress = status?.progress ?? downloadProgress
     return (
-      <div className="flex flex-col gap-1.5 w-full">
+      <div className="flex w-full flex-col gap-1.5">
         <div className="flex items-center gap-2">
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
-          <span className="text-xs text-muted-foreground">
+          <Loader2 className="text-primary h-3.5 w-3.5 animate-spin" />
+          <span className="text-muted-foreground text-xs">
             Downloading... {Math.round(progress * 100)}%
           </span>
         </div>
-        <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
+        <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
           <div
-            className="h-full bg-primary transition-all duration-200"
+            className="bg-primary h-full transition-all duration-200"
             style={{ width: `${progress * 100}%` }}
           />
         </div>
@@ -299,9 +337,9 @@ function KittenModelDownload() {
   if (status?.error) {
     return (
       <div className="flex flex-col gap-1.5">
-        <span className="text-xs text-destructive">{status.error}</span>
+        <span className="text-destructive text-xs">{status.error}</span>
         <Button size="sm" variant="outline" onClick={handleDownload}>
-          <Download className="h-3.5 w-3.5 mr-1.5" />
+          <Download className="mr-1.5 h-3.5 w-3.5" />
           Retry
         </Button>
       </div>
@@ -310,7 +348,7 @@ function KittenModelDownload() {
 
   return (
     <Button size="sm" variant="outline" onClick={handleDownload}>
-      <Download className="h-3.5 w-3.5 mr-1.5" />
+      <Download className="mr-1.5 h-3.5 w-3.5" />
       Download (~24MB)
     </Button>
   )
@@ -335,15 +373,22 @@ function KittenProviderSection({
     queryKey: ["kittenModelStatus"],
     queryFn: () => window.electron.ipcRenderer.invoke("getKittenModelStatus"),
   })
-  const modelDownloaded = (modelStatusQuery.data as { downloaded: boolean } | undefined)?.downloaded ?? false
+  const modelDownloaded =
+    (modelStatusQuery.data as { downloaded: boolean } | undefined)
+      ?.downloaded ?? false
   const handleTestVoice = async () => {
     try {
-      const result = await window.electron.ipcRenderer.invoke("synthesizeWithKitten", {
-        text: "Hello! This is a test of the Kitten text to speech voice.",
-        voiceId,
-      }) as { audio: string; sampleRate: number }
+      const result = (await window.electron.ipcRenderer.invoke(
+        "synthesizeWithKitten",
+        {
+          text: "Hello! This is a test of the Kitten text to speech voice.",
+          voiceId,
+        },
+      )) as { audio: string; sampleRate: number }
       // Decode base64 WAV audio and play it
-      const audioData = Uint8Array.from(atob(result.audio), c => c.charCodeAt(0))
+      const audioData = Uint8Array.from(atob(result.audio), (c) =>
+        c.charCodeAt(0),
+      )
       const blob = new Blob([audioData], { type: "audio/wav" })
       const url = URL.createObjectURL(blob)
       const audio = new Audio(url)
@@ -356,37 +401,41 @@ function KittenProviderSection({
   }
 
   return (
-    <div className={`rounded-lg border ${isActive ? 'border-primary/30 bg-primary/5' : ''}`}>
+    <div
+      className={`rounded-lg border ${isActive ? "border-primary/30 bg-primary/5" : ""}`}
+    >
       <button
         type="button"
-        className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
+        className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
         onClick={onToggleCollapse}
         aria-expanded={!isCollapsed}
         aria-controls="kitten-provider-content"
       >
         <span className="flex items-center gap-2 text-sm font-semibold">
           {isCollapsed ? (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            <ChevronRight className="text-muted-foreground h-4 w-4" />
           ) : (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            <ChevronDown className="text-muted-foreground h-4 w-4" />
           )}
           <Volume2 className="h-4 w-4" />
           Kitten (Local)
-          {isActive && (
-            <CheckCircle2 className="h-4 w-4 text-primary" />
-          )}
+          {isActive && <CheckCircle2 className="text-primary h-4 w-4" />}
         </span>
         {isActive && usageBadges.length > 0 && (
-          <div className="flex gap-1.5 flex-wrap justify-end">
+          <div className="flex flex-wrap justify-end gap-1.5">
             {usageBadges.map((badge) => (
-              <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+              <ActiveProviderBadge
+                key={badge.label}
+                label={badge.label}
+                icon={badge.icon}
+              />
             ))}
           </div>
         )}
       </button>
       {!isCollapsed && (
         <div id="kitten-provider-content" className="divide-y border-t">
-          <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+          <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
             {isActive
               ? "Local text-to-speech with Kitten on your device."
               : "Not selected above. You can still configure it here."}
@@ -405,8 +454,9 @@ function KittenProviderSection({
             <KittenModelDownload />
           </Control>
 
-          <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-            Voice selection now lives in Voice Models above. Use this section for install status and quick voice testing.
+          <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+            Voice selection now lives in Voice Models above. Use this section
+            for install status and quick voice testing.
           </p>
 
           {/* Test Voice Button - only shown when model is downloaded */}
@@ -421,7 +471,7 @@ function KittenProviderSection({
               className="px-3"
             >
               <Button size="sm" variant="outline" onClick={handleTestVoice}>
-                <Volume2 className="h-3.5 w-3.5 mr-1.5" />
+                <Volume2 className="mr-1.5 h-3.5 w-3.5" />
                 Test Voice
               </Button>
             </Control>
@@ -440,10 +490,11 @@ function SupertonicModelDownload() {
 
   const modelStatusQuery = useQuery({
     queryKey: ["supertonicModelStatus"],
-    queryFn: () => window.electron.ipcRenderer.invoke("getSupertonicModelStatus"),
+    queryFn: () =>
+      window.electron.ipcRenderer.invoke("getSupertonicModelStatus"),
     refetchInterval: (query) => {
       const status = query.state.data as { downloading?: boolean } | undefined
-      return (isDownloading || status?.downloading) ? 500 : false
+      return isDownloading || status?.downloading ? 500 : false
     },
   })
 
@@ -460,10 +511,17 @@ function SupertonicModelDownload() {
     }
   }
 
-  const status = modelStatusQuery.data as { downloaded: boolean; downloading: boolean; progress: number; error?: string } | undefined
+  const status = modelStatusQuery.data as
+    | {
+        downloaded: boolean
+        downloading: boolean
+        progress: number
+        error?: string
+      }
+    | undefined
 
   if (modelStatusQuery.isLoading) {
-    return <span className="text-xs text-muted-foreground">Checking...</span>
+    return <span className="text-muted-foreground text-xs">Checking...</span>
   }
 
   if (status?.downloaded) {
@@ -478,16 +536,16 @@ function SupertonicModelDownload() {
   if (status?.downloading || isDownloading) {
     const progress = status?.progress ?? downloadProgress
     return (
-      <div className="flex flex-col gap-1.5 w-full">
+      <div className="flex w-full flex-col gap-1.5">
         <div className="flex items-center gap-2">
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
-          <span className="text-xs text-muted-foreground">
+          <Loader2 className="text-primary h-3.5 w-3.5 animate-spin" />
+          <span className="text-muted-foreground text-xs">
             Downloading... {Math.round(progress * 100)}%
           </span>
         </div>
-        <div className="h-1.5 w-full bg-muted rounded-full overflow-hidden">
+        <div className="bg-muted h-1.5 w-full overflow-hidden rounded-full">
           <div
-            className="h-full bg-primary transition-all duration-200"
+            className="bg-primary h-full transition-all duration-200"
             style={{ width: `${progress * 100}%` }}
           />
         </div>
@@ -498,9 +556,9 @@ function SupertonicModelDownload() {
   if (status?.error) {
     return (
       <div className="flex flex-col gap-1.5">
-        <span className="text-xs text-destructive">{status.error}</span>
+        <span className="text-destructive text-xs">{status.error}</span>
         <Button size="sm" variant="outline" onClick={handleDownload}>
-          <Download className="h-3.5 w-3.5 mr-1.5" />
+          <Download className="mr-1.5 h-3.5 w-3.5" />
           Retry
         </Button>
       </div>
@@ -509,7 +567,7 @@ function SupertonicModelDownload() {
 
   return (
     <Button size="sm" variant="outline" onClick={handleDownload}>
-      <Download className="h-3.5 w-3.5 mr-1.5" />
+      <Download className="mr-1.5 h-3.5 w-3.5" />
       Download (~263MB)
     </Button>
   )
@@ -537,20 +595,28 @@ function SupertonicProviderSection({
 }) {
   const modelStatusQuery = useQuery({
     queryKey: ["supertonicModelStatus"],
-    queryFn: () => window.electron.ipcRenderer.invoke("getSupertonicModelStatus"),
+    queryFn: () =>
+      window.electron.ipcRenderer.invoke("getSupertonicModelStatus"),
   })
-  const modelDownloaded = (modelStatusQuery.data as { downloaded: boolean } | undefined)?.downloaded ?? false
+  const modelDownloaded =
+    (modelStatusQuery.data as { downloaded: boolean } | undefined)
+      ?.downloaded ?? false
 
   const handleTestVoice = async () => {
     try {
-      const result = await window.electron.ipcRenderer.invoke("synthesizeWithSupertonic", {
-        text: "Hello! This is a test of the Supertonic text to speech voice.",
-        voice,
-        lang: language,
-        speed,
-        steps,
-      }) as { audio: string; sampleRate: number }
-      const audioData = Uint8Array.from(atob(result.audio), c => c.charCodeAt(0))
+      const result = (await window.electron.ipcRenderer.invoke(
+        "synthesizeWithSupertonic",
+        {
+          text: "Hello! This is a test of the Supertonic text to speech voice.",
+          voice,
+          lang: language,
+          speed,
+          steps,
+        },
+      )) as { audio: string; sampleRate: number }
+      const audioData = Uint8Array.from(atob(result.audio), (c) =>
+        c.charCodeAt(0),
+      )
       const blob = new Blob([audioData], { type: "audio/wav" })
       const url = URL.createObjectURL(blob)
       const audio = new Audio(url)
@@ -563,37 +629,41 @@ function SupertonicProviderSection({
   }
 
   return (
-    <div className={`rounded-lg border ${isActive ? 'border-primary/30 bg-primary/5' : ''}`}>
+    <div
+      className={`rounded-lg border ${isActive ? "border-primary/30 bg-primary/5" : ""}`}
+    >
       <button
         type="button"
-        className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
+        className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
         onClick={onToggleCollapse}
         aria-expanded={!isCollapsed}
         aria-controls="supertonic-provider-content"
       >
         <span className="flex items-center gap-2 text-sm font-semibold">
           {isCollapsed ? (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+            <ChevronRight className="text-muted-foreground h-4 w-4" />
           ) : (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            <ChevronDown className="text-muted-foreground h-4 w-4" />
           )}
           <Volume2 className="h-4 w-4" />
           Supertonic (Local)
-          {isActive && (
-            <CheckCircle2 className="h-4 w-4 text-primary" />
-          )}
+          {isActive && <CheckCircle2 className="text-primary h-4 w-4" />}
         </span>
         {isActive && usageBadges.length > 0 && (
-          <div className="flex gap-1.5 flex-wrap justify-end">
+          <div className="flex flex-wrap justify-end gap-1.5">
             {usageBadges.map((badge) => (
-              <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+              <ActiveProviderBadge
+                key={badge.label}
+                label={badge.label}
+                icon={badge.icon}
+              />
             ))}
           </div>
         )}
       </button>
       {!isCollapsed && (
         <div id="supertonic-provider-content" className="divide-y border-t">
-          <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+          <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
             {isActive
               ? "Local text-to-speech with Supertonic on your device. Supports English, Korean, Spanish, Portuguese, and French."
               : "Not selected above. You can still configure it here."}
@@ -612,8 +682,9 @@ function SupertonicProviderSection({
             <SupertonicModelDownload />
           </Control>
 
-          <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-            Voice, language, and quality settings now live in Voice Models above. Use this section for install status and quick voice testing.
+          <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+            Voice, language, and quality settings now live in Voice Models
+            above. Use this section for install status and quick voice testing.
           </p>
 
           {modelDownloaded && (
@@ -627,7 +698,7 @@ function SupertonicProviderSection({
               className="px-3"
             >
               <Button size="sm" variant="outline" onClick={handleTestVoice}>
-                <Volume2 className="h-3.5 w-3.5 mr-1.5" />
+                <Volume2 className="mr-1.5 h-3.5 w-3.5" />
                 Test Voice
               </Button>
             </Control>
@@ -647,10 +718,16 @@ export function Component() {
 
   const saveConfigMutation = useSaveConfigMutation()
   const cfgRef = useRef(configQuery.data)
-  const providerSaveTimeoutsRef = useRef<Partial<Record<ProviderDraftKey, ReturnType<typeof setTimeout>>>>({})
-  const [providerDrafts, setProviderDrafts] = useState(() => getProviderDrafts(configQuery.data))
+  const providerSaveTimeoutsRef = useRef<
+    Partial<Record<ProviderDraftKey, ReturnType<typeof setTimeout>>>
+  >({})
+  const [providerDrafts, setProviderDrafts] = useState(() =>
+    getProviderDrafts(configQuery.data),
+  )
   const [chatgptWebAuthBusy, setChatgptWebAuthBusy] = useState(false)
-  const [chatgptWebAuthError, setChatgptWebAuthError] = useState<string | null>(null)
+  const [chatgptWebAuthError, setChatgptWebAuthError] = useState<string | null>(
+    null,
+  )
 
   const saveConfig = useCallback(
     (config: Partial<Config>) => {
@@ -682,53 +759,63 @@ export function Component() {
 
   useEffect(() => {
     return () => {
-      for (const timeout of Object.values(providerSaveTimeoutsRef.current) as Array<ReturnType<typeof setTimeout> | undefined>) {
+      for (const timeout of Object.values(
+        providerSaveTimeoutsRef.current,
+      ) as Array<ReturnType<typeof setTimeout> | undefined>) {
         if (timeout) clearTimeout(timeout)
       }
     }
   }, [])
 
-  const flushProviderSave = useCallback((key: ProviderDraftKey, value: string) => {
-    const pendingSave = providerSaveTimeoutsRef.current[key]
-    if (pendingSave) {
-      clearTimeout(pendingSave)
-      delete providerSaveTimeoutsRef.current[key]
-    }
+  const flushProviderSave = useCallback(
+    (key: ProviderDraftKey, value: string) => {
+      const pendingSave = providerSaveTimeoutsRef.current[key]
+      if (pendingSave) {
+        clearTimeout(pendingSave)
+        delete providerSaveTimeoutsRef.current[key]
+      }
 
-    saveConfig({ [key]: value } as Partial<Config>)
-  }, [saveConfig])
-
-  const scheduleProviderSave = useCallback((key: ProviderDraftKey, value: string) => {
-    const pendingSave = providerSaveTimeoutsRef.current[key]
-    if (pendingSave) {
-      clearTimeout(pendingSave)
-    }
-
-    providerSaveTimeoutsRef.current[key] = setTimeout(() => {
-      delete providerSaveTimeoutsRef.current[key]
       saveConfig({ [key]: value } as Partial<Config>)
-    }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
-  }, [saveConfig])
+    },
+    [saveConfig],
+  )
 
-  const updateProviderDraft = useCallback((key: ProviderDraftKey, value: string) => {
-    setProviderDrafts((currentDrafts) => ({
-      ...currentDrafts,
-      [key]: value,
-    }))
-    scheduleProviderSave(key, value)
-  }, [scheduleProviderSave])
+  const scheduleProviderSave = useCallback(
+    (key: ProviderDraftKey, value: string) => {
+      const pendingSave = providerSaveTimeoutsRef.current[key]
+      if (pendingSave) {
+        clearTimeout(pendingSave)
+      }
+
+      providerSaveTimeoutsRef.current[key] = setTimeout(() => {
+        delete providerSaveTimeoutsRef.current[key]
+        saveConfig({ [key]: value } as Partial<Config>)
+      }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
+
+  const updateProviderDraft = useCallback(
+    (key: ProviderDraftKey, value: string) => {
+      setProviderDrafts((currentDrafts) => ({
+        ...currentDrafts,
+        [key]: value,
+      }))
+      scheduleProviderSave(key, value)
+    },
+    [scheduleProviderSave],
+  )
 
   const handleChatgptWebAuth = useCallback(async () => {
     setChatgptWebAuthBusy(true)
     setChatgptWebAuthError(null)
     try {
       await tipcClient.loginChatGptWebOAuth()
-      await Promise.all([
-        chatgptWebAuthQuery.refetch(),
-        configQuery.refetch(),
-      ])
+      await Promise.all([chatgptWebAuthQuery.refetch(), configQuery.refetch()])
     } catch (error) {
-      setChatgptWebAuthError(error instanceof Error ? error.message : String(error))
+      setChatgptWebAuthError(
+        error instanceof Error ? error.message : String(error),
+      )
     } finally {
       setChatgptWebAuthBusy(false)
     }
@@ -739,65 +826,93 @@ export function Component() {
     setChatgptWebAuthError(null)
     try {
       await tipcClient.logoutChatGptWebOAuth()
-      await Promise.all([
-        chatgptWebAuthQuery.refetch(),
-        configQuery.refetch(),
-      ])
+      await Promise.all([chatgptWebAuthQuery.refetch(), configQuery.refetch()])
     } catch (error) {
-      setChatgptWebAuthError(error instanceof Error ? error.message : String(error))
+      setChatgptWebAuthError(
+        error instanceof Error ? error.message : String(error),
+      )
     } finally {
       setChatgptWebAuthBusy(false)
     }
   }, [chatgptWebAuthQuery, configQuery])
 
   const handleCopyChatgptCallbackUrl = useCallback(async () => {
-    const callbackUrl = (chatgptWebAuthQuery.data as { callbackUrl?: string } | undefined)?.callbackUrl || "http://localhost:1455/auth/callback"
+    const callbackUrl =
+      (chatgptWebAuthQuery.data as { callbackUrl?: string } | undefined)
+        ?.callbackUrl || "http://localhost:1455/auth/callback"
     try {
       await copyTextToClipboard(callbackUrl)
       setChatgptWebAuthError(null)
     } catch (error) {
-      setChatgptWebAuthError(error instanceof Error ? error.message : String(error))
+      setChatgptWebAuthError(
+        error instanceof Error ? error.message : String(error),
+      )
     }
   }, [chatgptWebAuthQuery.data])
 
   // Compute which providers are actively being used for each function
   const activeProviders = useMemo(() => {
-    if (!configQuery.data) return { openai: [], groq: [], gemini: [], chatgptWeb: [], parakeet: [], kitten: [], supertonic: [] }
+    if (!configQuery.data)
+      return {
+        openai: [],
+        groq: [],
+        gemini: [],
+        chatgptWeb: [],
+        parakeet: [],
+        kitten: [],
+        supertonic: [],
+      }
 
     const isMainAgentAcpMode = configQuery.data.mainAgentMode === "acpx"
     const stt = configQuery.data.sttProviderId || "openai"
-    const transcript = configQuery.data.transcriptPostProcessingProviderId || "openai"
-    const mcp = configQuery.data.agentProviderId || configQuery.data.mcpToolsProviderId || "openai"
+    const transcript =
+      configQuery.data.transcriptPostProcessingProviderId || "openai"
+    const mcp =
+      configQuery.data.agentProviderId ||
+      configQuery.data.mcpToolsProviderId ||
+      "openai"
     const tts = configQuery.data.ttsProviderId || "openai"
 
     return {
       openai: [
         ...(stt === "openai" ? [{ label: "STT", icon: Mic }] : []),
-        ...(transcript === "openai" ? [{ label: "Cleanup", icon: FileText }] : []),
-        ...(mcp === "openai" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
+        ...(transcript === "openai"
+          ? [{ label: "Cleanup", icon: FileText }]
+          : []),
+        ...(mcp === "openai" && !isMainAgentAcpMode
+          ? [{ label: "Agent", icon: Bot }]
+          : []),
         ...(tts === "openai" ? [{ label: "TTS", icon: Volume2 }] : []),
       ],
       groq: [
         ...(stt === "groq" ? [{ label: "STT", icon: Mic }] : []),
-        ...(transcript === "groq" ? [{ label: "Cleanup", icon: FileText }] : []),
-        ...(mcp === "groq" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
+        ...(transcript === "groq"
+          ? [{ label: "Cleanup", icon: FileText }]
+          : []),
+        ...(mcp === "groq" && !isMainAgentAcpMode
+          ? [{ label: "Agent", icon: Bot }]
+          : []),
         ...(tts === "groq" ? [{ label: "TTS", icon: Volume2 }] : []),
       ],
       gemini: [
-        ...(transcript === "gemini" ? [{ label: "Cleanup", icon: FileText }] : []),
-        ...(mcp === "gemini" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
+        ...(transcript === "gemini"
+          ? [{ label: "Cleanup", icon: FileText }]
+          : []),
+        ...(mcp === "gemini" && !isMainAgentAcpMode
+          ? [{ label: "Agent", icon: Bot }]
+          : []),
         ...(tts === "gemini" ? [{ label: "TTS", icon: Volume2 }] : []),
       ],
       chatgptWeb: [
-        ...(transcript === "chatgpt-web" ? [{ label: "Cleanup", icon: FileText }] : []),
-        ...(mcp === "chatgpt-web" && !isMainAgentAcpMode ? [{ label: "Agent", icon: Bot }] : []),
+        ...(transcript === "chatgpt-web"
+          ? [{ label: "Cleanup", icon: FileText }]
+          : []),
+        ...(mcp === "chatgpt-web" && !isMainAgentAcpMode
+          ? [{ label: "Agent", icon: Bot }]
+          : []),
       ],
-      parakeet: [
-        ...(stt === "parakeet" ? [{ label: "STT", icon: Mic }] : []),
-      ],
-      kitten: [
-        ...(tts === "kitten" ? [{ label: "TTS", icon: Volume2 }] : []),
-      ],
+      parakeet: [...(stt === "parakeet" ? [{ label: "STT", icon: Mic }] : [])],
+      kitten: [...(tts === "kitten" ? [{ label: "TTS", icon: Volume2 }] : [])],
       supertonic: [
         ...(tts === "supertonic" ? [{ label: "TTS", icon: Volume2 }] : []),
       ],
@@ -806,13 +921,16 @@ export function Component() {
 
   const selectableMainAcpAgents = useMemo(
     () => getSelectableMainAcpAgents(configQuery.data?.agentProfiles || [], []),
-    [configQuery.data?.agentProfiles]
+    [configQuery.data?.agentProfiles],
   )
 
   const selectedMainAcpAgentDisplayName = useMemo(() => {
     const selectedAgentName = configQuery.data?.mainAgentName?.trim()
     if (!selectedAgentName) return null
-    return selectableMainAcpAgents.find(agent => agent.name === selectedAgentName)?.displayName || selectedAgentName
+    return (
+      selectableMainAcpAgents.find((agent) => agent.name === selectedAgentName)
+        ?.displayName || selectedAgentName
+    )
   }, [configQuery.data?.mainAgentName, selectableMainAcpAgents])
 
   const isMainAgentAcpMode = configQuery.data?.mainAgentMode === "acpx"
@@ -855,54 +973,67 @@ export function Component() {
   )
 
   return (
-    <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-4 py-4 sm:px-6">
-
+    <SettingsPageShell>
       <div className="grid gap-4">
-        <div className="rounded-lg border bg-muted/20 px-4 py-3">
+        <div className="bg-muted/20 rounded-lg border px-4 py-3">
           <h2 className="text-sm font-semibold">Provider Setup</h2>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Use this page for API keys, base URLs, local engine downloads, and quick provider diagnostics. All model and voice
-            selection now lives on the Models page.
+          <p className="text-muted-foreground mt-1 text-sm">
+            Manage API keys, base URLs, local engine downloads, and quick
+            provider diagnostics for the Intelligence area.
           </p>
           {isMainAgentAcpMode && (
-            <div className="mt-3 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 text-xs">
-              <div className="flex items-center gap-1.5 font-medium text-primary">
+            <div className="border-primary/30 bg-primary/5 mt-3 rounded-md border px-3 py-2 text-xs">
+              <div className="text-primary flex items-center gap-1.5 font-medium">
                 <Bot className="h-3.5 w-3.5" />
                 ACP Main Agent:{" "}
-                <span className="text-foreground">{selectedMainAcpAgentDisplayName || "Not selected"}</span>
+                <span className="text-foreground">
+                  {selectedMainAcpAgentDisplayName || "Not selected"}
+                </span>
               </div>
-              <p className="mt-1 text-muted-foreground">
-                ACP mode handles chat submissions through the selected agent. Provider setup below still applies to API-backed
-                tools, voice, and local engines.
+              <p className="text-muted-foreground mt-1">
+                ACP mode handles chat submissions through the selected agent.
+                Provider setup below still applies to API-backed tools, voice,
+                and local engines.
               </p>
             </div>
           )}
         </div>
 
         {/* OpenAI Compatible Provider Section */}
-        <div className={`rounded-lg border ${activeProviders.openai.length > 0 ? 'border-primary/30 bg-primary/5' : ''}`}>
+        <div
+          className={`rounded-lg border ${activeProviders.openai.length > 0 ? "border-primary/30 bg-primary/5" : ""}`}
+        >
           <button
             type="button"
-            className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-            onClick={() => saveConfig({ providerSectionCollapsedOpenai: !configQuery.data.providerSectionCollapsedOpenai })}
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+            onClick={() =>
+              saveConfig({
+                providerSectionCollapsedOpenai:
+                  !configQuery.data.providerSectionCollapsedOpenai,
+              })
+            }
             aria-expanded={!configQuery.data.providerSectionCollapsedOpenai}
             aria-controls="openai-provider-content"
           >
             <span className="flex items-center gap-2 text-sm font-semibold">
               {configQuery.data.providerSectionCollapsedOpenai ? (
-                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
               ) : (
-                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
               )}
               OpenAI Compatible
               {activeProviders.openai.length > 0 && (
-                <CheckCircle2 className="h-4 w-4 text-primary" />
+                <CheckCircle2 className="text-primary h-4 w-4" />
               )}
             </span>
             {activeProviders.openai.length > 0 && (
-              <div className="flex gap-1.5 flex-wrap justify-end">
+              <div className="flex flex-wrap justify-end gap-1.5">
                 {activeProviders.openai.map((badge) => (
-                  <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+                  <ActiveProviderBadge
+                    key={badge.label}
+                    label={badge.label}
+                    icon={badge.icon}
+                  />
                 ))}
               </div>
             )}
@@ -910,14 +1041,16 @@ export function Component() {
           {!configQuery.data.providerSectionCollapsedOpenai && (
             <div id="openai-provider-content" className="divide-y border-t">
               {activeProviders.openai.length === 0 && (
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
-                  OpenAI-compatible presets are selected from the Models page.
+                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
+                  OpenAI-compatible presets are selected from the Models
+                  section.
                 </p>
               )}
 
               <div className="px-3 py-2">
-                <p className="text-sm text-muted-foreground">
-                  OpenAI-compatible presets, agent models, and transcript cleanup models are now managed on the Models page.
+                <p className="text-muted-foreground text-sm">
+                  OpenAI-compatible presets, agent models, and transcript
+                  cleanup models are managed in Models.
                 </p>
               </div>
             </div>
@@ -926,26 +1059,35 @@ export function Component() {
 
         {/* Groq Provider Section - rendered in order based on active status */}
         {isGroqActive && (
-          <div className="rounded-lg border border-primary/30 bg-primary/5">
+          <div className="border-primary/30 bg-primary/5 rounded-lg border">
             <button
               type="button"
-              className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-              onClick={() => saveConfig({ providerSectionCollapsedGroq: !configQuery.data.providerSectionCollapsedGroq })}
+              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+              onClick={() =>
+                saveConfig({
+                  providerSectionCollapsedGroq:
+                    !configQuery.data.providerSectionCollapsedGroq,
+                })
+              }
               aria-expanded={!configQuery.data.providerSectionCollapsedGroq}
               aria-controls="groq-provider-content"
             >
               <span className="flex items-center gap-2 text-sm font-semibold">
                 {configQuery.data.providerSectionCollapsedGroq ? (
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  <ChevronRight className="text-muted-foreground h-4 w-4" />
                 ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground h-4 w-4" />
                 )}
                 Groq
-                <CheckCircle2 className="h-4 w-4 text-primary" />
+                <CheckCircle2 className="text-primary h-4 w-4" />
               </span>
-              <div className="flex gap-1.5 flex-wrap justify-end">
+              <div className="flex flex-wrap justify-end gap-1.5">
                 {activeProviders.groq.map((badge) => (
-                  <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+                  <ActiveProviderBadge
+                    key={badge.label}
+                    label={badge.label}
+                    icon={badge.icon}
+                  />
                 ))}
               </div>
             </button>
@@ -962,8 +1104,8 @@ export function Component() {
                   placeholder: "https://api.groq.com/openai/v1",
                 })}
 
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Groq model selection now lives on the Models page.
+                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                  Groq model selection is managed in Models.
                 </p>
               </div>
             )}
@@ -972,26 +1114,35 @@ export function Component() {
 
         {/* Gemini Provider Section - rendered in order based on active status */}
         {isGeminiActive && (
-          <div className="rounded-lg border border-primary/30 bg-primary/5">
+          <div className="border-primary/30 bg-primary/5 rounded-lg border">
             <button
               type="button"
-              className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-              onClick={() => saveConfig({ providerSectionCollapsedGemini: !configQuery.data.providerSectionCollapsedGemini })}
+              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+              onClick={() =>
+                saveConfig({
+                  providerSectionCollapsedGemini:
+                    !configQuery.data.providerSectionCollapsedGemini,
+                })
+              }
               aria-expanded={!configQuery.data.providerSectionCollapsedGemini}
               aria-controls="gemini-provider-content"
             >
               <span className="flex items-center gap-2 text-sm font-semibold">
                 {configQuery.data.providerSectionCollapsedGemini ? (
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  <ChevronRight className="text-muted-foreground h-4 w-4" />
                 ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground h-4 w-4" />
                 )}
                 Gemini
-                <CheckCircle2 className="h-4 w-4 text-primary" />
+                <CheckCircle2 className="text-primary h-4 w-4" />
               </span>
-              <div className="flex gap-1.5 flex-wrap justify-end">
+              <div className="flex flex-wrap justify-end gap-1.5">
                 {activeProviders.gemini.map((badge) => (
-                  <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+                  <ActiveProviderBadge
+                    key={badge.label}
+                    label={badge.label}
+                    icon={badge.icon}
+                  />
                 ))}
               </div>
             </button>
@@ -1008,8 +1159,8 @@ export function Component() {
                   placeholder: "https://generativelanguage.googleapis.com",
                 })}
 
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Gemini model selection now lives on the Models page.
+                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                  Gemini model selection is managed in Models.
                 </p>
               </div>
             )}
@@ -1018,75 +1169,109 @@ export function Component() {
 
         {/* ChatGPT Web Provider Section - rendered in order based on active status */}
         {isChatgptWebActive && (
-          <div className="rounded-lg border border-primary/30 bg-primary/5">
+          <div className="border-primary/30 bg-primary/5 rounded-lg border">
             <button
               type="button"
-              className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-              onClick={() => saveConfig({ providerSectionCollapsedChatgptWeb: !configQuery.data.providerSectionCollapsedChatgptWeb })}
-              aria-expanded={!configQuery.data.providerSectionCollapsedChatgptWeb}
+              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+              onClick={() =>
+                saveConfig({
+                  providerSectionCollapsedChatgptWeb:
+                    !configQuery.data.providerSectionCollapsedChatgptWeb,
+                })
+              }
+              aria-expanded={
+                !configQuery.data.providerSectionCollapsedChatgptWeb
+              }
               aria-controls="chatgpt-web-provider-content"
             >
               <span className="flex items-center gap-2 text-sm font-semibold">
                 {configQuery.data.providerSectionCollapsedChatgptWeb ? (
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  <ChevronRight className="text-muted-foreground h-4 w-4" />
                 ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground h-4 w-4" />
                 )}
                 OpenAI Codex
-                <CheckCircle2 className="h-4 w-4 text-primary" />
+                <CheckCircle2 className="text-primary h-4 w-4" />
               </span>
-              <div className="flex gap-1.5 flex-wrap justify-end">
+              <div className="flex flex-wrap justify-end gap-1.5">
                 {activeProviders.chatgptWeb.map((badge) => (
-                  <ActiveProviderBadge key={badge.label} label={badge.label} icon={badge.icon} />
+                  <ActiveProviderBadge
+                    key={badge.label}
+                    label={badge.label}
+                    icon={badge.icon}
+                  />
                 ))}
               </div>
             </button>
             {!configQuery.data.providerSectionCollapsedChatgptWeb && (
-              <div id="chatgpt-web-provider-content" className="divide-y border-t">
-                <div className="px-3 py-3 space-y-3">
+              <div
+                id="chatgpt-web-provider-content"
+                className="divide-y border-t"
+              >
+                <div className="space-y-3 px-3 py-3">
                   <div className="text-sm">
                     <div className="font-medium">
                       {(chatgptWebAuthQuery.data as any)?.authenticated
                         ? `Connected${(chatgptWebAuthQuery.data as any)?.email ? ` as ${(chatgptWebAuthQuery.data as any).email}` : ""}`
                         : "Not connected"}
                     </div>
-                    <div className="text-xs text-muted-foreground mt-1">
+                    <div className="text-muted-foreground mt-1 text-xs">
                       {(chatgptWebAuthQuery.data as any)?.planType
                         ? `Plan: ${(chatgptWebAuthQuery.data as any).planType}`
                         : "Uses your ChatGPT Codex subscription via OAuth."}
                     </div>
                     {(chatgptWebAuthQuery.data as any)?.accountId && (
-                      <div className="text-xs text-muted-foreground mt-1">
-                        Account ID: {(chatgptWebAuthQuery.data as any).accountId}
+                      <div className="text-muted-foreground mt-1 text-xs">
+                        Account ID:{" "}
+                        {(chatgptWebAuthQuery.data as any).accountId}
                       </div>
                     )}
                   </div>
 
                   <div className="flex flex-wrap gap-2">
-                    <Button size="sm" variant="outline" onClick={handleChatgptWebAuth} disabled={chatgptWebAuthBusy}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleChatgptWebAuth}
+                      disabled={chatgptWebAuthBusy}
+                    >
                       {chatgptWebAuthBusy
                         ? "Working..."
                         : (chatgptWebAuthQuery.data as any)?.authenticated
                           ? "Re-auth"
                           : "Connect"}
                     </Button>
-                    <Button size="sm" variant="outline" onClick={handleCopyChatgptCallbackUrl} disabled={chatgptWebAuthBusy}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleCopyChatgptCallbackUrl}
+                      disabled={chatgptWebAuthBusy}
+                    >
                       Copy Callback URL
                     </Button>
                     {(chatgptWebAuthQuery.data as any)?.authenticated && (
-                      <Button size="sm" variant="outline" onClick={handleChatgptWebLogout} disabled={chatgptWebAuthBusy}>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleChatgptWebLogout}
+                        disabled={chatgptWebAuthBusy}
+                      >
                         Disconnect
                       </Button>
                     )}
                   </div>
 
                   {chatgptWebAuthError && (
-                    <p className="text-xs text-destructive">{chatgptWebAuthError}</p>
+                    <p className="text-destructive text-xs">
+                      {chatgptWebAuthError}
+                    </p>
                   )}
                 </div>
 
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Browser sign-in should return to `http://localhost:1455/auth/callback`. Use Copy Callback URL if you need to inspect or paste the callback target.
+                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                  Browser sign-in should return to
+                  `http://localhost:1455/auth/callback`. Use Copy Callback URL
+                  if you need to inspect or paste the callback target.
                 </p>
               </div>
             )}
@@ -1097,11 +1282,21 @@ export function Component() {
         {isParakeetActive && (
           <ParakeetProviderSection
             isActive={true}
-            isCollapsed={configQuery.data.providerSectionCollapsedParakeet ?? true}
-            onToggleCollapse={() => saveConfig({ providerSectionCollapsedParakeet: !(configQuery.data.providerSectionCollapsedParakeet ?? true) })}
+            isCollapsed={
+              configQuery.data.providerSectionCollapsedParakeet ?? true
+            }
+            onToggleCollapse={() =>
+              saveConfig({
+                providerSectionCollapsedParakeet: !(
+                  configQuery.data.providerSectionCollapsedParakeet ?? true
+                ),
+              })
+            }
             usageBadges={activeProviders.parakeet}
             numThreads={configQuery.data.parakeetNumThreads || 2}
-            onNumThreadsChange={(value) => saveConfig({ parakeetNumThreads: value })}
+            onNumThreadsChange={(value) =>
+              saveConfig({ parakeetNumThreads: value })
+            }
           />
         )}
 
@@ -1109,8 +1304,16 @@ export function Component() {
         {isKittenActive && (
           <KittenProviderSection
             isActive={true}
-            isCollapsed={configQuery.data.providerSectionCollapsedKitten ?? true}
-            onToggleCollapse={() => saveConfig({ providerSectionCollapsedKitten: !(configQuery.data.providerSectionCollapsedKitten ?? true) })}
+            isCollapsed={
+              configQuery.data.providerSectionCollapsedKitten ?? true
+            }
+            onToggleCollapse={() =>
+              saveConfig({
+                providerSectionCollapsedKitten: !(
+                  configQuery.data.providerSectionCollapsedKitten ?? true
+                ),
+              })
+            }
             usageBadges={activeProviders.kitten}
             voiceId={configQuery.data.kittenVoiceId ?? 0}
           />
@@ -1120,8 +1323,16 @@ export function Component() {
         {isSupertonicActive && (
           <SupertonicProviderSection
             isActive={true}
-            isCollapsed={configQuery.data.providerSectionCollapsedSupertonic ?? true}
-            onToggleCollapse={() => saveConfig({ providerSectionCollapsedSupertonic: !(configQuery.data.providerSectionCollapsedSupertonic ?? true) } as Partial<Config>)}
+            isCollapsed={
+              configQuery.data.providerSectionCollapsedSupertonic ?? true
+            }
+            onToggleCollapse={() =>
+              saveConfig({
+                providerSectionCollapsedSupertonic: !(
+                  configQuery.data.providerSectionCollapsedSupertonic ?? true
+                ),
+              } as Partial<Config>)
+            }
             usageBadges={activeProviders.supertonic}
             voice={configQuery.data.supertonicVoice ?? "M1"}
             language={configQuery.data.supertonicLanguage ?? "en"}
@@ -1135,23 +1346,31 @@ export function Component() {
           <div className="rounded-lg border">
             <button
               type="button"
-              className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-              onClick={() => saveConfig({ providerSectionCollapsedGroq: !configQuery.data.providerSectionCollapsedGroq })}
+              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+              onClick={() =>
+                saveConfig({
+                  providerSectionCollapsedGroq:
+                    !configQuery.data.providerSectionCollapsedGroq,
+                })
+              }
               aria-expanded={!configQuery.data.providerSectionCollapsedGroq}
               aria-controls="groq-provider-content-inactive"
             >
               <span className="flex items-center gap-2 text-sm font-semibold">
                 {configQuery.data.providerSectionCollapsedGroq ? (
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  <ChevronRight className="text-muted-foreground h-4 w-4" />
                 ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground h-4 w-4" />
                 )}
                 Groq
               </span>
             </button>
             {!configQuery.data.providerSectionCollapsedGroq && (
-              <div id="groq-provider-content-inactive" className="divide-y border-t">
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+              <div
+                id="groq-provider-content-inactive"
+                className="divide-y border-t"
+              >
+                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
                   Not selected above. You can still configure it here.
                 </p>
 
@@ -1166,8 +1385,8 @@ export function Component() {
                   placeholder: "https://api.groq.com/openai/v1",
                 })}
 
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Groq model selection now lives on the Models page.
+                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                  Groq model selection is managed in Models.
                 </p>
               </div>
             )}
@@ -1179,23 +1398,31 @@ export function Component() {
           <div className="rounded-lg border">
             <button
               type="button"
-              className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-              onClick={() => saveConfig({ providerSectionCollapsedGemini: !configQuery.data.providerSectionCollapsedGemini })}
+              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+              onClick={() =>
+                saveConfig({
+                  providerSectionCollapsedGemini:
+                    !configQuery.data.providerSectionCollapsedGemini,
+                })
+              }
               aria-expanded={!configQuery.data.providerSectionCollapsedGemini}
               aria-controls="gemini-provider-content-inactive"
             >
               <span className="flex items-center gap-2 text-sm font-semibold">
                 {configQuery.data.providerSectionCollapsedGemini ? (
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  <ChevronRight className="text-muted-foreground h-4 w-4" />
                 ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground h-4 w-4" />
                 )}
                 Gemini
               </span>
             </button>
             {!configQuery.data.providerSectionCollapsedGemini && (
-              <div id="gemini-provider-content-inactive" className="divide-y border-t">
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+              <div
+                id="gemini-provider-content-inactive"
+                className="divide-y border-t"
+              >
+                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
                   Not selected above. You can still configure it here.
                 </p>
 
@@ -1210,8 +1437,8 @@ export function Component() {
                   placeholder: "https://generativelanguage.googleapis.com",
                 })}
 
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Gemini model selection now lives on the Models page.
+                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                  Gemini model selection is managed in Models.
                 </p>
               </div>
             )}
@@ -1223,63 +1450,93 @@ export function Component() {
           <div className="rounded-lg border">
             <button
               type="button"
-              className="px-3 py-2 flex items-center justify-between w-full hover:bg-muted/30 transition-colors cursor-pointer"
-              onClick={() => saveConfig({ providerSectionCollapsedChatgptWeb: !configQuery.data.providerSectionCollapsedChatgptWeb })}
-              aria-expanded={!configQuery.data.providerSectionCollapsedChatgptWeb}
+              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+              onClick={() =>
+                saveConfig({
+                  providerSectionCollapsedChatgptWeb:
+                    !configQuery.data.providerSectionCollapsedChatgptWeb,
+                })
+              }
+              aria-expanded={
+                !configQuery.data.providerSectionCollapsedChatgptWeb
+              }
               aria-controls="chatgpt-web-provider-content-inactive"
             >
               <span className="flex items-center gap-2 text-sm font-semibold">
                 {configQuery.data.providerSectionCollapsedChatgptWeb ? (
-                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                  <ChevronRight className="text-muted-foreground h-4 w-4" />
                 ) : (
-                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  <ChevronDown className="text-muted-foreground h-4 w-4" />
                 )}
                 OpenAI Codex
               </span>
             </button>
             {!configQuery.data.providerSectionCollapsedChatgptWeb && (
-              <div id="chatgpt-web-provider-content-inactive" className="divide-y border-t">
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground">
+              <div
+                id="chatgpt-web-provider-content-inactive"
+                className="divide-y border-t"
+              >
+                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
                   Not selected above. You can still configure it here.
                 </p>
 
-                <div className="px-3 py-3 space-y-3">
+                <div className="space-y-3 px-3 py-3">
                   <div className="text-sm">
                     <div className="font-medium">
                       {(chatgptWebAuthQuery.data as any)?.authenticated
                         ? `Connected${(chatgptWebAuthQuery.data as any)?.email ? ` as ${(chatgptWebAuthQuery.data as any).email}` : ""}`
                         : "Not connected"}
                     </div>
-                    <div className="text-xs text-muted-foreground mt-1">
+                    <div className="text-muted-foreground mt-1 text-xs">
                       Uses your ChatGPT Codex subscription via OAuth.
                     </div>
                   </div>
 
                   <div className="flex flex-wrap gap-2">
-                    <Button size="sm" variant="outline" onClick={handleChatgptWebAuth} disabled={chatgptWebAuthBusy}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleChatgptWebAuth}
+                      disabled={chatgptWebAuthBusy}
+                    >
                       {chatgptWebAuthBusy
                         ? "Working..."
                         : (chatgptWebAuthQuery.data as any)?.authenticated
                           ? "Re-auth"
                           : "Connect"}
                     </Button>
-                    <Button size="sm" variant="outline" onClick={handleCopyChatgptCallbackUrl} disabled={chatgptWebAuthBusy}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleCopyChatgptCallbackUrl}
+                      disabled={chatgptWebAuthBusy}
+                    >
                       Copy Callback URL
                     </Button>
                     {(chatgptWebAuthQuery.data as any)?.authenticated && (
-                      <Button size="sm" variant="outline" onClick={handleChatgptWebLogout} disabled={chatgptWebAuthBusy}>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={handleChatgptWebLogout}
+                        disabled={chatgptWebAuthBusy}
+                      >
                         Disconnect
                       </Button>
                     )}
                   </div>
 
                   {chatgptWebAuthError && (
-                    <p className="text-xs text-destructive">{chatgptWebAuthError}</p>
+                    <p className="text-destructive text-xs">
+                      {chatgptWebAuthError}
+                    </p>
                   )}
                 </div>
 
-                <p className="px-3 py-1.5 text-[11px] text-muted-foreground border-t">
-                  Browser sign-in should return to `http://localhost:1455/auth/callback`. This provider now talks to the Codex responses transport, not the legacy conversation endpoint.
+                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                  Browser sign-in should return to
+                  `http://localhost:1455/auth/callback`. This provider now talks
+                  to the Codex responses transport, not the legacy conversation
+                  endpoint.
                 </p>
               </div>
             )}
@@ -1290,11 +1547,21 @@ export function Component() {
         {!isParakeetActive && (
           <ParakeetProviderSection
             isActive={false}
-            isCollapsed={configQuery.data.providerSectionCollapsedParakeet ?? true}
-            onToggleCollapse={() => saveConfig({ providerSectionCollapsedParakeet: !(configQuery.data.providerSectionCollapsedParakeet ?? true) })}
+            isCollapsed={
+              configQuery.data.providerSectionCollapsedParakeet ?? true
+            }
+            onToggleCollapse={() =>
+              saveConfig({
+                providerSectionCollapsedParakeet: !(
+                  configQuery.data.providerSectionCollapsedParakeet ?? true
+                ),
+              })
+            }
             usageBadges={activeProviders.parakeet}
             numThreads={configQuery.data.parakeetNumThreads || 2}
-            onNumThreadsChange={(value) => saveConfig({ parakeetNumThreads: value })}
+            onNumThreadsChange={(value) =>
+              saveConfig({ parakeetNumThreads: value })
+            }
           />
         )}
 
@@ -1302,8 +1569,16 @@ export function Component() {
         {!isKittenActive && (
           <KittenProviderSection
             isActive={false}
-            isCollapsed={configQuery.data.providerSectionCollapsedKitten ?? true}
-            onToggleCollapse={() => saveConfig({ providerSectionCollapsedKitten: !(configQuery.data.providerSectionCollapsedKitten ?? true) })}
+            isCollapsed={
+              configQuery.data.providerSectionCollapsedKitten ?? true
+            }
+            onToggleCollapse={() =>
+              saveConfig({
+                providerSectionCollapsedKitten: !(
+                  configQuery.data.providerSectionCollapsedKitten ?? true
+                ),
+              })
+            }
             usageBadges={activeProviders.kitten}
             voiceId={configQuery.data.kittenVoiceId ?? 0}
           />
@@ -1313,8 +1588,16 @@ export function Component() {
         {!isSupertonicActive && (
           <SupertonicProviderSection
             isActive={false}
-            isCollapsed={configQuery.data.providerSectionCollapsedSupertonic ?? true}
-            onToggleCollapse={() => saveConfig({ providerSectionCollapsedSupertonic: !(configQuery.data.providerSectionCollapsedSupertonic ?? true) } as Partial<Config>)}
+            isCollapsed={
+              configQuery.data.providerSectionCollapsedSupertonic ?? true
+            }
+            onToggleCollapse={() =>
+              saveConfig({
+                providerSectionCollapsedSupertonic: !(
+                  configQuery.data.providerSectionCollapsedSupertonic ?? true
+                ),
+              } as Partial<Config>)
+            }
             usageBadges={activeProviders.supertonic}
             voice={configQuery.data.supertonicVoice ?? "M1"}
             language={configQuery.data.supertonicLanguage ?? "en"}
@@ -1322,8 +1605,7 @@ export function Component() {
             steps={configQuery.data.supertonicSteps ?? 5}
           />
         )}
-
       </div>
-    </div>
+    </SettingsPageShell>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/settings-whatsapp.allowlist.test.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-whatsapp.allowlist.test.tsx
@@ -16,14 +16,26 @@ function createHookRuntime() {
   let refIndex = 0
   let effectIndex = 0
 
-  const depsChanged = (prev?: any[], next?: any[]) => !prev || !next || prev.length !== next.length || prev.some((value, index) => !Object.is(value, next[index]))
+  const depsChanged = (prev?: any[], next?: any[]) =>
+    !prev ||
+    !next ||
+    prev.length !== next.length ||
+    prev.some((value, index) => !Object.is(value, next[index]))
 
   const useState = <T,>(initial: T | (() => T)) => {
     const idx = stateIndex++
-    if (states[idx] === undefined) states[idx] = typeof initial === "function" ? (initial as () => T)() : initial
-    return [states[idx] as T, (update: T | ((prev: T) => T)) => {
-      states[idx] = typeof update === "function" ? (update as (prev: T) => T)(states[idx]) : update
-    }] as const
+    if (states[idx] === undefined)
+      states[idx] =
+        typeof initial === "function" ? (initial as () => T)() : initial
+    return [
+      states[idx] as T,
+      (update: T | ((prev: T) => T)) => {
+        states[idx] =
+          typeof update === "function"
+            ? (update as (prev: T) => T)(states[idx])
+            : update
+      },
+    ] as const
   }
 
   const useRef = <T,>(initial: T) => {
@@ -47,18 +59,21 @@ function createHookRuntime() {
     useRef,
     useEffect,
     useCallback: (fn: any) => fn,
-    forwardRef: (render: (props: any, ref: any) => any) => (props: any) => render(props, null),
+    forwardRef: (render: (props: any, ref: any) => any) => (props: any) =>
+      render(props, null),
   }
   reactMock.default = reactMock
 
   const Fragment = Symbol.for("react.fragment")
   const invoke = (type: any, props: any) => {
     if (type === Fragment) return props?.children ?? null
-    return typeof type === "function" ? type(props ?? {}) : { type, props: props ?? {} }
+    return typeof type === "function"
+      ? type(props ?? {})
+      : { type, props: props ?? {} }
   }
 
   return {
-    render<P,>(Component: (props: P) => any, props: P) {
+    render<P>(Component: (props: P) => any, props: P) {
       stateIndex = 0
       refIndex = 0
       effectIndex = 0
@@ -67,7 +82,8 @@ function createHookRuntime() {
     commitEffects() {
       for (const record of effects) {
         if (!record?.callback) continue
-        const shouldRun = !record.hasRun || depsChanged(record.deps, record.nextDeps)
+        const shouldRun =
+          !record.hasRun || depsChanged(record.deps, record.nextDeps)
         if (!shouldRun) continue
         if (typeof record.cleanup === "function") record.cleanup()
         const cleanup = record.callback()
@@ -77,7 +93,13 @@ function createHookRuntime() {
       }
     },
     reactMock,
-    jsxRuntimeMock: { __esModule: true, Fragment, jsx: invoke, jsxs: invoke, jsxDEV: invoke },
+    jsxRuntimeMock: {
+      __esModule: true,
+      Fragment,
+      jsx: invoke,
+      jsxs: invoke,
+      jsxDEV: invoke,
+    },
   }
 }
 
@@ -102,7 +124,11 @@ function findInput(node: any) {
 }
 
 function findControlGroup(node: any, title: string) {
-  return findNode(node, (candidate) => candidate.type === "ControlGroup" && candidate.props?.title === title)
+  return findNode(
+    node,
+    (candidate) =>
+      candidate.type === "ControlGroup" && candidate.props?.title === title,
+  )
 }
 
 function collectText(node: any, results: string[] = []): string[] {
@@ -125,7 +151,10 @@ async function flushPromises() {
   await Promise.resolve()
 }
 
-async function renderSettled(runtime: ReturnType<typeof createHookRuntime>, Component: (props: any) => any) {
+async function renderSettled(
+  runtime: ReturnType<typeof createHookRuntime>,
+  Component: (props: any) => any,
+) {
   let tree = runtime.render(Component, {} as any)
   runtime.commitEffects()
   await flushPromises()
@@ -133,7 +162,9 @@ async function renderSettled(runtime: ReturnType<typeof createHookRuntime>, Comp
   return tree
 }
 
-async function loadSettingsWhatsApp(runtime: ReturnType<typeof createHookRuntime>) {
+async function loadSettingsWhatsApp(
+  runtime: ReturnType<typeof createHookRuntime>,
+) {
   vi.resetModules()
 
   const Null = () => null
@@ -153,6 +184,14 @@ async function loadSettingsWhatsApp(runtime: ReturnType<typeof createHookRuntime
   vi.doMock("react", () => runtime.reactMock)
   vi.doMock("react/jsx-runtime", () => runtime.jsxRuntimeMock)
   vi.doMock("react/jsx-dev-runtime", () => runtime.jsxRuntimeMock)
+  vi.doMock("@renderer/components/settings-navigation", () => ({
+    SettingsPageShell: (props: any) => props?.children ?? null,
+    SettingsNavigation: Null,
+  }))
+  vi.doMock("../components/settings-navigation", () => ({
+    SettingsPageShell: (props: any) => props?.children ?? null,
+    SettingsNavigation: Null,
+  }))
   vi.doMock("@renderer/components/ui/control", () => ({
     Control: (props: any) => ({ type: "Control", props }),
     ControlGroup: (props: any) => ({ type: "ControlGroup", props }),
@@ -163,12 +202,24 @@ async function loadSettingsWhatsApp(runtime: ReturnType<typeof createHookRuntime
     ControlGroup: (props: any) => ({ type: "ControlGroup", props }),
     ControlLabel: (props: any) => ({ type: "ControlLabel", props }),
   }))
-  vi.doMock("@renderer/components/ui/switch", () => ({ Switch: (props: any) => ({ type: "Switch", props }) }))
-  vi.doMock("../components/ui/switch", () => ({ Switch: (props: any) => ({ type: "Switch", props }) }))
-  vi.doMock("@renderer/components/ui/input", () => ({ Input: (props: any) => ({ type: "Input", props }) }))
-  vi.doMock("../components/ui/input", () => ({ Input: (props: any) => ({ type: "Input", props }) }))
-  vi.doMock("@renderer/components/ui/button", () => ({ Button: (props: any) => ({ type: "Button", props }) }))
-  vi.doMock("../components/ui/button", () => ({ Button: (props: any) => ({ type: "Button", props }) }))
+  vi.doMock("@renderer/components/ui/switch", () => ({
+    Switch: (props: any) => ({ type: "Switch", props }),
+  }))
+  vi.doMock("../components/ui/switch", () => ({
+    Switch: (props: any) => ({ type: "Switch", props }),
+  }))
+  vi.doMock("@renderer/components/ui/input", () => ({
+    Input: (props: any) => ({ type: "Input", props }),
+  }))
+  vi.doMock("../components/ui/input", () => ({
+    Input: (props: any) => ({ type: "Input", props }),
+  }))
+  vi.doMock("@renderer/components/ui/button", () => ({
+    Button: (props: any) => ({ type: "Button", props }),
+  }))
+  vi.doMock("../components/ui/button", () => ({
+    Button: (props: any) => ({ type: "Button", props }),
+  }))
   vi.doMock("@renderer/lib/query-client", () => ({
     useConfigQuery: () => ({ data: currentConfig }),
     useSaveConfigMutation: () => ({ mutate }),
@@ -252,19 +303,24 @@ describe("desktop WhatsApp settings allowlist", () => {
 
     const input = findInput(tree)
     expect(input.props.placeholder).toBe("+14155551234, 98389177934034")
-    expect(collectText(tree)).toContain("Enter phone numbers or LIDs separated by commas. Phone numbers can include formatting like +, spaces, or punctuation.")
+    expect(collectText(tree)).toContain(
+      "Enter phone numbers or LIDs separated by commas. Phone numbers can include formatting like +, spaces, or punctuation.",
+    )
   })
 
   it("keeps a local draft and debounces config saves while editing", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, getCurrentConfig } = await loadSettingsWhatsApp(runtime)
+    const { Component, mutate, getCurrentConfig } =
+      await loadSettingsWhatsApp(runtime)
 
     let tree = await renderSettled(runtime, Component)
 
     let input = findInput(tree)
     expect(input.props.value).toBe("14155551234")
 
-    input.props.onChange({ currentTarget: { value: "14155551234, +442071838750" } })
+    input.props.onChange({
+      currentTarget: { value: "14155551234, +442071838750" },
+    })
 
     tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
@@ -286,17 +342,22 @@ describe("desktop WhatsApp settings allowlist", () => {
 
   it("flushes pending edits on blur and resyncs from updated config", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, setConfig, getCurrentConfig } = await loadSettingsWhatsApp(runtime)
+    const { Component, mutate, setConfig, getCurrentConfig } =
+      await loadSettingsWhatsApp(runtime)
 
     let tree = await renderSettled(runtime, Component)
 
     let input = findInput(tree)
-    input.props.onChange({ currentTarget: { value: "14155551234, 98389177934034" } })
+    input.props.onChange({
+      currentTarget: { value: "14155551234, 98389177934034" },
+    })
 
     tree = runtime.render(Component, {} as any)
     runtime.commitEffects()
     input = findInput(tree)
-    input.props.onBlur({ currentTarget: { value: "14155551234, 98389177934034" } })
+    input.props.onBlur({
+      currentTarget: { value: "14155551234, 98389177934034" },
+    })
 
     expect(mutate).toHaveBeenCalledTimes(1)
     expect(mutate).toHaveBeenCalledWith({
@@ -320,13 +381,18 @@ describe("desktop WhatsApp settings allowlist", () => {
 
   it("flushes the latest draft on blur even without an intervening rerender", async () => {
     const runtime = createHookRuntime()
-    const { Component, mutate, getCurrentConfig } = await loadSettingsWhatsApp(runtime)
+    const { Component, mutate, getCurrentConfig } =
+      await loadSettingsWhatsApp(runtime)
 
     const tree = await renderSettled(runtime, Component)
 
     const input = findInput(tree)
-    input.props.onChange({ currentTarget: { value: "14155551234, +442071838750" } })
-    input.props.onBlur({ currentTarget: { value: "14155551234, +442071838750" } })
+    input.props.onChange({
+      currentTarget: { value: "14155551234, +442071838750" },
+    })
+    input.props.onBlur({
+      currentTarget: { value: "14155551234, +442071838750" },
+    })
 
     expect(mutate).toHaveBeenCalledTimes(1)
     expect(mutate).toHaveBeenCalledWith({
@@ -351,19 +417,28 @@ describe("desktop WhatsApp settings allowlist", () => {
     const tree = await renderSettled(runtime, Component)
     const connectionGroup = findControlGroup(tree, "Connection")
     const connectionText = collectText(connectionGroup).join(" ")
-    const connectionEndDescriptionText = collectText(connectionGroup?.props?.endDescription).join(" ")
+    const connectionEndDescriptionText = collectText(
+      connectionGroup?.props?.endDescription,
+    ).join(" ")
 
     expect(connectionText).toContain("Connect with QR Code")
-    expect(connectionText).toContain("Open WhatsApp on your phone → Settings → Linked Devices → Scan this QR code")
+    expect(connectionText).toContain(
+      "Open WhatsApp on your phone → Settings → Linked Devices → Scan this QR code",
+    )
     expect(connectionGroup?.props?.endDescription).toBeUndefined()
     expect(connectionEndDescriptionText).toBe("")
-    expect(connectionText).not.toContain("Connect your WhatsApp account by scanning the QR code")
-    expect(connectionEndDescriptionText).not.toContain("Connect your WhatsApp account by scanning the QR code")
+    expect(connectionText).not.toContain(
+      "Connect your WhatsApp account by scanning the QR code",
+    )
+    expect(connectionEndDescriptionText).not.toContain(
+      "Connect your WhatsApp account by scanning the QR code",
+    )
   })
 
   it("renders allowlist guidance and empty-state warning as plain text in Settings", async () => {
     const runtime = createHookRuntime()
-    const { Component, setConfig, getCurrentConfig } = await loadSettingsWhatsApp(runtime)
+    const { Component, setConfig, getCurrentConfig } =
+      await loadSettingsWhatsApp(runtime)
 
     setConfig({
       ...getCurrentConfig(),
@@ -375,13 +450,16 @@ describe("desktop WhatsApp settings allowlist", () => {
     const settingsText = collectText(settingsGroup).join(" ")
 
     expect(settingsText).toContain("What are LIDs and how do I find them?")
-    expect(settingsText).toContain("No allowlist set - all incoming messages will be accepted")
+    expect(settingsText).toContain(
+      "No allowlist set - all incoming messages will be accepted",
+    )
     expect(settingsText).not.toMatch(/[ℹ️💡⚠️]/)
   })
 
   it("renders auto-reply success and prerequisite-warning copy as text-first state messages", async () => {
     const runtime = createHookRuntime()
-    const { Component, setConfig, getCurrentConfig } = await loadSettingsWhatsApp(runtime)
+    const { Component, setConfig, getCurrentConfig } =
+      await loadSettingsWhatsApp(runtime)
 
     setConfig({
       ...getCurrentConfig(),
@@ -393,7 +471,9 @@ describe("desktop WhatsApp settings allowlist", () => {
     let tree = await renderSettled(runtime, Component)
     let settingsText = collectText(findControlGroup(tree, "Settings")).join(" ")
 
-    expect(settingsText).toContain("Auto-reply enabled - incoming messages will be processed and replied to")
+    expect(settingsText).toContain(
+      "Auto-reply enabled - incoming messages will be processed and replied to",
+    )
     expect(settingsText).not.toMatch(/[✓⚠️]/)
 
     setConfig({
@@ -406,7 +486,9 @@ describe("desktop WhatsApp settings allowlist", () => {
     tree = await renderSettled(runtime, Component)
     settingsText = collectText(findControlGroup(tree, "Settings")).join(" ")
 
-    expect(settingsText).toContain("Auto-reply is enabled but Remote Server or API key is missing")
+    expect(settingsText).toContain(
+      "Auto-reply is enabled but Remote Server or API key is missing",
+    )
     expect(settingsText).not.toMatch(/[✓⚠️]/)
   })
 })

--- a/apps/desktop/src/renderer/src/pages/settings-whatsapp.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-whatsapp.tsx
@@ -1,11 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Control, ControlGroup, ControlLabel } from "@renderer/components/ui/control"
+import {
+  Control,
+  ControlGroup,
+  ControlLabel,
+} from "@renderer/components/ui/control"
 import { Switch } from "@renderer/components/ui/switch"
 import { Input } from "@renderer/components/ui/input"
 import { Button } from "@renderer/components/ui/button"
-import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
+import { SettingsPageShell } from "@renderer/components/settings-navigation"
+import {
+  useConfigQuery,
+  useSaveConfigMutation,
+} from "@renderer/lib/query-client"
 import type { Config } from "@shared/types"
-import { AlertTriangle, Loader2, CheckCircle2, XCircle, RefreshCw, LogOut, QrCode as QrCodeIcon, EyeOff } from "lucide-react"
+import {
+  AlertTriangle,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  RefreshCw,
+  LogOut,
+  QrCode as QrCodeIcon,
+  EyeOff,
+} from "lucide-react"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import { QRCodeSVG } from "qrcode.react"
 
@@ -29,7 +46,7 @@ function formatWhatsappAllowFrom(values: string[] | undefined): string {
 function parseWhatsappAllowFromDraft(value: string): string[] {
   return value
     .split(",")
-    .map(entry => entry.trim())
+    .map((entry) => entry.trim())
     .filter(Boolean)
 }
 
@@ -57,8 +74,12 @@ export function Component() {
   const [isConnecting, setIsConnecting] = useState(false)
   const [qrCodeData, setQrCodeData] = useState<string | null>(null)
   const [statusError, setStatusError] = useState<string | null>(null)
-  const [allowFromDraft, setAllowFromDraft] = useState(() => formatWhatsappAllowFrom(cfg?.whatsappAllowFrom))
-  const allowFromSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [allowFromDraft, setAllowFromDraft] = useState(() =>
+    formatWhatsappAllowFrom(cfg?.whatsappAllowFrom),
+  )
+  const allowFromSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
 
   useEffect(() => {
     cfgRef.current = cfg
@@ -73,25 +94,31 @@ export function Component() {
     [saveConfigMutation],
   )
 
-  const flushAllowFromSave = useCallback((draft: string) => {
-    if (allowFromSaveTimeoutRef.current) {
-      clearTimeout(allowFromSaveTimeoutRef.current)
-      allowFromSaveTimeoutRef.current = null
-    }
+  const flushAllowFromSave = useCallback(
+    (draft: string) => {
+      if (allowFromSaveTimeoutRef.current) {
+        clearTimeout(allowFromSaveTimeoutRef.current)
+        allowFromSaveTimeoutRef.current = null
+      }
 
-    saveConfig({ whatsappAllowFrom: parseWhatsappAllowFromDraft(draft) })
-  }, [saveConfig])
-
-  const scheduleAllowFromSave = useCallback((draft: string) => {
-    if (allowFromSaveTimeoutRef.current) {
-      clearTimeout(allowFromSaveTimeoutRef.current)
-    }
-
-    allowFromSaveTimeoutRef.current = setTimeout(() => {
-      allowFromSaveTimeoutRef.current = null
       saveConfig({ whatsappAllowFrom: parseWhatsappAllowFromDraft(draft) })
-    }, WHATSAPP_ALLOWLIST_SAVE_DEBOUNCE_MS)
-  }, [saveConfig])
+    },
+    [saveConfig],
+  )
+
+  const scheduleAllowFromSave = useCallback(
+    (draft: string) => {
+      if (allowFromSaveTimeoutRef.current) {
+        clearTimeout(allowFromSaveTimeoutRef.current)
+      }
+
+      allowFromSaveTimeoutRef.current = setTimeout(() => {
+        allowFromSaveTimeoutRef.current = null
+        saveConfig({ whatsappAllowFrom: parseWhatsappAllowFromDraft(draft) })
+      }, WHATSAPP_ALLOWLIST_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
 
   useEffect(() => {
     setAllowFromDraft(formatWhatsappAllowFrom(cfg?.whatsappAllowFrom))
@@ -187,34 +214,43 @@ export function Component() {
   const streamerMode = cfg.streamerModeEnabled ?? false
 
   return (
-    <div className="modern-panel h-full overflow-y-auto overflow-x-hidden px-6 py-4">
+    <SettingsPageShell>
       <div className="grid gap-4">
         <ControlGroup
           title="WhatsApp Integration"
-          endDescription={(
-            <div className="break-words whitespace-normal">
-              Connect your WhatsApp account to send and receive messages through DotAgents.
-              Messages from allowed phone numbers can trigger the AI agent and receive automatic replies.
+          endDescription={
+            <div className="whitespace-normal break-words">
+              Connect your WhatsApp account to send and receive messages through
+              DotAgents. Messages from allowed phone numbers can trigger the AI
+              agent and receive automatic replies.
             </div>
-          )}
+          }
         >
           {/* Warning if remote server is not enabled */}
           {!remoteServerEnabled && (
             <div className="mx-3 mb-2 flex items-start gap-2 rounded-md bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400">
-              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                <strong>Remote Server Required:</strong> WhatsApp auto-reply requires the Remote Server to be enabled.
-                <a href="/settings/remote-server" className="underline ml-1">Enable it here</a>.
+                <strong>Remote Server Required:</strong> WhatsApp auto-reply
+                requires the Remote Server to be enabled.
+                <a href="/settings/remote-server" className="ml-1 underline">
+                  Enable it here
+                </a>
+                .
               </div>
             </div>
           )}
 
           {remoteServerEnabled && !hasApiKey && (
             <div className="mx-3 mb-2 flex items-start gap-2 rounded-md bg-amber-500/10 p-3 text-sm text-amber-600 dark:text-amber-400">
-              <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                <strong>API Key Required:</strong> Generate an API key in Remote Server settings for WhatsApp to work.
-                <a href="/settings/remote-server" className="underline ml-1">Configure it here</a>.
+                <strong>API Key Required:</strong> Generate an API key in Remote
+                Server settings for WhatsApp to work.
+                <a href="/settings/remote-server" className="ml-1 underline">
+                  Configure it here
+                </a>
+                .
               </div>
             </div>
           )}
@@ -237,23 +273,32 @@ export function Component() {
               {streamerMode && (
                 <div className="mb-3 flex items-center gap-2 text-xs text-amber-600 dark:text-amber-400">
                   <EyeOff className="h-3.5 w-3.5" />
-                  <span>Streamer Mode: Phone numbers and QR codes are hidden</span>
+                  <span>
+                    Streamer Mode: Phone numbers and QR codes are hidden
+                  </span>
                 </div>
               )}
 
               {/* Status display */}
-              <div className="flex items-center gap-2 mb-4">
+              <div className="mb-4 flex items-center gap-2">
                 {status?.connected ? (
                   <>
                     <CheckCircle2 className="h-5 w-5 text-green-500" />
                     <span className="text-sm text-green-600 dark:text-green-400">
-                      Connected as {streamerMode ? "****" : (status.userName || "Unknown")} ({streamerMode ? maskPhoneNumber(status.phoneNumber) : status.phoneNumber})
+                      Connected as{" "}
+                      {streamerMode ? "****" : status.userName || "Unknown"} (
+                      {streamerMode
+                        ? maskPhoneNumber(status.phoneNumber)
+                        : status.phoneNumber}
+                      )
                     </span>
                   </>
                 ) : status?.available ? (
                   <>
-                    <XCircle className="h-5 w-5 text-muted-foreground" />
-                    <span className="text-sm text-muted-foreground">Not connected</span>
+                    <XCircle className="text-muted-foreground h-5 w-5" />
+                    <span className="text-muted-foreground text-sm">
+                      Not connected
+                    </span>
                   </>
                 ) : (
                   <>
@@ -267,7 +312,7 @@ export function Component() {
 
               {/* Error display */}
               {statusError && (
-                <div className="mb-4 p-2 rounded bg-red-500/10 text-sm text-red-600 dark:text-red-400">
+                <div className="mb-4 rounded bg-red-500/10 p-2 text-sm text-red-600 dark:text-red-400">
                   {statusError}
                 </div>
               )}
@@ -276,23 +321,31 @@ export function Component() {
               {qrCodeData && !status?.connected && (
                 <div className="mb-4 flex flex-col items-center">
                   {streamerMode ? (
-                    <div className="bg-muted/50 p-4 rounded-lg shadow-md flex flex-col items-center justify-center" style={{ width: 256, height: 256 }}>
-                      <EyeOff className="h-12 w-12 text-muted-foreground mb-2" />
-                      <span className="text-sm text-muted-foreground text-center">QR Code hidden<br />Streamer Mode is active</span>
+                    <div
+                      className="bg-muted/50 flex flex-col items-center justify-center rounded-lg p-4 shadow-md"
+                      style={{ width: 256, height: 256 }}
+                    >
+                      <EyeOff className="text-muted-foreground mb-2 h-12 w-12" />
+                      <span className="text-muted-foreground text-center text-sm">
+                        QR Code hidden
+                        <br />
+                        Streamer Mode is active
+                      </span>
                     </div>
                   ) : (
-                    <div className="bg-white p-4 rounded-lg shadow-md">
+                    <div className="rounded-lg bg-white p-4 shadow-md">
                       <QRCodeSVG value={qrCodeData} size={256} />
                     </div>
                   )}
-                  <p className="mt-2 text-sm text-muted-foreground text-center">
-                    Open WhatsApp on your phone → Settings → Linked Devices → Scan this QR code
+                  <p className="text-muted-foreground mt-2 text-center text-sm">
+                    Open WhatsApp on your phone → Settings → Linked Devices →
+                    Scan this QR code
                   </p>
                 </div>
               )}
 
               {/* Action buttons */}
-              <div className="flex gap-2 flex-wrap">
+              <div className="flex flex-wrap gap-2">
                 {!status?.connected ? (
                   <Button
                     onClick={handleConnect}
@@ -302,31 +355,42 @@ export function Component() {
                   >
                     {isConnecting ? (
                       <>
-                        <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                         Connecting...
                       </>
                     ) : (
                       <>
-                        <QrCodeIcon className="h-4 w-4 mr-2" />
-                        {status?.hasCredentials ? "Reconnect" : "Connect with QR Code"}
+                        <QrCodeIcon className="mr-2 h-4 w-4" />
+                        {status?.hasCredentials
+                          ? "Reconnect"
+                          : "Connect with QR Code"}
                       </>
                     )}
                   </Button>
                 ) : (
-                  <Button onClick={handleDisconnect} variant="outline" size="sm">
-                    <XCircle className="h-4 w-4 mr-2" />
+                  <Button
+                    onClick={handleDisconnect}
+                    variant="outline"
+                    size="sm"
+                  >
+                    <XCircle className="mr-2 h-4 w-4" />
                     Disconnect
                   </Button>
                 )}
 
                 <Button onClick={fetchStatus} variant="ghost" size="sm">
-                  <RefreshCw className="h-4 w-4 mr-2" />
+                  <RefreshCw className="mr-2 h-4 w-4" />
                   Refresh
                 </Button>
 
                 {(status?.connected || status?.hasCredentials) && (
-                  <Button onClick={handleLogout} variant="ghost" size="sm" className="text-red-600">
-                    <LogOut className="h-4 w-4 mr-2" />
+                  <Button
+                    onClick={handleLogout}
+                    variant="ghost"
+                    size="sm"
+                    className="text-red-600"
+                  >
+                    <LogOut className="mr-2 h-4 w-4" />
                     Logout
                   </Button>
                 )}
@@ -339,7 +403,12 @@ export function Component() {
         {enabled && (
           <ControlGroup title="Settings">
             <Control
-              label={<ControlLabel label="Allowed Senders" tooltip="Only messages from these senders will be processed. Accepts phone numbers (E.164) or WhatsApp LIDs. Leave empty to allow all (not recommended)." />}
+              label={
+                <ControlLabel
+                  label="Allowed Senders"
+                  tooltip="Only messages from these senders will be processed. Accepts phone numbers (E.164) or WhatsApp LIDs. Leave empty to allow all (not recommended)."
+                />
+              }
               className="px-3"
             >
               <Input
@@ -351,35 +420,47 @@ export function Component() {
                   scheduleAllowFromSave(nextDraft)
                 }}
                 onBlur={(e) => flushAllowFromSave(e.currentTarget.value)}
-                placeholder={streamerMode ? "••••••••••" : "+14155551234, 98389177934034"}
+                placeholder={
+                  streamerMode ? "••••••••••" : "+14155551234, 98389177934034"
+                }
                 className="w-full"
               />
-              <div className="mt-2 text-xs text-muted-foreground space-y-1">
-                <p>Enter phone numbers or LIDs separated by commas. Phone numbers can include formatting like +, spaces, or punctuation.</p>
+              <div className="text-muted-foreground mt-2 space-y-1 text-xs">
+                <p>
+                  Enter phone numbers or LIDs separated by commas. Phone numbers
+                  can include formatting like +, spaces, or punctuation.
+                </p>
                 <details className="cursor-pointer">
-                  <summary className="text-blue-600 dark:text-blue-400 hover:underline">
+                  <summary className="text-blue-600 hover:underline dark:text-blue-400">
                     What are LIDs and how do I find them?
                   </summary>
-                  <div className="mt-2 p-2 bg-muted/50 rounded-md space-y-2">
+                  <div className="bg-muted/50 mt-2 space-y-2 rounded-md p-2">
                     <p>
-                      <strong>LIDs (Linked IDs)</strong> are WhatsApp's privacy-focused identifiers that replace phone numbers in some cases.
+                      <strong>LIDs (Linked IDs)</strong> are WhatsApp's
+                      privacy-focused identifiers that replace phone numbers in
+                      some cases.
                     </p>
                     <p>
                       <strong>To find a sender's LID:</strong>
                     </p>
-                    <ol className="list-decimal list-inside space-y-1 ml-2">
+                    <ol className="ml-2 list-inside list-decimal space-y-1">
                       <li>Enable "Log Message Content" below</li>
                       <li>Have the person send you a message</li>
-                      <li>Check the logs - blocked messages show the LID to add</li>
+                      <li>
+                        Check the logs - blocked messages show the LID to add
+                      </li>
                       <li>Copy the LID number and add it here</li>
                     </ol>
                     <p className="text-amber-600 dark:text-amber-400">
-                      Tip: Phone numbers still work for many contacts. Try the phone number first, then use a LID if messages are blocked.
+                      Tip: Phone numbers still work for many contacts. Try the
+                      phone number first, then use a LID if messages are
+                      blocked.
                     </p>
                   </div>
                 </details>
               </div>
-              {(!cfg.whatsappAllowFrom || cfg.whatsappAllowFrom.length === 0) && (
+              {(!cfg.whatsappAllowFrom ||
+                cfg.whatsappAllowFrom.length === 0) && (
                 <div className="mt-2 text-xs text-amber-600 dark:text-amber-400">
                   No allowlist set - all incoming messages will be accepted
                 </div>
@@ -387,7 +468,12 @@ export function Component() {
             </Control>
 
             <Control
-              label={<ControlLabel label="Auto-Reply" tooltip="Automatically send agent responses back to WhatsApp. Requires Remote Server to be enabled." />}
+              label={
+                <ControlLabel
+                  label="Auto-Reply"
+                  tooltip="Automatically send agent responses back to WhatsApp. Requires Remote Server to be enabled."
+                />
+              }
               className="px-3"
             >
               <Switch
@@ -398,23 +484,32 @@ export function Component() {
                 disabled={
                   // Only disable when trying to enable without prerequisites
                   // Always allow turning OFF (unchecking) so users can opt out
-                  !(cfg.whatsappAutoReply ?? false) && (!remoteServerEnabled || !hasApiKey)
+                  !(cfg.whatsappAutoReply ?? false) &&
+                  (!remoteServerEnabled || !hasApiKey)
                 }
               />
               {cfg.whatsappAutoReply && remoteServerEnabled && hasApiKey && (
                 <div className="mt-1 text-xs text-green-600 dark:text-green-400">
-                  Auto-reply enabled - incoming messages will be processed and replied to
+                  Auto-reply enabled - incoming messages will be processed and
+                  replied to
                 </div>
               )}
-              {cfg.whatsappAutoReply && (!remoteServerEnabled || !hasApiKey) && (
-                <div className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                  Auto-reply is enabled but Remote Server or API key is missing
-                </div>
-              )}
+              {cfg.whatsappAutoReply &&
+                (!remoteServerEnabled || !hasApiKey) && (
+                  <div className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                    Auto-reply is enabled but Remote Server or API key is
+                    missing
+                  </div>
+                )}
             </Control>
 
             <Control
-              label={<ControlLabel label="Log Message Content" tooltip="Log the content of WhatsApp messages. Disable for privacy." />}
+              label={
+                <ControlLabel
+                  label="Log Message Content"
+                  tooltip="Log the content of WhatsApp messages. Disable for privacy."
+                />
+              }
               className="px-3"
             >
               <Switch
@@ -423,14 +518,14 @@ export function Component() {
                   saveConfig({ whatsappLogMessages: value })
                 }}
               />
-              <div className="mt-1 text-xs text-muted-foreground">
-                When enabled, message content will appear in logs. Disable for privacy.
+              <div className="text-muted-foreground mt-1 text-xs">
+                When enabled, message content will appear in logs. Disable for
+                privacy.
               </div>
             </Control>
           </ControlGroup>
         )}
       </div>
-    </div>
+    </SettingsPageShell>
   )
 }
-

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -38,6 +38,10 @@ export const router: ReturnType<typeof createBrowserRouter> =
           lazy: () => import("./pages/settings-general"),
         },
         {
+          path: "settings/knowledge",
+          lazy: () => import("./pages/knowledge"),
+        },
+        {
           path: "settings/providers",
           lazy: () => import("./pages/settings-providers"),
         },
@@ -100,7 +104,7 @@ export const router: ReturnType<typeof createBrowserRouter> =
         },
         {
           path: "knowledge",
-          lazy: () => import("./pages/knowledge"),
+          loader: legacySettingsRedirect("/settings/knowledge"),
         },
       ],
     },


### PR DESCRIPTION
## Summary
- Consolidates desktop settings into an internal settings sidebar and removes the old flat normal-sidebar settings links.
- Adds a persistent bottom bar for repeat tasks, provider/model, thinking, verbosity, and version controls.
- Moves Knowledge into Settings at `/settings/knowledge`, with `/knowledge` redirecting there.
- Removes duplicated session-view model/thinking/verbosity controls now owned by the bottom bar.

## Validation
- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/components/app-bottom-bar.test.ts src/renderer/src/components/agent-progress.tile-layout.test.ts src/renderer/src/components/app-layout.session-retention.test.ts src/renderer/src/pages/sessions.in-app-actions.test.ts src/renderer/src/lib/settings-navigation.test.ts src/renderer/src/lib/legacy-settings-redirect.test.ts src/renderer/src/pages/settings-providers.draft.test.tsx src/renderer/src/pages/settings-general.langfuse-draft.test.tsx src/renderer/src/pages/settings-whatsapp.allowlist.test.tsx src/renderer/src/pages/settings-agents.install-handoff.test.tsx`
- `pnpm --filter @dotagents/desktop typecheck:web`