### PR TITLE
[codex] Improve settings sidebar grouping

### DIFF
--- a/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/active-agents-sidebar.tsx
@@ -1603,9 +1603,9 @@ export function ActiveAgentsSidebar({
       {hasLaunchControls && (
         <div className="sticky top-0 z-40 -mx-2 bg-background/95 px-2 pb-2 pt-2">
           <div className="rounded-lg border border-border/60 bg-muted/20 p-2">
-            <div className="flex w-full flex-wrap items-center gap-2">
+            <div className="flex w-full flex-nowrap items-center gap-1.5">
               {onSelectAgent && (
-                <div className="min-w-0 flex-1">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center">
                   <AgentSelector
                     selectedAgentId={selectedAgentId}
                     onSelectAgent={onSelectAgent}
@@ -1613,7 +1613,7 @@ export function ActiveAgentsSidebar({
                   />
                 </div>
               )}
-              <div className="ml-auto flex items-center gap-2">
+              <div className="ml-auto flex min-w-0 items-center gap-1.5">
                 {onClearInactiveSessions && inactiveSessionCount > 0 && (
                   <Button
                     type="button"
@@ -2325,44 +2325,46 @@ export function ActiveAgentsSidebar({
                     <span className="ml-1 rounded-full bg-muted-foreground/20 px-1.5 py-px text-[9px] font-medium leading-none text-muted-foreground">
                       {userSidebarSessions.length}
                     </span>
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        createSessionGroup()
-                      }}
-                      className="text-muted-foreground hover:text-foreground focus:ring-ring ml-auto flex h-5 w-5 shrink-0 items-center justify-center rounded focus:outline-none focus:ring-1 transition-colors"
-                      title="New session group"
-                      aria-label="New session group"
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                    </button>
-                    {onOpenSavedConversationsDialog && (
+                    <div className="ml-auto flex shrink-0 items-center gap-0.5">
                       <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onOpenSavedConversationsDialog()
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          createSessionGroup()
                         }}
-                        className="text-muted-foreground hover:text-foreground focus:ring-ring flex h-5 w-5 shrink-0 items-center justify-center rounded focus:outline-none focus:ring-1 transition-colors"
-                        title="Saved conversations"
-                        aria-label="Saved conversations"
+                        className="text-muted-foreground hover:text-foreground focus:ring-ring flex h-4 w-4 shrink-0 items-center justify-center rounded focus:outline-none focus:ring-1 transition-colors"
+                        title="New session group"
+                        aria-label="New session group"
                       >
-                        <Clock className="h-3.5 w-3.5" />
+                        <Plus className="h-3 w-3" />
                       </button>
-                    )}
-                    {onOpenArchivedConversationsDialog && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          onOpenArchivedConversationsDialog()
-                        }}
-                        className="text-muted-foreground hover:text-foreground focus:ring-ring flex h-5 w-5 shrink-0 items-center justify-center rounded focus:outline-none focus:ring-1 transition-colors"
-                        title="Archived sessions"
-                        aria-label="Archived sessions"
-                      >
-                        <Archive className="h-3.5 w-3.5" />
-                      </button>
-                    )}
+                      {onOpenSavedConversationsDialog && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onOpenSavedConversationsDialog()
+                          }}
+                          className="text-muted-foreground hover:text-foreground focus:ring-ring flex h-4 w-4 shrink-0 items-center justify-center rounded focus:outline-none focus:ring-1 transition-colors"
+                          title="Saved conversations"
+                          aria-label="Saved conversations"
+                        >
+                          <Clock className="h-3 w-3" />
+                        </button>
+                      )}
+                      {onOpenArchivedConversationsDialog && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onOpenArchivedConversationsDialog()
+                          }}
+                          className="text-muted-foreground hover:text-foreground focus:ring-ring flex h-4 w-4 shrink-0 items-center justify-center rounded focus:outline-none focus:ring-1 transition-colors"
+                          title="Archived sessions"
+                          aria-label="Archived sessions"
+                        >
+                          <Archive className="h-3 w-3" />
+                        </button>
+                      )}
+                    </div>
                   </div>
                 )}
                 {isExpanded && userSidebarGroupSections.map(renderSessionGroupSection)}

