### PR TITLE
Improve repeat task loop guidance

### DIFF
--- a/apps/desktop/resources/bundled-skills/create-repeat-task/SKILL.md
+++ b/apps/desktop/resources/bundled-skills/create-repeat-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-repeat-task
-description: "Use this skill when the user asks to create, edit, or reason about a repeat task — including phrases like 'create repeat task', 'recurring task', 'scheduled task', 'continuous task', 'same session continue', 'speak the result', 'TTS for a task', or 'critique pass'. It teaches the canonical task.md frontmatter, the full set of scheduler/runtime options (intervalMinutes, schedule, runContinuously, continueInSession, speakOnTrigger, runOnStartup, profileId, critiquePass, criticProfileId), and the safe edit workflow."
+description: "Use this skill when the user asks to create, edit, or reason about a repeat task or loop — including phrases like 'create repeat task', 'recurring task', 'scheduled task', 'continuous task', 'same session continue', 'speak the result', 'TTS for a task', 'critique pass', or asks for good loop/cron prompt design. It teaches canonical task.md frontmatter, scheduler/runtime boundaries, prompt contracts, durable loop state, companion-skill factoring, and the safe edit workflow."
 ---
 
 # Create Repeat Task
@@ -14,7 +14,7 @@ A repeat task ("loop") is a DotAgents config object that runs a prompt against a
 
 Workspace tasks override global tasks with the same `id`.
 
-The file format is parsed by `packages/core/src/agents-files/tasks.ts`. The runtime fields come from the `LoopConfig` interface in `packages/core/src/types.ts`.
+The file format is parsed by `packages/core/src/agents-files/tasks.ts`. Desktop runtime behavior is in `apps/desktop/src/main/loop-service.ts`, and desktop-only task fields may also appear in `apps/desktop/src/shared/types.ts` and `packages/shared/src/api-types.ts`.
 
 ## When to use this skill
 
@@ -34,7 +34,7 @@ Before editing, inspect:
 
 1. `~/.agents/tasks/` (and `${DOTAGENTS_WORKSPACE_DIR}/.agents/tasks/` if set) to see existing task IDs and conventions.
 2. The user's existing agent profiles (`~/.agents/agents/<id>/`) so you can pick a valid `profileId` when the user names an agent.
-3. The current schema at `packages/core/src/agents-files/tasks.ts` and `packages/core/src/types.ts` if you suspect the available fields have evolved past what this skill documents.
+3. The current schema at `packages/core/src/agents-files/tasks.ts`, `apps/desktop/src/main/loop-service.ts`, `apps/desktop/src/shared/types.ts`, and `packages/shared/src/api-types.ts` if you suspect the available fields have evolved past what this skill documents.
 
 If you find an existing task with the requested ID, prefer editing it in place over recreating it.
 
@@ -58,7 +58,84 @@ If you find an existing task with the requested ID, prefer editing it in place o
 | `schedule`          | JSON object as string | unset       | Wall-clock schedule. When present, supersedes `intervalMinutes`. See "Schedules" below.         |
 | `lastRunAt`         | number (ms epoch)     | unset       | Auto-managed timestamp. Do not hand-set unless the user explicitly asks.                        |
 
