### PR TITLE
[codex] Add queued message injection boundaries

### DIFF
--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -8,6 +8,7 @@ import type {
 import { AgentProgressStep, AgentProgressUpdate, SessionProfileSnapshot } from "../shared/types"
 import type { ConversationCompactionMetadata } from "../shared/types"
 import { diagnosticsService } from "./diagnostics"
+import { getErrorMessage } from "./error-utils"
 
 import { makeLLMCallWithFetch, makeTextCompletionWithFetch, verifyCompletionWithFetch, RetryProgressCallback, makeLLMCallWithStreamingAndTools, StreamingCallback } from "./llm-fetch"
 import { constructSystemPrompt } from "./system-prompts"
@@ -18,6 +19,7 @@ import { getSessionCost } from "./session-cost"
 import { emitAgentProgress } from "./emit-agent-progress"
 import { agentSessionTracker } from "./agent-session-tracker"
 import { conversationService } from "./conversation-service"
+import { messageQueueService } from "./message-queue-service"
 import { getAcpSessionTitleOverride } from "./acp-session-state"
 import { hasRepeatTaskTitlePrefix } from "../shared/repeat-tasks"
 import { DEFAULT_TRANSCRIPT_POST_PROCESSING_PROMPT, getCurrentPresetName } from "@dotagents/shared"
@@ -1162,6 +1164,60 @@ export async function processTranscriptWithAgentMode(
     }
   }
 
+  let queuedMessageInjectedSinceLastDecision = false
+
+  const injectQueuedMessageAfterBoundary = async (
+    injectionTarget: "after_next_tool_response" | "after_next_agent_response",
+  ) => {
+    if (!currentConversationId) return
+
+    const queuedMessage = messageQueueService.peekInjectionTarget(
+      currentConversationId,
+      injectionTarget,
+    )
+    if (!queuedMessage) return
+
+    const markingSucceeded = messageQueueService.markProcessing(currentConversationId, queuedMessage.id)
+    if (!markingSucceeded) return
+
+    const timestamp = Date.now()
+    const injectedPromptIndex = conversationHistory.length
+    conversationHistory.push({
+      role: "user",
+      content: queuedMessage.text,
+      timestamp,
+      branchMessageIndex: nextBranchMessageIndex++,
+    })
+    currentPromptIndex = injectedPromptIndex
+    queuedMessageInjectedSinceLastDecision = true
+
+    try {
+      const addResult = await conversationService.addMessageToConversation(
+        currentConversationId,
+        queuedMessage.text,
+        "user",
+      )
+      if (!addResult) {
+        logLLM("[injectQueuedMessageAfterBoundary] Failed to persist injected queued message", {
+          conversationId: currentConversationId,
+          queuedMessageId: queuedMessage.id,
+          injectionTarget,
+        })
+        messageQueueService.markFailed(
+          currentConversationId,
+          queuedMessage.id,
+          "Failed to add injected message to conversation history",
+        )
+        return
+      }
+      messageQueueService.markProcessed(currentConversationId, queuedMessage.id)
+    } catch (error) {
+      logLLM("[injectQueuedMessageAfterBoundary] Failed to save injected queued message:", error)
+      diagnosticsService.logWarning("llm", "Failed to save injected queued message", error)
+      messageQueueService.markFailed(currentConversationId, queuedMessage.id, getErrorMessage(error))
+    }
+  }
+
   // Helper function to generate a step summary using the weak model (if dual-model enabled)
   const generateStepSummary = async (
     stepNumber: number,
@@ -1308,6 +1364,12 @@ export async function processTranscriptWithAgentMode(
     ).catch(err => {
       logLLM("[addMessage] Failed to save message:", err)
     })
+
+    if (role === "tool") {
+      void injectQueuedMessageAfterBoundary("after_next_tool_response")
+    } else if (role === "assistant" && content.trim().length > 0 && (toolCalls?.length ?? 0) === 0) {
+      void injectQueuedMessageAfterBoundary("after_next_agent_response")
+    }
   }
 
   // Helper function to add a message to the in-memory conversation history ONLY (not persisted).