--- a/apps/desktop/src/renderer/src/components/settings-navigation.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-navigation.tsx
@@ -165,11 +165,13 @@ export function SettingsPageShell({
     <div className="modern-panel flex h-full min-w-0 flex-col overflow-hidden">
       <div
         className={cn(
-          "min-h-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-5 sm:px-6",
+          "min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-5 pr-6 sm:px-6 sm:pr-8",
           contentClassName,
         )}
       >
-        <div className={cn("mx-auto w-full max-w-5xl", innerClassName)}>
+        <div
+          className={cn("mx-auto w-full min-w-0 max-w-full", innerClassName)}
+        >
           {children}
         </div>
       </div>

--- a/apps/desktop/src/renderer/src/components/settings-navigation.tsx
+++ b/apps/desktop/src/renderer/src/components/settings-navigation.tsx
@@ -27,7 +27,9 @@ export function SettingsSidebarNavigation({
   const navigate = useNavigate()
   const [searchQuery, setSearchQuery] = useState("")
   const configQuery = useConfigQuery()
-  const activeState = getSettingsNavigationState(location.pathname)
+  const activeState = getSettingsNavigationState(
+    `${location.pathname}${location.hash}`,
+  )
   const groups = getVisibleSettingsNavGroups({
     discordEnabled: configQuery.data?.discordEnabled ?? false,
     activeItemHref: activeState.itemHref,

--- a/apps/desktop/src/renderer/src/components/ui/control.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/control.tsx
@@ -98,16 +98,16 @@ export const Control = ({
   return (
     <div
       className={cn(
-        "flex flex-col gap-2 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-5",
+        "flex min-w-0 max-w-full flex-col gap-2 py-2 sm:flex-row sm:items-center sm:justify-between sm:gap-5",
         className,
       )}
     >
-      <div className="min-w-0 sm:max-w-[52%]">
+      <div className="min-w-0 max-w-full sm:max-w-[52%]">
         <div className="break-words text-sm font-medium leading-5">
           {displayLabel}
         </div>
       </div>
-      <div className="flex w-full min-w-0 items-center justify-start sm:max-w-[48%] sm:justify-end">
+      <div className="flex w-full min-w-0 max-w-full items-center justify-start overflow-hidden sm:max-w-[48%] sm:justify-end">
         {children}
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/components/ui/control.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/control.tsx
@@ -1,7 +1,12 @@
 import { cn } from "@renderer/lib/utils"
 import React, { createContext, useContext, useState } from "react"
 import { ChevronDown, ChevronRight, Info } from "lucide-react"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip"
 
 /**
  * Context for settings search filtering.
@@ -15,13 +20,20 @@ function extractLabelText(label: React.ReactNode): string {
   if (label && typeof label === "object" && "props" in label) {
     const props = (label as React.ReactElement).props as Record<string, unknown>
     if (typeof props.label === "string") return props.label
-    if (typeof props.tooltip === "string") return `${props.label ?? ""} ${props.tooltip}`
+    if (typeof props.tooltip === "string")
+      return `${props.label ?? ""} ${props.tooltip}`
   }
   return ""
 }
 
 /** Highlight matching substring in text */
-export function HighlightMatch({ text, query }: { text: string; query: string }) {
+export function HighlightMatch({
+  text,
+  query,
+}: {
+  text: string
+  query: string
+}) {
   if (!query) return <>{text}</>
   const lowerText = text.toLowerCase()
   const lowerQuery = query.toLowerCase()
@@ -30,22 +42,33 @@ export function HighlightMatch({ text, query }: { text: string; query: string })
   return (
     <>
       {text.slice(0, idx)}
-      <mark className="bg-yellow-200 dark:bg-yellow-700/60 text-inherit rounded-sm px-0.5">{text.slice(idx, idx + query.length)}</mark>
+      <mark className="rounded-sm bg-yellow-200 px-0.5 text-inherit dark:bg-yellow-700/60">
+        {text.slice(idx, idx + query.length)}
+      </mark>
       {text.slice(idx + query.length)}
     </>
   )
 }
 
 /** Apply search highlighting to a Control label */
-function highlightLabel(label: React.ReactNode, query: string): React.ReactNode {
+function highlightLabel(
+  label: React.ReactNode,
+  query: string,
+): React.ReactNode {
   if (!query) return label
-  if (typeof label === "string") return <HighlightMatch text={label} query={query} />
+  if (typeof label === "string")
+    return <HighlightMatch text={label} query={query} />
   if (label && typeof label === "object" && "props" in label) {
     const el = label as React.ReactElement
     const props = el.props as Record<string, unknown>
     if (typeof props.label === "string") {
       const { label: origLabel, ...rest } = props
-      return <ControlLabel label={<HighlightMatch text={origLabel as string} query={query} />} {...rest} />
+      return (
+        <ControlLabel
+          label={<HighlightMatch text={origLabel as string} query={query} />}
+          {...rest}
+        />
+      )
     }
   }
   return label
@@ -63,7 +86,11 @@ export const Control = ({
   const searchQuery = useContext(SettingsSearchContext)
   const text = extractLabelText(label)
   // When searching, hide controls that don't match
-  if (searchQuery && text && !text.toLowerCase().includes(searchQuery.toLowerCase())) {
+  if (
+    searchQuery &&
+    text &&
+    !text.toLowerCase().includes(searchQuery.toLowerCase())
+  ) {
     return null
   }
   const displayLabel = highlightLabel(label, searchQuery)
@@ -76,7 +103,9 @@ export const Control = ({
       )}
     >
       <div className="min-w-0 sm:max-w-[52%]">
-        <div className="text-sm font-medium leading-5 break-words">{displayLabel}</div>
+        <div className="break-words text-sm font-medium leading-5">
+          {displayLabel}
+        </div>
       </div>
       <div className="flex w-full min-w-0 items-center justify-start sm:max-w-[48%] sm:justify-end">
         {children}
@@ -98,11 +127,11 @@ export const ControlLabel = ({
 
   return (
     <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-      <span className="text-sm font-medium break-words">{label}</span>
+      <span className="break-words text-sm font-medium">{label}</span>
       <TooltipProvider delayDuration={0} disableHoverableContent>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Info className="h-3.5 w-3.5 shrink-0 text-muted-foreground cursor-help transition-colors hover:text-foreground" />
+            <Info className="text-muted-foreground hover:text-foreground h-3.5 w-3.5 shrink-0 cursor-help transition-colors" />
           </TooltipTrigger>
           <TooltipContent
             side="top"
@@ -123,6 +152,7 @@ export const ControlLabel = ({
 export const ControlGroup = ({
   children,
   className,
+  id,
   title,
   endDescription,
   collapsible = false,
@@ -132,6 +162,7 @@ export const ControlGroup = ({
 }: {
   children: React.ReactNode
   className?: string
+  id?: string
   title?: React.ReactNode
   endDescription?: React.ReactNode
   collapsible?: boolean
@@ -144,12 +175,12 @@ export const ControlGroup = ({
   const isCollapsed = forceOpen ? false : collapsed
 
   return (
-    <div className={className}>
+    <div id={id} className={className}>
       {title && collapsible ? (
         <div className="rounded-lg border">
           <button
             type="button"
-            className="flex w-full items-center justify-between px-3 py-2 text-left hover:bg-muted/30 transition-colors cursor-pointer"
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 text-left transition-colors"
             onClick={() => {
               const newCollapsed = !collapsed
               setCollapsed(newCollapsed)
@@ -159,9 +190,9 @@ export const ControlGroup = ({
           >
             <span className="flex items-center gap-2 text-sm font-semibold">
               {isCollapsed ? (
-                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
               ) : (
-                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
               )}
               <span>{title}</span>
             </span>
@@ -171,8 +202,8 @@ export const ControlGroup = ({
             <>
               <div className="divide-y border-t">{children}</div>
               {endDescription && (
-                <div className="border-t px-3 py-2 text-xs text-muted-foreground sm:flex sm:justify-end sm:text-right">
-                  <div className="w-full break-words whitespace-normal sm:max-w-[70%]">
+                <div className="text-muted-foreground border-t px-3 py-2 text-xs sm:flex sm:justify-end sm:text-right">
+                  <div className="w-full whitespace-normal break-words sm:max-w-[70%]">
                     {endDescription}
                   </div>
                 </div>
@@ -191,8 +222,8 @@ export const ControlGroup = ({
             <>
               <div className="divide-y rounded-lg border">{children}</div>
               {endDescription && (
-                <div className="mt-2 text-xs text-muted-foreground sm:flex sm:justify-end sm:text-right">
-                  <div className="w-full break-words whitespace-normal sm:max-w-[70%]">
+                <div className="text-muted-foreground mt-2 text-xs sm:flex sm:justify-end sm:text-right">
+                  <div className="w-full whitespace-normal break-words sm:max-w-[70%]">
                     {endDescription}
                   </div>
                 </div>

--- a/apps/desktop/src/renderer/src/components/ui/control.tsx
+++ b/apps/desktop/src/renderer/src/components/ui/control.tsx
@@ -107,7 +107,7 @@ export const Control = ({
           {displayLabel}
         </div>
       </div>
-      <div className="flex w-full min-w-0 max-w-full items-center justify-start overflow-hidden sm:max-w-[48%] sm:justify-end">
+      <div className="flex w-full min-w-0 max-w-full flex-wrap items-center justify-start gap-2 sm:max-w-[48%] sm:justify-end">
         {children}
       </div>
     </div>
@@ -188,14 +188,14 @@ export const ControlGroup = ({
             }}
             aria-expanded={!isCollapsed}
           >
-            <span className="flex items-center gap-2 text-sm font-semibold">
+            <div className="flex min-w-0 items-center gap-2 text-sm font-semibold">
               {isCollapsed ? (
                 <ChevronRight className="text-muted-foreground h-4 w-4" />
               ) : (
                 <ChevronDown className="text-muted-foreground h-4 w-4" />
               )}
-              <span>{title}</span>
-            </span>
+              <div className="min-w-0">{title}</div>
+            </div>
           </button>
 
           {!isCollapsed && (

--- a/apps/desktop/src/renderer/src/lib/legacy-settings-redirect.test.ts
+++ b/apps/desktop/src/renderer/src/lib/legacy-settings-redirect.test.ts
@@ -7,8 +7,8 @@ describe("getLegacySettingsRedirectPath", () => {
     expect(
       getLegacySettingsRedirectPath(
         "/settings/agents",
-        "http://localhost/settings/agent-personas?tab=custom#install-bundle"
-      )
+        "http://localhost/settings/agent-personas?tab=custom#install-bundle",
+      ),
     ).toBe("/settings/agents?tab=custom#install-bundle")
   })
 
@@ -16,8 +16,8 @@ describe("getLegacySettingsRedirectPath", () => {
     expect(
       getLegacySettingsRedirectPath(
         "/settings/capabilities",
-        "http://localhost/settings/mcp-tools"
-      )
+        "http://localhost/settings/mcp-tools",
+      ),
     ).toBe("/settings/capabilities")
   })
 
@@ -25,8 +25,8 @@ describe("getLegacySettingsRedirectPath", () => {
     expect(
       getLegacySettingsRedirectPath(
         "/settings/repeat-tasks",
-        "http://localhost/settings/loops#scheduled"
-      )
+        "http://localhost/settings/loops#scheduled",
+      ),
     ).toBe("/settings/repeat-tasks#scheduled")
   })
 
@@ -34,8 +34,26 @@ describe("getLegacySettingsRedirectPath", () => {
     expect(
       getLegacySettingsRedirectPath(
         "/settings/knowledge",
-        "http://localhost/knowledge?context=auto#notes"
-      )
+        "http://localhost/knowledge?context=auto#notes",
+      ),
     ).toBe("/settings/knowledge?context=auto#notes")
+  })
+
+  it("places preserved query params before target hashes", () => {
+    expect(
+      getLegacySettingsRedirectPath(
+        "/settings/models#provider-setup",
+        "http://localhost/settings/providers?provider=groq",
+      ),
+    ).toBe("/settings/models?provider=groq#provider-setup")
+  })
+
+  it("lets source hashes override target hashes", () => {
+    expect(
+      getLegacySettingsRedirectPath(
+        "/settings/models#provider-setup",
+        "http://localhost/settings/providers#groq",
+      ),
+    ).toBe("/settings/models#groq")
   })
 })

--- a/apps/desktop/src/renderer/src/lib/legacy-settings-redirect.ts
+++ b/apps/desktop/src/renderer/src/lib/legacy-settings-redirect.ts
@@ -1,4 +1,9 @@
-export function getLegacySettingsRedirectPath(targetPath: string, requestUrl: string): string {
+export function getLegacySettingsRedirectPath(
+  targetPath: string,
+  requestUrl: string,
+): string {
   const { search, hash } = new URL(requestUrl)
-  return `${targetPath}${search}${hash}`
+  const [targetBase, targetHash = ""] = targetPath.split("#", 2)
+  const nextHash = hash || (targetHash ? `#${targetHash}` : "")
+  return `${targetBase}${search}${nextHash}`
 }

--- a/apps/desktop/src/renderer/src/lib/settings-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-navigation.test.ts
@@ -10,38 +10,60 @@ import {
 describe("settings navigation", () => {
   it("maps consolidated settings routes to their internal group and subsection", () => {
     expect(getSettingsNavigationState("/settings")).toEqual({
-      groupId: "general",
-      itemHref: "/settings",
+      groupId: "app",
+      itemHref: "/settings#general",
+    })
+    expect(getSettingsNavigationState("/settings#shortcuts")).toEqual({
+      groupId: "app",
+      itemHref: "/settings#shortcuts",
     })
     expect(getSettingsNavigationState("/settings/knowledge")).toEqual({
-      groupId: "general",
+      groupId: "app",
       itemHref: "/settings/knowledge",
     })
     expect(getSettingsNavigationState("/settings/models")).toEqual({
       groupId: "intelligence",
-      itemHref: "/settings/models",
+      itemHref: "/settings/models#agent-models",
     })
-    expect(getSettingsNavigationState("/settings/providers")).toEqual({
+    expect(
+      getSettingsNavigationState("/settings/models#provider-setup"),
+    ).toEqual({
       groupId: "intelligence",
-      itemHref: "/settings/providers",
+      itemHref: "/settings/models#provider-setup",
     })
     expect(getSettingsNavigationState("/settings/agents")).toEqual({
       groupId: "agents",
       itemHref: "/settings/agents",
+    })
+    expect(getSettingsNavigationState("/settings#agent-settings")).toEqual({
+      groupId: "agents",
+      itemHref: "/settings#agent-settings",
     })
     expect(getSettingsNavigationState("/settings/capabilities")).toEqual({
       groupId: "agents",
       itemHref: "/settings/capabilities",
     })
     expect(getSettingsNavigationState("/settings/whatsapp")).toEqual({
-      groupId: "integrations",
+      groupId: "connect",
       itemHref: "/settings/whatsapp",
+    })
+    expect(getSettingsNavigationState("/settings/remote-server")).toEqual({
+      groupId: "connect",
+      itemHref: "/settings#remote-server",
     })
   })
 
   it("keeps legacy settings routes attached to the consolidated settings nav", () => {
     expect(normalizeSettingsPath("/settings/general")).toBe("/settings")
-    expect(normalizeSettingsPath("/settings/remote-server")).toBe("/settings")
+    expect(normalizeSettingsPath("/settings/remote-server")).toBe(
+      "/settings#remote-server",
+    )
+    expect(normalizeSettingsPath("/settings/langfuse")).toBe(
+      "/settings#observability",
+    )
+    expect(normalizeSettingsPath("/settings/providers")).toBe(
+      "/settings/models#provider-setup",
+    )
     expect(normalizeSettingsPath("/settings/mcp-tools")).toBe(
       "/settings/capabilities",
     )
@@ -65,18 +87,25 @@ describe("settings navigation", () => {
       discordEnabled: false,
     })
     const disabledIntegrationItems =
-      disabledGroups.find((group) => group.id === "integrations")?.items ?? []
+      disabledGroups.find((group) => group.id === "connect")?.items ?? []
 
     expect(disabledIntegrationItems.map((item) => item.href)).toEqual([
+      "/settings#remote-server",
+      "/settings#cloudflare-tunnel",
+      "/settings#whatsapp-integration",
       "/settings/whatsapp",
     ])
 
     const enabledGroups = getVisibleSettingsNavGroups({ discordEnabled: true })
     const enabledIntegrationItems =
-      enabledGroups.find((group) => group.id === "integrations")?.items ?? []
+      enabledGroups.find((group) => group.id === "connect")?.items ?? []
 
     expect(enabledIntegrationItems.map((item) => item.href)).toEqual([
+      "/settings#remote-server",
+      "/settings#cloudflare-tunnel",
+      "/settings#whatsapp-integration",
       "/settings/whatsapp",
+      "/settings#discord-integration",
       "/settings/discord",
     ])
 
@@ -85,11 +114,79 @@ describe("settings navigation", () => {
       activeItemHref: "/settings/discord",
     })
     const activeDiscordItems =
-      activeDiscordGroups.find((group) => group.id === "integrations")?.items ??
-      []
+      activeDiscordGroups.find((group) => group.id === "connect")?.items ?? []
 
     expect(activeDiscordItems.map((item) => item.href)).toContain(
       "/settings/discord",
     )
+  })
+
+  it("shows repeat tasks as a separate automation group in the settings sidebar", () => {
+    const groups = getVisibleSettingsNavGroups()
+    const automationItems =
+      groups.find((group) => group.id === "automation")?.items ?? []
+
+    expect(automationItems.map((item) => item.href)).toEqual([
+      "/settings/repeat-tasks",
+    ])
+  })
+
+  it("exposes main settings page groups as sidebar anchors", () => {
+    const groups = getVisibleSettingsNavGroups()
+
+    expect(
+      groups
+        .find((group) => group.id === "app")
+        ?.items.map((item) => item.href),
+    ).toEqual([
+      "/settings#general",
+      "/settings#shortcuts",
+      "/settings#panel-position",
+      "/settings/knowledge",
+    ])
+    expect(
+      groups
+        .find((group) => group.id === "voice")
+        ?.items.map((item) => item.href),
+    ).toEqual([
+      "/settings#audio-devices",
+      "/settings#speech-to-text",
+      "/settings#text-to-speech",
+    ])
+    expect(
+      groups
+        .find((group) => group.id === "connect")
+        ?.items.map((item) => item.href),
+    ).toEqual([
+      "/settings#remote-server",
+      "/settings#cloudflare-tunnel",
+      "/settings#whatsapp-integration",
+      "/settings/whatsapp",
+    ])
+    expect(
+      groups
+        .find((group) => group.id === "advanced")
+        ?.items.map((item) => item.href),
+    ).toEqual([
+      "/settings#modular-config",
+      "/settings#observability",
+      "/settings#about",
+    ])
+  })
+
+  it("consolidates model and provider setup into one intelligence page", () => {
+    const groups = getVisibleSettingsNavGroups()
+
+    expect(
+      groups
+        .find((group) => group.id === "intelligence")
+        ?.items.map((item) => item.href),
+    ).toEqual([
+      "/settings/models#agent-models",
+      "/settings/models#job-providers",
+      "/settings/models#transcript-processing",
+      "/settings/models#speech-voice-models",
+      "/settings/models#provider-setup",
+    ])
   })
 })

--- a/apps/desktop/src/renderer/src/lib/settings-navigation.test.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-navigation.test.ts
@@ -64,6 +64,12 @@ describe("settings navigation", () => {
     expect(normalizeSettingsPath("/settings/providers")).toBe(
       "/settings/models#provider-setup",
     )
+    expect(normalizeSettingsPath("/settings/providers#groq")).toBe(
+      "/settings/models#groq",
+    )
+    expect(
+      normalizeSettingsPath("/settings/remote-server#cloudflare-tunnel"),
+    ).toBe("/settings#cloudflare-tunnel")
     expect(normalizeSettingsPath("/settings/mcp-tools")).toBe(
       "/settings/capabilities",
     )
@@ -73,6 +79,12 @@ describe("settings navigation", () => {
     expect(normalizeSettingsPath("/settings/agent-personas")).toBe(
       "/settings/agents",
     )
+    expect(
+      getSettingsNavigationState("/settings/remote-server#cloudflare-tunnel"),
+    ).toEqual({
+      groupId: "connect",
+      itemHref: "/settings#cloudflare-tunnel",
+    })
   })
 
   it("excludes repeat tasks from the consolidated settings sidebar target", () => {

--- a/apps/desktop/src/renderer/src/lib/settings-navigation.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-navigation.ts
@@ -306,7 +306,11 @@ export function isConsolidatedSettingsRoute(pathname: string): boolean {
 
 export function normalizeSettingsPath(pathname: string): string {
   const { path, hash } = splitSettingsLocation(pathname)
-  return `${SETTINGS_ROUTE_ALIASES[path] ?? path}${hash}`
+  const aliasTarget = SETTINGS_ROUTE_ALIASES[path]
+  if (!aliasTarget) return `${path}${hash}`
+
+  const aliasLocation = splitSettingsLocation(aliasTarget)
+  return `${aliasLocation.path}${hash || aliasLocation.hash}`
 }
 
 export function getSettingsNavigationState(

--- a/apps/desktop/src/renderer/src/lib/settings-navigation.ts
+++ b/apps/desktop/src/renderer/src/lib/settings-navigation.ts
@@ -1,8 +1,11 @@
 export type SettingsNavGroupId =
-  | "general"
+  | "app"
   | "intelligence"
+  | "voice"
   | "agents"
-  | "integrations"
+  | "automation"
+  | "connect"
+  | "advanced"
 
 export type SettingsNavIntegrationGate = "discord"
 
@@ -34,23 +37,37 @@ export interface SettingsNavVisibility {
 
 export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
   {
-    id: "general",
-    label: "General",
+    id: "app",
+    label: "App",
     icon: "i-mingcute-settings-3-line",
     items: [
       {
         id: "general",
         label: "General",
-        href: "/settings",
+        href: "/settings#general",
         icon: "i-mingcute-settings-3-line",
-        groupId: "general",
+        groupId: "app",
+      },
+      {
+        id: "shortcuts",
+        label: "Shortcuts",
+        href: "/settings#shortcuts",
+        icon: "i-mingcute-keyboard-line",
+        groupId: "app",
+      },
+      {
+        id: "panel",
+        label: "Floating Panel",
+        href: "/settings#panel-position",
+        icon: "i-mingcute-layout-6-line",
+        groupId: "app",
       },
       {
         id: "knowledge",
         label: "Knowledge",
         href: "/settings/knowledge",
         icon: "i-mingcute-book-2-line",
-        groupId: "general",
+        groupId: "app",
       },
     ],
   },
@@ -62,16 +79,65 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
       {
         id: "models",
         label: "Models",
-        href: "/settings/models",
+        href: "/settings/models#agent-models",
         icon: "i-mingcute-brain-line",
         groupId: "intelligence",
       },
       {
-        id: "providers",
-        label: "Providers",
-        href: "/settings/providers",
+        id: "job-providers",
+        label: "Job Routing",
+        href: "/settings/models#job-providers",
         icon: "i-mingcute-tool-line",
         groupId: "intelligence",
+      },
+      {
+        id: "transcript-processing",
+        label: "Cleanup",
+        href: "/settings/models#transcript-processing",
+        icon: "i-mingcute-file-text-line",
+        groupId: "intelligence",
+      },
+      {
+        id: "speech-voice-models",
+        label: "Speech & Voice",
+        href: "/settings/models#speech-voice-models",
+        icon: "i-mingcute-mic-line",
+        groupId: "intelligence",
+      },
+      {
+        id: "provider-setup",
+        label: "Provider Setup",
+        href: "/settings/models#provider-setup",
+        icon: "i-mingcute-key-2-line",
+        groupId: "intelligence",
+      },
+    ],
+  },
+  {
+    id: "voice",
+    label: "Voice",
+    icon: "i-mingcute-mic-line",
+    items: [
+      {
+        id: "audio-devices",
+        label: "Audio Devices",
+        href: "/settings#audio-devices",
+        icon: "i-mingcute-volume-line",
+        groupId: "voice",
+      },
+      {
+        id: "speech-to-text",
+        label: "Speech-to-Text",
+        href: "/settings#speech-to-text",
+        icon: "i-mingcute-mic-line",
+        groupId: "voice",
+      },
+      {
+        id: "text-to-speech",
+        label: "Text to Speech",
+        href: "/settings#text-to-speech",
+        icon: "i-mingcute-volume-line",
+        groupId: "voice",
       },
     ],
   },
@@ -81,8 +147,15 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
     icon: "i-mingcute-group-line",
     items: [
       {
-        id: "agents",
-        label: "Agents",
+        id: "agent-settings",
+        label: "Agent Settings",
+        href: "/settings#agent-settings",
+        icon: "i-mingcute-robot-2-line",
+        groupId: "agents",
+      },
+      {
+        id: "agent-library",
+        label: "Agent Library",
         href: "/settings/agents",
         icon: "i-mingcute-group-line",
         groupId: "agents",
@@ -97,24 +170,95 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
     ],
   },
   {
-    id: "integrations",
-    label: "Integrations",
+    id: "automation",
+    label: "Automation",
+    icon: "i-mingcute-repeat-line",
+    items: [
+      {
+        id: "repeat-tasks",
+        label: "Repeat Tasks",
+        href: "/settings/repeat-tasks",
+        icon: "i-mingcute-repeat-line",
+        groupId: "automation",
+      },
+    ],
+  },
+  {
+    id: "connect",
+    label: "Connect",
     icon: "i-mingcute-message-4-line",
     items: [
+      {
+        id: "remote-server",
+        label: "Remote Server",
+        href: "/settings#remote-server",
+        icon: "i-mingcute-qr-code-line",
+        groupId: "connect",
+      },
+      {
+        id: "cloudflare-tunnel",
+        label: "Cloudflare Tunnel",
+        href: "/settings#cloudflare-tunnel",
+        icon: "i-mingcute-cloud-line",
+        groupId: "connect",
+      },
+      {
+        id: "whatsapp-integration",
+        label: "WhatsApp Integration",
+        href: "/settings#whatsapp-integration",
+        icon: "i-mingcute-message-4-line",
+        groupId: "connect",
+      },
       {
         id: "whatsapp",
         label: "WhatsApp",
         href: "/settings/whatsapp",
         icon: "i-mingcute-message-4-line",
-        groupId: "integrations",
+        groupId: "connect",
+      },
+      {
+        id: "discord-integration",
+        label: "Discord Integration",
+        href: "/settings#discord-integration",
+        icon: "i-mingcute-discord-line",
+        groupId: "connect",
+        requires: "discord",
       },
       {
         id: "discord",
         label: "Discord",
         href: "/settings/discord",
         icon: "i-mingcute-discord-line",
-        groupId: "integrations",
+        groupId: "connect",
         requires: "discord",
+      },
+    ],
+  },
+  {
+    id: "advanced",
+    label: "Advanced",
+    icon: "i-mingcute-settings-6-line",
+    items: [
+      {
+        id: "modular-config",
+        label: "Modular Config",
+        href: "/settings#modular-config",
+        icon: "i-mingcute-folder-open-line",
+        groupId: "advanced",
+      },
+      {
+        id: "observability",
+        label: "Observability",
+        href: "/settings#observability",
+        icon: "i-mingcute-pulse-line",
+        groupId: "advanced",
+      },
+      {
+        id: "about",
+        label: "About",
+        href: "/settings#about",
+        icon: "i-mingcute-information-line",
+        groupId: "advanced",
       },
     ],
   },
@@ -122,8 +266,9 @@ export const SETTINGS_NAV_GROUPS: readonly SettingsNavGroup[] = [
 
 const SETTINGS_ROUTE_ALIASES: Record<string, string> = {
   "/settings/general": "/settings",
-  "/settings/langfuse": "/settings",
-  "/settings/remote-server": "/settings",
+  "/settings/langfuse": "/settings#observability",
+  "/settings/remote-server": "/settings#remote-server",
+  "/settings/providers": "/settings/models#provider-setup",
   "/settings/mcp-tools": "/settings/capabilities",
   "/settings/skills": "/settings/capabilities",
   "/settings/agent-personas": "/settings/agents",
@@ -136,8 +281,19 @@ const SETTINGS_NAV_EXCLUDED_PREFIXES = [
   "/settings/loops",
 ] as const
 
+function splitSettingsLocation(pathname: string): {
+  path: string
+  hash: string
+} {
+  const [withoutHash, hash = ""] = pathname.split("#", 2)
+  return {
+    path: withoutHash.split("?", 1)[0] || "/",
+    hash: hash ? `#${hash}` : "",
+  }
+}
+
 function pathnameOnly(pathname: string): string {
-  return pathname.split(/[?#]/, 1)[0] || "/"
+  return splitSettingsLocation(pathname).path
 }
 
 export function isConsolidatedSettingsRoute(pathname: string): boolean {
@@ -149,22 +305,27 @@ export function isConsolidatedSettingsRoute(pathname: string): boolean {
 }
 
 export function normalizeSettingsPath(pathname: string): string {
-  const path = pathnameOnly(pathname)
-  return SETTINGS_ROUTE_ALIASES[path] ?? path
+  const { path, hash } = splitSettingsLocation(pathname)
+  return `${SETTINGS_ROUTE_ALIASES[path] ?? path}${hash}`
 }
 
 export function getSettingsNavigationState(
   pathname: string,
 ): SettingsNavigationState {
   const normalizedPath = normalizeSettingsPath(pathname)
+  const normalizedRoutePath = pathnameOnly(normalizedPath)
 
   for (const group of SETTINGS_NAV_GROUPS) {
     for (const item of group.items) {
-      const isItemRoute =
-        item.href === "/settings"
-          ? normalizedPath === item.href
-          : normalizedPath === item.href ||
-            normalizedPath.startsWith(`${item.href}/`)
+      const itemLocation = splitSettingsLocation(item.href)
+      const isItemRoute = item.href.includes("#")
+        ? normalizedPath === item.href ||
+          (!splitSettingsLocation(normalizedPath).hash &&
+            normalizedRoutePath === itemLocation.path)
+        : item.href === "/settings"
+          ? normalizedRoutePath === item.href
+          : normalizedRoutePath === item.href ||
+            normalizedRoutePath.startsWith(`${item.href}/`)
       if (isItemRoute) {
         return {
           groupId: group.id,
@@ -175,8 +336,8 @@ export function getSettingsNavigationState(
   }
 
   return {
-    groupId: "general",
-    itemHref: "/settings",
+    groupId: "app",
+    itemHref: "/settings#general",
   }
 }
 

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -35,7 +35,7 @@ import {
 import { toast } from "sonner"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import { Config } from "@shared/types"
 import { KeyRecorder } from "@renderer/components/key-recorder"
 import { SettingsPageShell } from "@renderer/components/settings-navigation"
@@ -80,6 +80,7 @@ export function Component() {
   const configQuery = useConfigQuery()
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const location = useLocation()
   const cfg = configQuery.data as Config | undefined
 
   const saveConfigMutation = useSaveConfigMutation()
@@ -466,6 +467,17 @@ export function Component() {
   const toggleVoiceDictationHelperText = `Press ${toggleVoiceDictationDisplay} to start dictation, press again to stop. Press Esc to cancel.`
 
   const isSearching = searchQuery.length > 0
+  const activeSectionId = location.hash.replace(/^#/, "")
+
+  useEffect(() => {
+    if (!activeSectionId) return
+
+    window.requestAnimationFrame(() => {
+      document
+        .getElementById(activeSectionId)
+        ?.scrollIntoView({ block: "start", behavior: "smooth" })
+    })
+  }, [activeSectionId])
 
   if (!configQuery.data) return null
 
@@ -500,8 +512,8 @@ export function Component() {
         <div className="grid gap-4">
           {/* Agent Settings */}
           <ControlGroup
+            id="agent-settings"
             collapsible
-            defaultCollapsed
             title="Agent Settings"
             forceOpen={isSearching}
           >
@@ -761,8 +773,8 @@ export function Component() {
           </ControlGroup>
 
           <ControlGroup
+            id="general"
             collapsible
-            defaultCollapsed
             title="General"
             forceOpen={isSearching}
           >
@@ -846,11 +858,15 @@ export function Component() {
 
           <RemoteServerSettingsGroups
             collapsible
-            defaultCollapsed
-            forceOpen={isSearching}
+            forceOpen={
+              isSearching ||
+              activeSectionId === "remote-server" ||
+              activeSectionId === "cloudflare-tunnel"
+            }
           />
 
           <ControlGroup
+            id="modular-config"
             collapsible
             defaultCollapsed
             title={
@@ -866,7 +882,7 @@ export function Component() {
                 )}
               </span>
             }
-            forceOpen={isSearching}
+            forceOpen={isSearching || activeSectionId === "modular-config"}
           >
             {systemPromptOverrideActive && (
               <div className="mx-3 mt-2 flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm">
@@ -965,8 +981,8 @@ export function Component() {
           </ControlGroup>
 
           <ControlGroup
+            id="shortcuts"
             collapsible
-            defaultCollapsed
             title="Shortcuts"
             forceOpen={isSearching}
           >
@@ -1294,8 +1310,8 @@ export function Component() {
           </ControlGroup>
 
           <ControlGroup
+            id="audio-devices"
             collapsible
-            defaultCollapsed
             title="Audio Devices"
             forceOpen={isSearching}
             onOpenChange={setAudioSectionOpen}
@@ -1389,8 +1405,8 @@ export function Component() {
           </ControlGroup>
 
           <ControlGroup
+            id="speech-to-text"
             collapsible
-            defaultCollapsed
             title="Speech-to-Text"
             forceOpen={isSearching}
           >
@@ -1595,8 +1611,8 @@ export function Component() {
           </ControlGroup>
 
           <ControlGroup
+            id="text-to-speech"
             collapsible
-            defaultCollapsed
             title="Text to Speech"
             forceOpen={isSearching}
           >
@@ -1770,8 +1786,8 @@ export function Component() {
 
           {/* Panel Position Settings */}
           <ControlGroup
+            id="panel-position"
             collapsible
-            defaultCollapsed
             title="Panel Position"
             forceOpen={isSearching}
           >
@@ -1948,10 +1964,13 @@ export function Component() {
 
           {/* WhatsApp Integration */}
           <ControlGroup
+            id="whatsapp-integration"
             collapsible
             defaultCollapsed
             title="WhatsApp Integration"
-            forceOpen={isSearching}
+            forceOpen={
+              isSearching || activeSectionId === "whatsapp-integration"
+            }
             endDescription={
               <div className="whitespace-normal break-words">
                 Enable WhatsApp messaging through DotAgents.{" "}
@@ -1982,6 +2001,7 @@ export function Component() {
 
           {/* Discord Integration */}
           <ControlGroup
+            id="discord-integration"
             collapsible
             defaultCollapsed
             title="Discord Integration"
@@ -1990,7 +2010,9 @@ export function Component() {
             // while disabled, so this section is the only place to turn it on
             // — surface it by default until the user enables it.
             forceOpen={
-              isSearching || !(configQuery.data?.discordEnabled ?? false)
+              isSearching ||
+              !(configQuery.data?.discordEnabled ?? false) ||
+              activeSectionId === "discord-integration"
             }
             endDescription={
               <div className="whitespace-normal break-words">
@@ -2022,10 +2044,11 @@ export function Component() {
 
           {/* Observability */}
           <ControlGroup
+            id="observability"
             collapsible
             defaultCollapsed
             title="Observability"
-            forceOpen={isSearching}
+            forceOpen={isSearching || activeSectionId === "observability"}
             endDescription={
               <div className="whitespace-normal break-words">
                 Optional tracing for LLM calls, agent sessions, and tools. Send
@@ -2208,7 +2231,7 @@ export function Component() {
           </ControlGroup>
 
           {/* About Section */}
-          <ControlGroup title="About">
+          <ControlGroup id="about" title="About">
             <Control label="Version" className="px-3">
               <div className="text-sm">{process.env.APP_VERSION}</div>
             </Control>

--- a/apps/desktop/src/renderer/src/pages/settings-models.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-models.tsx
@@ -34,6 +34,7 @@ import {
 import { PresetModelSelector } from "@renderer/components/preset-model-selector"
 import { SettingsPageShell } from "@renderer/components/settings-navigation"
 import { Config, ModelPreset } from "@shared/types"
+import { useLocation } from "react-router-dom"
 import {
   STT_PROVIDERS,
   CHAT_PROVIDERS,
@@ -58,6 +59,7 @@ import {
 } from "@dotagents/shared"
 import { getDefaultSttModel } from "@dotagents/shared/stt-models"
 import { Mic, FileText, Volume2, Bot } from "lucide-react"
+import { ProviderSettingsContent } from "./settings-providers"
 
 const SETTINGS_TEXT_SAVE_DEBOUNCE_MS = 400
 
@@ -109,6 +111,7 @@ function RoleProviderSelector({
 
 export function Component() {
   const configQuery = useConfigQuery()
+  const location = useLocation()
   const saveConfigMutation = useSaveConfigMutation()
   const transcriptProcessingPromptSaveTimeoutRef = useRef<ReturnType<
     typeof setTimeout
@@ -199,6 +202,18 @@ export function Component() {
     [allPresets],
   )
 
+  const activeSectionId = location.hash.replace(/^#/, "")
+
+  useEffect(() => {
+    if (!activeSectionId) return
+
+    window.requestAnimationFrame(() => {
+      document
+        .getElementById(activeSectionId)
+        ?.scrollIntoView({ block: "start", behavior: "smooth" })
+    })
+  }, [activeSectionId])
+
   if (!configQuery.data) return null
 
   const config = configQuery.data
@@ -233,7 +248,7 @@ export function Component() {
           </p>
         </div>
 
-        <ControlGroup title="Agent Models">
+        <ControlGroup id="agent-models" title="Agent Models">
           <div className="border-muted bg-muted/30 text-muted-foreground mx-3 my-2 rounded-md border px-3 py-2 text-xs">
             Choose which model powers the main agent. OpenAI-compatible presets
             can carry both an agent model and a transcript processing model.
@@ -390,7 +405,11 @@ export function Component() {
           )}
         </ControlGroup>
 
-        <ControlGroup title="Choose a Provider for Each Job" collapsible>
+        <ControlGroup
+          id="job-providers"
+          title="Choose a Provider for Each Job"
+          collapsible
+        >
           <RoleProviderSelector
             label="Speech-to-Text"
             tooltip="Choose which provider listens to your audio and turns it into text."
@@ -425,7 +444,11 @@ export function Component() {
           />
         </ControlGroup>
 
-        <ControlGroup title="Transcript Processing" collapsible>
+        <ControlGroup
+          id="transcript-processing"
+          title="Transcript Processing"
+          collapsible
+        >
           <Control
             label={
               <ControlLabel
@@ -532,7 +555,11 @@ export function Component() {
           )}
         </ControlGroup>
 
-        <ControlGroup title="Speech & Voice Models" collapsible>
+        <ControlGroup
+          id="speech-voice-models"
+          title="Speech & Voice Models"
+          collapsible
+        >
           <div className="px-3 py-2">
             {sttProviderId === "parakeet" ? (
               <Control
@@ -1050,6 +1077,10 @@ export function Component() {
             )}
           </div>
         </ControlGroup>
+
+        <div id="provider-setup">
+          <ProviderSettingsContent />
+        </div>
       </div>
     </SettingsPageShell>
   )

--- a/apps/desktop/src/renderer/src/pages/settings-providers.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-providers.tsx
@@ -709,7 +709,7 @@ function SupertonicProviderSection({
   )
 }
 
-export function Component() {
+export function ProviderSettingsContent() {
   const configQuery = useConfigQuery()
   const chatgptWebAuthQuery = useQuery({
     queryKey: ["chatgpt-web-auth-status"],
@@ -973,639 +973,635 @@ export function Component() {
   )
 
   return (
-    <SettingsPageShell>
-      <div className="grid gap-4">
-        <div className="bg-muted/20 rounded-lg border px-4 py-3">
-          <h2 className="text-sm font-semibold">Provider Setup</h2>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Manage API keys, base URLs, local engine downloads, and quick
-            provider diagnostics for the Intelligence area.
-          </p>
-          {isMainAgentAcpMode && (
-            <div className="border-primary/30 bg-primary/5 mt-3 rounded-md border px-3 py-2 text-xs">
-              <div className="text-primary flex items-center gap-1.5 font-medium">
-                <Bot className="h-3.5 w-3.5" />
-                ACP Main Agent:{" "}
-                <span className="text-foreground">
-                  {selectedMainAcpAgentDisplayName || "Not selected"}
-                </span>
-              </div>
-              <p className="text-muted-foreground mt-1">
-                ACP mode handles chat submissions through the selected agent.
-                Provider setup below still applies to API-backed tools, voice,
-                and local engines.
-              </p>
+    <div className="grid gap-4">
+      <div className="bg-muted/20 rounded-lg border px-4 py-3">
+        <h2 className="text-sm font-semibold">Provider Setup</h2>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Manage API keys, base URLs, local engine downloads, and quick provider
+          diagnostics for the Intelligence area.
+        </p>
+        {isMainAgentAcpMode && (
+          <div className="border-primary/30 bg-primary/5 mt-3 rounded-md border px-3 py-2 text-xs">
+            <div className="text-primary flex items-center gap-1.5 font-medium">
+              <Bot className="h-3.5 w-3.5" />
+              ACP Main Agent:{" "}
+              <span className="text-foreground">
+                {selectedMainAcpAgentDisplayName || "Not selected"}
+              </span>
+            </div>
+            <p className="text-muted-foreground mt-1">
+              ACP mode handles chat submissions through the selected agent.
+              Provider setup below still applies to API-backed tools, voice, and
+              local engines.
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* OpenAI Compatible Provider Section */}
+      <div
+        className={`rounded-lg border ${activeProviders.openai.length > 0 ? "border-primary/30 bg-primary/5" : ""}`}
+      >
+        <button
+          type="button"
+          className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+          onClick={() =>
+            saveConfig({
+              providerSectionCollapsedOpenai:
+                !configQuery.data.providerSectionCollapsedOpenai,
+            })
+          }
+          aria-expanded={!configQuery.data.providerSectionCollapsedOpenai}
+          aria-controls="openai-provider-content"
+        >
+          <span className="flex items-center gap-2 text-sm font-semibold">
+            {configQuery.data.providerSectionCollapsedOpenai ? (
+              <ChevronRight className="text-muted-foreground h-4 w-4" />
+            ) : (
+              <ChevronDown className="text-muted-foreground h-4 w-4" />
+            )}
+            OpenAI Compatible
+            {activeProviders.openai.length > 0 && (
+              <CheckCircle2 className="text-primary h-4 w-4" />
+            )}
+          </span>
+          {activeProviders.openai.length > 0 && (
+            <div className="flex flex-wrap justify-end gap-1.5">
+              {activeProviders.openai.map((badge) => (
+                <ActiveProviderBadge
+                  key={badge.label}
+                  label={badge.label}
+                  icon={badge.icon}
+                />
+              ))}
             </div>
           )}
-        </div>
+        </button>
+        {!configQuery.data.providerSectionCollapsedOpenai && (
+          <div id="openai-provider-content" className="divide-y border-t">
+            {activeProviders.openai.length === 0 && (
+              <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
+                OpenAI-compatible presets are selected from the Models section.
+              </p>
+            )}
 
-        {/* OpenAI Compatible Provider Section */}
-        <div
-          className={`rounded-lg border ${activeProviders.openai.length > 0 ? "border-primary/30 bg-primary/5" : ""}`}
-        >
+            <div className="px-3 py-2">
+              <p className="text-muted-foreground text-sm">
+                OpenAI-compatible presets, agent models, and transcript cleanup
+                models are managed in Models.
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Groq Provider Section - rendered in order based on active status */}
+      {isGroqActive && (
+        <div className="border-primary/30 bg-primary/5 rounded-lg border">
           <button
             type="button"
             className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
             onClick={() =>
               saveConfig({
-                providerSectionCollapsedOpenai:
-                  !configQuery.data.providerSectionCollapsedOpenai,
+                providerSectionCollapsedGroq:
+                  !configQuery.data.providerSectionCollapsedGroq,
               })
             }
-            aria-expanded={!configQuery.data.providerSectionCollapsedOpenai}
-            aria-controls="openai-provider-content"
+            aria-expanded={!configQuery.data.providerSectionCollapsedGroq}
+            aria-controls="groq-provider-content"
           >
             <span className="flex items-center gap-2 text-sm font-semibold">
-              {configQuery.data.providerSectionCollapsedOpenai ? (
+              {configQuery.data.providerSectionCollapsedGroq ? (
                 <ChevronRight className="text-muted-foreground h-4 w-4" />
               ) : (
                 <ChevronDown className="text-muted-foreground h-4 w-4" />
               )}
-              OpenAI Compatible
-              {activeProviders.openai.length > 0 && (
-                <CheckCircle2 className="text-primary h-4 w-4" />
-              )}
+              Groq
+              <CheckCircle2 className="text-primary h-4 w-4" />
             </span>
-            {activeProviders.openai.length > 0 && (
-              <div className="flex flex-wrap justify-end gap-1.5">
-                {activeProviders.openai.map((badge) => (
-                  <ActiveProviderBadge
-                    key={badge.label}
-                    label={badge.label}
-                    icon={badge.icon}
-                  />
-                ))}
-              </div>
-            )}
+            <div className="flex flex-wrap justify-end gap-1.5">
+              {activeProviders.groq.map((badge) => (
+                <ActiveProviderBadge
+                  key={badge.label}
+                  label={badge.label}
+                  icon={badge.icon}
+                />
+              ))}
+            </div>
           </button>
-          {!configQuery.data.providerSectionCollapsedOpenai && (
-            <div id="openai-provider-content" className="divide-y border-t">
-              {activeProviders.openai.length === 0 && (
-                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
-                  OpenAI-compatible presets are selected from the Models
-                  section.
-                </p>
-              )}
+          {!configQuery.data.providerSectionCollapsedGroq && (
+            <div id="groq-provider-content" className="divide-y border-t">
+              {renderProviderDraftInput("groqApiKey", {
+                label: "API Key",
+                type: "password",
+              })}
 
-              <div className="px-3 py-2">
-                <p className="text-muted-foreground text-sm">
-                  OpenAI-compatible presets, agent models, and transcript
-                  cleanup models are managed in Models.
-                </p>
-              </div>
+              {renderProviderDraftInput("groqBaseUrl", {
+                label: "API Base URL",
+                type: "url",
+                placeholder: "https://api.groq.com/openai/v1",
+              })}
+
+              <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                Groq model selection is managed in Models.
+              </p>
             </div>
           )}
         </div>
+      )}
 
-        {/* Groq Provider Section - rendered in order based on active status */}
-        {isGroqActive && (
-          <div className="border-primary/30 bg-primary/5 rounded-lg border">
-            <button
-              type="button"
-              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
-              onClick={() =>
-                saveConfig({
-                  providerSectionCollapsedGroq:
-                    !configQuery.data.providerSectionCollapsedGroq,
-                })
-              }
-              aria-expanded={!configQuery.data.providerSectionCollapsedGroq}
-              aria-controls="groq-provider-content"
+      {/* Gemini Provider Section - rendered in order based on active status */}
+      {isGeminiActive && (
+        <div className="border-primary/30 bg-primary/5 rounded-lg border">
+          <button
+            type="button"
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+            onClick={() =>
+              saveConfig({
+                providerSectionCollapsedGemini:
+                  !configQuery.data.providerSectionCollapsedGemini,
+              })
+            }
+            aria-expanded={!configQuery.data.providerSectionCollapsedGemini}
+            aria-controls="gemini-provider-content"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedGemini ? (
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
+              )}
+              Gemini
+              <CheckCircle2 className="text-primary h-4 w-4" />
+            </span>
+            <div className="flex flex-wrap justify-end gap-1.5">
+              {activeProviders.gemini.map((badge) => (
+                <ActiveProviderBadge
+                  key={badge.label}
+                  label={badge.label}
+                  icon={badge.icon}
+                />
+              ))}
+            </div>
+          </button>
+          {!configQuery.data.providerSectionCollapsedGemini && (
+            <div id="gemini-provider-content" className="divide-y border-t">
+              {renderProviderDraftInput("geminiApiKey", {
+                label: "API Key",
+                type: "password",
+              })}
+
+              {renderProviderDraftInput("geminiBaseUrl", {
+                label: "API Base URL",
+                type: "url",
+                placeholder: "https://generativelanguage.googleapis.com",
+              })}
+
+              <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                Gemini model selection is managed in Models.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ChatGPT Web Provider Section - rendered in order based on active status */}
+      {isChatgptWebActive && (
+        <div className="border-primary/30 bg-primary/5 rounded-lg border">
+          <button
+            type="button"
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+            onClick={() =>
+              saveConfig({
+                providerSectionCollapsedChatgptWeb:
+                  !configQuery.data.providerSectionCollapsedChatgptWeb,
+              })
+            }
+            aria-expanded={!configQuery.data.providerSectionCollapsedChatgptWeb}
+            aria-controls="chatgpt-web-provider-content"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedChatgptWeb ? (
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
+              )}
+              OpenAI Codex
+              <CheckCircle2 className="text-primary h-4 w-4" />
+            </span>
+            <div className="flex flex-wrap justify-end gap-1.5">
+              {activeProviders.chatgptWeb.map((badge) => (
+                <ActiveProviderBadge
+                  key={badge.label}
+                  label={badge.label}
+                  icon={badge.icon}
+                />
+              ))}
+            </div>
+          </button>
+          {!configQuery.data.providerSectionCollapsedChatgptWeb && (
+            <div
+              id="chatgpt-web-provider-content"
+              className="divide-y border-t"
             >
-              <span className="flex items-center gap-2 text-sm font-semibold">
-                {configQuery.data.providerSectionCollapsedGroq ? (
-                  <ChevronRight className="text-muted-foreground h-4 w-4" />
-                ) : (
-                  <ChevronDown className="text-muted-foreground h-4 w-4" />
-                )}
-                Groq
-                <CheckCircle2 className="text-primary h-4 w-4" />
-              </span>
-              <div className="flex flex-wrap justify-end gap-1.5">
-                {activeProviders.groq.map((badge) => (
-                  <ActiveProviderBadge
-                    key={badge.label}
-                    label={badge.label}
-                    icon={badge.icon}
-                  />
-                ))}
-              </div>
-            </button>
-            {!configQuery.data.providerSectionCollapsedGroq && (
-              <div id="groq-provider-content" className="divide-y border-t">
-                {renderProviderDraftInput("groqApiKey", {
-                  label: "API Key",
-                  type: "password",
-                })}
-
-                {renderProviderDraftInput("groqBaseUrl", {
-                  label: "API Base URL",
-                  type: "url",
-                  placeholder: "https://api.groq.com/openai/v1",
-                })}
-
-                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
-                  Groq model selection is managed in Models.
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Gemini Provider Section - rendered in order based on active status */}
-        {isGeminiActive && (
-          <div className="border-primary/30 bg-primary/5 rounded-lg border">
-            <button
-              type="button"
-              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
-              onClick={() =>
-                saveConfig({
-                  providerSectionCollapsedGemini:
-                    !configQuery.data.providerSectionCollapsedGemini,
-                })
-              }
-              aria-expanded={!configQuery.data.providerSectionCollapsedGemini}
-              aria-controls="gemini-provider-content"
-            >
-              <span className="flex items-center gap-2 text-sm font-semibold">
-                {configQuery.data.providerSectionCollapsedGemini ? (
-                  <ChevronRight className="text-muted-foreground h-4 w-4" />
-                ) : (
-                  <ChevronDown className="text-muted-foreground h-4 w-4" />
-                )}
-                Gemini
-                <CheckCircle2 className="text-primary h-4 w-4" />
-              </span>
-              <div className="flex flex-wrap justify-end gap-1.5">
-                {activeProviders.gemini.map((badge) => (
-                  <ActiveProviderBadge
-                    key={badge.label}
-                    label={badge.label}
-                    icon={badge.icon}
-                  />
-                ))}
-              </div>
-            </button>
-            {!configQuery.data.providerSectionCollapsedGemini && (
-              <div id="gemini-provider-content" className="divide-y border-t">
-                {renderProviderDraftInput("geminiApiKey", {
-                  label: "API Key",
-                  type: "password",
-                })}
-
-                {renderProviderDraftInput("geminiBaseUrl", {
-                  label: "API Base URL",
-                  type: "url",
-                  placeholder: "https://generativelanguage.googleapis.com",
-                })}
-
-                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
-                  Gemini model selection is managed in Models.
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* ChatGPT Web Provider Section - rendered in order based on active status */}
-        {isChatgptWebActive && (
-          <div className="border-primary/30 bg-primary/5 rounded-lg border">
-            <button
-              type="button"
-              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
-              onClick={() =>
-                saveConfig({
-                  providerSectionCollapsedChatgptWeb:
-                    !configQuery.data.providerSectionCollapsedChatgptWeb,
-                })
-              }
-              aria-expanded={
-                !configQuery.data.providerSectionCollapsedChatgptWeb
-              }
-              aria-controls="chatgpt-web-provider-content"
-            >
-              <span className="flex items-center gap-2 text-sm font-semibold">
-                {configQuery.data.providerSectionCollapsedChatgptWeb ? (
-                  <ChevronRight className="text-muted-foreground h-4 w-4" />
-                ) : (
-                  <ChevronDown className="text-muted-foreground h-4 w-4" />
-                )}
-                OpenAI Codex
-                <CheckCircle2 className="text-primary h-4 w-4" />
-              </span>
-              <div className="flex flex-wrap justify-end gap-1.5">
-                {activeProviders.chatgptWeb.map((badge) => (
-                  <ActiveProviderBadge
-                    key={badge.label}
-                    label={badge.label}
-                    icon={badge.icon}
-                  />
-                ))}
-              </div>
-            </button>
-            {!configQuery.data.providerSectionCollapsedChatgptWeb && (
-              <div
-                id="chatgpt-web-provider-content"
-                className="divide-y border-t"
-              >
-                <div className="space-y-3 px-3 py-3">
-                  <div className="text-sm">
-                    <div className="font-medium">
-                      {(chatgptWebAuthQuery.data as any)?.authenticated
-                        ? `Connected${(chatgptWebAuthQuery.data as any)?.email ? ` as ${(chatgptWebAuthQuery.data as any).email}` : ""}`
-                        : "Not connected"}
-                    </div>
+              <div className="space-y-3 px-3 py-3">
+                <div className="text-sm">
+                  <div className="font-medium">
+                    {(chatgptWebAuthQuery.data as any)?.authenticated
+                      ? `Connected${(chatgptWebAuthQuery.data as any)?.email ? ` as ${(chatgptWebAuthQuery.data as any).email}` : ""}`
+                      : "Not connected"}
+                  </div>
+                  <div className="text-muted-foreground mt-1 text-xs">
+                    {(chatgptWebAuthQuery.data as any)?.planType
+                      ? `Plan: ${(chatgptWebAuthQuery.data as any).planType}`
+                      : "Uses your ChatGPT Codex subscription via OAuth."}
+                  </div>
+                  {(chatgptWebAuthQuery.data as any)?.accountId && (
                     <div className="text-muted-foreground mt-1 text-xs">
-                      {(chatgptWebAuthQuery.data as any)?.planType
-                        ? `Plan: ${(chatgptWebAuthQuery.data as any).planType}`
-                        : "Uses your ChatGPT Codex subscription via OAuth."}
+                      Account ID: {(chatgptWebAuthQuery.data as any).accountId}
                     </div>
-                    {(chatgptWebAuthQuery.data as any)?.accountId && (
-                      <div className="text-muted-foreground mt-1 text-xs">
-                        Account ID:{" "}
-                        {(chatgptWebAuthQuery.data as any).accountId}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={handleChatgptWebAuth}
-                      disabled={chatgptWebAuthBusy}
-                    >
-                      {chatgptWebAuthBusy
-                        ? "Working..."
-                        : (chatgptWebAuthQuery.data as any)?.authenticated
-                          ? "Re-auth"
-                          : "Connect"}
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={handleCopyChatgptCallbackUrl}
-                      disabled={chatgptWebAuthBusy}
-                    >
-                      Copy Callback URL
-                    </Button>
-                    {(chatgptWebAuthQuery.data as any)?.authenticated && (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={handleChatgptWebLogout}
-                        disabled={chatgptWebAuthBusy}
-                      >
-                        Disconnect
-                      </Button>
-                    )}
-                  </div>
-
-                  {chatgptWebAuthError && (
-                    <p className="text-destructive text-xs">
-                      {chatgptWebAuthError}
-                    </p>
                   )}
                 </div>
 
-                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
-                  Browser sign-in should return to
-                  `http://localhost:1455/auth/callback`. Use Copy Callback URL
-                  if you need to inspect or paste the callback target.
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Parakeet (Local) Provider Section */}
-        {isParakeetActive && (
-          <ParakeetProviderSection
-            isActive={true}
-            isCollapsed={
-              configQuery.data.providerSectionCollapsedParakeet ?? true
-            }
-            onToggleCollapse={() =>
-              saveConfig({
-                providerSectionCollapsedParakeet: !(
-                  configQuery.data.providerSectionCollapsedParakeet ?? true
-                ),
-              })
-            }
-            usageBadges={activeProviders.parakeet}
-            numThreads={configQuery.data.parakeetNumThreads || 2}
-            onNumThreadsChange={(value) =>
-              saveConfig({ parakeetNumThreads: value })
-            }
-          />
-        )}
-
-        {/* Kitten (Local) TTS Provider Section */}
-        {isKittenActive && (
-          <KittenProviderSection
-            isActive={true}
-            isCollapsed={
-              configQuery.data.providerSectionCollapsedKitten ?? true
-            }
-            onToggleCollapse={() =>
-              saveConfig({
-                providerSectionCollapsedKitten: !(
-                  configQuery.data.providerSectionCollapsedKitten ?? true
-                ),
-              })
-            }
-            usageBadges={activeProviders.kitten}
-            voiceId={configQuery.data.kittenVoiceId ?? 0}
-          />
-        )}
-
-        {/* Supertonic (Local) TTS Provider Section */}
-        {isSupertonicActive && (
-          <SupertonicProviderSection
-            isActive={true}
-            isCollapsed={
-              configQuery.data.providerSectionCollapsedSupertonic ?? true
-            }
-            onToggleCollapse={() =>
-              saveConfig({
-                providerSectionCollapsedSupertonic: !(
-                  configQuery.data.providerSectionCollapsedSupertonic ?? true
-                ),
-              } as Partial<Config>)
-            }
-            usageBadges={activeProviders.supertonic}
-            voice={configQuery.data.supertonicVoice ?? "M1"}
-            language={configQuery.data.supertonicLanguage ?? "en"}
-            speed={configQuery.data.supertonicSpeed ?? 1.05}
-            steps={configQuery.data.supertonicSteps ?? 5}
-          />
-        )}
-
-        {/* Inactive Groq Provider Section - shown at bottom when not selected */}
-        {!isGroqActive && (
-          <div className="rounded-lg border">
-            <button
-              type="button"
-              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
-              onClick={() =>
-                saveConfig({
-                  providerSectionCollapsedGroq:
-                    !configQuery.data.providerSectionCollapsedGroq,
-                })
-              }
-              aria-expanded={!configQuery.data.providerSectionCollapsedGroq}
-              aria-controls="groq-provider-content-inactive"
-            >
-              <span className="flex items-center gap-2 text-sm font-semibold">
-                {configQuery.data.providerSectionCollapsedGroq ? (
-                  <ChevronRight className="text-muted-foreground h-4 w-4" />
-                ) : (
-                  <ChevronDown className="text-muted-foreground h-4 w-4" />
-                )}
-                Groq
-              </span>
-            </button>
-            {!configQuery.data.providerSectionCollapsedGroq && (
-              <div
-                id="groq-provider-content-inactive"
-                className="divide-y border-t"
-              >
-                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
-                  Not selected above. You can still configure it here.
-                </p>
-
-                {renderProviderDraftInput("groqApiKey", {
-                  label: "API Key",
-                  type: "password",
-                })}
-
-                {renderProviderDraftInput("groqBaseUrl", {
-                  label: "API Base URL",
-                  type: "url",
-                  placeholder: "https://api.groq.com/openai/v1",
-                })}
-
-                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
-                  Groq model selection is managed in Models.
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Inactive Gemini Provider Section - shown at bottom when not selected */}
-        {!isGeminiActive && (
-          <div className="rounded-lg border">
-            <button
-              type="button"
-              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
-              onClick={() =>
-                saveConfig({
-                  providerSectionCollapsedGemini:
-                    !configQuery.data.providerSectionCollapsedGemini,
-                })
-              }
-              aria-expanded={!configQuery.data.providerSectionCollapsedGemini}
-              aria-controls="gemini-provider-content-inactive"
-            >
-              <span className="flex items-center gap-2 text-sm font-semibold">
-                {configQuery.data.providerSectionCollapsedGemini ? (
-                  <ChevronRight className="text-muted-foreground h-4 w-4" />
-                ) : (
-                  <ChevronDown className="text-muted-foreground h-4 w-4" />
-                )}
-                Gemini
-              </span>
-            </button>
-            {!configQuery.data.providerSectionCollapsedGemini && (
-              <div
-                id="gemini-provider-content-inactive"
-                className="divide-y border-t"
-              >
-                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
-                  Not selected above. You can still configure it here.
-                </p>
-
-                {renderProviderDraftInput("geminiApiKey", {
-                  label: "API Key",
-                  type: "password",
-                })}
-
-                {renderProviderDraftInput("geminiBaseUrl", {
-                  label: "API Base URL",
-                  type: "url",
-                  placeholder: "https://generativelanguage.googleapis.com",
-                })}
-
-                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
-                  Gemini model selection is managed in Models.
-                </p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Inactive ChatGPT Web Provider Section - shown at bottom when not selected */}
-        {!isChatgptWebActive && (
-          <div className="rounded-lg border">
-            <button
-              type="button"
-              className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
-              onClick={() =>
-                saveConfig({
-                  providerSectionCollapsedChatgptWeb:
-                    !configQuery.data.providerSectionCollapsedChatgptWeb,
-                })
-              }
-              aria-expanded={
-                !configQuery.data.providerSectionCollapsedChatgptWeb
-              }
-              aria-controls="chatgpt-web-provider-content-inactive"
-            >
-              <span className="flex items-center gap-2 text-sm font-semibold">
-                {configQuery.data.providerSectionCollapsedChatgptWeb ? (
-                  <ChevronRight className="text-muted-foreground h-4 w-4" />
-                ) : (
-                  <ChevronDown className="text-muted-foreground h-4 w-4" />
-                )}
-                OpenAI Codex
-              </span>
-            </button>
-            {!configQuery.data.providerSectionCollapsedChatgptWeb && (
-              <div
-                id="chatgpt-web-provider-content-inactive"
-                className="divide-y border-t"
-              >
-                <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
-                  Not selected above. You can still configure it here.
-                </p>
-
-                <div className="space-y-3 px-3 py-3">
-                  <div className="text-sm">
-                    <div className="font-medium">
-                      {(chatgptWebAuthQuery.data as any)?.authenticated
-                        ? `Connected${(chatgptWebAuthQuery.data as any)?.email ? ` as ${(chatgptWebAuthQuery.data as any).email}` : ""}`
-                        : "Not connected"}
-                    </div>
-                    <div className="text-muted-foreground mt-1 text-xs">
-                      Uses your ChatGPT Codex subscription via OAuth.
-                    </div>
-                  </div>
-
-                  <div className="flex flex-wrap gap-2">
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleChatgptWebAuth}
+                    disabled={chatgptWebAuthBusy}
+                  >
+                    {chatgptWebAuthBusy
+                      ? "Working..."
+                      : (chatgptWebAuthQuery.data as any)?.authenticated
+                        ? "Re-auth"
+                        : "Connect"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleCopyChatgptCallbackUrl}
+                    disabled={chatgptWebAuthBusy}
+                  >
+                    Copy Callback URL
+                  </Button>
+                  {(chatgptWebAuthQuery.data as any)?.authenticated && (
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={handleChatgptWebAuth}
+                      onClick={handleChatgptWebLogout}
                       disabled={chatgptWebAuthBusy}
                     >
-                      {chatgptWebAuthBusy
-                        ? "Working..."
-                        : (chatgptWebAuthQuery.data as any)?.authenticated
-                          ? "Re-auth"
-                          : "Connect"}
+                      Disconnect
                     </Button>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={handleCopyChatgptCallbackUrl}
-                      disabled={chatgptWebAuthBusy}
-                    >
-                      Copy Callback URL
-                    </Button>
-                    {(chatgptWebAuthQuery.data as any)?.authenticated && (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={handleChatgptWebLogout}
-                        disabled={chatgptWebAuthBusy}
-                      >
-                        Disconnect
-                      </Button>
-                    )}
-                  </div>
-
-                  {chatgptWebAuthError && (
-                    <p className="text-destructive text-xs">
-                      {chatgptWebAuthError}
-                    </p>
                   )}
                 </div>
 
-                <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
-                  Browser sign-in should return to
-                  `http://localhost:1455/auth/callback`. This provider now talks
-                  to the Codex responses transport, not the legacy conversation
-                  endpoint.
-                </p>
+                {chatgptWebAuthError && (
+                  <p className="text-destructive text-xs">
+                    {chatgptWebAuthError}
+                  </p>
+                )}
               </div>
-            )}
-          </div>
-        )}
 
-        {/* Inactive Parakeet Provider Section - shown at bottom when not selected */}
-        {!isParakeetActive && (
-          <ParakeetProviderSection
-            isActive={false}
-            isCollapsed={
-              configQuery.data.providerSectionCollapsedParakeet ?? true
-            }
-            onToggleCollapse={() =>
+              <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                Browser sign-in should return to
+                `http://localhost:1455/auth/callback`. Use Copy Callback URL if
+                you need to inspect or paste the callback target.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Parakeet (Local) Provider Section */}
+      {isParakeetActive && (
+        <ParakeetProviderSection
+          isActive={true}
+          isCollapsed={
+            configQuery.data.providerSectionCollapsedParakeet ?? true
+          }
+          onToggleCollapse={() =>
+            saveConfig({
+              providerSectionCollapsedParakeet: !(
+                configQuery.data.providerSectionCollapsedParakeet ?? true
+              ),
+            })
+          }
+          usageBadges={activeProviders.parakeet}
+          numThreads={configQuery.data.parakeetNumThreads || 2}
+          onNumThreadsChange={(value) =>
+            saveConfig({ parakeetNumThreads: value })
+          }
+        />
+      )}
+
+      {/* Kitten (Local) TTS Provider Section */}
+      {isKittenActive && (
+        <KittenProviderSection
+          isActive={true}
+          isCollapsed={configQuery.data.providerSectionCollapsedKitten ?? true}
+          onToggleCollapse={() =>
+            saveConfig({
+              providerSectionCollapsedKitten: !(
+                configQuery.data.providerSectionCollapsedKitten ?? true
+              ),
+            })
+          }
+          usageBadges={activeProviders.kitten}
+          voiceId={configQuery.data.kittenVoiceId ?? 0}
+        />
+      )}
+
+      {/* Supertonic (Local) TTS Provider Section */}
+      {isSupertonicActive && (
+        <SupertonicProviderSection
+          isActive={true}
+          isCollapsed={
+            configQuery.data.providerSectionCollapsedSupertonic ?? true
+          }
+          onToggleCollapse={() =>
+            saveConfig({
+              providerSectionCollapsedSupertonic: !(
+                configQuery.data.providerSectionCollapsedSupertonic ?? true
+              ),
+            } as Partial<Config>)
+          }
+          usageBadges={activeProviders.supertonic}
+          voice={configQuery.data.supertonicVoice ?? "M1"}
+          language={configQuery.data.supertonicLanguage ?? "en"}
+          speed={configQuery.data.supertonicSpeed ?? 1.05}
+          steps={configQuery.data.supertonicSteps ?? 5}
+        />
+      )}
+
+      {/* Inactive Groq Provider Section - shown at bottom when not selected */}
+      {!isGroqActive && (
+        <div className="rounded-lg border">
+          <button
+            type="button"
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+            onClick={() =>
               saveConfig({
-                providerSectionCollapsedParakeet: !(
-                  configQuery.data.providerSectionCollapsedParakeet ?? true
-                ),
+                providerSectionCollapsedGroq:
+                  !configQuery.data.providerSectionCollapsedGroq,
               })
             }
-            usageBadges={activeProviders.parakeet}
-            numThreads={configQuery.data.parakeetNumThreads || 2}
-            onNumThreadsChange={(value) =>
-              saveConfig({ parakeetNumThreads: value })
-            }
-          />
-        )}
+            aria-expanded={!configQuery.data.providerSectionCollapsedGroq}
+            aria-controls="groq-provider-content-inactive"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedGroq ? (
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
+              )}
+              Groq
+            </span>
+          </button>
+          {!configQuery.data.providerSectionCollapsedGroq && (
+            <div
+              id="groq-provider-content-inactive"
+              className="divide-y border-t"
+            >
+              <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
+                Not selected above. You can still configure it here.
+              </p>
 
-        {/* Inactive Kitten Provider Section - shown at bottom when not selected */}
-        {!isKittenActive && (
-          <KittenProviderSection
-            isActive={false}
-            isCollapsed={
-              configQuery.data.providerSectionCollapsedKitten ?? true
-            }
-            onToggleCollapse={() =>
+              {renderProviderDraftInput("groqApiKey", {
+                label: "API Key",
+                type: "password",
+              })}
+
+              {renderProviderDraftInput("groqBaseUrl", {
+                label: "API Base URL",
+                type: "url",
+                placeholder: "https://api.groq.com/openai/v1",
+              })}
+
+              <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                Groq model selection is managed in Models.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Inactive Gemini Provider Section - shown at bottom when not selected */}
+      {!isGeminiActive && (
+        <div className="rounded-lg border">
+          <button
+            type="button"
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+            onClick={() =>
               saveConfig({
-                providerSectionCollapsedKitten: !(
-                  configQuery.data.providerSectionCollapsedKitten ?? true
-                ),
+                providerSectionCollapsedGemini:
+                  !configQuery.data.providerSectionCollapsedGemini,
               })
             }
-            usageBadges={activeProviders.kitten}
-            voiceId={configQuery.data.kittenVoiceId ?? 0}
-          />
-        )}
+            aria-expanded={!configQuery.data.providerSectionCollapsedGemini}
+            aria-controls="gemini-provider-content-inactive"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedGemini ? (
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
+              )}
+              Gemini
+            </span>
+          </button>
+          {!configQuery.data.providerSectionCollapsedGemini && (
+            <div
+              id="gemini-provider-content-inactive"
+              className="divide-y border-t"
+            >
+              <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
+                Not selected above. You can still configure it here.
+              </p>
 
-        {/* Inactive Supertonic Provider Section - shown at bottom when not selected */}
-        {!isSupertonicActive && (
-          <SupertonicProviderSection
-            isActive={false}
-            isCollapsed={
-              configQuery.data.providerSectionCollapsedSupertonic ?? true
-            }
-            onToggleCollapse={() =>
+              {renderProviderDraftInput("geminiApiKey", {
+                label: "API Key",
+                type: "password",
+              })}
+
+              {renderProviderDraftInput("geminiBaseUrl", {
+                label: "API Base URL",
+                type: "url",
+                placeholder: "https://generativelanguage.googleapis.com",
+              })}
+
+              <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                Gemini model selection is managed in Models.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Inactive ChatGPT Web Provider Section - shown at bottom when not selected */}
+      {!isChatgptWebActive && (
+        <div className="rounded-lg border">
+          <button
+            type="button"
+            className="hover:bg-muted/30 flex w-full cursor-pointer items-center justify-between px-3 py-2 transition-colors"
+            onClick={() =>
               saveConfig({
-                providerSectionCollapsedSupertonic: !(
-                  configQuery.data.providerSectionCollapsedSupertonic ?? true
-                ),
-              } as Partial<Config>)
+                providerSectionCollapsedChatgptWeb:
+                  !configQuery.data.providerSectionCollapsedChatgptWeb,
+              })
             }
-            usageBadges={activeProviders.supertonic}
-            voice={configQuery.data.supertonicVoice ?? "M1"}
-            language={configQuery.data.supertonicLanguage ?? "en"}
-            speed={configQuery.data.supertonicSpeed ?? 1.05}
-            steps={configQuery.data.supertonicSteps ?? 5}
-          />
-        )}
-      </div>
+            aria-expanded={!configQuery.data.providerSectionCollapsedChatgptWeb}
+            aria-controls="chatgpt-web-provider-content-inactive"
+          >
+            <span className="flex items-center gap-2 text-sm font-semibold">
+              {configQuery.data.providerSectionCollapsedChatgptWeb ? (
+                <ChevronRight className="text-muted-foreground h-4 w-4" />
+              ) : (
+                <ChevronDown className="text-muted-foreground h-4 w-4" />
+              )}
+              OpenAI Codex
+            </span>
+          </button>
+          {!configQuery.data.providerSectionCollapsedChatgptWeb && (
+            <div
+              id="chatgpt-web-provider-content-inactive"
+              className="divide-y border-t"
+            >
+              <p className="text-muted-foreground px-3 py-1.5 text-[11px]">
+                Not selected above. You can still configure it here.
+              </p>
+
+              <div className="space-y-3 px-3 py-3">
+                <div className="text-sm">
+                  <div className="font-medium">
+                    {(chatgptWebAuthQuery.data as any)?.authenticated
+                      ? `Connected${(chatgptWebAuthQuery.data as any)?.email ? ` as ${(chatgptWebAuthQuery.data as any).email}` : ""}`
+                      : "Not connected"}
+                  </div>
+                  <div className="text-muted-foreground mt-1 text-xs">
+                    Uses your ChatGPT Codex subscription via OAuth.
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleChatgptWebAuth}
+                    disabled={chatgptWebAuthBusy}
+                  >
+                    {chatgptWebAuthBusy
+                      ? "Working..."
+                      : (chatgptWebAuthQuery.data as any)?.authenticated
+                        ? "Re-auth"
+                        : "Connect"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={handleCopyChatgptCallbackUrl}
+                    disabled={chatgptWebAuthBusy}
+                  >
+                    Copy Callback URL
+                  </Button>
+                  {(chatgptWebAuthQuery.data as any)?.authenticated && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={handleChatgptWebLogout}
+                      disabled={chatgptWebAuthBusy}
+                    >
+                      Disconnect
+                    </Button>
+                  )}
+                </div>
+
+                {chatgptWebAuthError && (
+                  <p className="text-destructive text-xs">
+                    {chatgptWebAuthError}
+                  </p>
+                )}
+              </div>
+
+              <p className="text-muted-foreground border-t px-3 py-1.5 text-[11px]">
+                Browser sign-in should return to
+                `http://localhost:1455/auth/callback`. This provider now talks
+                to the Codex responses transport, not the legacy conversation
+                endpoint.
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Inactive Parakeet Provider Section - shown at bottom when not selected */}
+      {!isParakeetActive && (
+        <ParakeetProviderSection
+          isActive={false}
+          isCollapsed={
+            configQuery.data.providerSectionCollapsedParakeet ?? true
+          }
+          onToggleCollapse={() =>
+            saveConfig({
+              providerSectionCollapsedParakeet: !(
+                configQuery.data.providerSectionCollapsedParakeet ?? true
+              ),
+            })
+          }
+          usageBadges={activeProviders.parakeet}
+          numThreads={configQuery.data.parakeetNumThreads || 2}
+          onNumThreadsChange={(value) =>
+            saveConfig({ parakeetNumThreads: value })
+          }
+        />
+      )}
+
+      {/* Inactive Kitten Provider Section - shown at bottom when not selected */}
+      {!isKittenActive && (
+        <KittenProviderSection
+          isActive={false}
+          isCollapsed={configQuery.data.providerSectionCollapsedKitten ?? true}
+          onToggleCollapse={() =>
+            saveConfig({
+              providerSectionCollapsedKitten: !(
+                configQuery.data.providerSectionCollapsedKitten ?? true
+              ),
+            })
+          }
+          usageBadges={activeProviders.kitten}
+          voiceId={configQuery.data.kittenVoiceId ?? 0}
+        />
+      )}
+
+      {/* Inactive Supertonic Provider Section - shown at bottom when not selected */}
+      {!isSupertonicActive && (
+        <SupertonicProviderSection
+          isActive={false}
+          isCollapsed={
+            configQuery.data.providerSectionCollapsedSupertonic ?? true
+          }
+          onToggleCollapse={() =>
+            saveConfig({
+              providerSectionCollapsedSupertonic: !(
+                configQuery.data.providerSectionCollapsedSupertonic ?? true
+              ),
+            } as Partial<Config>)
+          }
+          usageBadges={activeProviders.supertonic}
+          voice={configQuery.data.supertonicVoice ?? "M1"}
+          language={configQuery.data.supertonicLanguage ?? "en"}
+          speed={configQuery.data.supertonicSpeed ?? 1.05}
+          steps={configQuery.data.supertonicSteps ?? 5}
+        />
+      )}
+    </div>
+  )
+}
+
+export function Component() {
+  return (
+    <SettingsPageShell>
+      <ProviderSettingsContent />
     </SettingsPageShell>
   )
 }

--- a/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
@@ -299,21 +299,11 @@ export function RemoteServerSettingsGroups({
         collapsible={collapsible}
         defaultCollapsed={defaultCollapsed}
         forceOpen={forceOpen}
-        title="Remote Server"
-        endDescription={
-          <div className="whitespace-normal break-words">
-            Expose DotAgents as an OpenAI-compatible{" "}
-            <span className="font-mono">/v1</span> endpoint for the{" "}
-            <a
-              href="https://github.com/aj47/DotAgentsMobile"
-              target="_blank"
-              rel="noreferrer noopener"
-              className="underline"
-            >
-              DotAgents Mobile app
-            </a>{" "}
-            and other clients.
-          </div>
+        title={
+          <ControlLabel
+            label="Remote Server"
+            tooltip="Expose DotAgents as an OpenAI-compatible /v1 endpoint for the DotAgents Mobile app and other clients."
+          />
         }
       >
         <Control label="Enable Remote Server" className="px-3">
@@ -327,63 +317,55 @@ export function RemoteServerSettingsGroups({
 
         {enabled && (
           <>
-            <Control
-              label={
+            <div className="px-3 py-3">
+              <div className="mb-2">
                 <ControlLabel
                   label="Easy Mobile Pairing"
-                  tooltip="Scan one QR code with the DotAgents mobile app to connect"
+                  tooltip="Scan one QR code with the DotAgents mobile app to connect."
                 />
-              }
-              className="px-3"
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
-                {streamerMode ? (
-                  <div
-                    className="bg-muted/50 flex shrink-0 flex-col items-center justify-center rounded-lg p-3"
-                    style={{ width: 196, height: 196 }}
-                  >
-                    <EyeOff className="text-muted-foreground mb-2 h-8 w-8" />
-                    <span className="text-muted-foreground text-center text-xs">
-                      QR hidden
-                      <br />
-                      Streamer Mode
-                    </span>
-                  </div>
-                ) : easyPairingDeepLink ? (
-                  <div className="shrink-0 rounded-lg bg-white p-3">
-                    <QRCodeSVG
-                      value={easyPairingDeepLink}
-                      size={196}
-                      level="M"
-                    />
-                  </div>
-                ) : (
-                  <div
-                    className="bg-muted/50 text-muted-foreground flex shrink-0 items-center justify-center rounded-lg p-3 text-center text-xs"
-                    style={{ width: 196, height: 196 }}
-                  >
-                    Pairing URL unavailable
-                  </div>
-                )}
-                <div className="min-w-0 flex-1 space-y-3">
-                  <div>
-                    <div className="text-sm font-medium">
-                      {easyPairingSource
-                        ? `${easyPairingSource} pairing`
-                        : "Mobile pairing"}
+              </div>
+              <div className="grid min-w-0 gap-3 sm:grid-cols-[144px_minmax(0,1fr)]">
+                <div className="flex min-w-0 justify-start">
+                  {streamerMode ? (
+                    <div className="bg-muted/50 flex h-36 w-36 shrink-0 flex-col items-center justify-center rounded-lg p-3">
+                      <EyeOff className="text-muted-foreground mb-2 h-7 w-7" />
+                      <span className="text-muted-foreground text-center text-xs">
+                        QR hidden
+                        <br />
+                        Streamer Mode
+                      </span>
                     </div>
-                    <div className="text-muted-foreground mt-1 break-words text-xs">
-                      {streamerMode && easyPairingBaseUrl
-                        ? maskUrl(easyPairingBaseUrl)
-                        : (easyPairingBaseUrl ?? "No pairing URL available")}
+                  ) : easyPairingDeepLink ? (
+                    <div className="shrink-0 rounded-lg bg-white p-2">
+                      <QRCodeSVG
+                        value={easyPairingDeepLink}
+                        size={128}
+                        level="M"
+                      />
                     </div>
-                    <div className="text-muted-foreground mt-1 break-words text-xs">
-                      {streamerMode
-                        ? "QR code and link hidden in Streamer Mode"
-                        : easyPairingStatusText}
+                  ) : (
+                    <div className="bg-muted/50 text-muted-foreground flex h-36 w-36 shrink-0 items-center justify-center rounded-lg p-3 text-center text-xs">
+                      Pairing URL unavailable
                     </div>
+                  )}
+                </div>
+                <div className="min-w-0 space-y-2">
+                  <div className="text-sm font-medium">
+                    {easyPairingSource
+                      ? `${easyPairingSource} pairing`
+                      : "Mobile pairing"}
                   </div>
-                  <div className="flex flex-wrap items-center gap-2">
+                  <div className="text-muted-foreground break-all text-xs">
+                    {streamerMode && easyPairingBaseUrl
+                      ? maskUrl(easyPairingBaseUrl)
+                      : (easyPairingBaseUrl ?? "No pairing URL available")}
+                  </div>
+                  <div className="text-muted-foreground text-xs">
+                    {streamerMode
+                      ? "QR code and link hidden in Streamer Mode"
+                      : easyPairingStatusText}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 pt-1">
                     <Button
                       variant="secondary"
                       size="sm"
@@ -461,7 +443,7 @@ export function RemoteServerSettingsGroups({
                   </div>
                 </div>
               </div>
-            </Control>
+            </div>
 
             <Control
               label={
@@ -677,10 +659,6 @@ export function RemoteServerSettingsGroups({
                 placeholder="* or http://localhost:8081, http://example.com"
                 className="w-full"
               />
-              <div className="text-muted-foreground mt-1 text-xs">
-                Use * for development or specify allowed origins separated by
-                commas
-              </div>
             </Control>
 
             {(baseUrl ||
@@ -821,21 +799,11 @@ export function RemoteServerSettingsGroups({
           collapsible={collapsible}
           defaultCollapsed={defaultCollapsed}
           forceOpen={forceOpen}
-          title="Cloudflare Tunnel"
-          endDescription={
-            <div className="whitespace-normal break-words">
-              Optional internet access for the remote server. Quick tunnels use
-              random URLs; named tunnels keep a{" "}
-              <a
-                href="https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/"
-                target="_blank"
-                rel="noreferrer noopener"
-                className="underline"
-              >
-                persistent URL
-              </a>
-              .
-            </div>
+          title={
+            <ControlLabel
+              label="Cloudflare Tunnel"
+              tooltip="Optional internet access for the remote server. Quick tunnels use random URLs; named tunnels keep a persistent URL."
+            />
           }
         >
           {!isCloudflaredInstalled ? (

--- a/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-remote-server.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useMemo } from "react"
-import { Control, ControlGroup, ControlLabel } from "@renderer/components/ui/control"
+import {
+  Control,
+  ControlGroup,
+  ControlLabel,
+} from "@renderer/components/ui/control"
 import { Switch } from "@renderer/components/ui/switch"
 import { Input } from "@renderer/components/ui/input"
 import { Button } from "@renderer/components/ui/button"
@@ -10,7 +14,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@renderer/components/ui/select"
-import { useConfigQuery, useSaveConfigMutation } from "@renderer/lib/query-client"
+import {
+  useConfigQuery,
+  useSaveConfigMutation,
+} from "@renderer/lib/query-client"
 import { copyTextToClipboard } from "@renderer/lib/clipboard"
 import { tipcClient } from "@renderer/lib/tipc-client"
 import type { Config } from "@shared/types"
@@ -25,7 +32,9 @@ import { EyeOff, ExternalLink, RotateCcw } from "lucide-react"
 function maskUrl(url: string): string {
   if (!url) return "https://***.***.***.***:****/v1"
   // Replace the sensitive parts with asterisks while preserving structure
-  return url.replace(/([a-zA-Z0-9-]+)/g, (match) => "*".repeat(Math.min(match.length, 8)))
+  return url.replace(/([a-zA-Z0-9-]+)/g, (match) =>
+    "*".repeat(Math.min(match.length, 8)),
+  )
 }
 
 function normalizeHostForComparison(host: string): string {
@@ -43,7 +52,11 @@ function isWildcardMobileHost(host: string): boolean {
 
 function isLoopbackMobileHost(host: string): boolean {
   const normalizedHost = normalizeHostForComparison(host)
-  return normalizedHost === "127.0.0.1" || normalizedHost === "localhost" || normalizedHost === "::1"
+  return (
+    normalizedHost === "127.0.0.1" ||
+    normalizedHost === "localhost" ||
+    normalizedHost === "::1"
+  )
 }
 
 function isUnconnectableMobileHost(host: string): boolean {
@@ -52,7 +65,11 @@ function isUnconnectableMobileHost(host: string): boolean {
 
 function formatHostForHttpUrl(host: string): string {
   const normalizedHost = host.trim()
-  if (normalizedHost.includes(":") && !normalizedHost.startsWith("[") && !normalizedHost.endsWith("]")) {
+  if (
+    normalizedHost.includes(":") &&
+    !normalizedHost.startsWith("[") &&
+    !normalizedHost.endsWith("]")
+  ) {
     return `[${normalizedHost}]`
   }
   return normalizedHost
@@ -61,19 +78,23 @@ function formatHostForHttpUrl(host: string): string {
 function generateRemoteServerApiKey(): string {
   const bytes = new Uint8Array(32)
   window.crypto.getRandomValues(bytes)
-  return Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("")
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
 }
 
 interface RemoteServerSettingsGroupsProps {
   collapsible?: boolean
   defaultCollapsed?: boolean
   forceOpen?: boolean
+  id?: string
 }
 
 export function RemoteServerSettingsGroups({
   collapsible = false,
   defaultCollapsed = false,
   forceOpen,
+  id,
 }: RemoteServerSettingsGroupsProps = {}) {
   const configQuery = useConfigQuery()
   const saveConfigMutation = useSaveConfigMutation()
@@ -115,7 +136,10 @@ export function RemoteServerSettingsGroups({
     queryKey: ["cloudflare-tunnel-list"],
     queryFn: () => tipcClient.listCloudflareTunnels(),
     staleTime: 60000, // Refresh once per minute
-    enabled: cfg?.remoteServerEnabled && cfg?.cloudflareTunnelMode === "named" && (cloudflaredLoggedInQuery.data ?? false),
+    enabled:
+      cfg?.remoteServerEnabled &&
+      cfg?.cloudflareTunnelMode === "named" &&
+      (cloudflaredLoggedInQuery.data ?? false),
   })
 
   const tunnelStatusQuery = useQuery({
@@ -133,7 +157,11 @@ export function RemoteServerSettingsGroups({
   })
 
   const remoteServerPairingApiKeyQuery = useQuery({
-    queryKey: ["remote-server-pairing-api-key", cfg?.remoteServerApiKey, cfg?.streamerModeEnabled],
+    queryKey: [
+      "remote-server-pairing-api-key",
+      cfg?.remoteServerApiKey,
+      cfg?.streamerModeEnabled,
+    ],
     queryFn: () => tipcClient.getRemoteServerPairingApiKey(),
     enabled: !!cfg?.remoteServerApiKey && !(cfg?.streamerModeEnabled ?? false),
   })
@@ -146,8 +174,11 @@ export function RemoteServerSettingsGroups({
   })
 
   const startNamedTunnelMutation = useMutation({
-    mutationFn: (params: { tunnelId: string; hostname: string; credentialsPath?: string }) =>
-      tipcClient.startNamedCloudflareTunnel(params),
+    mutationFn: (params: {
+      tunnelId: string
+      hostname: string
+      credentialsPath?: string
+    }) => tipcClient.startNamedCloudflareTunnel(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["cloudflare-tunnel-status"] })
     },
@@ -164,40 +195,46 @@ export function RemoteServerSettingsGroups({
   const remoteServerStatus = remoteServerStatusQuery.data
   const isCloudflaredInstalled = cloudflaredInstalledQuery.data ?? false
   const isCloudflaredLoggedIn = cloudflaredLoggedInQuery.data ?? false
-  const tunnelList: Array<{ id: string; name: string; created_at: string }> = tunnelListQuery.data?.tunnels ?? []
+  const tunnelList: Array<{ id: string; name: string; created_at: string }> =
+    tunnelListQuery.data?.tunnels ?? []
   const tunnelMode = cfg?.cloudflareTunnelMode ?? "quick"
 
-  const bindOptions: Array<{ label: string; value: string }> = useMemo(
-    () => {
-      const options = [
+  const bindOptions: Array<{ label: string; value: string }> = useMemo(() => {
+    const options = [
       { label: "Localhost (127.0.0.1)", value: "127.0.0.1" },
       { label: "All Interfaces (0.0.0.0)", value: "0.0.0.0" },
-      ]
-      const tailscaleIpv4 = remoteServerStatus?.tailscale?.ipv4
-      if (tailscaleIpv4) {
-        options.push({ label: `Tailscale (${tailscaleIpv4})`, value: tailscaleIpv4 })
-      }
-      return options
-    },
-    [remoteServerStatus?.tailscale?.ipv4],
-  )
+    ]
+    const tailscaleIpv4 = remoteServerStatus?.tailscale?.ipv4
+    if (tailscaleIpv4) {
+      options.push({
+        label: `Tailscale (${tailscaleIpv4})`,
+        value: tailscaleIpv4,
+      })
+    }
+    return options
+  }, [remoteServerStatus?.tailscale?.ipv4])
 
   if (!cfg) return null
 
   const enabled = cfg.remoteServerEnabled ?? false
   const streamerMode = cfg.streamerModeEnabled ?? false
-  const remoteServerPairingApiKey = typeof remoteServerPairingApiKeyQuery.data === "string"
-    ? remoteServerPairingApiKeyQuery.data
-    : ""
+  const remoteServerPairingApiKey =
+    typeof remoteServerPairingApiKeyQuery.data === "string"
+      ? remoteServerPairingApiKeyQuery.data
+      : ""
   const hasRemoteServerApiKey = remoteServerPairingApiKey.length > 0
-  const hasConfiguredRemoteServerApiKey = (cfg.remoteServerApiKey ?? "").trim().length > 0
-  const shouldShowPairingSurface = streamerMode ? hasConfiguredRemoteServerApiKey : hasRemoteServerApiKey
+  const hasConfiguredRemoteServerApiKey =
+    (cfg.remoteServerApiKey ?? "").trim().length > 0
+  const shouldShowPairingSurface = streamerMode
+    ? hasConfiguredRemoteServerApiKey
+    : hasRemoteServerApiKey
   const configuredBindAddress = cfg.remoteServerBindAddress || "127.0.0.1"
   const configuredPort = cfg.remoteServerPort ?? 3210
-  const isRemoteServerRunning = enabled && (remoteServerStatus?.running ?? false)
+  const isRemoteServerRunning =
+    enabled && (remoteServerStatus?.running ?? false)
 
-  const fallbackBaseUrl = !isUnconnectableMobileHost(configuredBindAddress) &&
-    configuredPort
+  const fallbackBaseUrl =
+    !isUnconnectableMobileHost(configuredBindAddress) && configuredPort
       ? `http://${formatHostForHttpUrl(configuredBindAddress)}:${configuredPort}/v1`
       : undefined
 
@@ -206,26 +243,33 @@ export function RemoteServerSettingsGroups({
     : undefined
   const baseUrl = liveConnectableUrl ?? fallbackBaseUrl
   const localServerBaseUrl =
-    baseUrl ?? `http://${formatHostForHttpUrl(configuredBindAddress)}:${configuredPort}/v1`
+    baseUrl ??
+    `http://${formatHostForHttpUrl(configuredBindAddress)}:${configuredPort}/v1`
   const tailscaleStatus = remoteServerStatus?.tailscale
   const easyPairingUrl = isRemoteServerRunning
     ? remoteServerStatus?.easyPairingUrl
     : undefined
-  const easyPairingSource = remoteServerStatus?.easyPairingSource === "tailscale"
-    ? "Tailscale"
-    : remoteServerStatus?.easyPairingSource === "lan"
-      ? "LAN"
-      : tunnelStatus?.running && tunnelStatus.url
-        ? "Cloudflare"
-        : undefined
-  const easyPairingBaseUrl = easyPairingUrl ?? (
-    tunnelStatus?.running && tunnelStatus.url ? `${tunnelStatus.url}/v1` : undefined
-  )
-  const easyPairingDeepLink = easyPairingBaseUrl && remoteServerPairingApiKey
-    ? `dotagents://config?baseUrl=${encodeURIComponent(easyPairingBaseUrl)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`
-    : undefined
-  const isUsingTailscaleBind = !!tailscaleStatus?.ipv4 && configuredBindAddress === tailscaleStatus.ipv4
-  const canUseTailscale = enabled && !!tailscaleStatus?.running && !!tailscaleStatus.ipv4
+  const easyPairingSource =
+    remoteServerStatus?.easyPairingSource === "tailscale"
+      ? "Tailscale"
+      : remoteServerStatus?.easyPairingSource === "lan"
+        ? "LAN"
+        : tunnelStatus?.running && tunnelStatus.url
+          ? "Cloudflare"
+          : undefined
+  const easyPairingBaseUrl =
+    easyPairingUrl ??
+    (tunnelStatus?.running && tunnelStatus.url
+      ? `${tunnelStatus.url}/v1`
+      : undefined)
+  const easyPairingDeepLink =
+    easyPairingBaseUrl && remoteServerPairingApiKey
+      ? `dotagents://config?baseUrl=${encodeURIComponent(easyPairingBaseUrl)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`
+      : undefined
+  const isUsingTailscaleBind =
+    !!tailscaleStatus?.ipv4 && configuredBindAddress === tailscaleStatus.ipv4
+  const canUseTailscale =
+    enabled && !!tailscaleStatus?.running && !!tailscaleStatus.ipv4
   const easyPairingStatusText = !enabled
     ? "Enable the remote server to pair mobile."
     : tailscaleStatus?.baseUrl
@@ -242,294 +286,989 @@ export function RemoteServerSettingsGroups({
     isUnconnectableMobileHost(configuredBindAddress) &&
     !liveConnectableUrl
   const showConnectableUrlResolutionWarning =
-    shouldShowConnectabilityWarning && isWildcardMobileHost(configuredBindAddress)
+    shouldShowConnectabilityWarning &&
+    isWildcardMobileHost(configuredBindAddress)
   const showLoopbackBindWarning =
-    shouldShowConnectabilityWarning && isLoopbackMobileHost(configuredBindAddress)
+    shouldShowConnectabilityWarning &&
+    isLoopbackMobileHost(configuredBindAddress)
 
   return (
-    <>
+    <div id={id} className="grid gap-4">
+      <ControlGroup
+        id="remote-server"
+        collapsible={collapsible}
+        defaultCollapsed={defaultCollapsed}
+        forceOpen={forceOpen}
+        title="Remote Server"
+        endDescription={
+          <div className="whitespace-normal break-words">
+            Expose DotAgents as an OpenAI-compatible{" "}
+            <span className="font-mono">/v1</span> endpoint for the{" "}
+            <a
+              href="https://github.com/aj47/DotAgentsMobile"
+              target="_blank"
+              rel="noreferrer noopener"
+              className="underline"
+            >
+              DotAgents Mobile app
+            </a>{" "}
+            and other clients.
+          </div>
+        }
+      >
+        <Control label="Enable Remote Server" className="px-3">
+          <Switch
+            checked={enabled}
+            onCheckedChange={(value) => {
+              saveConfig({ remoteServerEnabled: value })
+            }}
+          />
+        </Control>
+
+        {enabled && (
+          <>
+            <Control
+              label={
+                <ControlLabel
+                  label="Easy Mobile Pairing"
+                  tooltip="Scan one QR code with the DotAgents mobile app to connect"
+                />
+              }
+              className="px-3"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+                {streamerMode ? (
+                  <div
+                    className="bg-muted/50 flex shrink-0 flex-col items-center justify-center rounded-lg p-3"
+                    style={{ width: 196, height: 196 }}
+                  >
+                    <EyeOff className="text-muted-foreground mb-2 h-8 w-8" />
+                    <span className="text-muted-foreground text-center text-xs">
+                      QR hidden
+                      <br />
+                      Streamer Mode
+                    </span>
+                  </div>
+                ) : easyPairingDeepLink ? (
+                  <div className="shrink-0 rounded-lg bg-white p-3">
+                    <QRCodeSVG
+                      value={easyPairingDeepLink}
+                      size={196}
+                      level="M"
+                    />
+                  </div>
+                ) : (
+                  <div
+                    className="bg-muted/50 text-muted-foreground flex shrink-0 items-center justify-center rounded-lg p-3 text-center text-xs"
+                    style={{ width: 196, height: 196 }}
+                  >
+                    Pairing URL unavailable
+                  </div>
+                )}
+                <div className="min-w-0 flex-1 space-y-3">
+                  <div>
+                    <div className="text-sm font-medium">
+                      {easyPairingSource
+                        ? `${easyPairingSource} pairing`
+                        : "Mobile pairing"}
+                    </div>
+                    <div className="text-muted-foreground mt-1 break-words text-xs">
+                      {streamerMode && easyPairingBaseUrl
+                        ? maskUrl(easyPairingBaseUrl)
+                        : (easyPairingBaseUrl ?? "No pairing URL available")}
+                    </div>
+                    <div className="text-muted-foreground mt-1 break-words text-xs">
+                      {streamerMode
+                        ? "QR code and link hidden in Streamer Mode"
+                        : easyPairingStatusText}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={!canUseTailscale || isUsingTailscaleBind}
+                      title={
+                        !canUseTailscale
+                          ? "Tailscale is unavailable"
+                          : isUsingTailscaleBind
+                            ? "Already using Tailscale"
+                            : undefined
+                      }
+                      onClick={() => {
+                        if (!tailscaleStatus?.ipv4) return
+                        saveConfig({
+                          remoteServerBindAddress: tailscaleStatus.ipv4,
+                        })
+                      }}
+                    >
+                      {isUsingTailscaleBind
+                        ? "Using Tailscale"
+                        : "Use Tailscale"}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={streamerMode || !easyPairingDeepLink}
+                      title={
+                        streamerMode
+                          ? "Disabled in Streamer Mode"
+                          : !easyPairingDeepLink
+                            ? "Pairing link unavailable"
+                            : undefined
+                      }
+                      onClick={() => {
+                        if (streamerMode || !easyPairingDeepLink) return
+                        void copyTextToClipboard(easyPairingDeepLink).catch(
+                          (err) => {
+                            console.error(
+                              "Failed to copy easy pairing deep link",
+                              err,
+                            )
+                          },
+                        )
+                      }}
+                    >
+                      {streamerMode ? (
+                        <>
+                          <EyeOff className="mr-1 h-3.5 w-3.5" />
+                          Hidden
+                        </>
+                      ) : (
+                        "Copy Link"
+                      )}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={streamerMode || !easyPairingBaseUrl}
+                      title={
+                        streamerMode
+                          ? "Disabled in Streamer Mode"
+                          : !easyPairingBaseUrl
+                            ? "Pairing URL unavailable"
+                            : "Print QR code to terminal"
+                      }
+                      onClick={() => {
+                        if (streamerMode || !easyPairingBaseUrl) return
+                        tipcClient.printRemoteServerQRCode({
+                          url: easyPairingBaseUrl,
+                        })
+                      }}
+                    >
+                      Print QR
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Auto-Show Panel"
+                  tooltip="Automatically show the floating panel when receiving messages from remote clients"
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={cfg.remoteServerAutoShowPanel ?? false}
+                onCheckedChange={(value) => {
+                  saveConfig({ remoteServerAutoShowPanel: value })
+                }}
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Terminal QR Code"
+                  tooltip="Print QR code to terminal on server start (auto-enabled in headless environments)"
+                />
+              }
+              className="px-3"
+            >
+              <Switch
+                checked={cfg.remoteServerTerminalQrEnabled ?? false}
+                onCheckedChange={(value) => {
+                  saveConfig({ remoteServerTerminalQrEnabled: value })
+                }}
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel label="Port" tooltip="HTTP port to listen on" />
+              }
+              className="px-3"
+            >
+              <Input
+                type="number"
+                min={1}
+                max={65535}
+                value={cfg.remoteServerPort ?? 3210}
+                onChange={(e) =>
+                  saveConfig({
+                    remoteServerPort: parseInt(
+                      e.currentTarget.value || "3210",
+                      10,
+                    ),
+                  })
+                }
+                className="w-36"
+              />
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Bind Address"
+                  tooltip="127.0.0.1 for local-only access; 0.0.0.0 to allow LAN access (requires API key)"
+                />
+              }
+              className="px-3"
+            >
+              <Select
+                value={(cfg.remoteServerBindAddress as any) || "127.0.0.1"}
+                onValueChange={(value: any) =>
+                  saveConfig({ remoteServerBindAddress: value })
+                }
+              >
+                <SelectTrigger className="w-full sm:w-[220px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {bindOptions.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {cfg.remoteServerBindAddress === "0.0.0.0" && (
+                <div className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                  Warning: Exposes the server on your local network. Keep your
+                  API key secure.
+                </div>
+              )}
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="API Key"
+                  tooltip="Bearer token required in Authorization header"
+                />
+              }
+              className="px-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Input
+                  type="password"
+                  value={cfg.remoteServerApiKey ? "••••••••" : ""}
+                  readOnly
+                  className="w-full min-w-0 max-w-full sm:w-[360px]"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={streamerMode || !hasRemoteServerApiKey}
+                  title={
+                    streamerMode
+                      ? "Disabled in Streamer Mode"
+                      : !hasRemoteServerApiKey
+                        ? "API key unavailable"
+                        : undefined
+                  }
+                  onClick={() => {
+                    if (!remoteServerPairingApiKey || streamerMode) return
+                    void copyTextToClipboard(remoteServerPairingApiKey).catch(
+                      (err) => {
+                        console.error(
+                          "Failed to copy remote server API key",
+                          err,
+                        )
+                      },
+                    )
+                  }}
+                >
+                  {streamerMode ? (
+                    <>
+                      <EyeOff className="mr-1 h-3.5 w-3.5" />
+                      Hidden
+                    </>
+                  ) : (
+                    "Copy"
+                  )}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={async () => {
+                    await saveConfigAsync({
+                      remoteServerApiKey: generateRemoteServerApiKey(),
+                    })
+                    await Promise.all([
+                      configQuery.refetch(),
+                      remoteServerPairingApiKeyQuery.refetch(),
+                    ])
+                  }}
+                >
+                  Regenerate
+                </Button>
+              </div>
+              {streamerMode && (
+                <div className="mt-1 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+                  <EyeOff className="h-3 w-3" />
+                  Copy disabled in Streamer Mode
+                </div>
+              )}
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Log Level"
+                  tooltip="Fastify logger level"
+                />
+              }
+              className="px-3"
+            >
+              <Select
+                value={(cfg.remoteServerLogLevel as any) || "info"}
+                onValueChange={(value: any) =>
+                  saveConfig({ remoteServerLogLevel: value })
+                }
+              >
+                <SelectTrigger className="w-full sm:w-[160px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="error">error</SelectItem>
+                  <SelectItem value="info">info</SelectItem>
+                  <SelectItem value="debug">debug</SelectItem>
+                </SelectContent>
+              </Select>
+            </Control>
+
+            <Control
+              label={
+                <ControlLabel
+                  label="CORS Origins"
+                  tooltip="Allowed origins for CORS requests. Use * for all origins (development), or specify comma-separated URLs like http://localhost:8081"
+                />
+              }
+              className="px-3"
+            >
+              <Input
+                type="text"
+                value={(cfg.remoteServerCorsOrigins || ["*"]).join(", ")}
+                onChange={(e) => {
+                  const origins = e.currentTarget.value
+                    .split(",")
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                  saveConfig({
+                    remoteServerCorsOrigins:
+                      origins.length > 0 ? origins : ["*"],
+                  })
+                }}
+                placeholder="* or http://localhost:8081, http://example.com"
+                className="w-full"
+              />
+              <div className="text-muted-foreground mt-1 text-xs">
+                Use * for development or specify allowed origins separated by
+                commas
+              </div>
+            </Control>
+
+            {(baseUrl ||
+              showConnectableUrlResolutionWarning ||
+              showLoopbackBindWarning) && (
+              <>
+                <Control label="Base URL" className="px-3">
+                  {baseUrl ? (
+                    <div className="text-muted-foreground select-text break-all text-sm">
+                      {streamerMode ? maskUrl(baseUrl) : baseUrl}
+                    </div>
+                  ) : (
+                    <div className="break-words text-sm text-amber-700 dark:text-amber-300">
+                      Unable to resolve a LAN-reachable URL for the current bind
+                      address.
+                    </div>
+                  )}
+                  {streamerMode && baseUrl && (
+                    <div className="mt-1 flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400">
+                      <EyeOff className="h-3 w-3" />
+                      URL masked in Streamer Mode
+                    </div>
+                  )}
+                  {showConnectableUrlResolutionWarning && (
+                    <div className="mt-1 break-words text-xs text-amber-600 dark:text-amber-400">
+                      The server is running, but no LAN-reachable address was
+                      detected for wildcard bind (0.0.0.0/::). Connect to a
+                      local network or use a specific LAN IP/host to enable
+                      mobile pairing.
+                    </div>
+                  )}
+                  {showLoopbackBindWarning && (
+                    <div className="mt-1 break-words text-xs text-amber-600 dark:text-amber-400">
+                      The server is running on loopback ({configuredBindAddress}
+                      ), which is only reachable from this computer. Use 0.0.0.0
+                      or a LAN IP to enable mobile pairing.
+                    </div>
+                  )}
+                </Control>
+
+                {shouldShowPairingSurface && (
+                  <Control
+                    label={
+                      <ControlLabel
+                        label="Local Server QR Code"
+                        tooltip="Scan this QR code with the DotAgents mobile app to connect to the local remote server"
+                      />
+                    }
+                    className="px-3"
+                  >
+                    <div className="flex flex-col items-start gap-3">
+                      {streamerMode ? (
+                        <div
+                          className="bg-muted/50 flex flex-col items-center justify-center rounded-lg p-3"
+                          style={{ width: 160, height: 160 }}
+                        >
+                          <EyeOff className="text-muted-foreground mb-2 h-8 w-8" />
+                          <span className="text-muted-foreground text-center text-xs">
+                            QR hidden
+                            <br />
+                            Streamer Mode
+                          </span>
+                        </div>
+                      ) : (
+                        <div className="rounded-lg bg-white p-3">
+                          <QRCodeSVG
+                            value={`dotagents://config?baseUrl=${encodeURIComponent(localServerBaseUrl)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`}
+                            size={160}
+                            level="M"
+                          />
+                        </div>
+                      )}
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={streamerMode || !hasRemoteServerApiKey}
+                          title={
+                            streamerMode
+                              ? "Disabled in Streamer Mode"
+                              : !hasRemoteServerApiKey
+                                ? "API key unavailable"
+                                : undefined
+                          }
+                          onClick={() => {
+                            if (streamerMode || !remoteServerPairingApiKey)
+                              return
+                            const deepLink = `dotagents://config?baseUrl=${encodeURIComponent(localServerBaseUrl)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`
+                            void copyTextToClipboard(deepLink).catch((err) => {
+                              console.error("Failed to copy deep link", err)
+                            })
+                          }}
+                        >
+                          {streamerMode ? (
+                            <>
+                              <EyeOff className="mr-1 h-3.5 w-3.5" />
+                              Hidden
+                            </>
+                          ) : (
+                            "Copy Deep Link"
+                          )}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={streamerMode}
+                          title={
+                            streamerMode
+                              ? "Disabled in Streamer Mode"
+                              : "Print QR code to terminal (useful for SSH/headless access)"
+                          }
+                          onClick={() => {
+                            if (streamerMode) return
+                            tipcClient.printRemoteServerQRCode()
+                          }}
+                        >
+                          Print to Terminal
+                        </Button>
+                      </div>
+                      <div className="text-muted-foreground text-xs">
+                        {streamerMode
+                          ? "QR code and deep link hidden in Streamer Mode"
+                          : "Scan with the DotAgents mobile app to auto-configure the local server connection."}
+                      </div>
+                    </div>
+                  </Control>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </ControlGroup>
+
+      {/* Cloudflare Tunnel Section - only show when remote server is enabled */}
+      {enabled && (
         <ControlGroup
+          id="cloudflare-tunnel"
           collapsible={collapsible}
           defaultCollapsed={defaultCollapsed}
           forceOpen={forceOpen}
-          title="Remote Server"
-          endDescription={(
-            <div className="break-words whitespace-normal">
-              Expose DotAgents as an OpenAI-compatible <span className="font-mono">/v1</span>{" "}
-              endpoint for the{" "}
+          title="Cloudflare Tunnel"
+          endDescription={
+            <div className="whitespace-normal break-words">
+              Optional internet access for the remote server. Quick tunnels use
+              random URLs; named tunnels keep a{" "}
               <a
-                href="https://github.com/aj47/DotAgentsMobile"
+                href="https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/"
                 target="_blank"
                 rel="noreferrer noopener"
                 className="underline"
               >
-                DotAgents Mobile app
-              </a>{" "}
-              and other clients.
+                persistent URL
+              </a>
+              .
             </div>
-          )}
+          }
         >
-          <Control label="Enable Remote Server" className="px-3">
-            <Switch
-              checked={enabled}
-              onCheckedChange={(value) => {
-                saveConfig({ remoteServerEnabled: value })
-              }}
-            />
-          </Control>
-
-          {enabled && (
+          {!isCloudflaredInstalled ? (
+            <div className="px-3 py-2">
+              <div className="mb-2 text-sm text-amber-600 dark:text-amber-400">
+                cloudflared is not installed. Please install it to use
+                Cloudflare Tunnel.
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  window.open(
+                    "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
+                    "_blank",
+                  )
+                }
+              >
+                Download cloudflared
+              </Button>
+            </div>
+          ) : (
             <>
-              <Control label={<ControlLabel label="Easy Mobile Pairing" tooltip="Scan one QR code with the DotAgents mobile app to connect" />} className="px-3">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
-                  {streamerMode ? (
-                    <div className="p-3 bg-muted/50 rounded-lg flex flex-col items-center justify-center shrink-0" style={{ width: 196, height: 196 }}>
-                      <EyeOff className="h-8 w-8 text-muted-foreground mb-2" />
-                      <span className="text-xs text-muted-foreground text-center">QR hidden<br />Streamer Mode</span>
-                    </div>
-                  ) : easyPairingDeepLink ? (
-                    <div className="p-3 bg-white rounded-lg shrink-0">
-                      <QRCodeSVG
-                        value={easyPairingDeepLink}
-                        size={196}
-                        level="M"
-                      />
-                    </div>
-                  ) : (
-                    <div className="p-3 bg-muted/50 rounded-lg flex items-center justify-center shrink-0 text-xs text-muted-foreground text-center" style={{ width: 196, height: 196 }}>
-                      Pairing URL unavailable
-                    </div>
-                  )}
-                  <div className="min-w-0 flex-1 space-y-3">
-                    <div>
-                      <div className="text-sm font-medium">
-                        {easyPairingSource ? `${easyPairingSource} pairing` : "Mobile pairing"}
+              <Control
+                label={
+                  <ControlLabel
+                    label="Tunnel Mode"
+                    tooltip="Quick tunnels are easy but have random URLs. Named tunnels require setup but have persistent URLs."
+                  />
+                }
+                className="px-3"
+              >
+                <Select
+                  value={tunnelMode}
+                  onValueChange={(value: "quick" | "named") => {
+                    // Stop any running tunnel when switching modes
+                    if (tunnelStatus?.running) {
+                      stopTunnelMutation.mutate()
+                    }
+                    saveConfig({ cloudflareTunnelMode: value })
+                  }}
+                >
+                  <SelectTrigger className="w-full sm:w-[200px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="quick">
+                      Quick Tunnel (Random URL)
+                    </SelectItem>
+                    <SelectItem value="named">
+                      Named Tunnel (Persistent)
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </Control>
+
+              <Control
+                label={
+                  <ControlLabel
+                    label="Auto-Start Tunnel"
+                    tooltip="Automatically start the Cloudflare Tunnel when the application launches (requires Remote Server to be enabled)"
+                  />
+                }
+                className="px-3"
+              >
+                <Switch
+                  checked={cfg?.cloudflareTunnelAutoStart ?? false}
+                  onCheckedChange={(value) => {
+                    saveConfig({ cloudflareTunnelAutoStart: value })
+                  }}
+                />
+              </Control>
+
+              {/* Named Tunnel Configuration */}
+              {tunnelMode === "named" && (
+                <>
+                  {!isCloudflaredLoggedIn ? (
+                    <div className="px-3 py-2">
+                      <div className="mb-2 text-sm text-amber-600 dark:text-amber-400">
+                        You need to authenticate with Cloudflare first. Run{" "}
+                        <code className="bg-muted rounded px-1">
+                          cloudflared tunnel login
+                        </code>{" "}
+                        in your terminal.
                       </div>
-                      <div className="mt-1 text-xs text-muted-foreground break-words">
-                        {streamerMode && easyPairingBaseUrl ? maskUrl(easyPairingBaseUrl) : easyPairingBaseUrl ?? "No pairing URL available"}
-                      </div>
-                      <div className="mt-1 text-xs text-muted-foreground break-words">
-                        {streamerMode
-                          ? "QR code and link hidden in Streamer Mode"
-                          : easyPairingStatusText}
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        disabled={!canUseTailscale || isUsingTailscaleBind}
-                        title={!canUseTailscale ? "Tailscale is unavailable" : isUsingTailscaleBind ? "Already using Tailscale" : undefined}
-                        onClick={() => {
-                          if (!tailscaleStatus?.ipv4) return
-                          saveConfig({ remoteServerBindAddress: tailscaleStatus.ipv4 })
-                        }}
-                      >
-                        {isUsingTailscaleBind ? "Using Tailscale" : "Use Tailscale"}
-                      </Button>
                       <Button
                         variant="outline"
                         size="sm"
-                        disabled={streamerMode || !easyPairingDeepLink}
-                        title={streamerMode ? "Disabled in Streamer Mode" : !easyPairingDeepLink ? "Pairing link unavailable" : undefined}
+                        onClick={() =>
+                          window.open(
+                            "https://developers.cloudflare.com/load-balancing/private-network/public-to-tunnel/#1-configure-a-cloudflare-tunnel-with-an-assigned-virtual-network",
+                            "_blank",
+                          )
+                        }
+                      >
+                        <ExternalLink className="mr-1 h-3.5 w-3.5" />
+                        Setup Guide
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      <Control
+                        label={
+                          <ControlLabel
+                            label="Tunnel ID"
+                            tooltip="The UUID of your named tunnel. Find it with 'cloudflared tunnel list'"
+                          />
+                        }
+                        className="px-3"
+                      >
+                        <div className="flex flex-col gap-2">
+                          <Input
+                            type="text"
+                            value={cfg?.cloudflareTunnelId ?? ""}
+                            onChange={(e) =>
+                              saveConfig({
+                                cloudflareTunnelId: e.currentTarget.value,
+                              })
+                            }
+                            placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                            className="w-full min-w-0 max-w-full font-mono text-xs sm:w-[360px]"
+                          />
+                          {tunnelList.length > 0 && (
+                            <div className="text-muted-foreground text-xs">
+                              Available tunnels:{" "}
+                              {tunnelList
+                                .map((t) => (
+                                  <button
+                                    key={t.id}
+                                    type="button"
+                                    className="hover:text-foreground ml-1 cursor-pointer underline"
+                                    onClick={() =>
+                                      saveConfig({
+                                        cloudflareTunnelId: t.id,
+                                        cloudflareTunnelName: t.name,
+                                      })
+                                    }
+                                  >
+                                    {t.name}
+                                  </button>
+                                ))
+                                .reduce<React.ReactNode[]>(
+                                  (acc, el, i) =>
+                                    i === 0 ? [el] : [...acc, ", ", el],
+                                  [],
+                                )}
+                            </div>
+                          )}
+                        </div>
+                      </Control>
+
+                      <Control
+                        label={
+                          <ControlLabel
+                            label="Hostname"
+                            tooltip="The public hostname for your tunnel (e.g., myapp.example.com). Must be configured in Cloudflare DNS."
+                          />
+                        }
+                        className="px-3"
+                      >
+                        <Input
+                          type="text"
+                          value={cfg?.cloudflareTunnelHostname ?? ""}
+                          onChange={(e) =>
+                            saveConfig({
+                              cloudflareTunnelHostname: e.currentTarget.value,
+                            })
+                          }
+                          placeholder="myapp.example.com"
+                          className="w-full min-w-0 max-w-full sm:w-[300px]"
+                        />
+                      </Control>
+
+                      <Control
+                        label={
+                          <ControlLabel
+                            label="Credentials Path"
+                            tooltip="Path to credentials JSON file. Leave empty to use default (~/.cloudflared/<tunnel-id>.json)"
+                          />
+                        }
+                        className="px-3"
+                      >
+                        <Input
+                          type="text"
+                          value={cfg?.cloudflareTunnelCredentialsPath ?? ""}
+                          onChange={(e) =>
+                            saveConfig({
+                              cloudflareTunnelCredentialsPath:
+                                e.currentTarget.value,
+                            })
+                          }
+                          placeholder="~/.cloudflared/<tunnel-id>.json (default)"
+                          className="w-full min-w-0 max-w-full font-mono text-xs sm:w-[360px]"
+                        />
+                      </Control>
+                    </>
+                  )}
+                </>
+              )}
+
+              <Control label="Tunnel Status" className="px-3">
+                <div className="flex items-center gap-2">
+                  {tunnelStatus?.starting ? (
+                    <>
+                      <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
+                      <span className="text-sm text-yellow-600 dark:text-yellow-400">
+                        Starting...
+                      </span>
+                    </>
+                  ) : tunnelStatus?.running ? (
+                    <>
+                      <span className="inline-block h-2 w-2 rounded-full bg-green-500" />
+                      <span className="text-sm text-green-600 dark:text-green-400">
+                        Connected{" "}
+                        {tunnelStatus.mode === "named" ? "(Named)" : "(Quick)"}
+                      </span>
+                    </>
+                  ) : (
+                    <>
+                      <span className="inline-block h-2 w-2 rounded-full bg-gray-400" />
+                      <span className="text-muted-foreground text-sm">
+                        Not running
+                      </span>
+                    </>
+                  )}
+                </div>
+              </Control>
+
+              <Control label="Actions" className="px-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  {!tunnelStatus?.running && !tunnelStatus?.starting ? (
+                    <Button
+                      variant="default"
+                      size="sm"
+                      onClick={() => {
+                        if (tunnelMode === "named") {
+                          if (
+                            !cfg?.cloudflareTunnelId ||
+                            !cfg?.cloudflareTunnelHostname
+                          ) {
+                            return // Validation handled in UI
+                          }
+                          startNamedTunnelMutation.mutate({
+                            tunnelId: cfg.cloudflareTunnelId,
+                            hostname: cfg.cloudflareTunnelHostname,
+                            credentialsPath:
+                              cfg.cloudflareTunnelCredentialsPath || undefined,
+                          })
+                        } else {
+                          startTunnelMutation.mutate()
+                        }
+                      }}
+                      disabled={
+                        startTunnelMutation.isPending ||
+                        startNamedTunnelMutation.isPending ||
+                        (tunnelMode === "named" &&
+                          (!cfg?.cloudflareTunnelId ||
+                            !cfg?.cloudflareTunnelHostname))
+                      }
+                    >
+                      {startTunnelMutation.isPending ||
+                      startNamedTunnelMutation.isPending
+                        ? "Starting..."
+                        : "Start Tunnel"}
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => stopTunnelMutation.mutate()}
+                      disabled={
+                        stopTunnelMutation.isPending || tunnelStatus?.starting
+                      }
+                    >
+                      {stopTunnelMutation.isPending
+                        ? "Stopping..."
+                        : "Stop Tunnel"}
+                    </Button>
+                  )}
+                  {tunnelMode === "named" && !cfg?.cloudflareTunnelId && (
+                    <span className="text-xs text-amber-600 dark:text-amber-400">
+                      Enter Tunnel ID to start
+                    </span>
+                  )}
+                  {tunnelMode === "named" &&
+                    cfg?.cloudflareTunnelId &&
+                    !cfg?.cloudflareTunnelHostname && (
+                      <span className="text-xs text-amber-600 dark:text-amber-400">
+                        Enter Hostname to start
+                      </span>
+                    )}
+                </div>
+              </Control>
+
+              <Control
+                label={
+                  <ControlLabel
+                    label="Reset Pairing"
+                    tooltip="Regenerates the remote server API key and clears the current Cloudflare tunnel URL/config. Start the tunnel again to get a fresh URL."
+                  />
+                }
+                className="px-3"
+              >
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={
+                    saveConfigMutation.isPending ||
+                    stopTunnelMutation.isPending ||
+                    startTunnelMutation.isPending ||
+                    startNamedTunnelMutation.isPending
+                  }
+                  onClick={async () => {
+                    if (tunnelStatus?.running || tunnelStatus?.starting) {
+                      await stopTunnelMutation.mutateAsync()
+                    }
+                    await saveConfigAsync({
+                      remoteServerApiKey: generateRemoteServerApiKey(),
+                      cloudflareTunnelAutoStart: false,
+                      cloudflareTunnelId: "",
+                      cloudflareTunnelName: "",
+                      cloudflareTunnelCredentialsPath: "",
+                      cloudflareTunnelHostname: "",
+                    })
+                    await Promise.all([
+                      configQuery.refetch(),
+                      remoteServerPairingApiKeyQuery.refetch(),
+                      queryClient.invalidateQueries({
+                        queryKey: ["cloudflare-tunnel-status"],
+                      }),
+                      queryClient.invalidateQueries({
+                        queryKey: ["remote-server-status"],
+                      }),
+                    ])
+                  }}
+                >
+                  <RotateCcw className="mr-1 h-3.5 w-3.5" />
+                  Reset Key + URL
+                </Button>
+                <div className="text-muted-foreground mt-1 text-xs">
+                  Existing mobile deep links will stop working after reset.
+                </div>
+              </Control>
+
+              {tunnelStatus?.url && tunnelStatus?.running && (
+                <>
+                  <Control
+                    label={
+                      <ControlLabel
+                        label="Public URL"
+                        tooltip="Use this URL to access your remote server from anywhere"
+                      />
+                    }
+                    className="px-3"
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Input
+                        type={streamerMode ? "password" : "text"}
+                        value={
+                          streamerMode
+                            ? "••••••••••••••••••••"
+                            : `${tunnelStatus.url}/v1`
+                        }
+                        readOnly
+                        className="w-full min-w-0 max-w-full font-mono text-xs sm:w-[360px]"
+                      />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={streamerMode}
+                        title={
+                          streamerMode ? "Disabled in Streamer Mode" : undefined
+                        }
                         onClick={() => {
-                          if (streamerMode || !easyPairingDeepLink) return
-                          void copyTextToClipboard(easyPairingDeepLink).catch((err) => {
-                            console.error("Failed to copy easy pairing deep link", err)
+                          if (streamerMode) return
+                          void copyTextToClipboard(
+                            `${tunnelStatus.url}/v1`,
+                          ).catch((err) => {
+                            console.error("Failed to copy tunnel URL", err)
                           })
                         }}
                       >
-                        {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy Link"}
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        disabled={streamerMode || !easyPairingBaseUrl}
-                        title={streamerMode ? "Disabled in Streamer Mode" : !easyPairingBaseUrl ? "Pairing URL unavailable" : "Print QR code to terminal"}
-                        onClick={() => {
-                          if (streamerMode || !easyPairingBaseUrl) return
-                          tipcClient.printRemoteServerQRCode({ url: easyPairingBaseUrl })
-                        }}
-                      >
-                        Print QR
+                        {streamerMode ? (
+                          <>
+                            <EyeOff className="mr-1 h-3.5 w-3.5" />
+                            Hidden
+                          </>
+                        ) : (
+                          "Copy"
+                        )}
                       </Button>
                     </div>
-                  </div>
-                </div>
-              </Control>
-
-              <Control label={<ControlLabel label="Auto-Show Panel" tooltip="Automatically show the floating panel when receiving messages from remote clients" />} className="px-3">
-                <Switch
-                  checked={cfg.remoteServerAutoShowPanel ?? false}
-                  onCheckedChange={(value) => {
-                    saveConfig({ remoteServerAutoShowPanel: value })
-                  }}
-                />
-              </Control>
-
-              <Control label={<ControlLabel label="Terminal QR Code" tooltip="Print QR code to terminal on server start (auto-enabled in headless environments)" />} className="px-3">
-                <Switch
-                  checked={cfg.remoteServerTerminalQrEnabled ?? false}
-                  onCheckedChange={(value) => {
-                    saveConfig({ remoteServerTerminalQrEnabled: value })
-                  }}
-                />
-              </Control>
-
-              <Control label={<ControlLabel label="Port" tooltip="HTTP port to listen on" />} className="px-3">
-                <Input
-                  type="number"
-                  min={1}
-                  max={65535}
-                  value={cfg.remoteServerPort ?? 3210}
-                  onChange={(e) =>
-                    saveConfig({ remoteServerPort: parseInt(e.currentTarget.value || "3210", 10) })
-                  }
-                  className="w-36"
-                />
-              </Control>
-
-              <Control label={<ControlLabel label="Bind Address" tooltip="127.0.0.1 for local-only access; 0.0.0.0 to allow LAN access (requires API key)" />} className="px-3">
-                <Select
-                  value={(cfg.remoteServerBindAddress as any) || "127.0.0.1"}
-                  onValueChange={(value: any) =>
-                    saveConfig({ remoteServerBindAddress: value })
-                  }
-                >
-                  <SelectTrigger className="w-full sm:w-[220px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {bindOptions.map((opt) => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {cfg.remoteServerBindAddress === "0.0.0.0" && (
-                  <div className="mt-2 text-xs text-amber-600 dark:text-amber-400">
-                    Warning: Exposes the server on your local network. Keep your API key secure.
-                  </div>
-                )}
-              </Control>
-
-              <Control label={<ControlLabel label="API Key" tooltip="Bearer token required in Authorization header" />} className="px-3">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Input type="password" value={cfg.remoteServerApiKey ? "••••••••" : ""} readOnly className="w-full sm:w-[360px] max-w-full min-w-0" />
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={streamerMode || !hasRemoteServerApiKey}
-                    title={streamerMode ? "Disabled in Streamer Mode" : !hasRemoteServerApiKey ? "API key unavailable" : undefined}
-                    onClick={() => {
-                      if (!remoteServerPairingApiKey || streamerMode) return
-                      void copyTextToClipboard(remoteServerPairingApiKey).catch((err) => {
-                        console.error("Failed to copy remote server API key", err)
-                      })
-                    }}
-                  >
-                    {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy"}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={async () => {
-                      await saveConfigAsync({ remoteServerApiKey: generateRemoteServerApiKey() })
-                      await Promise.all([
-                        configQuery.refetch(),
-                        remoteServerPairingApiKeyQuery.refetch(),
-                      ])
-                    }}
-                  >
-                    Regenerate
-                  </Button>
-                </div>
-                {streamerMode && (
-                  <div className="mt-1 text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1">
-                    <EyeOff className="h-3 w-3" />
-                    Copy disabled in Streamer Mode
-                  </div>
-                )}
-              </Control>
-
-              <Control label={<ControlLabel label="Log Level" tooltip="Fastify logger level" />} className="px-3">
-                <Select
-                  value={(cfg.remoteServerLogLevel as any) || "info"}
-                  onValueChange={(value: any) => saveConfig({ remoteServerLogLevel: value })}
-                >
-                  <SelectTrigger className="w-full sm:w-[160px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="error">error</SelectItem>
-                    <SelectItem value="info">info</SelectItem>
-                    <SelectItem value="debug">debug</SelectItem>
-                  </SelectContent>
-                </Select>
-              </Control>
-
-              <Control label={<ControlLabel label="CORS Origins" tooltip="Allowed origins for CORS requests. Use * for all origins (development), or specify comma-separated URLs like http://localhost:8081" />} className="px-3">
-                <Input
-                  type="text"
-                  value={(cfg.remoteServerCorsOrigins || ["*"]).join(", ")}
-                  onChange={(e) => {
-                    const origins = e.currentTarget.value
-                      .split(",")
-                      .map(s => s.trim())
-                      .filter(Boolean)
-                    saveConfig({ remoteServerCorsOrigins: origins.length > 0 ? origins : ["*"] })
-                  }}
-                  placeholder="* or http://localhost:8081, http://example.com"
-                  className="w-full"
-                />
-                <div className="mt-1 text-xs text-muted-foreground">
-                  Use * for development or specify allowed origins separated by commas
-                </div>
-              </Control>
-
-              {(baseUrl || showConnectableUrlResolutionWarning || showLoopbackBindWarning) && (
-                <>
-                  <Control label="Base URL" className="px-3">
-                    {baseUrl ? (
-                      <div className="text-sm text-muted-foreground select-text break-all">
-                        {streamerMode ? maskUrl(baseUrl) : baseUrl}
-                      </div>
-                    ) : (
-                      <div className="text-sm text-amber-700 dark:text-amber-300 break-words">
-                        Unable to resolve a LAN-reachable URL for the current bind address.
-                      </div>
-                    )}
-                    {streamerMode && baseUrl && (
-                      <div className="mt-1 text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1">
-                        <EyeOff className="h-3 w-3" />
-                        URL masked in Streamer Mode
-                      </div>
-                    )}
-                    {showConnectableUrlResolutionWarning && (
-                      <div className="mt-1 text-xs text-amber-600 dark:text-amber-400 break-words">
-                        The server is running, but no LAN-reachable address was detected for wildcard bind (0.0.0.0/::). Connect to a local network or use a specific LAN IP/host to enable mobile pairing.
-                      </div>
-                    )}
-                    {showLoopbackBindWarning && (
-                      <div className="mt-1 text-xs text-amber-600 dark:text-amber-400 break-words">
-                        The server is running on loopback ({configuredBindAddress}), which is only reachable from this computer. Use 0.0.0.0 or a LAN IP to enable mobile pairing.
-                      </div>
-                    )}
+                    <div className="text-muted-foreground mt-1 text-xs">
+                      {streamerMode ? (
+                        <span className="flex items-center gap-1 text-amber-600 dark:text-amber-400">
+                          <EyeOff className="h-3 w-3" />
+                          URL hidden in Streamer Mode
+                        </span>
+                      ) : tunnelStatus.mode === "named" ? (
+                        "This URL is persistent and will remain the same across restarts."
+                      ) : (
+                        "This URL is temporary and will change when you restart the tunnel."
+                      )}
+                    </div>
                   </Control>
 
                   {shouldShowPairingSurface && (
-                    <Control label={<ControlLabel label="Local Server QR Code" tooltip="Scan this QR code with the DotAgents mobile app to connect to the local remote server" />} className="px-3">
+                    <Control
+                      label={
+                        <ControlLabel
+                          label="Mobile App QR Code"
+                          tooltip="Scan this QR code with the DotAgents mobile app to connect"
+                        />
+                      }
+                      className="px-3"
+                    >
                       <div className="flex flex-col items-start gap-3">
                         {streamerMode ? (
-                          <div className="p-3 bg-muted/50 rounded-lg flex flex-col items-center justify-center" style={{ width: 160, height: 160 }}>
-                            <EyeOff className="h-8 w-8 text-muted-foreground mb-2" />
-                            <span className="text-xs text-muted-foreground text-center">QR hidden<br />Streamer Mode</span>
+                          <div
+                            className="bg-muted/50 flex flex-col items-center justify-center rounded-lg p-3"
+                            style={{ width: 160, height: 160 }}
+                          >
+                            <EyeOff className="text-muted-foreground mb-2 h-8 w-8" />
+                            <span className="text-muted-foreground text-center text-xs">
+                              QR hidden
+                              <br />
+                              Streamer Mode
+                            </span>
                           </div>
                         ) : (
-                          <div className="p-3 bg-white rounded-lg">
+                          <div className="rounded-lg bg-white p-3">
                             <QRCodeSVG
-                              value={`dotagents://config?baseUrl=${encodeURIComponent(localServerBaseUrl)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`}
+                              value={`dotagents://config?baseUrl=${encodeURIComponent(`${tunnelStatus.url}/v1`)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`}
                               size={160}
                               level="M"
                             />
@@ -540,388 +1279,60 @@ export function RemoteServerSettingsGroups({
                             variant="outline"
                             size="sm"
                             disabled={streamerMode || !hasRemoteServerApiKey}
-                            title={streamerMode ? "Disabled in Streamer Mode" : !hasRemoteServerApiKey ? "API key unavailable" : undefined}
+                            title={
+                              streamerMode
+                                ? "Disabled in Streamer Mode"
+                                : !hasRemoteServerApiKey
+                                  ? "API key unavailable"
+                                  : undefined
+                            }
                             onClick={() => {
-                              if (streamerMode || !remoteServerPairingApiKey) return
-                              const deepLink = `dotagents://config?baseUrl=${encodeURIComponent(localServerBaseUrl)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`
-                              void copyTextToClipboard(deepLink).catch((err) => {
-                                console.error("Failed to copy deep link", err)
-                              })
+                              if (streamerMode || !remoteServerPairingApiKey)
+                                return
+                              const deepLink = `dotagents://config?baseUrl=${encodeURIComponent(`${tunnelStatus.url}/v1`)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`
+                              void copyTextToClipboard(deepLink).catch(
+                                (err) => {
+                                  console.error(
+                                    "Failed to copy tunnel deep link",
+                                    err,
+                                  )
+                                },
+                              )
                             }}
                           >
-                            {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy Deep Link"}
-                          </Button>
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            disabled={streamerMode}
-                            title={streamerMode ? "Disabled in Streamer Mode" : "Print QR code to terminal (useful for SSH/headless access)"}
-                            onClick={() => {
-                              if (streamerMode) return
-                              tipcClient.printRemoteServerQRCode()
-                            }}
-                          >
-                            Print to Terminal
+                            {streamerMode ? (
+                              <>
+                                <EyeOff className="mr-1 h-3.5 w-3.5" />
+                                Hidden
+                              </>
+                            ) : (
+                              "Copy Deep Link"
+                            )}
                           </Button>
                         </div>
-                        <div className="text-xs text-muted-foreground">
+                        <div className="text-muted-foreground text-xs">
                           {streamerMode
                             ? "QR code and deep link hidden in Streamer Mode"
-                            : "Scan with the DotAgents mobile app to auto-configure the local server connection."}
+                            : "Scan with the DotAgents mobile app to auto-configure the connection."}
                         </div>
                       </div>
                     </Control>
                   )}
                 </>
               )}
+
+              {tunnelStatus?.error && (
+                <div className="px-3 py-2">
+                  <div className="text-sm text-red-600 dark:text-red-400">
+                    Error: {tunnelStatus.error}
+                  </div>
+                </div>
+              )}
             </>
           )}
         </ControlGroup>
-
-        {/* Cloudflare Tunnel Section - only show when remote server is enabled */}
-        {enabled && (
-          <ControlGroup
-            collapsible={collapsible}
-            defaultCollapsed={defaultCollapsed}
-            forceOpen={forceOpen}
-            title="Cloudflare Tunnel"
-            endDescription={(
-              <div className="break-words whitespace-normal">
-                Optional internet access for the remote server. Quick tunnels use random
-                URLs; named tunnels keep a{" "}
-                <a
-                  href="https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/"
-                  target="_blank"
-                  rel="noreferrer noopener"
-                  className="underline"
-                >
-                  persistent URL
-                </a>.
-              </div>
-            )}
-          >
-            {!isCloudflaredInstalled ? (
-              <div className="px-3 py-2">
-                <div className="text-sm text-amber-600 dark:text-amber-400 mb-2">
-                  cloudflared is not installed. Please install it to use Cloudflare Tunnel.
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => window.open("https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/", "_blank")}
-                >
-                  Download cloudflared
-                </Button>
-              </div>
-            ) : (
-              <>
-                <Control label={<ControlLabel label="Tunnel Mode" tooltip="Quick tunnels are easy but have random URLs. Named tunnels require setup but have persistent URLs." />} className="px-3">
-                  <Select
-                    value={tunnelMode}
-                    onValueChange={(value: "quick" | "named") => {
-                      // Stop any running tunnel when switching modes
-                      if (tunnelStatus?.running) {
-                        stopTunnelMutation.mutate()
-                      }
-                      saveConfig({ cloudflareTunnelMode: value })
-                    }}
-                  >
-                    <SelectTrigger className="w-full sm:w-[200px]">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="quick">Quick Tunnel (Random URL)</SelectItem>
-                      <SelectItem value="named">Named Tunnel (Persistent)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </Control>
-
-                <Control label={<ControlLabel label="Auto-Start Tunnel" tooltip="Automatically start the Cloudflare Tunnel when the application launches (requires Remote Server to be enabled)" />} className="px-3">
-                  <Switch
-                    checked={cfg?.cloudflareTunnelAutoStart ?? false}
-                    onCheckedChange={(value) => {
-                      saveConfig({ cloudflareTunnelAutoStart: value })
-                    }}
-                  />
-                </Control>
-
-                {/* Named Tunnel Configuration */}
-                {tunnelMode === "named" && (
-                  <>
-                    {!isCloudflaredLoggedIn ? (
-                      <div className="px-3 py-2">
-                        <div className="text-sm text-amber-600 dark:text-amber-400 mb-2">
-                          You need to authenticate with Cloudflare first. Run <code className="bg-muted px-1 rounded">cloudflared tunnel login</code> in your terminal.
-                        </div>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => window.open("https://developers.cloudflare.com/load-balancing/private-network/public-to-tunnel/#1-configure-a-cloudflare-tunnel-with-an-assigned-virtual-network", "_blank")}
-                        >
-                          <ExternalLink className="h-3.5 w-3.5 mr-1" />
-                          Setup Guide
-                        </Button>
-                      </div>
-                    ) : (
-                      <>
-                        <Control label={<ControlLabel label="Tunnel ID" tooltip="The UUID of your named tunnel. Find it with 'cloudflared tunnel list'" />} className="px-3">
-                          <div className="flex flex-col gap-2">
-                            <Input
-                              type="text"
-                              value={cfg?.cloudflareTunnelId ?? ""}
-                              onChange={(e) => saveConfig({ cloudflareTunnelId: e.currentTarget.value })}
-                              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                              className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
-                            />
-                            {tunnelList.length > 0 && (
-                              <div className="text-xs text-muted-foreground">
-                                Available tunnels: {tunnelList.map((t) => (
-                                  <button
-                                    key={t.id}
-                                    type="button"
-                                    className="underline cursor-pointer ml-1 hover:text-foreground"
-                                    onClick={() => saveConfig({
-                                      cloudflareTunnelId: t.id,
-                                      cloudflareTunnelName: t.name,
-                                    })}
-                                  >
-                                    {t.name}
-                                  </button>
-                                )).reduce<React.ReactNode[]>((acc, el, i) => (i === 0 ? [el] : [...acc, ", ", el]), [])}
-                              </div>
-                            )}
-                          </div>
-                        </Control>
-
-                        <Control label={<ControlLabel label="Hostname" tooltip="The public hostname for your tunnel (e.g., myapp.example.com). Must be configured in Cloudflare DNS." />} className="px-3">
-                          <Input
-                            type="text"
-                            value={cfg?.cloudflareTunnelHostname ?? ""}
-                            onChange={(e) => saveConfig({ cloudflareTunnelHostname: e.currentTarget.value })}
-                            placeholder="myapp.example.com"
-                            className="w-full sm:w-[300px] max-w-full min-w-0"
-                          />
-                        </Control>
-
-                        <Control label={<ControlLabel label="Credentials Path" tooltip="Path to credentials JSON file. Leave empty to use default (~/.cloudflared/<tunnel-id>.json)" />} className="px-3">
-                          <Input
-                            type="text"
-                            value={cfg?.cloudflareTunnelCredentialsPath ?? ""}
-                            onChange={(e) => saveConfig({ cloudflareTunnelCredentialsPath: e.currentTarget.value })}
-                            placeholder="~/.cloudflared/<tunnel-id>.json (default)"
-                            className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
-                          />
-                        </Control>
-                      </>
-                    )}
-                  </>
-                )}
-
-                <Control label="Tunnel Status" className="px-3">
-                  <div className="flex items-center gap-2">
-                    {tunnelStatus?.starting ? (
-                      <>
-                        <span className="inline-block w-2 h-2 rounded-full bg-yellow-500 animate-pulse" />
-                        <span className="text-sm text-yellow-600 dark:text-yellow-400">Starting...</span>
-                      </>
-                    ) : tunnelStatus?.running ? (
-                      <>
-                        <span className="inline-block w-2 h-2 rounded-full bg-green-500" />
-                        <span className="text-sm text-green-600 dark:text-green-400">
-                          Connected {tunnelStatus.mode === "named" ? "(Named)" : "(Quick)"}
-                        </span>
-                      </>
-                    ) : (
-                      <>
-                        <span className="inline-block w-2 h-2 rounded-full bg-gray-400" />
-                        <span className="text-sm text-muted-foreground">Not running</span>
-                      </>
-                    )}
-                  </div>
-                </Control>
-
-                <Control label="Actions" className="px-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    {!tunnelStatus?.running && !tunnelStatus?.starting ? (
-                      <Button
-                        variant="default"
-                        size="sm"
-                        onClick={() => {
-                          if (tunnelMode === "named") {
-                            if (!cfg?.cloudflareTunnelId || !cfg?.cloudflareTunnelHostname) {
-                              return // Validation handled in UI
-                            }
-                            startNamedTunnelMutation.mutate({
-                              tunnelId: cfg.cloudflareTunnelId,
-                              hostname: cfg.cloudflareTunnelHostname,
-                              credentialsPath: cfg.cloudflareTunnelCredentialsPath || undefined,
-                            })
-                          } else {
-                            startTunnelMutation.mutate()
-                          }
-                        }}
-                        disabled={
-                          startTunnelMutation.isPending ||
-                          startNamedTunnelMutation.isPending ||
-                          (tunnelMode === "named" && (!cfg?.cloudflareTunnelId || !cfg?.cloudflareTunnelHostname))
-                        }
-                      >
-                        {startTunnelMutation.isPending || startNamedTunnelMutation.isPending
-                          ? "Starting..."
-                          : "Start Tunnel"}
-                      </Button>
-                    ) : (
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => stopTunnelMutation.mutate()}
-                        disabled={stopTunnelMutation.isPending || tunnelStatus?.starting}
-                      >
-                        {stopTunnelMutation.isPending ? "Stopping..." : "Stop Tunnel"}
-                      </Button>
-                    )}
-                    {tunnelMode === "named" && !cfg?.cloudflareTunnelId && (
-                      <span className="text-xs text-amber-600 dark:text-amber-400">
-                        Enter Tunnel ID to start
-                      </span>
-                    )}
-                    {tunnelMode === "named" && cfg?.cloudflareTunnelId && !cfg?.cloudflareTunnelHostname && (
-                      <span className="text-xs text-amber-600 dark:text-amber-400">
-                        Enter Hostname to start
-                      </span>
-                    )}
-                  </div>
-                </Control>
-
-                <Control label={<ControlLabel label="Reset Pairing" tooltip="Regenerates the remote server API key and clears the current Cloudflare tunnel URL/config. Start the tunnel again to get a fresh URL." />} className="px-3">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={
-                      saveConfigMutation.isPending ||
-                      stopTunnelMutation.isPending ||
-                      startTunnelMutation.isPending ||
-                      startNamedTunnelMutation.isPending
-                    }
-                    onClick={async () => {
-                      if (tunnelStatus?.running || tunnelStatus?.starting) {
-                        await stopTunnelMutation.mutateAsync()
-                      }
-                      await saveConfigAsync({
-                        remoteServerApiKey: generateRemoteServerApiKey(),
-                        cloudflareTunnelAutoStart: false,
-                        cloudflareTunnelId: "",
-                        cloudflareTunnelName: "",
-                        cloudflareTunnelCredentialsPath: "",
-                        cloudflareTunnelHostname: "",
-                      })
-                      await Promise.all([
-                        configQuery.refetch(),
-                        remoteServerPairingApiKeyQuery.refetch(),
-                        queryClient.invalidateQueries({ queryKey: ["cloudflare-tunnel-status"] }),
-                        queryClient.invalidateQueries({ queryKey: ["remote-server-status"] }),
-                      ])
-                    }}
-                  >
-                    <RotateCcw className="h-3.5 w-3.5 mr-1" />
-                    Reset Key + URL
-                  </Button>
-                  <div className="mt-1 text-xs text-muted-foreground">
-                    Existing mobile deep links will stop working after reset.
-                  </div>
-                </Control>
-
-                {tunnelStatus?.url && tunnelStatus?.running && (
-                  <>
-                    <Control label={<ControlLabel label="Public URL" tooltip="Use this URL to access your remote server from anywhere" />} className="px-3">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <Input
-                          type={streamerMode ? "password" : "text"}
-                          value={streamerMode ? "••••••••••••••••••••" : `${tunnelStatus.url}/v1`}
-                          readOnly
-                          className="w-full sm:w-[360px] max-w-full min-w-0 font-mono text-xs"
-                        />
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          disabled={streamerMode}
-                          title={streamerMode ? "Disabled in Streamer Mode" : undefined}
-                          onClick={() => {
-                            if (streamerMode) return
-                            void copyTextToClipboard(`${tunnelStatus.url}/v1`).catch((err) => {
-                              console.error("Failed to copy tunnel URL", err)
-                            })
-                          }}
-                        >
-                          {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy"}
-                        </Button>
-                      </div>
-                      <div className="mt-1 text-xs text-muted-foreground">
-                        {streamerMode
-                          ? <span className="text-amber-600 dark:text-amber-400 flex items-center gap-1"><EyeOff className="h-3 w-3" />URL hidden in Streamer Mode</span>
-                          : tunnelStatus.mode === "named"
-                            ? "This URL is persistent and will remain the same across restarts."
-                            : "This URL is temporary and will change when you restart the tunnel."}
-                      </div>
-                    </Control>
-
-                    {shouldShowPairingSurface && (
-                      <Control label={<ControlLabel label="Mobile App QR Code" tooltip="Scan this QR code with the DotAgents mobile app to connect" />} className="px-3">
-                        <div className="flex flex-col items-start gap-3">
-                          {streamerMode ? (
-                            <div className="p-3 bg-muted/50 rounded-lg flex flex-col items-center justify-center" style={{ width: 160, height: 160 }}>
-                              <EyeOff className="h-8 w-8 text-muted-foreground mb-2" />
-                              <span className="text-xs text-muted-foreground text-center">QR hidden<br />Streamer Mode</span>
-                            </div>
-                          ) : (
-                            <div className="p-3 bg-white rounded-lg">
-                              <QRCodeSVG
-                                value={`dotagents://config?baseUrl=${encodeURIComponent(`${tunnelStatus.url}/v1`)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`}
-                                size={160}
-                                level="M"
-                              />
-                            </div>
-                          )}
-                          <div className="flex flex-wrap items-center gap-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              disabled={streamerMode || !hasRemoteServerApiKey}
-                              title={streamerMode ? "Disabled in Streamer Mode" : !hasRemoteServerApiKey ? "API key unavailable" : undefined}
-                              onClick={() => {
-                                if (streamerMode || !remoteServerPairingApiKey) return
-                                const deepLink = `dotagents://config?baseUrl=${encodeURIComponent(`${tunnelStatus.url}/v1`)}&apiKey=${encodeURIComponent(remoteServerPairingApiKey)}`
-                                void copyTextToClipboard(deepLink).catch((err) => {
-                                  console.error("Failed to copy tunnel deep link", err)
-                                })
-                              }}
-                            >
-                              {streamerMode ? <><EyeOff className="h-3.5 w-3.5 mr-1" />Hidden</> : "Copy Deep Link"}
-                            </Button>
-                          </div>
-                          <div className="text-xs text-muted-foreground">
-                            {streamerMode
-                              ? "QR code and deep link hidden in Streamer Mode"
-                              : "Scan with the DotAgents mobile app to auto-configure the connection."}
-                          </div>
-                        </div>
-                      </Control>
-                    )}
-                  </>
-                )}
-
-                {tunnelStatus?.error && (
-                  <div className="px-3 py-2">
-                    <div className="text-sm text-red-600 dark:text-red-400">
-                      Error: {tunnelStatus.error}
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </ControlGroup>
-        )}
-    </>
+      )}
+    </div>
   )
 }
 

--- a/apps/desktop/src/renderer/src/router.tsx
+++ b/apps/desktop/src/renderer/src/router.tsx
@@ -8,122 +8,125 @@ const legacySettingsRedirect =
     redirect(getLegacySettingsRedirectPath(targetPath, request.url))
 
 export const router: ReturnType<typeof createBrowserRouter> =
-  createBrowserRouter([
-    {
-      path: "/",
-      lazy: () => import("./components/app-layout"),
-      children: [
-        {
-          path: "",
-          lazy: () => import("./pages/sessions"),
-        },
-        {
-          path: ":id",
-          lazy: () => import("./pages/sessions"),
-        },
-        {
-          path: "history",
-          lazy: () => import("./pages/sessions"),
-        },
-        {
-          path: "history/:id",
-          lazy: () => import("./pages/sessions"),
-        },
-        {
-          path: "settings",
-          lazy: () => import("./pages/settings-general"),
-        },
-        {
-          path: "settings/general",
-          lazy: () => import("./pages/settings-general"),
-        },
-        {
-          path: "settings/knowledge",
-          lazy: () => import("./pages/knowledge"),
-        },
-        {
-          path: "settings/providers",
-          lazy: () => import("./pages/settings-providers"),
-        },
-        {
-          path: "settings/models",
-          lazy: () => import("./pages/settings-models"),
-        },
+  createBrowserRouter(
+    [
+      {
+        path: "/",
+        lazy: () => import("./components/app-layout"),
+        children: [
+          {
+            path: "",
+            lazy: () => import("./pages/sessions"),
+          },
+          {
+            path: ":id",
+            lazy: () => import("./pages/sessions"),
+          },
+          {
+            path: "history",
+            lazy: () => import("./pages/sessions"),
+          },
+          {
+            path: "history/:id",
+            lazy: () => import("./pages/sessions"),
+          },
+          {
+            path: "settings",
+            lazy: () => import("./pages/settings-general"),
+          },
+          {
+            path: "settings/general",
+            lazy: () => import("./pages/settings-general"),
+          },
+          {
+            path: "settings/knowledge",
+            lazy: () => import("./pages/knowledge"),
+          },
+          {
+            path: "settings/providers",
+            loader: legacySettingsRedirect("/settings/models#provider-setup"),
+          },
+          {
+            path: "settings/models",
+            lazy: () => import("./pages/settings-models"),
+          },
 
-        {
-          path: "settings/capabilities",
-          lazy: () => import("./pages/settings-capabilities"),
-        },
-        {
-          path: "settings/mcp-tools",
-          loader: legacySettingsRedirect("/settings/capabilities"),
-        },
-        {
-          path: "settings/skills",
-          loader: legacySettingsRedirect("/settings/capabilities"),
-        },
-        {
-          path: "settings/remote-server",
-          loader: legacySettingsRedirect("/settings"),
-        },
-        {
-          path: "settings/whatsapp",
-          lazy: () => import("./pages/settings-whatsapp"),
-        },
-        {
-          path: "settings/discord",
-          lazy: () => import("./pages/settings-discord"),
-        },
-        {
-          path: "settings/agents",
-          lazy: () => import("./pages/settings-agents"),
-        },
-        {
-          path: "settings/repeat-tasks",
-          lazy: () => import("./pages/settings-loops"),
-        },
-        {
-          path: "settings/loops",
-          loader: legacySettingsRedirect("/settings/repeat-tasks"),
-        },
-        {
-          path: "settings/agent-personas",
-          loader: legacySettingsRedirect("/settings/agents"),
-        },
-        {
-          path: "settings/external-agents",
-          loader: legacySettingsRedirect("/settings/agents"),
-        },
-        {
-          path: "settings/agent-profiles",
-          loader: legacySettingsRedirect("/settings/agents"),
-        },
-        {
-          path: "settings/langfuse",
-          loader: legacySettingsRedirect("/settings"),
-        },
-        {
-          path: "knowledge",
-          loader: legacySettingsRedirect("/settings/knowledge"),
-        },
-      ],
-    },
+          {
+            path: "settings/capabilities",
+            lazy: () => import("./pages/settings-capabilities"),
+          },
+          {
+            path: "settings/mcp-tools",
+            loader: legacySettingsRedirect("/settings/capabilities"),
+          },
+          {
+            path: "settings/skills",
+            loader: legacySettingsRedirect("/settings/capabilities"),
+          },
+          {
+            path: "settings/remote-server",
+            loader: legacySettingsRedirect("/settings#remote-server"),
+          },
+          {
+            path: "settings/whatsapp",
+            lazy: () => import("./pages/settings-whatsapp"),
+          },
+          {
+            path: "settings/discord",
+            lazy: () => import("./pages/settings-discord"),
+          },
+          {
+            path: "settings/agents",
+            lazy: () => import("./pages/settings-agents"),
+          },
+          {
+            path: "settings/repeat-tasks",
+            lazy: () => import("./pages/settings-loops"),
+          },
+          {
+            path: "settings/loops",
+            loader: legacySettingsRedirect("/settings/repeat-tasks"),
+          },
+          {
+            path: "settings/agent-personas",
+            loader: legacySettingsRedirect("/settings/agents"),
+          },
+          {
+            path: "settings/external-agents",
+            loader: legacySettingsRedirect("/settings/agents"),
+          },
+          {
+            path: "settings/agent-profiles",
+            loader: legacySettingsRedirect("/settings/agents"),
+          },
+          {
+            path: "settings/langfuse",
+            loader: legacySettingsRedirect("/settings#observability"),
+          },
+          {
+            path: "knowledge",
+            loader: legacySettingsRedirect("/settings/knowledge"),
+          },
+        ],
+      },
+      {
+        path: "/setup",
+        lazy: () => import("./pages/setup"),
+      },
+      {
+        path: "/onboarding",
+        lazy: () => import("./pages/onboarding"),
+      },
+      {
+        path: "/panel",
+        lazy: () => import("./pages/panel"),
+      },
+    ],
     {
-      path: "/setup",
-      lazy: () => import("./pages/setup"),
+      future: {
+        // React Router future flags are version-dependent. Keep this enabled when
+        // supported, but don't fail typechecking on versions that don't include it.
+        v7_startTransition: true,
+      } as any,
     },
-    {
-      path: "/onboarding",
-      lazy: () => import("./pages/onboarding"),
-    },
-    {
-      path: "/panel",
-      lazy: () => import("./pages/panel"),
-    },
-  ], {
-    future: {
-	      // React Router future flags are version-dependent. Keep this enabled when
-	      // supported, but don't fail typechecking on versions that don't include it.
-	      v7_startTransition: true,
-	    } as any,
-  })
+  )


### PR DESCRIPTION
## Summary

- Expands the settings sidebar into clearer groups for App, Intelligence, Voice, Agents, Automation, Connect, and Advanced.
- Adds hash-based sidebar anchors for main settings sections, including Remote Server, Cloudflare Tunnel, audio, shortcuts, panel position, observability, and about.
- Consolidates provider setup into the Models settings page and redirects legacy settings routes to the right anchored sections.

## Validation

- `pnpm --filter @dotagents/desktop exec vitest run src/renderer/src/lib/settings-navigation.test.ts src/renderer/src/lib/legacy-settings-redirect.test.ts`
- `pnpm --filter @dotagents/desktop typecheck`