-The markdown body (everything after the closing `---`) is the **prompt** sent to the agent on each run. It may be empty but is usually a short instruction.
+The markdown body (everything after the closing `---`) is the **prompt** sent to the agent on each run. Write it as per-run work instructions, not as a second scheduler config.
+
+## Frontmatter vs prompt boundary
+
+Keep runtime mechanics in frontmatter and per-run behavior in the prompt.
+
+Frontmatter/runtime owns:
+
+- cadence: `intervalMinutes`, `schedule`, `runContinuously`
+- lifecycle: `enabled`, `runOnStartup`
+- session/delivery: `profileId`, `continueInSession`, `speakOnTrigger`
+- review wiring: `critiquePass`, `criticProfileId`
+- auto-managed state: `lastRunAt`, `lastSessionId`
+
+Prompt body owns:
+
+- current objective and scope
+- input sources or search paths
+- durable output files or artifact directories
+- per-run quota or done condition
+- blocked/no-change fallback
+- final response shape
+
+Do not restate cadence or harness mechanics in the prompt. Avoid phrases like "every 20 minutes", "when this startup task fires", "because continueInSession is on", or "the critic will revise once" unless that timing itself changes the work product. Prefer "On each run..." for the prompt objective.
+
+Bad:
+
+```markdown
+Every 20 minutes overnight, search my inbox and send me anything important.
+```
+
+Good:
+
+```markdown
+On each run, check for new important mail since the last saved checkpoint. Update `~/.agents/tasks/important-mail/ledger.md`. If nothing clears the bar, return one compact no-change bullet.
+```
+
+## Good loop prompt contract
+
+For non-trivial loops, include these pieces in the prompt body:
+
+1. **Objective** — one sentence starting with "On each run..." and focused on the artifact or decision produced in that run.
+2. **Inputs** — files, URLs, repositories, tools, or local folders to inspect first.
+3. **Durable state** — one or more files under the task folder for checkpoint, source ledger, output, or report state. Do not rely only on conversation memory.
+4. **Per-run quota** — the smallest concrete unit of progress: add one artifact, process one queue item, inspect one source family, update one report, or return no-change.
+5. **Fallback ladder** — what to do when the preferred source is blocked or empty.
+6. **Stop condition** — what counts as done for this run; then the agent should stop.
+7. **Final response shape** — compact status for the loop transcript or TTS.
+
+Good loop prompts are usually short but specific. They should make repeated runs additive instead of re-opening strategy from scratch.
+
+## Companion skills
+
+If the task body starts becoming a reusable playbook, create or update a companion skill and keep the repeat-task prompt thin.
+
+Use a companion skill when the loop needs:
+
+- reusable tool recipes, command sequences, or API caveats
+- domain review criteria that will be reused outside this task
+- long examples, templates, or generated-asset instructions
+- security or source-quality rules that should be maintained independently
+
+Then the task prompt should name the skill and bind it to the current objective and artifact paths, for example:
+
+```markdown
+On each run, use the `youtube-thumbnail` skill to improve one thumbnail candidate for the current video. Read and update `~/.agents/tasks/video-packaging/thumbnail-board.md`; save generated assets under `~/.agents/tasks/video-packaging/assets/thumbnails/`; return the best current direction and next lane.
+```
+
+Do not paste the whole companion skill into the task prompt.
+
+## Quiet and cheap monitor pattern
+
+For monitoring jobs, avoid high-frequency LLM work that only says "nothing changed." If a deterministic script, API, or existing tool can decide whether anything changed, prefer that outside the repeat-task prompt when available. If the loop must run through the agent, define a cheap no-change path:
+
+- check only the minimal state needed
+- update a small checkpoint or ledger
+- return one compact no-change bullet
+- do not re-run broad research or generation when inputs are unchanged
 
 ## Schedules
 
@@ -91,6 +168,8 @@ Set `continueInSession: true` when the user wants the agent to remember previous
 
 If the user wants each run to start from a clean slate (the default for a simple summarizer), leave `continueInSession` off.
 
+Even with `continueInSession: true`, use durable state files for important checkpoints. Conversation context can help continuity, but task progress should survive session fallback, compaction, and manual inspection.
+
 ## Speaking the result
 
 Set `speakOnTrigger: true` when the user wants the task to "speak" or "read out" the result. The task then runs snoozed (silent / hidden) and is unsnoozed on completion so the renderer auto-plays TTS for the final assistant message. Leaving this off keeps the run completely passive in the background.
@@ -107,16 +186,20 @@ This increases runtime and token use because each scheduled run performs a worke
 
 For artifact-heavy tasks, include artifact paths and critic expectations in the task prompt. The built-in critic inspects referenced artifacts when they are available, so the prompt should name canonical files such as dashboards, HTML previews, reports, render outputs, or state files.
 
+Do not describe the worker -> critic -> worker revision mechanics in the task prompt. The runtime already owns that. The prompt should only say what the critic should judge and which artifacts matter.
+
 ## Workflow
 
-1. Confirm what the user wants the task to do (the prompt body) and how often it should run.
+1. Confirm what the task should produce and how often the harness should run it.
 2. Pick the cadence model: schedule, continuous, or interval.
 3. Pick an `id`. Prefer short, kebab-case, descriptive — e.g. `daily-standup`, `queue-processor`, `morning-summary`.
 4. Choose `profileId` if a specific agent should own the task; otherwise omit it.
 5. Decide `continueInSession` (state across runs?), `speakOnTrigger` (TTS on completion?), and `critiquePass` (critic feedback loop?).
 6. Decide `runOnStartup` (fire immediately when the app boots?).
-7. Write `~/.agents/tasks/<id>/task.md` (or the workspace equivalent) using direct file editing, not app-specific config tools.
-8. Confirm with the user, then check it appears in Settings > Loops / Repeat Tasks and that `enabled` is correct.
+7. Decide whether complex reusable procedure belongs in a companion skill instead of the task prompt.
+8. Write a prompt contract with objective, inputs, durable state, per-run quota, fallback, stop condition, and final response shape.
+9. Write `~/.agents/tasks/<id>/task.md` (or the workspace equivalent) using direct file editing, not app-specific config tools.
+10. Confirm with the user, then check it appears in Settings > Loops / Repeat Tasks and that `enabled` is correct.
 
 See `examples.md` (next to this `SKILL.md`) for ready-to-paste templates for each common shape.
 
