### PR TITLE
Add repeat task notification mute toggle

### DIFF
--- a/apps/desktop/src/main/bundle-service.ts
+++ b/apps/desktop/src/main/bundle-service.ts
@@ -109,6 +109,7 @@ export interface BundleRepeatTask {
   intervalMinutes: number
   enabled: boolean
   runOnStartup?: boolean
+  pushNotificationsMuted?: boolean
   speakOnTrigger?: boolean
   continueInSession?: boolean
   runContinuously?: boolean
@@ -684,6 +685,7 @@ function loadRepeatTasksForBundle(layer: AgentsLayerPaths, options?: BundleItemS
         intervalMinutes: task.intervalMinutes,
         enabled: task.enabled,
         runOnStartup: task.runOnStartup,
+        pushNotificationsMuted: task.pushNotificationsMuted,
         speakOnTrigger: task.speakOnTrigger,
         continueInSession: task.continueInSession,
         runContinuously: task.runContinuously,
@@ -1670,6 +1672,7 @@ export async function importBundle(
           intervalMinutes: bundleTask.intervalMinutes,
           enabled: bundleTask.enabled,
           runOnStartup: bundleTask.runOnStartup,
+          pushNotificationsMuted: bundleTask.pushNotificationsMuted,
           speakOnTrigger: bundleTask.speakOnTrigger,
           continueInSession: bundleTask.continueInSession,
           runContinuously: bundleTask.runContinuously,

--- a/apps/desktop/src/main/remote-server.routes.test.ts
+++ b/apps/desktop/src/main/remote-server.routes.test.ts
@@ -368,6 +368,21 @@ describe("remote-server route registration", () => {
     expect(updateLoopSection).toContain("if (!updated.critiquePass)")
   })
 
+  it("exposes and validates the repeat task push notification mute field", () => {
+    const source = getRemoteServerSource()
+    const listLoopSection = getSection(source, 'fastify.get("/v1/loops"', '// POST /v1/loops/import/markdown')
+    const createLoopSection = getSection(source, 'fastify.post("/v1/loops"', '// PATCH /v1/loops/:id - Update a loop/repeat task')
+    const updateLoopSection = getSection(source, 'fastify.patch("/v1/loops/:id"', '// DELETE /v1/loops/:id - Delete a loop/repeat task')
+
+    expect(listLoopSection).toContain("pushNotificationsMuted: l.pushNotificationsMuted")
+    expect(createLoopSection).toContain("pushNotificationsMuted?: unknown")
+    expect(createLoopSection).toContain('pushNotificationsMuted must be a boolean when provided')
+    expect(createLoopSection).toContain("const pushNotificationsMuted = body.pushNotificationsMuted === true")
+    expect(updateLoopSection).toContain("pushNotificationsMuted?: unknown")
+    expect(updateLoopSection).toContain('pushNotificationsMuted must be a boolean when provided')
+    expect(updateLoopSection).toContain("const pushNotificationsMuted = typeof body.pushNotificationsMuted === \"boolean\" ? body.pushNotificationsMuted : undefined")
+  })
+
   it("does not report repeat task creation as successful when loop persistence fails", () => {
     const source = getRemoteServerSource()
     const createLoopSection = getSection(source, 'fastify.post("/v1/loops"', '// PATCH /v1/loops/:id - Update a loop/repeat task')

--- a/apps/desktop/src/main/remote-server.ts
+++ b/apps/desktop/src/main/remote-server.ts
@@ -7526,6 +7526,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       profileId: loop.profileId,
       profileName: getLoopProfileName(loop.profileId),
       runOnStartup: loop.runOnStartup,
+      pushNotificationsMuted: loop.pushNotificationsMuted,
       speakOnTrigger: loop.speakOnTrigger,
       continueInSession: loop.continueInSession,
       lastSessionId: loop.lastSessionId,
@@ -7563,6 +7564,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
             profileId: l.profileId,
             profileName: getLoopProfileName(l.profileId),
             runOnStartup: l.runOnStartup,
+            pushNotificationsMuted: l.pushNotificationsMuted,
             speakOnTrigger: l.speakOnTrigger,
             continueInSession: l.continueInSession,
             lastSessionId: l.lastSessionId,
@@ -7921,6 +7923,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         enabled?: unknown
         profileId?: unknown
         runOnStartup?: unknown
+        pushNotificationsMuted?: unknown
         speakOnTrigger?: unknown
         continueInSession?: unknown
         lastSessionId?: unknown
@@ -7967,6 +7970,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       if (body.runOnStartup !== undefined && typeof body.runOnStartup !== "boolean") {
         return reply.code(400).send({ error: "runOnStartup must be a boolean when provided" })
       }
+      if (body.pushNotificationsMuted !== undefined && typeof body.pushNotificationsMuted !== "boolean") {
+        return reply.code(400).send({ error: "pushNotificationsMuted must be a boolean when provided" })
+      }
       if (body.speakOnTrigger !== undefined && typeof body.speakOnTrigger !== "boolean") {
         return reply.code(400).send({ error: "speakOnTrigger must be a boolean when provided" })
       }
@@ -7990,6 +7996,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       const runContinuously = body.runContinuously === true
       const critiquePass = body.critiquePass === true
       const runOnStartup = body.runOnStartup === true
+      const pushNotificationsMuted = body.pushNotificationsMuted === true
       const speakOnTrigger = body.speakOnTrigger === true
       const continueInSession = body.continueInSession === true
       const lastSessionId = typeof body.lastSessionId === "string" ? body.lastSessionId.trim() : undefined
@@ -8004,6 +8011,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         enabled,
         profileId: profileId || undefined,
         runOnStartup,
+        pushNotificationsMuted,
         speakOnTrigger,
         continueInSession,
         lastSessionId: continueInSession ? (lastSessionId || undefined) : undefined,
@@ -8050,6 +8058,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         enabled?: unknown
         profileId?: unknown
         runOnStartup?: unknown
+        pushNotificationsMuted?: unknown
         speakOnTrigger?: unknown
         continueInSession?: unknown
         lastSessionId?: unknown
@@ -8114,6 +8123,9 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       if (body.runOnStartup !== undefined && typeof body.runOnStartup !== "boolean") {
         return reply.code(400).send({ error: "runOnStartup must be a boolean when provided" })
       }
+      if (body.pushNotificationsMuted !== undefined && typeof body.pushNotificationsMuted !== "boolean") {
+        return reply.code(400).send({ error: "pushNotificationsMuted must be a boolean when provided" })
+      }
       if (body.speakOnTrigger !== undefined && typeof body.speakOnTrigger !== "boolean") {
         return reply.code(400).send({ error: "speakOnTrigger must be a boolean when provided" })
       }
@@ -8145,6 +8157,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
       const critiquePass = typeof body.critiquePass === "boolean" ? body.critiquePass : undefined
       const nextCritiquePass = critiquePass ?? (existing.critiquePass === true)
       const runOnStartup = typeof body.runOnStartup === "boolean" ? body.runOnStartup : undefined
+      const pushNotificationsMuted = typeof body.pushNotificationsMuted === "boolean" ? body.pushNotificationsMuted : undefined
       const speakOnTrigger = typeof body.speakOnTrigger === "boolean" ? body.speakOnTrigger : undefined
       const continueInSession = typeof body.continueInSession === "boolean" ? body.continueInSession : undefined
       const lastSessionId = typeof body.lastSessionId === "string" ? body.lastSessionId.trim() : undefined
@@ -8156,6 +8169,7 @@ async function startRemoteServerInternal(options: StartRemoteServerOptions = {})
         ...(enabled !== undefined && { enabled }),
         ...(body.profileId !== undefined && { profileId: profileId || undefined }),
         ...(runOnStartup !== undefined && { runOnStartup }),
+        ...(pushNotificationsMuted !== undefined && { pushNotificationsMuted }),
         ...(speakOnTrigger !== undefined && { speakOnTrigger }),
         ...(continueInSession !== undefined && { continueInSession }),
         ...(body.lastSessionId !== undefined && { lastSessionId: lastSessionId || undefined }),

--- a/apps/desktop/src/main/tipc.repeat-task-session-flag.test.ts
+++ b/apps/desktop/src/main/tipc.repeat-task-session-flag.test.ts
@@ -42,4 +42,16 @@ describe("getAgentSessions repeat-task session flag", () => {
     expect(tipcSource).toContain("function truncateAgentLoopFallbackTitle")
     expect(tipcSource).toContain("agentSessionTracker.getSession(existingSessionId)?.conversationTitle?.trim()")
   })
+
+  it("suppresses completion push notifications for muted repeat tasks", () => {
+    const pushNotificationSection = tipcSource.slice(
+      tipcSource.indexOf("function sendAgentCompletionPushNotification"),
+      tipcSource.indexOf("async function withRepeatTaskSessionFlag"),
+    )
+
+    expect(pushNotificationSection).toContain('input.repeatTask?.type === "repeat_task_run"')
+    expect(pushNotificationSection).toContain("loopService.getLoop(input.repeatTask.taskId)")
+    expect(pushNotificationSection).toContain("loop?.pushNotificationsMuted")
+    expect(pushNotificationSection).toContain("Skipping push notification for muted repeat task")
+  })
 })

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -127,9 +127,18 @@ function sendAgentCompletionPushNotification(input: {
   sessionId: string
   conversationTitle: string
   content: string
+  repeatTask?: ConversationRepeatTaskSource
 }) {
   if (!input.conversationId || !isPushEnabled()) {
     return
+  }
+
+  if (input.repeatTask?.type === "repeat_task_run") {
+    const loop = loopService.getLoop(input.repeatTask.taskId)
+    if (loop?.pushNotificationsMuted) {
+      logApp(`[tipc] Skipping push notification for muted repeat task "${loop.name}" (${loop.id})`)
+      return
+    }
   }
 
   sendMessageNotification(
@@ -515,12 +524,14 @@ async function processWithAgentMode(
       // Mark session as completed
       if (result.success) {
         logLLM(`[processWithAgentMode] ACP mode completed successfully for session ${sessionId}, conversation ${conversationId}`)
+        const completionRepeatTask = agentSessionTracker.getSession(sessionId)?.repeatTask
         agentSessionTracker.completeSession(sessionId, "ACP agent completed successfully")
         sendAgentCompletionPushNotification({
           conversationId,
           sessionId,
           conversationTitle,
           content: result.response || "Agent completed.",
+          repeatTask: completionRepeatTask,
         })
       } else {
         logLLM(`[processWithAgentMode] ACP mode failed for session ${sessionId}: ${result.error}`)
@@ -718,12 +729,14 @@ async function processWithAgentMode(
     )
 
     // Mark session as completed
+    const completionRepeatTask = agentSessionTracker.getSession(sessionId)?.repeatTask
     agentSessionTracker.completeSession(sessionId, "Agent completed successfully")
     sendAgentCompletionPushNotification({
       conversationId,
       sessionId,
       conversationTitle,
       content: agentResult.content,
+      repeatTask: completionRepeatTask,
     })
 
     return agentResult.content

--- a/apps/desktop/src/renderer/src/pages/settings-loops.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-loops.tsx
@@ -30,6 +30,7 @@ interface EditingLoop {
   intervalMinutesDraft: string
   enabled: boolean
   runOnStartup: boolean
+  pushNotificationsMuted: boolean
   speakOnTrigger: boolean
   continueInSession: boolean
   lastSessionId?: string
@@ -55,6 +56,7 @@ const emptyLoop: EditingLoop = {
   intervalMinutesDraft: "15",
   enabled: true,
   runOnStartup: false,
+  pushNotificationsMuted: false,
   speakOnTrigger: false,
   continueInSession: false,
   critiquePass: false,
@@ -291,6 +293,7 @@ export function SettingsLoops() {
       intervalMinutesDraft: formatLoopIntervalDraft(loop.intervalMinutes),
       enabled: loop.enabled,
       runOnStartup: loop.runOnStartup ?? false,
+      pushNotificationsMuted: loop.pushNotificationsMuted ?? false,
       speakOnTrigger: loop.speakOnTrigger ?? false,
       continueInSession: loop.continueInSession ?? false,
       lastSessionId: loop.lastSessionId,
@@ -356,6 +359,7 @@ export function SettingsLoops() {
       intervalMinutes: savedIntervalMinutes,
       enabled: editing.enabled,
       runOnStartup: editing.runOnStartup,
+      pushNotificationsMuted: editing.pushNotificationsMuted,
       speakOnTrigger: editing.speakOnTrigger,
       continueInSession: editing.continueInSession,
       runContinuously: editing.scheduleMode === "continuous",
@@ -520,6 +524,7 @@ export function SettingsLoops() {
                 {describeLoopCadence(loop)}
               </div>
               {loop.runOnStartup && <div>Runs on startup</div>}
+              {loop.pushNotificationsMuted && <div>Push muted</div>}
               {loop.speakOnTrigger && <div>Speaks on trigger</div>}
               {loop.continueInSession && <div>Continues in same session</div>}
               {loop.critiquePass && <div>Built-in critique</div>}
@@ -708,6 +713,14 @@ export function SettingsLoops() {
                 onCheckedChange={(v) => setEditing({ ...editing, runOnStartup: v })}
               />
               <Label htmlFor="runOnStartup">Run on Startup</Label>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="pushNotifications"
+                checked={!editing.pushNotificationsMuted}
+                onCheckedChange={(v) => setEditing({ ...editing, pushNotificationsMuted: !v })}
+              />
+              <Label htmlFor="pushNotifications">Push Notifications</Label>
             </div>
             <div className="flex items-center space-x-2">
               <Switch

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1136,6 +1136,7 @@ export interface LoopConfig {
   profileId?: string       // optional profile to use for the agent session
   lastRunAt?: number       // timestamp (ms) of last execution
   runOnStartup?: boolean   // if true, fires immediately on app start before first interval
+  pushNotificationsMuted?: boolean // if true, suppresses repeat-task completion push notifications
   speakOnTrigger?: boolean // if true, unsnoozes session on completion so TTS auto-plays
   continueInSession?: boolean // if true, reuses the prior session across iterations
   lastSessionId?: string   // session id to resume on next run when continueInSession is on

--- a/apps/mobile/src/lib/settingsApi.ts
+++ b/apps/mobile/src/lib/settingsApi.ts
@@ -469,6 +469,7 @@ export interface LoopCreateRequest {
   enabled: boolean;
   profileId?: string;
   runOnStartup?: boolean;
+  pushNotificationsMuted?: boolean;
   speakOnTrigger?: boolean;
   continueInSession?: boolean;
   lastSessionId?: string;
@@ -486,6 +487,7 @@ export interface LoopUpdateRequest {
   enabled?: boolean;
   profileId?: string | null;
   runOnStartup?: boolean;
+  pushNotificationsMuted?: boolean;
   speakOnTrigger?: boolean;
   continueInSession?: boolean;
   lastSessionId?: string | null;

--- a/apps/mobile/src/screens/LoopEditScreen.tsx
+++ b/apps/mobile/src/screens/LoopEditScreen.tsx
@@ -34,6 +34,7 @@ type LoopFormData = {
   enabled: boolean;
   profileId: string;
   runOnStartup: boolean;
+  pushNotificationsMuted: boolean;
   speakOnTrigger: boolean;
   continueInSession: boolean;
   lastSessionId: string;
@@ -60,6 +61,7 @@ const defaultFormData: LoopFormData = {
   enabled: true,
   profileId: '',
   runOnStartup: false,
+  pushNotificationsMuted: false,
   speakOnTrigger: false,
   continueInSession: false,
   lastSessionId: '',
@@ -149,6 +151,7 @@ function loopToFormData(loop: Loop): LoopFormData {
     enabled: loop.enabled,
     profileId: loop.profileId || '',
     runOnStartup: !!loop.runOnStartup,
+    pushNotificationsMuted: !!loop.pushNotificationsMuted,
     speakOnTrigger: !!loop.speakOnTrigger,
     continueInSession: !!loop.continueInSession,
     lastSessionId: loop.lastSessionId || '',
@@ -347,6 +350,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
           enabled: formData.enabled,
           profileId: formData.profileId || undefined,
           runOnStartup: formData.runOnStartup,
+          pushNotificationsMuted: formData.pushNotificationsMuted,
           speakOnTrigger: formData.speakOnTrigger,
           continueInSession: formData.continueInSession,
           lastSessionId: formData.continueInSession ? (formData.lastSessionId.trim() || null) : null,
@@ -365,6 +369,7 @@ export default function LoopEditScreen({ navigation, route }: any) {
           enabled: formData.enabled,
           profileId: formData.profileId || undefined,
           runOnStartup: formData.runOnStartup,
+          pushNotificationsMuted: formData.pushNotificationsMuted,
           speakOnTrigger: formData.speakOnTrigger,
           continueInSession: formData.continueInSession,
           ...(formData.continueInSession && formData.lastSessionId.trim() ? { lastSessionId: formData.lastSessionId.trim() } : {}),
@@ -550,6 +555,18 @@ export default function LoopEditScreen({ navigation, route }: any) {
           onValueChange={value => updateField('runOnStartup', value)}
           trackColor={{ false: theme.colors.muted, true: theme.colors.primary }}
           thumbColor={formData.runOnStartup ? theme.colors.primaryForeground : theme.colors.background}
+        />
+      </View>
+      <View style={styles.switchRow}>
+        <View style={styles.switchInfo}>
+          <Text style={styles.switchLabel}>Push notifications</Text>
+          <Text style={styles.switchHelperText}>Send a push notification when this repeat task completes.</Text>
+        </View>
+        <Switch
+          value={!formData.pushNotificationsMuted}
+          onValueChange={value => updateField('pushNotificationsMuted', !value)}
+          trackColor={{ false: theme.colors.muted, true: theme.colors.primary }}
+          thumbColor={!formData.pushNotificationsMuted ? theme.colors.primaryForeground : theme.colors.background}
         />
       </View>
       <View style={styles.switchRow}>

--- a/packages/core/src/agents-files/tasks.test.ts
+++ b/packages/core/src/agents-files/tasks.test.ts
@@ -53,4 +53,35 @@ describe("agents-files/tasks", () => {
     expect(parsed?.critiquePass).toBe(true)
     expect(parsed?.criticProfileId).toBe("critic-agent")
   })
+
+  it("roundtrips muted push notifications in task frontmatter", () => {
+    const task: LoopConfig = {
+      id: "quiet-task",
+      name: "Quiet task",
+      prompt: "Run quietly.",
+      intervalMinutes: 30,
+      enabled: true,
+      pushNotificationsMuted: true,
+    }
+
+    const markdown = stringifyTaskMarkdown(task)
+    expect(markdown).toContain("pushNotificationsMuted: true")
+
+    const parsed = parseTaskMarkdown(markdown)
+    expect(parsed?.pushNotificationsMuted).toBe(true)
+  })
+
+  it("omits muted push notifications when false or missing", () => {
+    const task: LoopConfig = {
+      id: "noisy-task",
+      name: "Noisy task",
+      prompt: "Notify on completion.",
+      intervalMinutes: 30,
+      enabled: true,
+    }
+
+    const markdown = stringifyTaskMarkdown(task)
+    expect(markdown).not.toContain("pushNotificationsMuted")
+    expect(parseTaskMarkdown(markdown)?.pushNotificationsMuted).toBeUndefined()
+  })
 })

--- a/packages/core/src/agents-files/tasks.ts
+++ b/packages/core/src/agents-files/tasks.ts
@@ -130,6 +130,7 @@ export function stringifyTaskMarkdown(task: LoopConfig): string {
 
   if (task.profileId) frontmatter.profileId = task.profileId
   if (task.runOnStartup) frontmatter.runOnStartup = "true"
+  if (task.pushNotificationsMuted) frontmatter.pushNotificationsMuted = "true"
   if (task.speakOnTrigger) frontmatter.speakOnTrigger = "true"
   if (task.continueInSession) frontmatter.continueInSession = "true"
   if (task.lastSessionId) frontmatter.lastSessionId = task.lastSessionId
@@ -169,6 +170,7 @@ export function parseTaskMarkdown(
     enabled: parseBoolean(fm.enabled, true),
     profileId: (fm.profileId ?? "").trim() || undefined,
     runOnStartup: parseBoolean(fm.runOnStartup, false) || undefined,
+    pushNotificationsMuted: parseBoolean(fm.pushNotificationsMuted, false) || undefined,
     speakOnTrigger: parseBoolean(fm.speakOnTrigger, false) || undefined,
     continueInSession: parseBoolean(fm.continueInSession, false) || undefined,
     lastSessionId: (fm.lastSessionId ?? "").trim() || undefined,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,6 +77,8 @@ export interface LoopConfig {
   profileId?: string
   lastRunAt?: number
   runOnStartup?: boolean
+  /** If true, repeat-task completion push notifications are suppressed. */
+  pushNotificationsMuted?: boolean
   /**
    * If true, the session is automatically unsnoozed when the loop completes
    * so the renderer auto-plays TTS for the assistant response. The session

--- a/packages/shared/src/api-types.ts
+++ b/packages/shared/src/api-types.ts
@@ -1038,6 +1038,7 @@ export interface Loop {
   profileId?: string;
   profileName?: string;
   runOnStartup?: boolean;
+  pushNotificationsMuted?: boolean;
   speakOnTrigger?: boolean;
   continueInSession?: boolean;
   lastSessionId?: string;


### PR DESCRIPTION
## Summary
- add a per-repeat-task push notification mute flag persisted in task frontmatter and bundles
- expose the flag through desktop/mobile loop editing and remote loop APIs
- skip completion push notifications for muted repeat-task runs without stopping the task

Closes #561

## Tests
- pnpm --filter @dotagents/core test -- src/agents-files/tasks.test.ts
- pnpm --filter @dotagents/desktop exec vitest run src/main/tipc.repeat-task-session-flag.test.ts src/main/remote-server.routes.test.ts
- pnpm --filter @dotagents/shared typecheck
- pnpm --filter @dotagents/core typecheck
- pnpm --filter @dotagents/desktop typecheck
- pnpm --filter @dotagents/mobile test:vitest

Note: an initial full desktop package test script invocation ran the whole desktop suite and hit unrelated existing failures; the touched desktop tests passed in that run and passed again via the targeted command above.