### PR TITLE
[codex] Add desktop-driven mobile push notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ augment.mjs
 
 # Mobile specific
 .expo/
+apps/mobile/android/app/google-services.json
+google-services.json
+*-firebase-adminsdk-*.json
+*service-account*.json
 *.jks
 *.p8
 *.p12

--- a/apps/desktop/src/main/push-notification-service.test.ts
+++ b/apps/desktop/src/main/push-notification-service.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { Config, PushNotificationToken } from "../shared/types"
+
+const mockConfig = vi.hoisted(() => ({
+  current: {} as Config,
+  saveCalls: [] as Config[],
+}))
+
+const mockConfigStore = vi.hoisted(() => ({
+  get: vi.fn(() => mockConfig.current),
+  save: vi.fn((next: Config) => {
+    mockConfig.current = next
+    mockConfig.saveCalls.push(next)
+  }),
+}))
+
+const mockDiagnostics = vi.hoisted(() => ({
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+  logError: vi.fn(),
+}))
+
+vi.mock("./config", () => ({
+  configStore: mockConfigStore,
+}))
+
+vi.mock("./diagnostics", () => ({
+  diagnosticsService: mockDiagnostics,
+}))
+
+function token(input: Partial<PushNotificationToken> & Pick<PushNotificationToken, "token" | "platform">): PushNotificationToken {
+  return {
+    type: "expo",
+    registeredAt: 1,
+    ...input,
+  }
+}
+
+function expoResponse(data: unknown) {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("push notification service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    mockConfig.current = {}
+    mockConfig.saveCalls = []
+  })
+
+  it("skips delivery when no mobile tokens are registered", async () => {
+    const { sendPushNotification } = await import("./push-notification-service")
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await sendPushNotification({ title: "DotAgents", body: "Done" })
+
+    expect(result).toEqual({ success: true, sent: 0, failed: 0, errors: [] })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(mockConfigStore.save).not.toHaveBeenCalled()
+  })
+
+  it("sends compact Expo payloads and increments badge counts", async () => {
+    mockConfig.current = {
+      pushNotificationTokens: [
+        token({ token: "ExponentPushToken[a]", platform: "android", badgeCount: 4 }),
+      ],
+    } as Config
+    const fetchMock = vi.fn().mockResolvedValue(expoResponse([{ status: "ok", id: "ticket-1" }]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { sendMessageNotification } = await import("./push-notification-service")
+    await sendMessageNotification(
+      "conv_1",
+      "Daily brief with a very long pasted prompt",
+      "  Agent   completed.  ",
+      "session_1",
+    )
+
+    expect(mockConfig.current.pushNotificationTokens?.[0]?.badgeCount).toBe(5)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const request = fetchMock.mock.calls[0]?.[1]
+    const payload = JSON.parse(String(request.body))
+    expect(payload).toEqual([
+      {
+        to: "ExponentPushToken[a]",
+        title: "DotAgents",
+        body: "Agent completed.",
+        data: {
+          type: "message",
+          conversationId: "conv_1",
+          conversationTitle: "Daily brief with a very long p...",
+          sessionId: "session_1",
+        },
+        badge: 5,
+        sound: "default",
+        channelId: "default",
+        priority: "high",
+      },
+    ])
+  })
+
+  it("removes Expo tokens reported as unregistered without dropping fresh config entries", async () => {
+    mockConfig.current = {
+      pushNotificationTokens: [
+        token({ token: "ExponentPushToken[old]", platform: "android" }),
+        token({ token: "ExponentPushToken[good]", platform: "ios" }),
+      ],
+    } as Config
+    const fetchMock = vi.fn().mockResolvedValue(expoResponse([
+      { status: "error", message: "gone", details: { error: "DeviceNotRegistered" } },
+      { status: "ok", id: "ticket-2" },
+    ]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { sendPushNotification } = await import("./push-notification-service")
+    const result = await sendPushNotification({ title: "DotAgents", body: "Done" })
+
+    expect(result.success).toBe(false)
+    expect(result.sent).toBe(1)
+    expect(result.failed).toBe(1)
+    expect(mockConfig.current.pushNotificationTokens?.map((entry) => entry.token)).toEqual([
+      "ExponentPushToken[good]",
+    ])
+    expect(mockConfigStore.save).toHaveBeenCalledTimes(2)
+  })
+
+  it("clears badge counts for the matching token only", async () => {
+    mockConfig.current = {
+      pushNotificationTokens: [
+        token({ token: "ExponentPushToken[a]", platform: "android", badgeCount: 7 }),
+        token({ token: "ExponentPushToken[b]", platform: "ios", badgeCount: 3 }),
+      ],
+    } as Config
+
+    const { clearBadgeCount } = await import("./push-notification-service")
+    clearBadgeCount("ExponentPushToken[a]")
+
+    expect(mockConfig.current.pushNotificationTokens?.map((entry) => entry.badgeCount)).toEqual([0, 3])
+  })
+})

--- a/apps/desktop/src/main/push-notification-service.ts
+++ b/apps/desktop/src/main/push-notification-service.ts
@@ -8,6 +8,7 @@ import { diagnosticsService } from "./diagnostics"
 import { PushNotificationToken } from "../shared/types"
 
 const EXPO_PUSH_URL = "https://exp.host/--/api/v2/push/send"
+const MAX_PUSH_CONVERSATION_TITLE_CHARS = 30
 
 export interface PushNotificationPayload {
   title: string
@@ -145,19 +146,26 @@ export async function sendPushNotification(payload: PushNotificationPayload): Pr
 export async function sendMessageNotification(
   conversationId: string,
   conversationTitle: string,
-  messagePreview: string
+  messagePreview: string,
+  sessionId?: string,
 ): Promise<void> {
-  const truncatedPreview = messagePreview.length > 100
-    ? messagePreview.substring(0, 100) + "..."
-    : messagePreview
+  const trimmedPreview = messagePreview.replace(/\s+/g, " ").trim()
+  const truncatedPreview = trimmedPreview.length > 100
+    ? trimmedPreview.substring(0, 100) + "..."
+    : trimmedPreview
+  const trimmedConversationTitle = conversationTitle.replace(/\s+/g, " ").trim()
+  const truncatedConversationTitle = trimmedConversationTitle.length > MAX_PUSH_CONVERSATION_TITLE_CHARS
+    ? trimmedConversationTitle.substring(0, MAX_PUSH_CONVERSATION_TITLE_CHARS) + "..."
+    : trimmedConversationTitle
 
   await sendPushNotification({
     title: "DotAgents",
-    body: truncatedPreview,
+    body: truncatedPreview || "Agent completed.",
     data: {
       type: "message",
       conversationId,
-      conversationTitle,
+      conversationTitle: truncatedConversationTitle,
+      ...(sessionId ? { sessionId } : {}),
     },
     // badge is now handled per-token in sendPushNotification
     sound: "default",
@@ -190,4 +198,3 @@ export function clearBadgeCount(tokenValue: string): void {
   configStore.save({ ...cfg, pushNotificationTokens: updatedTokens })
   diagnosticsService.logInfo("push-service", `Badge count cleared for token: ${tokenValue.substring(0, 20)}...`)
 }
-

--- a/apps/desktop/src/main/remote-server.routes.test.ts
+++ b/apps/desktop/src/main/remote-server.routes.test.ts
@@ -237,6 +237,25 @@ describe("remote-server route registration", () => {
     expect(source).toContain("remoteServerApiKey: getMaskedRemoteServerApiKey(cfg.remoteServerApiKey)")
   })
 
+  it("registers authenticated mobile push endpoints with token hygiene", () => {
+    const source = getRemoteServerSource()
+    const pushSection = getSection(
+      source,
+      "// Push Notification Endpoints (for mobile app)",
+      "// Helper function to validate message objects",
+    )
+
+    expect(pushSection).toContain('fastify.post("/v1/push/register"')
+    expect(pushSection).toContain('fastify.post("/v1/push/unregister"')
+    expect(pushSection).toContain('fastify.get("/v1/push/status"')
+    expect(pushSection).toContain('fastify.post("/v1/push/clear-badge"')
+    expect(pushSection).toContain('body.type !== undefined && body.type !== "expo"')
+    expect(pushSection).toContain("badgeCount: existingToken?.badgeCount ?? 0")
+    expect(pushSection).toContain("deviceId.trim()")
+    expect(pushSection).toContain("platforms: [...new Set(tokens.map(t => t.platform))].sort()")
+    expect(source).toContain("const currentApiKey = getResolvedRemoteServerApiKey(current)")
+  })
+
   it("exposes Tailscale-backed easy pairing status for mobile QR setup", () => {
     const source = getRemoteServerSource()
     const operatorRemoteServerStatusSection = getSection(source, "function buildOperatorRemoteServerStatus", "function buildOperatorTunnelStatus")

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -1136,6 +1136,7 @@ function formatConversationHistoryForApi(
 export async function runAgent(options: RunAgentOptions): Promise<{
   content: string
   conversationId: string
+  sessionId: string
   conversationHistory: Array<{
     role: "user" | "assistant" | "tool"
     content: string
@@ -1298,6 +1299,7 @@ export async function runAgent(options: RunAgentOptions): Promise<{
         return {
           content: mainAgentSelection.error,
           conversationId,
+          sessionId,
           conversationHistory: await loadFormattedConversationHistory(),
         }
       }
@@ -1335,6 +1337,7 @@ export async function runAgent(options: RunAgentOptions): Promise<{
         return {
           content: result.response || result.error || "No response from agent",
           conversationId,
+          sessionId,
           conversationHistory: formattedHistory,
         }
       } finally {
@@ -1378,7 +1381,7 @@ export async function runAgent(options: RunAgentOptions): Promise<{
     // Notify renderer that conversation history has changed (for sidebar refresh)
     notifyConversationHistoryChanged()
 
-    return { content: agentResult.content, conversationId, conversationHistory: formattedHistory }
+    return { content: agentResult.content, conversationId, sessionId, conversationHistory: formattedHistory }
   } catch (error) {
     // Mark session as errored
     const errorMessage = getErrorMessage(error)
@@ -3372,6 +3375,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         success: true,
         action: "run-agent",
         conversationId: result.conversationId,
+        sessionId: result.sessionId,
         content: result.content,
         messageCount: result.conversationHistory.length,
       })
@@ -3500,7 +3504,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
           if (shouldSendPush) {
             const conversationTitle = prompt.length > 30 ? prompt.substring(0, 30) + "..." : prompt
             // Fire and forget - don't block the response
-            sendMessageNotification(result.conversationId, conversationTitle, result.content).catch((err) => {
+            sendMessageNotification(result.conversationId, conversationTitle, result.content, result.sessionId).catch((err) => {
               diagnosticsService.logWarning("remote-server", "Failed to send push notification", err)
             })
           }
@@ -3537,7 +3541,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       if (shouldSendPush) {
         const conversationTitle = prompt.length > 30 ? prompt.substring(0, 30) + "..." : prompt
         // Fire and forget - don't block the response
-        sendMessageNotification(result.conversationId, conversationTitle, result.content).catch((err) => {
+        sendMessageNotification(result.conversationId, conversationTitle, result.content, result.sessionId).catch((err) => {
           diagnosticsService.logWarning("remote-server", "Failed to send push notification", err)
         })
       }
@@ -5870,6 +5874,10 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         return reply.code(400).send({ error: "Missing or invalid token" })
       }
 
+      if (body.type !== undefined && body.type !== "expo") {
+        return reply.code(400).send({ error: "Invalid token type. Must be 'expo'" })
+      }
+
       if (!body.platform || !["ios", "android"].includes(body.platform)) {
         return reply.code(400).send({ error: "Invalid platform. Must be 'ios' or 'android'" })
       }
@@ -5879,12 +5887,17 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
 
       // Check if token already exists
       const existingIndex = existingTokens.findIndex(t => t.token === body.token)
+      const existingToken = existingIndex >= 0 ? existingTokens[existingIndex] : undefined
+      const deviceId = typeof body.deviceId === "string" && body.deviceId.trim()
+        ? body.deviceId.trim()
+        : undefined
       const newToken = {
         token: body.token,
         type: "expo" as const,
         platform: body.platform as "ios" | "android",
         registeredAt: Date.now(),
-        deviceId: body.deviceId,
+        deviceId,
+        badgeCount: existingToken?.badgeCount ?? 0,
       }
 
       let updatedTokens: typeof existingTokens
@@ -5952,7 +5965,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       return reply.send({
         enabled: tokens.length > 0,
         tokenCount: tokens.length,
-        platforms: [...new Set(tokens.map(t => t.platform))],
+        platforms: [...new Set(tokens.map(t => t.platform))].sort(),
       })
     } catch (error: any) {
       diagnosticsService.logError("remote-server", "Failed to get push status", error)

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -102,6 +102,7 @@ import { loopService } from "./loop-service"
 import { clearSessionUserResponse } from "./session-user-response-store"
 import { isMissingApiKeyErrorMessage } from "@dotagents/shared"
 import { hasRepeatTaskTitlePrefix } from "../shared/repeat-tasks"
+import { isPushEnabled, sendMessageNotification } from "./push-notification-service"
 
 function describeAgentSessionId(sessionId?: string | null): "missing" | "pending" | "subsession" | "session" | "unknown" {
   if (!sessionId) return "missing"
@@ -115,6 +116,26 @@ function reconcileAgentSessionsWithRuntime(): void {
   agentSessionTracker.reconcileActiveSessions((session) =>
     agentSessionStateManager.isSessionRegistered(session.id),
   )
+}
+
+function sendAgentCompletionPushNotification(input: {
+  conversationId?: string
+  sessionId: string
+  conversationTitle: string
+  content: string
+}) {
+  if (!input.conversationId || !isPushEnabled()) {
+    return
+  }
+
+  sendMessageNotification(
+    input.conversationId,
+    input.conversationTitle,
+    input.content,
+    input.sessionId,
+  ).catch((error) => {
+    logApp("[tipc] Failed to send completion push notification:", error)
+  })
 }
 
 async function withRepeatTaskSessionFlag<T extends {
@@ -473,6 +494,12 @@ async function processWithAgentMode(
       if (result.success) {
         logLLM(`[processWithAgentMode] ACP mode completed successfully for session ${sessionId}, conversation ${conversationId}`)
         agentSessionTracker.completeSession(sessionId, "ACP agent completed successfully")
+        sendAgentCompletionPushNotification({
+          conversationId,
+          sessionId,
+          conversationTitle,
+          content: result.response || "Agent completed.",
+        })
       } else {
         logLLM(`[processWithAgentMode] ACP mode failed for session ${sessionId}: ${result.error}`)
         agentSessionTracker.errorSession(sessionId, result.error || "Unknown error")
@@ -670,6 +697,12 @@ async function processWithAgentMode(
 
     // Mark session as completed
     agentSessionTracker.completeSession(sessionId, "Agent completed successfully")
+    sendAgentCompletionPushNotification({
+      conversationId,
+      sessionId,
+      conversationTitle,
+      content: agentResult.content,
+    })
 
     return agentResult.content
   } catch (error) {

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -56,6 +56,7 @@ const dotagentsIcon = require('./assets/dotagents-icon.png');
 const darkSpinner = require('./assets/loading-spinner.gif');
 const lightSpinner = require('./assets/light-spinner.gif');
 const SESSION_SYNC_POLL_INTERVAL_MS = 15000;
+const NOTIFICATION_SYNC_RETRY_DELAY_MS = 500;
 
 const Stack = createNativeStackNavigator();
 
@@ -249,8 +250,19 @@ function Navigation() {
     };
   }, [cfg.ready, cfg.config.ttsVoiceId, cfg.setConfig]);
 
+  const syncSessionsForNotificationTap = useCallback(async () => {
+    if (!cfg.config.baseUrl || !cfg.config.apiKey) return;
+
+    const client = new SettingsApiClient(cfg.config.baseUrl, cfg.config.apiKey);
+    const result = await sessionStore.syncWithServer(client);
+    if (result.errors.includes('Sync already in progress')) {
+      await new Promise(resolve => setTimeout(resolve, NOTIFICATION_SYNC_RETRY_DELAY_MS));
+      await sessionStore.syncWithServer(client);
+    }
+  }, [cfg.config.baseUrl, cfg.config.apiKey, sessionStore]);
+
   // Handle notification taps for deep linking to conversations
-  const handleNotificationTap = useCallback((data: NotificationData) => {
+  const handleNotificationTap = useCallback(async (data: NotificationData) => {
     console.log('[App] Notification tapped:', data);
     if (!isNavigationReady.current) {
       console.log('[App] Navigation not ready, skipping notification navigation');
@@ -258,22 +270,28 @@ function Navigation() {
     }
 
     if (data.type === 'message' && (data.sessionId || data.conversationId)) {
-      // Navigate to the specific chat session
-      // Try to find session by local sessionId first, then by server conversationId
-      let targetSessionId: string | null = null;
-
-      if (data.sessionId) {
-        // sessionId from notification is already a local session ID
-        targetSessionId = data.sessionId;
-      } else if (data.conversationId) {
-        // conversationId is a server-side ID - need to find the matching local session
-        const session = sessionStore.findSessionByServerConversationId(data.conversationId);
-        if (session) {
-          targetSessionId = session.id;
-          console.log('[App] Found session by serverConversationId:', session.id);
-        } else {
-          console.log('[App] No session found for conversationId:', data.conversationId);
+      const findTargetSessionId = (): string | null => {
+        if (
+          typeof data.sessionId === 'string' &&
+          sessionStore.sessions.some(session => session.id === data.sessionId)
+        ) {
+          return data.sessionId;
         }
+
+        if (typeof data.conversationId === 'string') {
+          const session = sessionStore.findSessionByServerConversationId(data.conversationId);
+          return session?.id ?? null;
+        }
+
+        return null;
+      };
+
+      let targetSessionId = findTargetSessionId();
+      if (!targetSessionId && data.conversationId) {
+        await syncSessionsForNotificationTap().catch((error) => {
+          console.warn('[App] Notification session sync failed:', error);
+        });
+        targetSessionId = findTargetSessionId();
       }
 
       if (targetSessionId) {
@@ -287,7 +305,7 @@ function Navigation() {
       // Navigate to sessions list if no specific session
       navigationRef.navigate('Sessions' as never);
     }
-  }, [sessionStore, navigationRef]);
+  }, [navigationRef, sessionStore, syncSessionsForNotificationTap]);
 
   const refreshCurrentRouteName = useCallback(() => {
     const routeName = navigationRef.getCurrentRoute()?.name;
@@ -410,6 +428,23 @@ function Navigation() {
     pushNotifications.setOnNotificationTap(handleNotificationTap);
     return () => pushNotifications.setOnNotificationTap(null);
   }, [handleNotificationTap, pushNotifications]);
+
+  // Keep the desktop-side token registration fresh when the paired desktop URL changes.
+  useEffect(() => {
+    if (!cfg.ready || !pushNotifications.isSupported || !pushNotifications.isRegistered) return;
+    if (!cfg.config.baseUrl || !cfg.config.apiKey) return;
+
+    pushNotifications.register(cfg.config.baseUrl, cfg.config.apiKey).catch((error) => {
+      console.warn('[App] Failed to refresh push registration:', error);
+    });
+  }, [
+    cfg.ready,
+    cfg.config.baseUrl,
+    cfg.config.apiKey,
+    pushNotifications.isSupported,
+    pushNotifications.isRegistered,
+    pushNotifications.register,
+  ]);
 
   // Clear notifications when app becomes active (including from background)
   useEffect(() => {

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -65,6 +65,25 @@ Open the app and configure Settings:
 
 For the desktop flow, enable **Settings > Remote Server** in DotAgents desktop and scan the QR code from the mobile **Connection Settings** screen.
 
+## Android push notifications
+
+Android push notifications require a native development or release build. They do not work in Expo Go or the web build.
+
+The Android Firebase file is local app configuration and must stay out of git:
+
+- `android/app/google-services.json` must match the Firebase Android app package name `com.aj47.dotagents`
+- `app.json` must point `expo.android.googleServicesFile` at `./android/app/google-services.json`
+- `android/build.gradle` and `android/app/build.gradle` must apply the Google Services Gradle plugin
+
+Expo also needs an Android FCM V1 credential for the EAS project. To set it up or rotate it:
+
+1. In Firebase, create or open the Android app for `com.aj47.dotagents`.
+2. Download `google-services.json` and place it at `android/app/google-services.json` locally. Do not commit it.
+3. In Firebase service account settings, generate a new private service-account JSON key.
+4. Upload that JSON key to Expo/EAS as the Android FCM V1 credential for the DotAgents Mobile project and application identifier `com.aj47.dotagents`.
+5. Delete the downloaded private key after upload. Never commit service-account keys.
+6. Build and install a native Android app, register push notifications from Settings, then verify delivery with an Expo push ticket/receipt and `adb shell dumpsys notification --noredact`.
+
 ## Voice UX
 
 - Press‑and‑hold mic (when hands‑free is off):

--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
+apply plugin: "com.google.gms.google-services"
 
 def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 

--- a/apps/mobile/android/build.gradle
+++ b/apps/mobile/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
   dependencies {
     classpath('com.android.tools.build:gradle')
     classpath('com.facebook.react:react-native-gradle-plugin')
+    classpath('com.google.gms:google-services:4.4.4')
     classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')
   }
 }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -29,6 +29,7 @@
     },
     "android": {
       "versionCode": 10,
+      "googleServicesFile": "./android/app/google-services.json",
       "adaptiveIcon": {
         "foregroundImage": "./assets/dotagents-icon.png",
         "backgroundColor": "#ffffff"
@@ -46,6 +47,11 @@
     },
     "web": {
       "favicon": "./assets/dotagents-icon.png"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "442b8947-8eae-4ba1-aed1-efd8ca48a2cd"
+      }
     },
     "plugins": [
       "expo-speech-recognition",

--- a/apps/mobile/src/lib/pushNotifications.ts
+++ b/apps/mobile/src/lib/pushNotifications.ts
@@ -14,6 +14,7 @@ import * as Device from 'expo-device';
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getDeviceIdentity } from './deviceIdentity';
 
 const PUSH_TOKEN_KEY = 'push_token_v2';
 const SERVER_REGISTERED_KEY = 'push_server_registered_v2';
@@ -94,13 +95,10 @@ async function getPushToken(): Promise<string | null> {
   const projectId = Constants.expoConfig?.extra?.eas?.projectId
     ?? Constants.easConfig?.projectId;
 
-  if (!projectId) {
-    console.error('[Push] No EAS projectId configured');
-    return null;
-  }
-
   try {
-    const { data } = await Notifications.getExpoPushTokenAsync({ projectId });
+    const { data } = projectId
+      ? await Notifications.getExpoPushTokenAsync({ projectId })
+      : await Notifications.getExpoPushTokenAsync();
     await AsyncStorage.setItem(PUSH_TOKEN_KEY, data);
     return data;
   } catch (error) {
@@ -127,6 +125,7 @@ export async function registerWithServer(baseUrl: string, apiKey: string): Promi
   if (!token) return false;
 
   try {
+    const identity = await getDeviceIdentity();
     const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/push/register`, {
       method: 'POST',
       headers: {
@@ -137,6 +136,7 @@ export async function registerWithServer(baseUrl: string, apiKey: string): Promi
         token,
         type: 'expo',
         platform: Platform.OS as 'ios' | 'android',
+        deviceId: identity.deviceId,
       }),
     });
 
@@ -350,4 +350,3 @@ export function usePushNotifications(): UsePushNotificationsResult {
     clear,
   };
 }
-

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -2462,8 +2462,8 @@ export default function SettingsScreen({ navigation, route }: any) {
       const success = await registerPush(config.baseUrl, config.apiKey);
       if (!success) {
         Alert.alert(
-          'Permission Required',
-          'Push notifications require permission. Please enable notifications in your device settings.',
+          'Push Registration Failed',
+          'DotAgents could not register this device for push notifications. Check the app logs for the Expo or Firebase setup error.',
           [{ text: 'OK' }]
         );
       }

--- a/apps/mobile/tests/push-notifications-local.test.js
+++ b/apps/mobile/tests/push-notifications-local.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const appSource = fs.readFileSync(path.join(__dirname, '..', 'App.tsx'), 'utf8');
+const pushSource = fs.readFileSync(
+  path.join(__dirname, '..', 'src', 'lib', 'pushNotifications.ts'),
+  'utf8'
+);
+
+test('registers push tokens with the stable mobile device ID', () => {
+  assert.match(pushSource, /import \{ getDeviceIdentity \} from '\.\/deviceIdentity';/);
+  assert.match(pushSource, /const identity = await getDeviceIdentity\(\);/);
+  assert.match(pushSource, /deviceId: identity\.deviceId,/);
+});
+
+test('notification taps sync from desktop before giving up on a conversation link', () => {
+  assert.match(appSource, /const syncSessionsForNotificationTap = useCallback\(async \(\) => \{/);
+  assert.match(appSource, /await sessionStore\.syncWithServer\(client\);/);
+  assert.match(appSource, /result\.errors\.includes\('Sync already in progress'\)/);
+  assert.match(appSource, /targetSessionId = findTargetSessionId\(\);/);
+  assert.match(appSource, /navigationRef\.navigate\('Chat' as never\);/);
+});
+
+test('existing push registrations refresh when the paired desktop connection changes', () => {
+  assert.match(appSource, /Keep the desktop-side token registration fresh/);
+  assert.match(appSource, /pushNotifications\.isRegistered/);
+  assert.match(appSource, /pushNotifications\.register\(cfg\.config\.baseUrl, cfg\.config\.apiKey\)/);
+});

--- a/docs-site/docs/development/build-release-deploy.md
+++ b/docs-site/docs/development/build-release-deploy.md
@@ -200,6 +200,8 @@ pnpm --filter @dotagents/mobile android
 
 Native iOS/Android builds require a development build because the app uses `expo-speech-recognition`, which Expo Go does not include.
 
+Android push notifications also require local Firebase Android app config in `apps/mobile/android/app/google-services.json` and an Expo/EAS Android FCM V1 credential for `com.aj47.dotagents`. Keep Firebase config files and service-account private keys out of the repo; see `apps/mobile/README.md` for setup and rotation steps.
+
 The root release script has mobile package paths for IPA/APK builds, but mobile release signing requires platform-specific Apple/Android credentials and native tooling.
 
 ## Docs Site

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -388,6 +388,7 @@ export interface OperatorRunAgentResponse {
   success: boolean;
   action: 'run-agent';
   conversationId: string;
+  sessionId?: string;
   content: string;
   messageCount: number;
   error?: string;


### PR DESCRIPTION
## Summary
- Add desktop-owned Expo push delivery for final agent responses and repeat-task completions.
- Harden mobile push token registration, badge handling, and invalid-token cleanup.
- Sync mobile sessions on notification taps before navigating to a conversation.

## Validation
- pnpm --filter @dotagents/shared build
- pnpm --filter @dotagents/desktop exec vitest run src/main/push-notification-service.test.ts src/main/remote-server.routes.test.ts
- node --test apps/mobile/tests/push-notifications-local.test.js
- pnpm --filter @dotagents/desktop run typecheck:node
- pnpm --filter @dotagents/mobile exec tsc --noEmit
- git diff --check