@@ -127,5 +210,8 @@ See `examples.md` (next to this `SKILL.md`) for ready-to-paste templates for eac
 - Do not invent fields. Unknown frontmatter keys are ignored silently, so typos look like the option "didn't work".
 - `schedule` must be valid JSON on a single line — wrap it in double quotes carefully if your YAML formatter complains.
 - Do not hand-set `lastSessionId` or `lastRunAt` unless the user explicitly asks; they are auto-managed.
+- Do not put cadence, startup, same-session, TTS, or critique mechanics in the prompt body just because the user mentioned them; encode those in frontmatter.
+- For stateful loops, name durable files under the task folder and tell the loop how to update them.
+- For artifact-heavy loops, make each run add or improve at least one artifact, ledger entry, or concrete decision.
 - Never delete a task directory to "disable" it — set `enabled: false` instead.
 - If both global and workspace `.agents/tasks/<id>/` exist, ask the user which layer should own the change before editing.

--- a/apps/desktop/resources/bundled-skills/create-repeat-task/examples.md
+++ b/apps/desktop/resources/bundled-skills/create-repeat-task/examples.md
@@ -32,7 +32,7 @@ intervalMinutes: 240
 runOnStartup: true
 ---
 
-Summarize new emails and calendar events since I last logged in.
+On each run, summarize new emails and calendar events since the previous task run. Return only urgent items and the next concrete action.
 ```
 
 ## 3. Wall-clock daily schedule
@@ -49,7 +49,7 @@ intervalMinutes: 60
 schedule: {"type":"daily","times":["09:00","17:00"]}
 ---
 
-List the three highest-priority tasks for today based on my notes and open issues.
+On each run, list the three highest-priority tasks for today based on my notes and open issues.
 ```
 
 ## 4. Weekly schedule (weekdays only)
@@ -66,7 +66,7 @@ intervalMinutes: 60
 schedule: {"type":"weekly","times":["09:00"],"daysOfWeek":[1,2,3,4,5]}
 ---
 
-Summarize this week's commits and surface anything that still needs review.
+On each run, summarize this week's commits and surface anything that still needs review.
 ```
 
 ## 5. Continuous task
@@ -84,7 +84,7 @@ runContinuously: true
 profileId: background-worker
 ---
 
-Pull the next item from the processing queue and handle it. If the queue is empty, report idle.
+On each run, pull the next item from the processing queue and handle it. If the queue is empty, report idle and stop.
 ```
 
 ## 6. Same-session continuation
@@ -101,7 +101,7 @@ intervalMinutes: 120
 continueInSession: true
 ---
 
-Append today's progress to the running journal we've been keeping. Note any decisions or blockers since the last entry.
+On each run, append current progress to `~/.agents/tasks/ongoing-journal/journal.md`. Note new decisions, blockers, and the next checkpoint, then stop.
 ```
 
 ## 7. Speak the result (TTS)
@@ -119,7 +119,7 @@ speakOnTrigger: true
 profileId: news-anchor
 ---
 
-Give me a 60-second brief on the top three tech headlines since the last brief, formatted for spoken delivery.
+On each run, give me a 60-second brief on the top three tech headlines since the last saved brief, formatted for spoken delivery.
 ```
 
 ## 8. Pinned to a specific agent profile
@@ -136,7 +136,7 @@ intervalMinutes: 30
 profileId: code-reviewer
 ---
 
-Review any PR opened on this repo in the last 30 minutes and post inline comments for obvious issues.
+On each run, review newly opened PRs in this repo that are not already listed in `~/.agents/tasks/code-review-bot/ledger.md`. Post inline comments only for obvious issues, update the ledger, and return PRs reviewed plus comments posted.
 ```
 
 ## 9. Built-in critique pass
@@ -155,12 +155,44 @@ critiquePass: true
 criticProfileId: critical-reviewer
 ---
 
-Draft today's execution plan from my goals, calendar, and open work. Prioritize what most improves leverage and identify any risky assumptions.
+On each run, draft today's execution plan from my goals, calendar, and open work. Prioritize what most improves leverage and identify any risky assumptions.
 
 When producing artifacts, write them to `~/.agents/tasks/reviewed-daily-plan/latest-plan.md`. The critique pass should inspect that file and challenge unsupported assumptions, vague next actions, and priority inversions before the final revision.
 ```
 