@@ -1692,7 +1754,7 @@ export async function processTranscriptWithAgentMode(
 
   // Track the index where the current user prompt was added
   // This is used to scope tool result checks to only the current turn
-  const currentPromptIndex = preparedPreviousConversationHistory.length
+  let currentPromptIndex = preparedPreviousConversationHistory.length
 
   const buildIntentOnlyToolUsageNudge = (contentText: string) => {
     const selectorRef = contentText.match(/@[a-z][0-9]+/i)?.[0]
@@ -2274,6 +2336,17 @@ export async function processTranscriptWithAgentMode(
   let cachedSystemPrompt: string | undefined // Cached rebuilt prompt when tools are excluded
   let suppressReadMoreContextAfterExactAnswer = false
 
+  const continueAfterQueuedMessageInjection = () => {
+    if (!queuedMessageInjectedSinceLastDecision) return false
+
+    queuedMessageInjectedSinceLastDecision = false
+    noOpCount = 0
+    totalNudgeCount = 0
+    garbledToolCallCount = 0
+    finalContent = ""
+    return true
+  }
+
   while (iteration < maxIterations) {
     iteration++
     currentIterationRef = iteration // Update ref for retry progress callback
@@ -2811,6 +2884,9 @@ export async function processTranscriptWithAgentMode(
           }
           finalContent = contentText
           addMessage("assistant", finalContent, undefined, undefined, undefined, displayOnlyMessageOptions)
+          if (continueAfterQueuedMessageInjection()) {
+            continue
+          }
           emit({
             currentIteration: iteration,
             maxIterations,
@@ -2918,6 +2994,10 @@ export async function processTranscriptWithAgentMode(
         if (completionForcedByVerificationLimit && !existingUserResponse1?.trim().length) {
           finalContent = buildIncompleteTaskFallback(finalContent, completionForcedIncompleteDetails)
           addMessage("assistant", finalContent)
+        }
+
+        if (continueAfterQueuedMessageInjection()) {
+          continue
         }
 
         const completionStep = createProgressStep(
@@ -3045,6 +3125,9 @@ export async function processTranscriptWithAgentMode(
       if (!config.mcpVerifyCompletionEnabled) {
         finalContent = buildIncompleteTaskFallback(contentText)
         addMessage("assistant", finalContent)
+        if (continueAfterQueuedMessageInjection()) {
+          continue
+        }
         emit({
           currentIteration: iteration,
           maxIterations,
@@ -3482,6 +3565,10 @@ export async function processTranscriptWithAgentMode(
       })
     }
 
+    if (continueAfterQueuedMessageInjection()) {
+      continue
+    }
+
     if (onlyCommunicationTools && !completionSignalConfirmed) {
       const latestCommunicationOnlyResponse = latestMaterializedUserResponse ?? resolveLatestUserFacingResponse({
         storedResponse: getSessionUserResponse(currentSessionId, effectiveRunId),
@@ -3878,6 +3965,12 @@ export async function processTranscriptWithAgentMode(
 	        conversationHistory.push({ role: "assistant", content: finalContent, timestamp: Date.now() })
 	      }
 
+      if (finalContent.trim().length > 0) {
+        await injectQueuedMessageAfterBoundary("after_next_agent_response")
+        if (continueAfterQueuedMessageInjection()) {
+          continue
+        }
+      }
 
 	      // Add completion step
 	      const completionStep = createProgressStep(

--- a/apps/desktop/src/main/message-queue-service.test.ts
+++ b/apps/desktop/src/main/message-queue-service.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("./window", () => ({
+  WINDOWS: new Map(),
+}))
+
+vi.mock("@egoist/tipc/main", () => ({
+  getRendererHandlers: () => ({}),
+}))
+
+vi.mock("./debug", () => ({
+  logApp: vi.fn(),
+}))
+
+describe("MessageQueueService injection targets", () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it("lets ordinary queued messages proceed past a pending injection message", async () => {
+    const { messageQueueService } = await import("./message-queue-service")
+    const conversationId = `conv-${Date.now()}-${Math.random()}`
+
+    const first = messageQueueService.enqueue(
+      conversationId,
+      "Inject after tool",
+    )
+    const second = messageQueueService.enqueue(
+      conversationId,
+      "Normal follow-up",
+    )
+
+    expect(
+      messageQueueService.setInjectionTarget(
+        conversationId,
+        first.id,
+        "after_next_tool_response",
+      ),
+    ).toBe(true)
+
+    expect(messageQueueService.peek(conversationId)?.id).toBe(second.id)
+
+    const injectionMessage = messageQueueService.peekInjectionTarget(
+      conversationId,
+      "after_next_tool_response",
+    )
+    expect(injectionMessage?.id).toBe(first.id)
+    expect(messageQueueService.markProcessing(conversationId, injectionMessage!.id)).toBe(true)
+    expect(messageQueueService.markProcessed(conversationId, injectionMessage!.id)).toBe(true)
+    expect(messageQueueService.peek(conversationId)?.id).toBe(second.id)
+  })
+
+  it("can clear a pending message injection target", async () => {
+    const { messageQueueService } = await import("./message-queue-service")
+    const conversationId = `conv-${Date.now()}-${Math.random()}`
+    const message = messageQueueService.enqueue(
+      conversationId,
+      "Queued follow-up",
+    )
+
+    expect(
+      messageQueueService.setInjectionTarget(
+        conversationId,
+        message.id,
+        "after_next_agent_response",
+      ),
+    ).toBe(true)
+    expect(messageQueueService.peek(conversationId)).toBeNull()
+
+    expect(
+      messageQueueService.setInjectionTarget(conversationId, message.id, null),
+    ).toBe(true)
+    expect(messageQueueService.peek(conversationId)?.id).toBe(message.id)
+  })
+})

--- a/apps/desktop/src/main/message-queue-service.ts
+++ b/apps/desktop/src/main/message-queue-service.ts
@@ -231,10 +231,13 @@ class MessageQueueService {
   peek(conversationId: string): QueuedMessage | null {
     const queue = this.queues.get(conversationId)
     if (!queue || queue.length === 0) return null
-    // Strict FIFO: only return first item if it's pending
-    // Failed/cancelled messages block the queue until user handles them (retry or remove)
-    const firstMessage = queue[0]
-    return firstMessage.status === "pending" ? firstMessage : null
+    // Strict FIFO for ordinary queued messages, but allow pending injection
+    // messages to wait for their boundary without blocking later ordinary work.
+    for (const message of queue) {
+      if (message.status !== "pending") return null
+      if (!message.injectionTarget) return message
+    }
+    return null
   }
 
   /**
@@ -253,6 +256,53 @@ class MessageQueueService {
     this.emitQueueUpdate(conversationId)
 
     return true
+  }
+
+  /**
+   * Mark a pending queued message to be injected after a specific active-session boundary.
+   * Passing null clears the injection mode and returns the message to ordinary FIFO behavior.
+   */
+  setInjectionTarget(
+    conversationId: string,
+    messageId: string,
+    injectionTarget: QueuedMessage["injectionTarget"] | null,
+  ): boolean {
+    const queue = this.queues.get(conversationId)
+    if (!queue) return false
+
+    const message = queue.find((m) => m.id === messageId)
+    if (!message) return false
+
+    if (message.status !== "pending" || message.addedToHistory) {
+      logApp(`[MessageQueueService] Cannot update injection target for ${messageId} - status: ${message.status}, addedToHistory: ${message.addedToHistory === true}`)
+      return false
+    }
+
+    if (injectionTarget) {
+      message.injectionTarget = injectionTarget
+    } else {
+      delete message.injectionTarget
+    }
+    logApp(`[MessageQueueService] Set injection target for ${messageId} in ${conversationId}: ${injectionTarget ?? "none"}`)
+    this.emitQueueUpdate(conversationId)
+
+    return true
+  }
+
+  /**
+   * Return the next pending message waiting for this injection boundary.
+   */
+  peekInjectionTarget(
+    conversationId: string,
+    injectionTarget: NonNullable<QueuedMessage["injectionTarget"]>,
+  ): QueuedMessage | null {
+    const queue = this.queues.get(conversationId)
+    if (!queue || queue.length === 0) return null
+
+    return queue.find(
+      (message) => message.status === "pending" && message.injectionTarget === injectionTarget,
+    )
+      ?? null
   }
 
   /**
@@ -414,4 +464,3 @@ class MessageQueueService {
 }
 
 export const messageQueueService = MessageQueueService.getInstance()
-

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -65,6 +65,7 @@ import {
   SessionProfileSnapshot,
   LoopConfig,
   ArtifactKind,
+  QueuedMessage,
 } from "../shared/types"
 import { DEFAULT_STT_MODELS, getConfiguredSttModel } from "@dotagents/shared"
 import { getBranchMessageIndexMap } from "@shared/conversation-progress"
@@ -4903,6 +4904,20 @@ export const router = {
       }
 
       return true
+    }),
+
+  setQueuedMessageInjectionTarget: t.procedure
+    .input<{
+      conversationId: string
+      messageId: string
+      injectionTarget: QueuedMessage["injectionTarget"] | null
+    }>()
+    .action(async ({ input }) => {
+      return messageQueueService.setInjectionTarget(
+        input.conversationId,
+        input.messageId,
+        input.injectionTarget,
+      )
     }),
 
   retryQueuedMessage: t.procedure

--- a/apps/desktop/src/renderer/src/components/message-queue-panel.tsx
+++ b/apps/desktop/src/renderer/src/components/message-queue-panel.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react"
 import { cn } from "@renderer/lib/utils"
-import { Clock, Trash2, Check, ChevronDown, ChevronUp, AlertCircle, Loader2, Play, Pause, Pencil, RotateCcw } from "lucide-react"
+import { Clock, Trash2, Check, ChevronDown, ChevronUp, AlertCircle, Loader2, Play, Pause, Pencil, RotateCcw, Wrench, MessageSquare } from "lucide-react"
 import { Button } from "@renderer/components/ui/button"
 import { QueuedMessage } from "@shared/types"
 import { useMutation } from "@tanstack/react-query"
@@ -90,6 +90,8 @@ function QueuedMessageItem({
   const isFailed = message.status === "failed"
   const isProcessing = message.status === "processing"
   const isAddedToHistory = message.addedToHistory === true
+  const isWaitingForToolBoundary = message.injectionTarget === "after_next_tool_response"
+  const isWaitingForAgentBoundary = message.injectionTarget === "after_next_agent_response"
 
   // Mutation to retry a failed message by resetting its status to pending
   const retryMutation = useMutation({
@@ -101,6 +103,24 @@ function QueuedMessageItem({
       })
     },
   })
+
+  const injectionTargetMutation = useMutation({
+    mutationFn: async (injectionTarget: QueuedMessage["injectionTarget"] | null) => {
+      const success = await tipcClient.setQueuedMessageInjectionTarget({
+        conversationId,
+        messageId: message.id,
+        injectionTarget,
+      })
+      if (!success) {
+        throw new Error("Failed to update injection target")
+      }
+      return success
+    },
+  })
+
+  const toggleInjectionTarget = (injectionTarget: NonNullable<QueuedMessage["injectionTarget"]>) => {
+    injectionTargetMutation.mutate(message.injectionTarget === injectionTarget ? null : injectionTarget)
+  }
 
   return (
     <div
@@ -174,6 +194,11 @@ function QueuedMessageItem({
                   Error: {message.errorMessage}
                 </p>
               )}
+              {message.injectionTarget && (
+                <p className="text-[10px] text-muted-foreground mt-0.5">
+                  Waiting for next {isWaitingForToolBoundary ? "tool response" : "agent response"}
+                </p>
+              )}
               {isLongMessage && (
                 <Button
                   variant="ghost"
@@ -220,6 +245,32 @@ function QueuedMessageItem({
                   >
                     <Pencil className="h-3.5 w-3.5" />
                   </Button>
+                )}
+                {!isFailed && !isAddedToHistory && (
+                  <>
+                    <Button
+                      variant="ghost"
+                      size="sm-icon"
+                      className={cn(isWaitingForToolBoundary && "bg-primary/10 text-primary")}
+                      onClick={() => toggleInjectionTarget("after_next_tool_response")}
+                      disabled={injectionTargetMutation.isPending}
+                      title={isWaitingForToolBoundary ? "Use ordinary queue order" : "Inject after next tool response"}
+                      aria-label={isWaitingForToolBoundary ? "Use ordinary queue order" : "Inject after next tool response"}
+                    >
+                      <Wrench className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm-icon"
+                      className={cn(isWaitingForAgentBoundary && "bg-primary/10 text-primary")}
+                      onClick={() => toggleInjectionTarget("after_next_agent_response")}
+                      disabled={injectionTargetMutation.isPending}
+                      title={isWaitingForAgentBoundary ? "Use ordinary queue order" : "Inject after next agent response"}
+                      aria-label={isWaitingForAgentBoundary ? "Use ordinary queue order" : "Inject after next agent response"}
+                    >
+                      <MessageSquare className="h-3.5 w-3.5" />
+                    </Button>
+                  </>
                 )}
                 <Button
                   variant="ghost"

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -83,6 +83,8 @@ export interface QueuedMessage {
   errorMessage?: string;
   /** Indicates the message was added to conversation history before processing failed */
   addedToHistory?: boolean;
+  /** Optional boundary where this queued message should be injected into active history. */
+  injectionTarget?: 'after_next_tool_response' | 'after_next_agent_response';
 }
 
 /**


### PR DESCRIPTION
## Summary
- add queue message injection targets for after the next tool response or plain agent response
- consume targeted queued messages into active conversation history and persist them at the boundary
- expose compact queue-panel controls and status text for injection mode

Fixes #558.

## Validation
- pnpm --filter @dotagents/desktop exec vitest run src/main/message-queue-service.test.ts
- pnpm --filter @dotagents/desktop typecheck

## Notes
- Initial dependency install populated node_modules but the desktop postinstall native rebuild failed under Node 25 for @egoist/electron-panel-window; the targeted checks passed after workspace packages were built.