### PR TITLE
[codex] Add context compaction controls and background cleanup

### DIFF
--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -482,6 +482,14 @@ async function getMaxContextTokens(providerId: string, model: string): Promise<n
   return result
 }
 
+export async function getActiveContextTargetTokens(): Promise<number> {
+  const config = configStore.get()
+  const targetRatio = config.mcpContextTargetRatio ?? 0.4
+  const { providerId, model } = getProviderAndModel()
+  const maxTokens = await getMaxContextTokens(providerId, model)
+  return Math.floor(maxTokens * targetRatio)
+}
+
 export function estimateTokensFromMessages(messages: LLMMessage[]): number {
   // Rough estimate: 4 chars ≈ 1 token
   const totalChars = messages.reduce((sum, m) => {

--- a/apps/desktop/src/main/conversation-service.lazy-load.test.ts
+++ b/apps/desktop/src/main/conversation-service.lazy-load.test.ts
@@ -405,6 +405,116 @@ describe("conversation lazy loading", () => {
     })
   })
 
+  it("loads conversation for a live run without synchronous compaction", async () => {
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_active_session",
+      title: "Active session",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 25 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const { summarizeContent } = await import("./context-budget")
+    const loaded = await service.loadConversationForRun(
+      "conv_active_session",
+    )
+
+    expect(loaded?.messages).toHaveLength(25)
+    expect(loaded?.compaction).toBeUndefined()
+    expect(summarizeContent).not.toHaveBeenCalled()
+  })
+
+  it("schedules conversation compaction as deduped background cleanup", async () => {
+    vi.useFakeTimers()
+    try {
+      const service = await setupConversationServiceTest()
+      await service.saveConversation({
+        id: "conv_scheduled_compaction",
+        title: "Scheduled compaction",
+        createdAt: 100,
+        updatedAt: 200,
+        messages: Array.from({ length: 25 }, (_, index) => ({
+          id: `m${index}`,
+          role: index % 2 === 0 ? "user" as const : "assistant" as const,
+          content: `Message ${index}`,
+          timestamp: 1_700_000_000_000 + index,
+        })),
+      }, true)
+
+      const { summarizeContent } = await import("./context-budget")
+      const compactSpy = vi.spyOn(service, "compactConversationNow")
+
+      service.scheduleConversationCompaction("conv_scheduled_compaction", "test")
+      service.scheduleConversationCompaction("conv_scheduled_compaction", "duplicate")
+
+      expect(summarizeContent).not.toHaveBeenCalled()
+
+      await vi.runOnlyPendingTimersAsync()
+      expect(compactSpy).toHaveBeenCalledTimes(1)
+      await compactSpy.mock.results[0]?.value
+
+      expect(summarizeContent).toHaveBeenCalledTimes(1)
+      const loaded = await service.loadConversation("conv_scheduled_compaction")
+      expect(loaded?.messages).toHaveLength(11)
+      expect(loaded?.messages[0]).toMatchObject({ isSummary: true, content: summaryResult })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not persist stale compaction if the conversation changes while summarizing", async () => {
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_stale_compaction",
+      title: "Stale compaction",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 25 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const { summarizeContent } = await import("./context-budget")
+    let resolveSummary: ((value: string) => void) | undefined
+    ;(summarizeContent as any).mockImplementationOnce(() =>
+      new Promise<string>((resolve) => {
+        resolveSummary = resolve
+      })
+    )
+
+    const compactPromise = service.compactConversationNow("conv_stale_compaction")
+    for (let attempt = 0; attempt < 20 && (summarizeContent as any).mock.calls.length === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+
+    expect(summarizeContent).toHaveBeenCalledTimes(1)
+
+    await service.addMessageToConversation(
+      "conv_stale_compaction",
+      "New user prompt while cleanup is running",
+      "user",
+    )
+
+    resolveSummary?.("Stale compacted summary")
+    const result = await compactPromise
+
+    expect(result?.messages).toHaveLength(26)
+    expect(result?.messages.some((message) => message.isSummary)).toBe(false)
+
+    const reloaded = await service.loadConversation("conv_stale_compaction")
+    expect(reloaded?.messages).toHaveLength(26)
+    expect(reloaded?.messages.some((message) => message.isSummary)).toBe(false)
+  })
+
   it("uses the configured message threshold to compact shorter conversations", async () => {
     mockConfig = { mcpConversationCompactionMessageThreshold: 12 }
     const service = await setupConversationServiceTest()

--- a/apps/desktop/src/main/conversation-service.lazy-load.test.ts
+++ b/apps/desktop/src/main/conversation-service.lazy-load.test.ts
@@ -5,6 +5,8 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 const tempDirs: string[] = []
 let summaryResult = "Compacted conversation summary."
+let mockConfig: Record<string, unknown> = {}
+let mockActiveContextTargetTokens = 12_000
 
 async function setupConversationServiceTest() {
   const conversationsFolder = await fs.mkdtemp(path.join(os.tmpdir(), "dotagents-conv-lazy-"))
@@ -16,9 +18,21 @@ async function setupConversationServiceTest() {
     recordingsFolder: path.join(conversationsFolder, "recordings"),
     conversationsFolder,
     configPath: path.join(conversationsFolder, "config.json"),
-    configStore: { get: vi.fn(), save: vi.fn(), reload: vi.fn(), config: undefined },
+    configStore: {
+      get: vi.fn(() => mockConfig),
+      save: vi.fn(),
+      reload: vi.fn(() => mockConfig),
+      config: undefined,
+    },
   }))
-  vi.doMock("./context-budget", () => ({ summarizeContent: vi.fn(() => summaryResult) }))
+  vi.doMock("./context-budget", () => ({
+    estimateTokensFromMessages: vi.fn((messages: Array<{ content?: string }>) => {
+      const chars = messages.reduce((sum, message) => sum + (message.content?.length || 0), 0)
+      return Math.ceil(chars / 4)
+    }),
+    getActiveContextTargetTokens: vi.fn(() => mockActiveContextTargetTokens),
+    summarizeContent: vi.fn(() => summaryResult),
+  }))
   vi.doMock("./llm-fetch", () => ({ makeTextCompletionWithFetch: vi.fn() }))
 
   const { ConversationService } = await import("./conversation-service")
@@ -27,6 +41,8 @@ async function setupConversationServiceTest() {
 
 afterEach(async () => {
   summaryResult = "Compacted conversation summary."
+  mockConfig = {}
+  mockActiveContextTargetTokens = 12_000
   vi.resetModules()
   vi.clearAllMocks()
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })))
@@ -387,6 +403,146 @@ describe("conversation lazy loading", () => {
       sourceMessageId: "m2",
       repoSlugs: ["Bin-Huang/youtube-analytics-cli"],
     })
+  })
+
+  it("uses the configured message threshold to compact shorter conversations", async () => {
+    mockConfig = { mcpConversationCompactionMessageThreshold: 12 }
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_low_message_threshold",
+      title: "Low threshold",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 13 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const loaded = await service.loadConversationWithCompaction(
+      "conv_low_message_threshold",
+    )
+
+    expect(loaded?.messages).toHaveLength(11)
+    expect(loaded?.messages[0]).toMatchObject({ isSummary: true, content: summaryResult })
+    expect(loaded?.compaction).toMatchObject({
+      storedRawMessageCount: 13,
+      firstKeptMessageId: "m3",
+      summarizedMessageCount: 3,
+    })
+  })
+
+  it("uses the configured message threshold to avoid default compaction", async () => {
+    mockConfig = { mcpConversationCompactionMessageThreshold: 30 }
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_high_message_threshold",
+      title: "High threshold",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 25 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const loaded = await service.loadConversationWithCompaction(
+      "conv_high_message_threshold",
+    )
+
+    expect(loaded?.messages).toHaveLength(25)
+    expect(loaded?.compaction).toBeUndefined()
+  })
+
+  it("uses the configured token threshold to compact below the message threshold", async () => {
+    mockConfig = {
+      mcpConversationCompactionMessageThreshold: 30,
+      mcpConversationCompactionTokenThreshold: 1000,
+    }
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_token_threshold",
+      title: "Token threshold",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 12 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index} ${"token-heavy ".repeat(60)}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const loaded = await service.loadConversationWithCompaction(
+      "conv_token_threshold",
+    )
+
+    expect(loaded?.messages).toHaveLength(11)
+    expect(loaded?.messages[0]).toMatchObject({ isSummary: true, content: summaryResult })
+    expect(loaded?.compaction).toMatchObject({
+      storedRawMessageCount: 12,
+      firstKeptMessageId: "m2",
+      summarizedMessageCount: 2,
+    })
+  })
+
+  it("uses the active context target tokens when the token threshold is unset", async () => {
+    mockConfig = { mcpConversationCompactionMessageThreshold: 30 }
+    mockActiveContextTargetTokens = 1_000
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_ratio_token_threshold",
+      title: "Ratio token threshold",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 12 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index} ${"token-heavy ".repeat(60)}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const loaded = await service.loadConversationWithCompaction(
+      "conv_ratio_token_threshold",
+    )
+
+    expect(loaded?.messages).toHaveLength(11)
+    expect(loaded?.messages[0]).toMatchObject({ isSummary: true, content: summaryResult })
+    expect(loaded?.compaction).toMatchObject({
+      storedRawMessageCount: 12,
+      firstKeptMessageId: "m2",
+      summarizedMessageCount: 2,
+    })
+  })
+
+  it("does not compact below the active context target tokens", async () => {
+    mockConfig = { mcpConversationCompactionMessageThreshold: 30 }
+    mockActiveContextTargetTokens = 12_000
+    const service = await setupConversationServiceTest()
+    await service.saveConversation({
+      id: "conv_no_token_threshold",
+      title: "No token threshold",
+      createdAt: 100,
+      updatedAt: 200,
+      messages: Array.from({ length: 12 }, (_, index) => ({
+        id: `m${index}`,
+        role: index % 2 === 0 ? "user" as const : "assistant" as const,
+        content: `Message ${index} ${"token-heavy ".repeat(60)}`,
+        timestamp: 1_700_000_000_000 + index,
+      })),
+    }, true)
+
+    const loaded = await service.loadConversationWithCompaction(
+      "conv_no_token_threshold",
+    )
+
+    expect(loaded?.messages).toHaveLength(12)
+    expect(loaded?.compaction).toBeUndefined()
   })
 
   it("backfills missing checkpoint metadata without refreshing updatedAt", async () => {

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { createHash } from "crypto"
 import { Writable } from "stream"
 import { pipeline } from "stream/promises"
-import { conversationsFolder } from "./config"
+import { configStore, conversationsFolder } from "./config"
 import { logApp } from "./debug"
 import {
   Conversation,
@@ -17,7 +17,11 @@ import {
   LoadedConversation,
   TitleSource,
 } from "../shared/types"
-import { summarizeContent } from "./context-budget"
+import {
+  estimateTokensFromMessages,
+  getActiveContextTargetTokens,
+  summarizeContent,
+} from "./context-budget"
 import { extractHighSignalFactsFromConversationMessages } from "./conversation-context-builder"
 import { assertSafeConversationId, validateAndSanitizeConversationId } from "./conversation-id"
 import {
@@ -47,6 +51,39 @@ import { scheduleConversationHistoryChanged } from "./conversation-history-event
 const COMPACTION_MESSAGE_THRESHOLD = 20
 // Number of recent messages to keep intact after compaction
 const COMPACTION_KEEP_LAST = 10
+
+function getConfiguredConversationCompactionMessageThreshold(): number {
+  const configured = configStore.get()?.mcpConversationCompactionMessageThreshold
+  return typeof configured === "number" &&
+    Number.isFinite(configured) &&
+    configured >= 2
+    ? Math.floor(configured)
+    : COMPACTION_MESSAGE_THRESHOLD
+}
+
+function getConfiguredConversationCompactionTokenThreshold(): number | undefined {
+  const configured = configStore.get()?.mcpConversationCompactionTokenThreshold
+  return typeof configured === "number" &&
+    Number.isFinite(configured) &&
+    configured >= 1000
+    ? Math.floor(configured)
+    : undefined
+}
+
+async function getConversationCompactionTokenThreshold(): Promise<number | undefined> {
+  const configured = getConfiguredConversationCompactionTokenThreshold()
+  if (configured) return configured
+
+  try {
+    return await getActiveContextTargetTokens()
+  } catch (error) {
+    logApp(
+      "[conversationService] failed to resolve context target tokens for compaction:",
+      error,
+    )
+    return undefined
+  }
+}
 
 // Debounce delay for writing the conversation index to disk (ms)
 const INDEX_WRITE_DEBOUNCE_MS = 500
@@ -1790,7 +1827,20 @@ export class ConversationService {
   private async compactOnLoad(conversation: Conversation, sessionId?: string): Promise<Conversation> {
     const fullMessageHistory = this.getStoredRawMessages(conversation)
     const messageCount = fullMessageHistory.length
-    if (messageCount <= COMPACTION_MESSAGE_THRESHOLD) {
+    const messageThreshold = getConfiguredConversationCompactionMessageThreshold()
+    const tokenThreshold = await getConversationCompactionTokenThreshold()
+    const tokenCount = tokenThreshold
+      ? estimateTokensFromMessages(
+        fullMessageHistory.map((message) => ({
+          role: message.role,
+          content: message.content,
+        })),
+      )
+      : 0
+    if (
+      messageCount <= messageThreshold &&
+      (!tokenThreshold || tokenCount <= tokenThreshold)
+    ) {
       return conversation
     }
 

--- a/apps/desktop/src/main/conversation-service.ts
+++ b/apps/desktop/src/main/conversation-service.ts
@@ -99,6 +99,7 @@ const MAX_CONVERSATION_HISTORY_LAST_MESSAGE_CHARS = 500
 const MAX_CONVERSATION_HISTORY_PREVIEW_CHARS = 200
 const MAX_CONVERSATION_HISTORY_SEARCH_TEXT_CHARS = 8000
 const COMPACTION_EXTRACTED_FACT_LIMIT = 8
+const BACKGROUND_COMPACTION_DELAY_MS = 5000
 
 export interface RepeatTaskConversationBackfillSource {
   taskId: string
@@ -160,6 +161,8 @@ export class ConversationService {
   private indexMutationQueue: Promise<void> = Promise.resolve()
   // Flag to block new per-conversation mutations during deleteAllConversations.
   private deletingAll = false
+  // Dedupes background compaction so repeated live runs do not spawn redundant cleanup work.
+  private scheduledCompactionConversationIds = new Set<string>()
 
   static getInstance(): ConversationService {
     if (!ConversationService.instance) {
@@ -1308,10 +1311,17 @@ export class ConversationService {
     }
   }
 
-  private async persistCompactionCheckpointIfMissing(
+  private getConversationCompactionRevision(conversation: Conversation): string {
+    const fullMessageHistory = this.getStoredRawMessages(conversation)
+    return createHash("sha256")
+      .update(JSON.stringify(fullMessageHistory))
+      .digest("hex")
+  }
+
+  private buildCompactionCheckpointIfMissing(
     conversation: Conversation,
     fullMessageHistory: ConversationMessage[],
-  ): Promise<Conversation> {
+  ): Conversation {
     if (this.hasPersistedCompactionCheckpoint(conversation.compaction)) {
       return conversation
     }
@@ -1349,14 +1359,7 @@ export class ConversationService {
       ),
       updatedAt: conversation.updatedAt,
     }
-
-    try {
-      await this.saveConversation(compactedConversation, true)
-      return compactedConversation
-    } catch (error) {
-      logApp(`[conversationService] compactOnLoad: failed to persist checkpoint backfill, returning original:`, error)
-      return conversation
-    }
+    return compactedConversation
   }
 
 
@@ -1494,28 +1497,94 @@ export class ConversationService {
   }
 
   /**
-   * Load a conversation and compact it if it exceeds the message threshold.
-   * Use this when loading conversations for continued use (e.g., in agent mode).
-   * The compaction is persisted to disk, so subsequent loads will be faster.
+   * Load a conversation for a live agent run.
    *
-   * @param conversationId - The ID of the conversation to load
-   * @param sessionId - Optional session ID for cancellation support during summarization
-   * @returns The conversation (possibly compacted), or null if not found
+   * This must stay cheap: no LLM summarization, no durable compaction, and no
+   * cleanup side effects that can make a user's follow-up wait on maintenance.
    */
-  async loadConversationWithCompaction(conversationId: string, sessionId?: string): Promise<Conversation | null> {
-    const conversation = await this.loadConversation(conversationId)
+  async loadConversationForRun(conversationId: string): Promise<LoadedConversation | null> {
+    return this.loadConversation(conversationId)
+  }
+
+  /**
+   * Schedule best-effort conversation cleanup outside the live prompt path.
+   */
+  scheduleConversationCompaction(conversationId: string, reason: string = "background"): void {
+    if (this.scheduledCompactionConversationIds.has(conversationId)) {
+      return
+    }
+
+    this.scheduledCompactionConversationIds.add(conversationId)
+    setTimeout(() => {
+      void this.compactConversationNow(conversationId, { reason })
+        .catch((error) => {
+          logApp(`[conversationService] background compaction failed for ${conversationId}:`, error)
+        })
+        .finally(() => {
+          this.scheduledCompactionConversationIds.delete(conversationId)
+        })
+    }, BACKGROUND_COMPACTION_DELAY_MS)
+  }
+
+  /**
+   * Explicit maintenance path for durable conversation compaction.
+   *
+   * Do not call this from the pre-response live prompt path; use
+   * loadConversationForRun() there and schedule this after completion/idle.
+   */
+  async compactConversationNow(
+    conversationId: string,
+    options: { sessionId?: string; reason?: string } = {},
+  ): Promise<Conversation | null> {
+    const conversation = await this.enqueueConversationMutation(conversationId, async () =>
+      this.loadConversationFromDisk(conversationId)
+    )
     if (!conversation) {
       return null
     }
 
-    // Compact if needed (this will save to disk if compaction occurs)
-    // Best-effort: if compaction fails, return the original conversation
+    const sourceRevision = this.getConversationCompactionRevision(conversation)
+    let compactedConversation: Conversation
     try {
-      return await this.compactOnLoad(conversation, sessionId)
+      compactedConversation = await this.compactConversationSnapshot(conversation, options.sessionId)
     } catch (error) {
-      logApp(`Failed to compact conversation ${conversationId}, returning original: ${error}`)
+      logApp(`[conversationService] compactConversationNow failed for ${conversationId}, returning original:`, error)
       return conversation
     }
+
+    if (compactedConversation === conversation) {
+      return conversation
+    }
+
+    const preserveTimestamp = compactedConversation.updatedAt === conversation.updatedAt
+    return this.enqueueConversationMutation(conversationId, async () => {
+      const latestConversation = await this.loadConversationFromDisk(conversationId)
+      if (!latestConversation) {
+        return null
+      }
+
+      const latestRevision = this.getConversationCompactionRevision(latestConversation)
+      if (latestRevision !== sourceRevision) {
+        logApp(`[conversationService] compactConversationNow: skipped stale compaction for ${conversationId}`)
+        return latestConversation
+      }
+
+      try {
+        await this.saveConversationUnlocked(compactedConversation, preserveTimestamp)
+        return compactedConversation
+      } catch (error) {
+        logApp(`[conversationService] compactConversationNow: failed to persist, returning original:`, error)
+        return latestConversation
+      }
+    })
+  }
+
+  /**
+   * Backwards-compatible explicit compaction entry point.
+   * Prefer loadConversationForRun() for live agent prompts.
+   */
+  async loadConversationWithCompaction(conversationId: string, sessionId?: string): Promise<Conversation | null> {
+    return this.compactConversationNow(conversationId, { sessionId, reason: "explicit-load" })
   }
 
   async getConversationHistory(): Promise<ConversationHistoryItem[]> {
@@ -1824,7 +1893,7 @@ export class ConversationService {
    * @param sessionId - Optional session ID for cancellation support during summarization
    * @returns The compacted conversation
    */
-  private async compactOnLoad(conversation: Conversation, sessionId?: string): Promise<Conversation> {
+  private async compactConversationSnapshot(conversation: Conversation, sessionId?: string): Promise<Conversation> {
     const fullMessageHistory = this.getStoredRawMessages(conversation)
     const messageCount = fullMessageHistory.length
     const messageThreshold = getConfiguredConversationCompactionMessageThreshold()
@@ -1852,7 +1921,7 @@ export class ConversationService {
       this.getRepresentedMessageCount(conversation) === messageCount &&
       activeNonSummaryCount <= COMPACTION_KEEP_LAST
     ) {
-      return this.persistCompactionCheckpointIfMissing(conversation, fullMessageHistory)
+      return this.buildCompactionCheckpointIfMissing(conversation, fullMessageHistory)
     }
 
     // Calculate how many messages to summarize
@@ -1863,7 +1932,7 @@ export class ConversationService {
       return conversation
     }
 
-    logApp(`[conversationService] compactOnLoad: compacting ${messagesToSummarize.length} messages for ${conversation.id}`)
+    logApp(`[conversationService] compactConversationNow: compacting ${messagesToSummarize.length} messages for ${conversation.id}`)
 
     // Build a summary of the older messages
     const summaryInput = messagesToSummarize
@@ -1906,11 +1975,11 @@ export class ConversationService {
       // Detect this by checking if the result equals or contains the full prompt (failure case).
       // A successful summary should be significantly shorter than the prompt.
       if (summaryContent === summarizationPrompt || summaryContent.length >= summarizationPrompt.length * 0.9) {
-        logApp(`[conversationService] compactOnLoad: summarization likely failed (output too similar to input), keeping original`)
+        logApp(`[conversationService] compactConversationNow: summarization likely failed (output too similar to input), keeping original`)
         return conversation
       }
     } catch (error) {
-      logApp(`[conversationService] compactOnLoad: summarization failed, keeping original:`, error)
+      logApp(`[conversationService] compactConversationNow: summarization failed, keeping original:`, error)
       return conversation
     }
 
@@ -1940,17 +2009,7 @@ export class ConversationService {
       updatedAt: Date.now(),
     }
 
-    // Persist the compacted conversation
-    // Note: saveConversation() already calls updateConversationIndex(), so no need to call it separately
-    // If save fails, return the original conversation (best-effort)
-    try {
-      await this.saveConversation(compactedConversation)
-    } catch (error) {
-      logApp(`[conversationService] compactOnLoad: failed to persist, returning original:`, error)
-      return conversation
-    }
-
-    logApp(`[conversationService] compactOnLoad: compacted ${messagesToSummarize.length} messages into summary, new count: ${compactedConversation.messages.length}`)
+    logApp(`[conversationService] compactConversationNow: compacted ${messagesToSummarize.length} messages into summary, new count: ${compactedConversation.messages.length}`)
     return compactedConversation
   }
 

--- a/apps/desktop/src/main/tipc.ts
+++ b/apps/desktop/src/main/tipc.ts
@@ -670,7 +670,7 @@ async function processWithAgentMode(
 
     if (conversationId) {
       logLLM(`[tipc.ts processWithAgentMode] Loading conversation history for conversationId: ${conversationId}`)
-      const conversation = await conversationService.loadConversationWithCompaction(conversationId, sessionId)
+      const conversation = await conversationService.loadConversationForRun(conversationId)
 
       if (conversation && conversation.messages.length > 0) {
         logLLM(`[tipc.ts processWithAgentMode] Loaded conversation with ${conversation.messages.length} messages`)
@@ -746,6 +746,9 @@ async function processWithAgentMode(
       content: agentResult.content,
       repeatTask: completionRepeatTask,
     })
+    if (conversationId) {
+      conversationService.scheduleConversationCompaction(conversationId, "agent-run-complete")
+    }
 
     return agentResult.content
   } catch (error) {

--- a/apps/desktop/src/renderer/src/pages/settings-general.tsx
+++ b/apps/desktop/src/renderer/src/pages/settings-general.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from "@renderer/components/ui/select"
 import { Switch } from "@renderer/components/ui/switch"
+import { Slider } from "@renderer/components/ui/slider"
 import { STT_PROVIDER_ID, SUPPORTED_LANGUAGES } from "@dotagents/shared"
 import { Textarea } from "@renderer/components/ui/textarea"
 import { Input } from "@renderer/components/ui/input"
@@ -51,6 +52,14 @@ const SETTINGS_TEXT_SAVE_DEBOUNCE_MS = 400
 const MCP_MAX_ITERATIONS_MIN = 1
 const MCP_MAX_ITERATIONS_MAX = 50
 const MCP_MAX_ITERATIONS_DEFAULT = 10
+const MCP_CONTEXT_TARGET_RATIO_PERCENT_MIN = 10
+const MCP_CONTEXT_TARGET_RATIO_PERCENT_MAX = 95
+const MCP_CONTEXT_TARGET_RATIO_PERCENT_DEFAULT = 40
+const MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_MIN = 500
+const MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_DEFAULT = 2000
+const MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_MIN = 2
+const MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_DEFAULT = 20
+const MCP_CONVERSATION_COMPACTION_TOKEN_THRESHOLD_MIN = 1000
 
 type LangfuseDraftKey =
   | "langfusePublicKey"
@@ -74,6 +83,29 @@ function parseMcpMaxIterationsDraft(value: string) {
   )
     return null
   return parsedValue
+}
+
+function parseIntegerDraft(value: string, min: number) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (Number.isNaN(parsedValue) || parsedValue < min) return null
+  return parsedValue
+}
+
+function parseRatioPercentDraft(value: string) {
+  const parsedValue = Number.parseInt(value, 10)
+  if (
+    Number.isNaN(parsedValue) ||
+    parsedValue < MCP_CONTEXT_TARGET_RATIO_PERCENT_MIN ||
+    parsedValue > MCP_CONTEXT_TARGET_RATIO_PERCENT_MAX
+  )
+    return null
+  return parsedValue
+}
+
+function getContextTargetRatioPercent(config: Config | undefined) {
+  return Math.round(
+    (config?.mcpContextTargetRatio ?? 0.4) * 100,
+  )
 }
 
 export function Component() {
@@ -103,6 +135,44 @@ export function Component() {
   const mcpMaxIterationsSaveTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
+  const [mcpContextTargetRatioPercentDraft, setMcpContextTargetRatioPercentDraft] =
+    useState(() => String(getContextTargetRatioPercent(cfg)))
+  const mcpContextTargetRatioSaveTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const [
+    mcpContextSummarizeCharThresholdDraft,
+    setMcpContextSummarizeCharThresholdDraft,
+  ] = useState(() =>
+    String(
+      cfg?.mcpContextSummarizeCharThreshold ??
+        MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_DEFAULT,
+    ),
+  )
+  const mcpContextSummarizeCharThresholdSaveTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const [
+    mcpConversationCompactionMessageThresholdDraft,
+    setMcpConversationCompactionMessageThresholdDraft,
+  ] = useState(() =>
+    String(
+      cfg?.mcpConversationCompactionMessageThreshold ??
+        MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_DEFAULT,
+    ),
+  )
+  const mcpConversationCompactionMessageThresholdSaveTimeoutRef =
+    useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [
+    mcpConversationCompactionTokenThresholdDraft,
+    setMcpConversationCompactionTokenThresholdDraft,
+  ] = useState(() =>
+    cfg?.mcpConversationCompactionTokenThreshold
+      ? String(cfg.mcpConversationCompactionTokenThreshold)
+      : "",
+  )
+  const mcpConversationCompactionTokenThresholdSaveTimeoutRef =
+    useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Settings search
   const [searchQuery, setSearchQuery] = useState("")
@@ -261,6 +331,38 @@ export function Component() {
   }, [cfg?.mcpMaxIterations])
 
   useEffect(() => {
+    setMcpContextTargetRatioPercentDraft(
+      String(getContextTargetRatioPercent(cfg)),
+    )
+  }, [cfg?.mcpContextTargetRatio])
+
+  useEffect(() => {
+    setMcpContextSummarizeCharThresholdDraft(
+      String(
+        cfg?.mcpContextSummarizeCharThreshold ??
+          MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_DEFAULT,
+      ),
+    )
+  }, [cfg?.mcpContextSummarizeCharThreshold])
+
+  useEffect(() => {
+    setMcpConversationCompactionMessageThresholdDraft(
+      String(
+        cfg?.mcpConversationCompactionMessageThreshold ??
+          MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_DEFAULT,
+      ),
+    )
+  }, [cfg?.mcpConversationCompactionMessageThreshold])
+
+  useEffect(() => {
+    setMcpConversationCompactionTokenThresholdDraft(
+      cfg?.mcpConversationCompactionTokenThreshold
+        ? String(cfg.mcpConversationCompactionTokenThreshold)
+        : "",
+    )
+  }, [cfg?.mcpConversationCompactionTokenThreshold])
+
+  useEffect(() => {
     return () => {
       for (const timeout of Object.values(
         langfuseSaveTimeoutsRef.current,
@@ -274,6 +376,26 @@ export function Component() {
 
       if (mcpMaxIterationsSaveTimeoutRef.current) {
         clearTimeout(mcpMaxIterationsSaveTimeoutRef.current)
+      }
+
+      if (mcpContextTargetRatioSaveTimeoutRef.current) {
+        clearTimeout(mcpContextTargetRatioSaveTimeoutRef.current)
+      }
+
+      if (mcpContextSummarizeCharThresholdSaveTimeoutRef.current) {
+        clearTimeout(mcpContextSummarizeCharThresholdSaveTimeoutRef.current)
+      }
+
+      if (mcpConversationCompactionMessageThresholdSaveTimeoutRef.current) {
+        clearTimeout(
+          mcpConversationCompactionMessageThresholdSaveTimeoutRef.current,
+        )
+      }
+
+      if (mcpConversationCompactionTokenThresholdSaveTimeoutRef.current) {
+        clearTimeout(
+          mcpConversationCompactionTokenThresholdSaveTimeoutRef.current,
+        )
       }
     }
   }, [])
@@ -397,6 +519,245 @@ export function Component() {
       scheduleMcpMaxIterationsSave(value)
     },
     [scheduleMcpMaxIterationsSave],
+  )
+
+  const flushMcpContextTargetRatioSave = useCallback(
+    (value: string) => {
+      if (mcpContextTargetRatioSaveTimeoutRef.current) {
+        clearTimeout(mcpContextTargetRatioSaveTimeoutRef.current)
+        mcpContextTargetRatioSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseRatioPercentDraft(value)
+      if (parsedValue === null) {
+        setMcpContextTargetRatioPercentDraft(
+          String(getContextTargetRatioPercent(cfgRef.current)),
+        )
+        return
+      }
+
+      saveConfig({ mcpContextTargetRatio: parsedValue / 100 })
+    },
+    [saveConfig],
+  )
+
+  const scheduleMcpContextTargetRatioSave = useCallback(
+    (value: string) => {
+      if (mcpContextTargetRatioSaveTimeoutRef.current) {
+        clearTimeout(mcpContextTargetRatioSaveTimeoutRef.current)
+        mcpContextTargetRatioSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseRatioPercentDraft(value)
+      if (parsedValue === null) return
+
+      mcpContextTargetRatioSaveTimeoutRef.current = setTimeout(() => {
+        mcpContextTargetRatioSaveTimeoutRef.current = null
+        saveConfig({ mcpContextTargetRatio: parsedValue / 100 })
+      }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
+
+  const updateMcpContextTargetRatioPercentDraft = useCallback(
+    (value: string) => {
+      setMcpContextTargetRatioPercentDraft(value)
+      scheduleMcpContextTargetRatioSave(value)
+    },
+    [scheduleMcpContextTargetRatioSave],
+  )
+
+  const flushMcpContextSummarizeCharThresholdSave = useCallback(
+    (value: string) => {
+      if (mcpContextSummarizeCharThresholdSaveTimeoutRef.current) {
+        clearTimeout(mcpContextSummarizeCharThresholdSaveTimeoutRef.current)
+        mcpContextSummarizeCharThresholdSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseIntegerDraft(
+        value,
+        MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_MIN,
+      )
+      if (parsedValue === null) {
+        setMcpContextSummarizeCharThresholdDraft(
+          String(
+            cfgRef.current?.mcpContextSummarizeCharThreshold ??
+              MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_DEFAULT,
+          ),
+        )
+        return
+      }
+
+      saveConfig({ mcpContextSummarizeCharThreshold: parsedValue })
+    },
+    [saveConfig],
+  )
+
+  const scheduleMcpContextSummarizeCharThresholdSave = useCallback(
+    (value: string) => {
+      if (mcpContextSummarizeCharThresholdSaveTimeoutRef.current) {
+        clearTimeout(mcpContextSummarizeCharThresholdSaveTimeoutRef.current)
+        mcpContextSummarizeCharThresholdSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseIntegerDraft(
+        value,
+        MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_MIN,
+      )
+      if (parsedValue === null) return
+
+      mcpContextSummarizeCharThresholdSaveTimeoutRef.current = setTimeout(
+        () => {
+          mcpContextSummarizeCharThresholdSaveTimeoutRef.current = null
+          saveConfig({ mcpContextSummarizeCharThreshold: parsedValue })
+        },
+        SETTINGS_TEXT_SAVE_DEBOUNCE_MS,
+      )
+    },
+    [saveConfig],
+  )
+
+  const updateMcpContextSummarizeCharThresholdDraft = useCallback(
+    (value: string) => {
+      setMcpContextSummarizeCharThresholdDraft(value)
+      scheduleMcpContextSummarizeCharThresholdSave(value)
+    },
+    [scheduleMcpContextSummarizeCharThresholdSave],
+  )
+
+  const flushMcpConversationCompactionMessageThresholdSave = useCallback(
+    (value: string) => {
+      if (mcpConversationCompactionMessageThresholdSaveTimeoutRef.current) {
+        clearTimeout(
+          mcpConversationCompactionMessageThresholdSaveTimeoutRef.current,
+        )
+        mcpConversationCompactionMessageThresholdSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseIntegerDraft(
+        value,
+        MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_MIN,
+      )
+      if (parsedValue === null) {
+        setMcpConversationCompactionMessageThresholdDraft(
+          String(
+            cfgRef.current?.mcpConversationCompactionMessageThreshold ??
+              MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_DEFAULT,
+          ),
+        )
+        return
+      }
+
+      saveConfig({ mcpConversationCompactionMessageThreshold: parsedValue })
+    },
+    [saveConfig],
+  )
+
+  const scheduleMcpConversationCompactionMessageThresholdSave = useCallback(
+    (value: string) => {
+      if (mcpConversationCompactionMessageThresholdSaveTimeoutRef.current) {
+        clearTimeout(
+          mcpConversationCompactionMessageThresholdSaveTimeoutRef.current,
+        )
+        mcpConversationCompactionMessageThresholdSaveTimeoutRef.current = null
+      }
+
+      const parsedValue = parseIntegerDraft(
+        value,
+        MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_MIN,
+      )
+      if (parsedValue === null) return
+
+      mcpConversationCompactionMessageThresholdSaveTimeoutRef.current =
+        setTimeout(() => {
+          mcpConversationCompactionMessageThresholdSaveTimeoutRef.current = null
+          saveConfig({
+            mcpConversationCompactionMessageThreshold: parsedValue,
+          })
+        }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
+
+  const updateMcpConversationCompactionMessageThresholdDraft = useCallback(
+    (value: string) => {
+      setMcpConversationCompactionMessageThresholdDraft(value)
+      scheduleMcpConversationCompactionMessageThresholdSave(value)
+    },
+    [scheduleMcpConversationCompactionMessageThresholdSave],
+  )
+
+  const flushMcpConversationCompactionTokenThresholdSave = useCallback(
+    (value: string) => {
+      if (mcpConversationCompactionTokenThresholdSaveTimeoutRef.current) {
+        clearTimeout(
+          mcpConversationCompactionTokenThresholdSaveTimeoutRef.current,
+        )
+        mcpConversationCompactionTokenThresholdSaveTimeoutRef.current = null
+      }
+
+      if (!value.trim()) {
+        saveConfig({ mcpConversationCompactionTokenThreshold: undefined })
+        return
+      }
+
+      const parsedValue = parseIntegerDraft(
+        value,
+        MCP_CONVERSATION_COMPACTION_TOKEN_THRESHOLD_MIN,
+      )
+      if (parsedValue === null) {
+        setMcpConversationCompactionTokenThresholdDraft(
+          cfgRef.current?.mcpConversationCompactionTokenThreshold
+            ? String(cfgRef.current.mcpConversationCompactionTokenThreshold)
+            : "",
+        )
+        return
+      }
+
+      saveConfig({ mcpConversationCompactionTokenThreshold: parsedValue })
+    },
+    [saveConfig],
+  )
+
+  const scheduleMcpConversationCompactionTokenThresholdSave = useCallback(
+    (value: string) => {
+      if (mcpConversationCompactionTokenThresholdSaveTimeoutRef.current) {
+        clearTimeout(
+          mcpConversationCompactionTokenThresholdSaveTimeoutRef.current,
+        )
+        mcpConversationCompactionTokenThresholdSaveTimeoutRef.current = null
+      }
+
+      if (!value.trim()) {
+        mcpConversationCompactionTokenThresholdSaveTimeoutRef.current =
+          setTimeout(() => {
+            mcpConversationCompactionTokenThresholdSaveTimeoutRef.current = null
+            saveConfig({ mcpConversationCompactionTokenThreshold: undefined })
+          }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+        return
+      }
+
+      const parsedValue = parseIntegerDraft(
+        value,
+        MCP_CONVERSATION_COMPACTION_TOKEN_THRESHOLD_MIN,
+      )
+      if (parsedValue === null) return
+
+      mcpConversationCompactionTokenThresholdSaveTimeoutRef.current =
+        setTimeout(() => {
+          mcpConversationCompactionTokenThresholdSaveTimeoutRef.current = null
+          saveConfig({ mcpConversationCompactionTokenThreshold: parsedValue })
+        }, SETTINGS_TEXT_SAVE_DEBOUNCE_MS)
+    },
+    [saveConfig],
+  )
+
+  const updateMcpConversationCompactionTokenThresholdDraft = useCallback(
+    (value: string) => {
+      setMcpConversationCompactionTokenThresholdDraft(value)
+      scheduleMcpConversationCompactionTokenThresholdSave(value)
+    },
+    [scheduleMcpConversationCompactionTokenThresholdSave],
   )
 
   // Sync theme preference from config to localStorage when config loads
@@ -698,6 +1059,147 @@ export function Component() {
                 />
               </Control>
             )}
+
+            <Control
+              label={
+                <ControlLabel
+                  label="Context Compaction"
+                  tooltip="Tune when older context is summarized automatically. The ratio is applied to the active model's context window."
+                />
+              }
+              className="px-3"
+            >
+              <div className="space-y-3">
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-muted-foreground text-xs">
+                      Context window ratio
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <Input
+                        type="number"
+                        min={String(MCP_CONTEXT_TARGET_RATIO_PERCENT_MIN)}
+                        max={String(MCP_CONTEXT_TARGET_RATIO_PERCENT_MAX)}
+                        step="5"
+                        value={mcpContextTargetRatioPercentDraft}
+                        onChange={(e) =>
+                          updateMcpContextTargetRatioPercentDraft(
+                            e.currentTarget.value,
+                          )
+                        }
+                        onBlur={(e) =>
+                          flushMcpContextTargetRatioSave(
+                            e.currentTarget.value,
+                          )
+                        }
+                        placeholder={String(
+                          MCP_CONTEXT_TARGET_RATIO_PERCENT_DEFAULT,
+                        )}
+                        className="h-7 w-16 text-right"
+                      />
+                      <span className="text-muted-foreground text-xs">%</span>
+                    </div>
+                  </div>
+                  <Slider
+                    value={[
+                      parseRatioPercentDraft(
+                        mcpContextTargetRatioPercentDraft,
+                      ) ?? MCP_CONTEXT_TARGET_RATIO_PERCENT_DEFAULT,
+                    ]}
+                    min={MCP_CONTEXT_TARGET_RATIO_PERCENT_MIN}
+                    max={MCP_CONTEXT_TARGET_RATIO_PERCENT_MAX}
+                    step={5}
+                    onValueChange={(value) => {
+                      const nextValue = value[0]
+                      if (typeof nextValue !== "number") return
+                      updateMcpContextTargetRatioPercentDraft(
+                        String(nextValue),
+                      )
+                    }}
+                    className="w-full"
+                  />
+                </div>
+                <div className="grid gap-2 sm:grid-cols-3">
+                  <label className="space-y-1.5">
+                    <span className="text-muted-foreground text-xs">
+                      Summary chars
+                    </span>
+                    <Input
+                      type="number"
+                      min={String(MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_MIN)}
+                      step="100"
+                      value={mcpContextSummarizeCharThresholdDraft}
+                      onChange={(e) =>
+                        updateMcpContextSummarizeCharThresholdDraft(
+                          e.currentTarget.value,
+                        )
+                      }
+                      onBlur={(e) =>
+                        flushMcpContextSummarizeCharThresholdSave(
+                          e.currentTarget.value,
+                        )
+                      }
+                      placeholder={String(
+                        MCP_CONTEXT_SUMMARIZE_CHAR_THRESHOLD_DEFAULT,
+                      )}
+                      className="h-8 w-full"
+                    />
+                  </label>
+                  <label className="space-y-1.5">
+                    <span className="text-muted-foreground text-xs">
+                      Messages
+                    </span>
+                    <Input
+                      type="number"
+                      min={String(
+                        MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_MIN,
+                      )}
+                      step="1"
+                      value={mcpConversationCompactionMessageThresholdDraft}
+                      onChange={(e) =>
+                        updateMcpConversationCompactionMessageThresholdDraft(
+                          e.currentTarget.value,
+                        )
+                      }
+                      onBlur={(e) =>
+                        flushMcpConversationCompactionMessageThresholdSave(
+                          e.currentTarget.value,
+                        )
+                      }
+                      placeholder={String(
+                        MCP_CONVERSATION_COMPACTION_MESSAGE_THRESHOLD_DEFAULT,
+                      )}
+                      className="h-8 w-full"
+                    />
+                  </label>
+                  <label className="space-y-1.5">
+                    <span className="text-muted-foreground text-xs">
+                      Token override
+                    </span>
+                    <Input
+                      type="number"
+                      min={String(
+                        MCP_CONVERSATION_COMPACTION_TOKEN_THRESHOLD_MIN,
+                      )}
+                      step="1000"
+                      value={mcpConversationCompactionTokenThresholdDraft}
+                      onChange={(e) =>
+                        updateMcpConversationCompactionTokenThresholdDraft(
+                          e.currentTarget.value,
+                        )
+                      }
+                      onBlur={(e) =>
+                        flushMcpConversationCompactionTokenThresholdSave(
+                          e.currentTarget.value,
+                        )
+                      }
+                      placeholder="Use ratio"
+                      className="h-8 w-full"
+                    />
+                  </label>
+                </div>
+              </div>
+            </Control>
 
             <Control
               label={

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -1430,6 +1430,8 @@ export type Config = {
   mcpContextTargetRatio?: number
   mcpContextLastNMessages?: number
   mcpContextSummarizeCharThreshold?: number
+  mcpConversationCompactionMessageThreshold?: number
+  mcpConversationCompactionTokenThreshold?: number
   mcpMaxContextTokensOverride?: number
 
   // Tool Response Processing Configuration

--- a/apps/desktop/tests/settings-general-context-compaction.test.mjs
+++ b/apps/desktop/tests/settings-general-context-compaction.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const settingsGeneralSource = fs.readFileSync(
+  path.join(process.cwd(), 'apps/desktop/src/renderer/src/pages/settings-general.tsx'),
+  'utf8',
+)
+
+const compactionControl = settingsGeneralSource.match(
+  /<Control[\s\S]*?label="Context Compaction"[\s\S]*?<\/Control>/,
+)?.[0] ?? ''
+
+test('desktop settings exposes compact context compaction threshold controls', () => {
+  assert.ok(compactionControl, 'expected to find the Context Compaction control')
+  assert.match(compactionControl, /Context window ratio/)
+  assert.match(compactionControl, /Summary chars/)
+  assert.match(compactionControl, /Messages/)
+  assert.match(compactionControl, /Token override/)
+  assert.match(compactionControl, /sm:grid-cols-3/)
+  assert.match(compactionControl, /placeholder="Use ratio"/)
+})
+
+test('desktop settings saves all context compaction threshold config keys', () => {
+  assert.match(settingsGeneralSource, /mcpContextTargetRatioPercentDraft/)
+  assert.match(settingsGeneralSource, /mcpContextTargetRatio: parsedValue \/ 100/)
+  assert.match(settingsGeneralSource, /mcpContextSummarizeCharThresholdDraft/)
+  assert.match(settingsGeneralSource, /saveConfig\(\{ mcpContextSummarizeCharThreshold: parsedValue \}\)/)
+  assert.match(settingsGeneralSource, /mcpConversationCompactionMessageThresholdDraft/)
+  assert.match(settingsGeneralSource, /mcpConversationCompactionMessageThreshold: parsedValue/)
+  assert.match(settingsGeneralSource, /mcpConversationCompactionTokenThresholdDraft/)
+  assert.match(settingsGeneralSource, /mcpConversationCompactionTokenThreshold: parsedValue/)
+  assert.match(settingsGeneralSource, /mcpConversationCompactionTokenThreshold: undefined/)
+})

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -306,6 +306,7 @@ const getConfig = (): LoadedConfig => {
     mcpContextTargetRatio: 0.4,
     mcpContextLastNMessages: 3,
     mcpContextSummarizeCharThreshold: 2000,
+    mcpConversationCompactionMessageThreshold: 20,
 
     // Tool response processing defaults
     mcpToolResponseProcessingEnabled: true,


### PR DESCRIPTION
## Summary
- Adds Settings > Agent Settings controls for context compaction thresholds.
- Uses the active model context target as the default saved-conversation token compaction budget, with an optional absolute token override.
- Moves saved-conversation compaction off the live prompt path so follow-up prompts do not wait on old-history summarization.
- Schedules delayed, deduped background compaction after agent completion and skips stale compaction if the conversation changes mid-summary.

## Root Cause
The live agent follow-up path loaded conversation history through a method that could synchronously compact old history. For long conversations, that could trigger serial LLM summarization calls before the new prompt was handled, making the UI sit on “thinking” for tens of seconds.

## Validation
- `CI=1 pnpm --filter @dotagents/desktop test -- conversation-service.lazy-load.test.ts`
- `node --test apps/desktop/tests/settings-general-context-compaction.test.mjs`
- `CI=1 pnpm --filter @dotagents/desktop typecheck`
- `CI=1 pnpm typecheck`

## Notes
- PR is ready for review.
- Left unrelated local changes out of this PR: `apps/mobile/src/store/sessions.ts`, `apps/mobile/src/store/sessions.storage.test.ts`, and `apps/desktop/heroic`.