-## 10. Disable without deleting
+## 10. Stateful inventory builder
+
+Runs on an interval, carries session context, and writes durable artifacts so repeated runs add inventory instead of reopening strategy. Notice that the prompt says "On each run" and does not restate the interval.
+
+```markdown
+---
+kind: task
+id: video-packaging
+name: Video Packaging
+enabled: true
+intervalMinutes: 20
+profileId: main-agent
+continueInSession: true
+critiquePass: true
+---
+
+On each run, build usable packaging inventory for the current TechFren video: title candidates, thumbnail directions, supporting visuals, sourced facts, and viewer-value bullets.
+
+Canonical files:
+- `~/.agents/tasks/video-packaging/morning-brief.md` — ranked summary and next recording move.
+- `~/.agents/tasks/video-packaging/title-bank.md` — append and organize title ideas by angle.
+- `~/.agents/tasks/video-packaging/thumbnail-board.md` — prompt log, image paths, rankings, and critique notes.
+- `~/.agents/tasks/video-packaging/source-ledger.md` — checked, exhausted, and next sources.
+- `~/.agents/tasks/video-packaging/assets/` — generated or downloaded media.
+
+Per-run contract:
+- Add or improve at least one concrete artifact, source, title cluster, thumbnail draft, or ranked decision.
+- If a source is blocked or exhausted, update `source-ledger.md` and switch lanes instead of retrying.
+- The critic should judge artifact usefulness, evidence quality, clickability, and recordability against the files above.
+- Return only 3 bullets: new inventory added, best current direction, and next lane.
+```
+
+## 11. Disable without deleting
 
 To pause a task without losing its config or history, set `enabled: false`. Do not delete the directory.
 

--- a/apps/desktop/src/main/bundled-skills.test.ts
+++ b/apps/desktop/src/main/bundled-skills.test.ts
@@ -73,6 +73,14 @@ describe("bundled create-repeat-task skill", () => {
     expect(parsed?.instructions).toContain("schedule")
     expect(parsed?.instructions).toContain("profileId")
     expect(parsed?.instructions).toContain("critiquePass")
+
+    // Prompt design guidance keeps scheduler mechanics out of the body.
+    expect(parsed?.instructions).toContain("Frontmatter vs prompt boundary")
+    expect(parsed?.instructions).toContain("Do not restate cadence")
+    expect(parsed?.instructions).toContain("On each run")
+    expect(parsed?.instructions).toContain("durable state")
+    expect(parsed?.instructions).toContain("companion skill")
+    expect(parsed?.instructions).toContain("per-run quota")
   })
 
   it("ships an examples.md whose task frontmatter blocks all parse as valid LoopConfigs", () => {
@@ -108,6 +116,15 @@ describe("bundled create-repeat-task skill", () => {
     expect(parsedTasks.some((t) => t.schedule?.type === "weekly")).toBe(true)
     expect(parsedTasks.some((t) => t.critiquePass === true)).toBe(true)
     expect(parsedTasks.some((t) => t.enabled === false)).toBe(true)
+
+    const inventoryBuilder = parsedTasks.find((t) => t.id === "video-packaging")
+    expect(inventoryBuilder).toBeTruthy()
+    expect(inventoryBuilder?.continueInSession).toBe(true)
+    expect(inventoryBuilder?.critiquePass).toBe(true)
+    expect(inventoryBuilder?.prompt).toContain("On each run")
+    expect(inventoryBuilder?.prompt).toContain("source-ledger.md")
+    expect(inventoryBuilder?.prompt).toContain("Per-run contract")
+    expect(inventoryBuilder?.prompt).not.toMatch(/Every 20 minutes/i)
   })
 })
 


### PR DESCRIPTION
## Summary
- clarify the boundary between repeat-task frontmatter/runtime mechanics and per-run prompt behavior
- add loop prompt contract guidance for durable state, per-run quotas, fallback paths, and companion skills
- refresh examples with `On each run` prompts plus a stateful inventory-builder template and add regression coverage

## Verification
- `pnpm --filter @dotagents/desktop exec vitest run src/main/bundled-skills.test.ts`
- `git diff --check -- apps/desktop/resources/bundled-skills/create-repeat-task/SKILL.md apps/desktop/resources/bundled-skills/create-repeat-task/examples.md apps/desktop/src/main/bundled-skills.test.ts`

Note: `pnpm --filter @dotagents/desktop run test:run -- src/main/bundled-skills.test.ts` forwards the file argument as `--` and ran the broader desktop suite; `src/main/bundled-skills.test.ts` passed there, but unrelated pre-existing tests failed elsewhere.