### PR TITLE
Add profile-scoped local context control

### DIFF
--- a/apps/desktop/resources/bundled-skills/dotagents-config-admin/SKILL.md
+++ b/apps/desktop/resources/bundled-skills/dotagents-config-admin/SKILL.md
@@ -71,6 +71,7 @@ Edit `mcp.json` for MCP server definitions and enablement-related config.
 
 - Edit `agents/<id>/agent.md` for identity, display text, role, and other frontmatter-friendly fields
 - Edit `agents/<id>/config.json` for nested config like connection, tools, models, or skills config
+- To keep an isolated agent from receiving DotAgents-owned knowledge, stored-conversation/config locations, and runtime filesystem manifests, set `"promptConfig": { "includeLocalContext": false }` in `agents/<id>/config.json`. The default is `true`, and current conversation history is unaffected.
 
 ### Change a skill
 

--- a/apps/desktop/src/main/agent-profile-service.test.ts
+++ b/apps/desktop/src/main/agent-profile-service.test.ts
@@ -70,4 +70,14 @@ describe("agentProfileService skills", () => {
     expect(agentProfileService.hasAllSkillsEnabledByDefault(profile.id)).toBe(true)
     expect(agentProfileService.getEnabledSkillIdsForProfile(profile.id)).toBeNull()
   })
+
+  it("captures prompt context settings in a session snapshot", async () => {
+    const { agentProfileService, createSessionSnapshotFromProfile } = await import("./agent-profile-service")
+    const profile = agentProfileService.getAll()[0]
+    profile.promptConfig = { includeLocalContext: false }
+
+    expect(createSessionSnapshotFromProfile(profile).promptConfig).toEqual({
+      includeLocalContext: false,
+    })
+  })
 })

--- a/apps/desktop/src/main/agent-profile-service.ts
+++ b/apps/desktop/src/main/agent-profile-service.ts
@@ -179,6 +179,7 @@ export function createSessionSnapshotFromProfile(
     skillsInstructions,
     agentProperties: profile.properties,
     skillsConfig: profile.skillsConfig,
+    promptConfig: profile.promptConfig,
   }
 }
 

--- a/apps/desktop/src/main/context-budget.ts
+++ b/apps/desktop/src/main/context-budget.ts
@@ -1867,6 +1867,8 @@ export interface ShrinkOptions {
   skillsIndex?: string
   /** Optional absolute filesystem locations to preserve when using Tier-3 minimal prompts. */
   filesystemContext?: string
+  /** Whether Tier-3 prompts may include DotAgents-owned local context guidance. */
+  includeLocalContext?: boolean
   isAgentMode?: boolean
   targetRatio?: number // default 0.4
   lastNMessages?: number // default 3
@@ -2289,6 +2291,7 @@ export async function shrinkMessagesForLLM(opts: ShrinkOptions): Promise<ShrinkR
     opts.relevantTools,
     opts.skillsIndex,
     opts.filesystemContext,
+    opts.includeLocalContext !== false,
   )
   if (systemMsgIdx >= 0) {
     messages[systemMsgIdx] = { role: "system", content: minimal }

--- a/apps/desktop/src/main/llm.ts
+++ b/apps/desktop/src/main/llm.ts
@@ -577,15 +577,21 @@ export async function processTranscriptWithTools(
     : enabledSkillIdsOrNull
   const skillsInstructions = skillsService.getEnabledSkillsInstructionsForProfile(enabledSkillIds)
   const skillsIndex = extractSkillsIndexForMinimalPrompt(skillsInstructions)
+  const promptConfig = mainAgent?.promptConfig
+  const includeLocalContext = promptConfig?.includeLocalContext !== false
 
   const workspaceAgentsFolder = resolveWorkspaceAgentsFolder()
-  const workingNotes = loadWorkingKnowledgeNotesForPrompt({
-    globalAgentsDir: globalAgentsFolder,
-    workspaceAgentsDir: workspaceAgentsFolder,
-    maxNotes: NON_AGENT_WORKING_NOTES_LIMIT,
-  })
+  const workingNotes = includeLocalContext
+    ? loadWorkingKnowledgeNotesForPrompt({
+        globalAgentsDir: globalAgentsFolder,
+        workspaceAgentsDir: workspaceAgentsFolder,
+        maxNotes: NON_AGENT_WORKING_NOTES_LIMIT,
+      })
+    : []
   logLLM(`[processTranscriptWithLLM] Loaded ${workingNotes.length} working notes for prompt context`)
-  const filesystemContext = buildFilesystemContextForPrompt(uniqueAvailableTools)
+  const filesystemContext = includeLocalContext
+    ? buildFilesystemContextForPrompt(uniqueAvailableTools)
+    : undefined
 
   const systemPrompt = constructSystemPrompt(
     uniqueAvailableTools,
@@ -598,6 +604,7 @@ export async function processTranscriptWithTools(
     workingNotes,
     undefined,
     filesystemContext,
+    promptConfig,
   )
 
   const messages = [
@@ -617,6 +624,7 @@ export async function processTranscriptWithTools(
     isAgentMode: false,
     skillsIndex,
     filesystemContext,
+    includeLocalContext,
   })
 
   const chatProviderId = config.mcpToolsProviderId
@@ -1631,6 +1639,8 @@ export async function processTranscriptWithAgentMode(
   const agentSkillsInstructions = effectiveProfileSnapshot?.skillsInstructions
   // Get agent properties from profile snapshot (dynamic key-value pairs)
   const agentProperties = effectiveProfileSnapshot?.agentProperties
+  const promptConfig = effectiveProfileSnapshot?.promptConfig ?? mainAgent?.promptConfig
+  const includeLocalContext = promptConfig?.includeLocalContext !== false
 
   // Load enabled agent skills instructions for the current profile
   // Skills provide specialized instructions that improve AI performance on specific tasks
@@ -1656,13 +1666,17 @@ export async function processTranscriptWithAgentMode(
   const skillsIndex = extractSkillsIndexForMinimalPrompt(skillsInstructions)
 
   const workspaceAgentsFolder = resolveWorkspaceAgentsFolder()
-  const workingNotes = loadWorkingKnowledgeNotesForPrompt({
-    globalAgentsDir: globalAgentsFolder,
-    workspaceAgentsDir: workspaceAgentsFolder,
-    maxNotes: AGENT_WORKING_NOTES_LIMIT,
-  })
+  const workingNotes = includeLocalContext
+    ? loadWorkingKnowledgeNotesForPrompt({
+        globalAgentsDir: globalAgentsFolder,
+        workspaceAgentsDir: workspaceAgentsFolder,
+        maxNotes: AGENT_WORKING_NOTES_LIMIT,
+      })
+    : []
   logLLM(`[processTranscriptWithAgentMode] Loaded ${workingNotes.length} working notes for prompt context`)
-  const filesystemContext = buildFilesystemContextForPrompt(baseAvailableTools, currentSessionId)
+  const filesystemContext = includeLocalContext
+    ? buildFilesystemContextForPrompt(baseAvailableTools, currentSessionId)
+    : undefined
 
   // The agent's profile ID is used to exclude itself from delegation targets in the system prompt
   const excludeAgentId = effectiveProfileSnapshot?.profileId
@@ -1679,6 +1693,7 @@ export async function processTranscriptWithAgentMode(
     workingNotes, // injected working notes
     excludeAgentId, // exclude this agent from delegation targets
     filesystemContext,
+    promptConfig,
   )
 
   logLLM(`[llm.ts processTranscriptWithAgentMode] Initializing conversationHistory for session ${currentSessionId}`)
@@ -2011,6 +2026,7 @@ export async function processTranscriptWithAgentMode(
       workingNotes, // injected working notes
       excludeAgentId, // exclude this agent from delegation targets
       filesystemContext,
+      promptConfig,
     )
 
     const postVerifySummaryMessages = [
@@ -2025,6 +2041,7 @@ export async function processTranscriptWithAgentMode(
       isAgentMode: true,
       skillsIndex,
       filesystemContext,
+      includeLocalContext,
       sessionId: currentSessionId,
       onSummarizationProgress: (current, total) => {
         const lastThinkingStep = progressSteps.findLast(step => step.type === "thinking")
@@ -2383,6 +2400,7 @@ export async function processTranscriptWithAgentMode(
           workingNotes, // injected working notes
           excludeAgentId, // exclude this agent from delegation targets
           filesystemContext,
+          promptConfig,
         )
         lastExcludedToolCount = excludedToolCount
         logLLM(`[processTranscriptWithAgentMode] Rebuilt system prompt with ${activeTools.length} active tools (excluded ${excludedToolCount})`)
@@ -2494,6 +2512,7 @@ export async function processTranscriptWithAgentMode(
       isAgentMode: true,
       skillsIndex,
       filesystemContext,
+      includeLocalContext,
       sessionId: currentSessionId,
       onSummarizationProgress: (current, total, message) => {
         // Update thinking step with summarization progress
@@ -3756,6 +3775,7 @@ export async function processTranscriptWithAgentMode(
           workingNotes, // injected working notes
           excludeAgentId, // exclude this agent from delegation targets
           filesystemContext,
+          promptConfig,
         )
 
         const summaryMessages = [
@@ -3770,6 +3790,7 @@ export async function processTranscriptWithAgentMode(
           isAgentMode: true,
           skillsIndex,
           filesystemContext,
+          includeLocalContext,
           sessionId: currentSessionId,
           onSummarizationProgress: (current, total) => {
             summaryStep.description = `Summarizing for summary generation (${current}/${total})`

--- a/apps/desktop/src/main/system-prompts.test.ts
+++ b/apps/desktop/src/main/system-prompts.test.ts
@@ -149,6 +149,37 @@ describe("constructSystemPrompt", () => {
     expect(prompt).toContain("Skills, settings, knowledge, tasks, prompts, runtime metadata, and past conversations are files")
   })
 
+  it("can isolate a profile from DotAgents-owned local context", async () => {
+    const { constructSystemPrompt } = await import("./system-prompts")
+
+    const prompt = constructSystemPrompt(
+      [
+        { name: "execute_command", description: "Execute command", inputSchema: { type: "object", properties: {} } },
+      ] as any,
+      undefined,
+      true,
+      undefined,
+      "Isolated profile prompt.",
+      undefined,
+      undefined,
+      [{ id: "private-note", title: "Private", context: "auto", body: "Do not inject me." } as any],
+      undefined,
+      "Global .agents: /tmp/private/.agents",
+      { includeLocalContext: false },
+    )
+
+    expect(prompt).toContain("Isolated profile prompt.")
+    expect(prompt).toContain("AGENT MODE")
+    expect(prompt).toContain("AGENT FILE & COMMAND EXECUTION")
+    expect(prompt).toContain("DOTAGENTS TOOLS: execute_command")
+    expect(prompt).not.toContain("LOCAL MEMORY & CONFIG")
+    expect(prompt).not.toContain("FILESYSTEM LOCATIONS")
+    expect(prompt).not.toContain("WORKING NOTES")
+    expect(prompt).not.toContain("Do not inject me")
+    expect(prompt).not.toContain("DOTAGENTS_RUNTIME_DIR")
+    expect(prompt).not.toContain("past conversations are files")
+  })
+
   it("keeps local memory guidance available outside agent mode", async () => {
     const { constructSystemPrompt } = await import("./system-prompts")
 
@@ -212,6 +243,26 @@ describe("constructSystemPrompt", () => {
     expect(prompt).toContain("When file tools are unavailable")
     expect(prompt).not.toContain("use execute_command on both knowledge notes")
     expect(prompt).not.toContain("DOTAGENTS_TOOL_MANIFEST")
+  })
+
+  it("keeps local context disabled in the minimal fallback prompt", async () => {
+    const { constructMinimalSystemPrompt } = await import("./system-prompts")
+
+    const prompt = constructMinimalSystemPrompt(
+      [{ name: "execute_command", description: "Execute command", inputSchema: { type: "object", properties: {} } }],
+      true,
+      undefined,
+      undefined,
+      "Global .agents: /tmp/private/.agents",
+      false,
+    )
+
+    expect(prompt).toContain("AVAILABLE DOTAGENTS RUNTIME TOOLS")
+    expect(prompt).toContain("execute_command")
+    expect(prompt).toContain("Use only the provided conversation context for prior state")
+    expect(prompt).not.toContain("FILESYSTEM LOCATIONS")
+    expect(prompt).not.toContain("DOTAGENTS_RUNTIME_DIR")
+    expect(prompt).not.toContain("index.json")
   })
 
   it("separates MCP tools from DotAgents runtime tools in the full prompt", async () => {

--- a/apps/desktop/src/main/system-prompts.ts
+++ b/apps/desktop/src/main/system-prompts.ts
@@ -2,7 +2,7 @@ import { acpSmartRouter } from './acp/acp-smart-router'
 import { acpService } from './acp-service'
 import { getInternalAgentInfo } from './acp/internal-agent'
 import { agentProfileService } from './agent-profile-service'
-import type { KnowledgeNote } from "@dotagents/core"
+import type { KnowledgeNote, ProfilePromptConfig } from "@dotagents/core"
 
 import { DEFAULT_SYSTEM_PROMPT } from './system-prompts-default'
 
@@ -97,7 +97,7 @@ function hasPromptTool(tools: PromptTool[], toolName: string): boolean {
   return tools.some((tool) => tool.name === toolName)
 }
 
-function getAgentModeAdditions(availableTools: PromptTool[]): string {
+function getAgentModeAdditions(availableTools: PromptTool[], includeLocalContext: boolean): string {
   const hasRespondToUser = hasPromptTool(availableTools, 'respond_to_user')
   const hasMarkWorkComplete = hasPromptTool(availableTools, 'mark_work_complete')
   const hasExecuteCommand = hasPromptTool(availableTools, 'execute_command')
@@ -153,12 +153,18 @@ function getAgentModeAdditions(availableTools: PromptTool[]): string {
   }
 
   if (hasExecuteCommand) {
-    sections.push(`AGENT FILE & COMMAND EXECUTION:
-- Use execute_command for shell/file automation. Infer package manager from lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lock*) and do not default to npm against another lockfile.
-- For planning/status/context, prefer read-only probes (git status, ls, find, rg, sed/head/tail/cat). Do not run install/test/build/lint/typecheck unless asked or validating your code changes.
-- Before reading large files, check size (wc -l) and read targeted ranges with sed/head/tail; avoid cat on large files. Output over 10K chars is truncated.
-- Skills, settings, knowledge, tasks, prompts, runtime metadata, and past conversations are files. Use the absolute paths shown in this prompt when available; otherwise discover with filesystem search.
-- For rare runtime discovery, inspect $DOTAGENTS_RUNTIME_DIR, $DOTAGENTS_AGENT_REGISTRY, $DOTAGENTS_TOOL_MANIFEST, or $DOTAGENTS_TOOL_SCHEMA_DIR with execute_command instead of expecting list/schema helper tools.`)
+    const executionGuidance = [
+      "- Use execute_command for shell/file automation. Infer package manager from lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, bun.lock*) and do not default to npm against another lockfile.",
+      "- For planning/status/context, prefer read-only probes (git status, ls, find, rg, sed/head/tail/cat). Do not run install/test/build/lint/typecheck unless asked or validating your code changes.",
+      "- Before reading large files, check size (wc -l) and read targeted ranges with sed/head/tail; avoid cat on large files. Output over 10K chars is truncated.",
+    ]
+    if (includeLocalContext) {
+      executionGuidance.push(
+        "- Skills, settings, knowledge, tasks, prompts, runtime metadata, and past conversations are files. Use the absolute paths shown in this prompt when available; otherwise discover with filesystem search.",
+        "- For rare runtime discovery, inspect $DOTAGENTS_RUNTIME_DIR, $DOTAGENTS_AGENT_REGISTRY, $DOTAGENTS_TOOL_MANIFEST, or $DOTAGENTS_TOOL_SCHEMA_DIR with execute_command instead of expecting list/schema helper tools.",
+      )
+    }
+    sections.push(`AGENT FILE & COMMAND EXECUTION:\n${executionGuidance.join("\n")}`)
   }
 
   if (hasSetSessionTitle) {
@@ -345,8 +351,10 @@ export function constructSystemPrompt(
   workingNotes?: KnowledgeNote[],
   excludeAgentId?: string,
   filesystemContext?: string,
+  promptConfig?: ProfilePromptConfig,
 ): string {
   let prompt = getEffectiveSystemPrompt(customSystemPrompt)
+  const includeLocalContext = promptConfig?.includeLocalContext !== false
 
   // Inject local date/time so the LLM can reason about relative dates and timestamps.
   const now = new Date()
@@ -354,14 +362,16 @@ export function constructSystemPrompt(
   const compactNow = formatPromptNow(now, tz)
   prompt += `\n\nNow: ${compactNow} ${tz}`
 
-  if (filesystemContext?.trim()) {
+  if (includeLocalContext && filesystemContext?.trim()) {
     prompt += `\n\nFILESYSTEM LOCATIONS:\n${filesystemContext.trim()}`
   }
 
-  prompt += `\n\n${getLocalMemoryAndConfigPrompt(hasPromptTool(availableTools, 'execute_command'))}`
+  if (includeLocalContext) {
+    prompt += `\n\n${getLocalMemoryAndConfigPrompt(hasPromptTool(availableTools, 'execute_command'))}`
+  }
 
   if (isAgentMode) {
-    prompt += getAgentModeAdditions(availableTools)
+    prompt += getAgentModeAdditions(availableTools, includeLocalContext)
 
     const hasDelegationTool = hasPromptTool(availableTools, 'delegate_to_agent')
 
@@ -392,7 +402,9 @@ export function constructSystemPrompt(
 
   // Add working notes if provided.
   // Only a tiny subset of context:auto knowledge notes should be injected at runtime.
-  const formattedWorkingNotes = formatWorkingNotesForPrompt(workingNotes || [])
+  const formattedWorkingNotes = includeLocalContext
+    ? formatWorkingNotesForPrompt(workingNotes || [])
+    : ""
   if (formattedWorkingNotes) {
     prompt += `\n\nWORKING NOTES:\nThese were injected from configured knowledge roots because their frontmatter sets context: auto. Prefer note summaries when present, keep this subset tiny, and leave most notes as context: search-only.\n\n${formattedWorkingNotes}`
   }
@@ -480,6 +492,7 @@ export function constructMinimalSystemPrompt(
   }>,
   skillsIndex?: string,
   filesystemContext?: string,
+  includeLocalContext: boolean = true,
 ): string {
   const hasExecuteCommand = availableTools?.some((tool) => tool.name === 'execute_command') ?? false
   const hasReadMoreContext = availableTools?.some((tool) => tool.name === 'read_more_context') ?? false
@@ -493,17 +506,21 @@ export function constructMinimalSystemPrompt(
     "Latest user request wins; preserve constraints/approval boundaries. No recaps, completion summaries, or next safe actions unless asked for status/next steps. ",
     "Continuation: preserve the exact next action from evidence; don't soften quit/reopen/verify. ",
     "Before asking, use available context; ask one focused follow-up only if facts are missing. ",
-    hasExecuteCommand
-      ? "personal legal/immigration/health/finance/career prep: use execute_command on both knowledge notes and recent conversations before generic advice. Skills, settings, knowledge, tasks, prompts, runtime metadata, and conversations are files; use rg/find/ls/wc/sed/head/tail. Runtime: $DOTAGENTS_RUNTIME_DIR, $DOTAGENTS_AGENT_REGISTRY, $DOTAGENTS_TOOL_MANIFEST, $DOTAGENTS_TOOL_SCHEMA_DIR. Knowledge: configured knowledge roots, <knowledge-root>/<slug>/<slug>.md, context: search-only default, context: auto rare. Prior DotAgents conversations are JSON in the runtime-supplied conversations directory; search index.json then conv_*.json. Config: layered global/workspace .agents folders; read dotagents-config-admin SKILL.md when available."
-      : "When file tools are unavailable, answer from provided context and do not claim filesystem searches.",
+    includeLocalContext
+      ? hasExecuteCommand
+        ? "personal legal/immigration/health/finance/career prep: use execute_command on both knowledge notes and recent conversations before generic advice. Skills, settings, knowledge, tasks, prompts, runtime metadata, and conversations are files; use rg/find/ls/wc/sed/head/tail. Runtime: $DOTAGENTS_RUNTIME_DIR, $DOTAGENTS_AGENT_REGISTRY, $DOTAGENTS_TOOL_MANIFEST, $DOTAGENTS_TOOL_SCHEMA_DIR. Knowledge: configured knowledge roots, <knowledge-root>/<slug>/<slug>.md, context: search-only default, context: auto rare. Prior DotAgents conversations are JSON in the runtime-supplied conversations directory; search index.json then conv_*.json. Config: layered global/workspace .agents folders; read dotagents-config-admin SKILL.md when available."
+        : "When file tools are unavailable, answer from provided context and do not claim filesystem searches."
+      : "Use only the provided conversation context for prior state; do not search DotAgents knowledge, config, or stored conversations unless the user explicitly asks.",
   ].join("")
   const contextRecoveryPrompt = [
     "You are an autonomous AI assistant that uses tools to complete tasks. Use exact tool names and parameter keys, batch independent calls when useful, verify results, and be concise. ",
     "Respect earlier user constraints and approval boundaries. Answer the latest user request only; do not append workflow recaps, completion summaries, or next safe actions unless the user asks for status or next steps. ",
     "Before asking for facts, use available context and ask only the minimum high-signal follow-up if facts are missing. ",
-    hasExecuteCommand
-      ? "personal legal/immigration/health/finance/career prep: use execute_command on both knowledge notes and recent conversations before generic advice. Skills, settings, knowledge, tasks, prompts, runtime metadata, and conversations are files; use rg/find/ls/wc/sed/head/tail when filesystem paths are available. Inspect $DOTAGENTS_RUNTIME_DIR, $DOTAGENTS_AGENT_REGISTRY, $DOTAGENTS_TOOL_MANIFEST, or $DOTAGENTS_TOOL_SCHEMA_DIR for runtime discovery. Durable knowledge lives in configured knowledge roots as <knowledge-root>/<slug>/<slug>.md notes; use context: search-only by default, reserve context: auto for a tiny curated subset, and prefer direct file editing. Prior DotAgents conversations are JSON in the runtime-supplied conversations directory; use index.json then conv_*.json. DotAgents config lives in layered global/workspace .agents folders; read dotagents-config-admin SKILL.md when available before unfamiliar config edits."
-      : "When execute_command is unavailable, rely on provided history and read_more_context results; do not claim filesystem searches.",
+    includeLocalContext
+      ? hasExecuteCommand
+        ? "personal legal/immigration/health/finance/career prep: use execute_command on both knowledge notes and recent conversations before generic advice. Skills, settings, knowledge, tasks, prompts, runtime metadata, and conversations are files; use rg/find/ls/wc/sed/head/tail when filesystem paths are available. Inspect $DOTAGENTS_RUNTIME_DIR, $DOTAGENTS_AGENT_REGISTRY, $DOTAGENTS_TOOL_MANIFEST, or $DOTAGENTS_TOOL_SCHEMA_DIR for runtime discovery. Durable knowledge lives in configured knowledge roots as <knowledge-root>/<slug>/<slug>.md notes; use context: search-only by default, reserve context: auto for a tiny curated subset, and prefer direct file editing. Prior DotAgents conversations are JSON in the runtime-supplied conversations directory; use index.json then conv_*.json. DotAgents config lives in layered global/workspace .agents folders; read dotagents-config-admin SKILL.md when available before unfamiliar config edits."
+        : "When execute_command is unavailable, rely on provided history and read_more_context results; do not claim filesystem searches."
+      : "Use only provided history and read_more_context results for prior state; do not search DotAgents knowledge, config, or stored conversations unless the user explicitly asks.",
   ].join("")
 
   // Keep the fuller fallback when read_more_context is available; it preserves
@@ -511,15 +528,18 @@ export function constructMinimalSystemPrompt(
   let prompt = hasReadMoreContext ? contextRecoveryPrompt : compactPrompt
 
   if (isAgentMode) {
-    prompt += hasReadMoreContext
-      ? " Agent mode: continue with tools until the requested work is resolved. Whenever you need more context - continuation, status, debugging, or high-context planning - search the conversation store (index.json then conv_*.json) before asking follow-up questions, and use recovered context to answer or continue when sufficient."
-      : " Agent mode: continue with tools until the requested work is resolved. Whenever you need more context - continuation, status, debugging, or high-context planning - search the conversation store (index.json then conv_*.json) before asking, and use recovered context to answer or continue when sufficient."
+    prompt += " Agent mode: continue with tools until the requested work is resolved."
+    if (includeLocalContext) {
+      prompt += hasReadMoreContext
+        ? " Whenever you need more context - continuation, status, debugging, or high-context planning - search the conversation store (index.json then conv_*.json) before asking follow-up questions, and use recovered context to answer or continue when sufficient."
+        : " Whenever you need more context - continuation, status, debugging, or high-context planning - search the conversation store (index.json then conv_*.json) before asking, and use recovered context to answer or continue when sufficient."
+    }
     if (hasReadMoreContext) {
       prompt += ' For compacted Context refs, call read_more_context(mode: "search") with the exact needed query when known; once the returned result contains the requested evidence, answer instead of searching again.'
     }
   }
 
-  if (filesystemContext?.trim() && hasExecuteCommand) {
+  if (includeLocalContext && filesystemContext?.trim() && hasExecuteCommand) {
     prompt += `\n\nFILESYSTEM LOCATIONS:\n${filesystemContext.trim()}`
   }
 

--- a/apps/desktop/src/shared/types.ts
+++ b/apps/desktop/src/shared/types.ts
@@ -438,6 +438,14 @@ export type ProfileSkillsConfig = {
   allSkillsDisabledByDefault?: boolean
 }
 
+export type ProfilePromptConfig = {
+  /**
+   * Whether to inject DotAgents-owned local knowledge/configuration context.
+   * Existing conversation history is unaffected. Defaults to true.
+   */
+  includeLocalContext?: boolean
+}
+
 // Profile Management Types
 export type Profile = {
   id: string
@@ -449,6 +457,7 @@ export type Profile = {
   mcpServerConfig?: ProfileMcpServerConfig
   modelConfig?: ProfileModelConfig
   skillsConfig?: ProfileSkillsConfig
+  promptConfig?: ProfilePromptConfig
   systemPrompt?: string
 }
 
@@ -473,6 +482,7 @@ export type SessionProfileSnapshot = {
   /** Dynamic agent properties exposed in system prompt (from agent's properties) */
   agentProperties?: Record<string, string>
   skillsConfig?: ProfileSkillsConfig
+  promptConfig?: ProfilePromptConfig
 }
 
 // ============================================================================
@@ -722,6 +732,10 @@ export type AgentProfile = {
   /** Skills configuration */
   skillsConfig?: ProfileSkillsConfig
 
+  // Prompt context
+  /** DotAgents-owned local context injection settings */
+  promptConfig?: ProfilePromptConfig
+
   // Connection - how to run this agent
   /** Connection configuration for the underlying agent */
   connection: AgentProfileConnection
@@ -788,6 +802,7 @@ export function profileToAgentProfile(profile: Profile): AgentProfile {
       enabledRuntimeTools: profile.mcpServerConfig.enabledRuntimeTools,
     } : undefined,
     skillsConfig: profile.skillsConfig,
+    promptConfig: profile.promptConfig,
     connection: { type: "internal" },
     isStateful: false,
     role: "chat-agent",

--- a/packages/core/src/agents-files/agent-profiles.test.ts
+++ b/packages/core/src/agents-files/agent-profiles.test.ts
@@ -6,6 +6,7 @@ import type { AgentProfile, AgentProfileConnectionType, AgentProfileRole } from 
 import { getAgentsLayerPaths, type AgentsLayerPaths } from "./modular-config"
 import {
   AGENTS_PROFILE_CANONICAL_FILENAME,
+  agentProfileIdToConfigJsonPath,
   agentProfileIdToFilePath,
   getAgentProfilesDir,
   loadAgentProfilesLayer,
@@ -110,6 +111,27 @@ describe("agent-profiles role inference", () => {
 })
 
 describe("agent-profiles write behaviour", () => {
+  it("round-trips profile prompt context configuration through config.json", () => {
+    const layer = mkTempLayer("dotagents-agent-profiles-prompt-config-")
+    const profile: AgentProfile = {
+      id: "isolated-agent",
+      name: "isolated-agent",
+      displayName: "Isolated Agent",
+      guidelines: "",
+      promptConfig: { includeLocalContext: false },
+      connection: { type: "internal" },
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    }
+
+    writeAgentsProfileFiles(layer, profile)
+
+    const config = JSON.parse(fs.readFileSync(agentProfileIdToConfigJsonPath(layer, profile.id), "utf8"))
+    expect(config.promptConfig).toEqual({ includeLocalContext: false })
+    expect(loadAgentProfilesLayer(layer).profiles[0].promptConfig).toEqual({ includeLocalContext: false })
+  })
+
   it("does not rewrite agent.md when the in-memory profile is unchanged", () => {
     const layer = mkTempLayer("dotagents-agent-profiles-skip-")
     const profile: AgentProfile = {

--- a/packages/core/src/agents-files/agent-profiles.ts
+++ b/packages/core/src/agents-files/agent-profiles.ts
@@ -8,6 +8,7 @@ import type {
   AgentProfileToolConfig,
   PreferredAgentProfileRole,
   ProfileModelConfig,
+  ProfilePromptConfig,
   ProfileSkillsConfig,
 } from "../types"
 import type { AgentsLayerPaths } from "./modular-config"
@@ -112,6 +113,7 @@ export type AgentProfileConfigJson = {
   toolConfig?: AgentProfileToolConfig
   modelConfig?: ProfileModelConfig
   skillsConfig?: ProfileSkillsConfig
+  promptConfig?: ProfilePromptConfig
   connection?: Partial<AgentProfileConnection>
 }
 
@@ -133,6 +135,7 @@ function writeConfigJson(
     config.toolConfig ||
     config.modelConfig ||
     config.skillsConfig ||
+    config.promptConfig ||
     (config.connection && Object.keys(config.connection).length > 0)
 
   if (!hasContent) return
@@ -263,6 +266,7 @@ function assembleAgentProfile(
     toolConfig: configJson.toolConfig,
     modelConfig: configJson.modelConfig,
     skillsConfig: configJson.skillsConfig,
+    promptConfig: configJson.promptConfig,
   }
 }
 
@@ -363,6 +367,7 @@ export function writeAgentsProfileFiles(
     ...(profile.toolConfig ? { toolConfig: profile.toolConfig } : {}),
     ...(profile.modelConfig ? { modelConfig: profile.modelConfig } : {}),
     ...(profile.skillsConfig ? { skillsConfig: profile.skillsConfig } : {}),
+    ...(profile.promptConfig ? { promptConfig: profile.promptConfig } : {}),
     ...(Object.keys(connectionExtra).length > 0 ? { connection: connectionExtra } : {}),
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export type {
   AgentProfileToolConfig,
   ProfileMcpServerConfig,
   ProfileModelConfig,
+  ProfilePromptConfig,
   ProfileSkillsConfig,
   SessionProfileSnapshot,
 } from './types';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -164,6 +164,16 @@ export type ProfileSkillsConfig = {
   allSkillsDisabledByDefault?: boolean
 }
 
+export type ProfilePromptConfig = {
+  /**
+   * Whether DotAgents should inject its local knowledge/configuration context,
+   * including knowledge notes, stored-conversation locations, and runtime
+   * filesystem manifests. Existing conversation history is not affected.
+   * Defaults to true when omitted.
+   */
+  includeLocalContext?: boolean
+}
+
 export type SessionProfileSnapshot = {
   profileId: string
   profileName: string
@@ -174,6 +184,7 @@ export type SessionProfileSnapshot = {
   skillsInstructions?: string
   agentProperties?: Record<string, string>
   skillsConfig?: ProfileSkillsConfig
+  promptConfig?: ProfilePromptConfig
 }
 
 export type AgentProfileConnectionType = "internal" | "acpx" | "acp" | "stdio" | "remote"
@@ -212,6 +223,7 @@ export type AgentProfile = {
   modelConfig?: ProfileModelConfig
   toolConfig?: AgentProfileToolConfig
   skillsConfig?: ProfileSkillsConfig
+  promptConfig?: ProfilePromptConfig
   connection: AgentProfileConnection
   isStateful?: boolean
   conversationId?: string


### PR DESCRIPTION
## Summary

- add a persisted `promptConfig.includeLocalContext` setting to agent profiles and session snapshots
- skip DotAgents-owned knowledge notes, stored-conversation/config locations, and runtime filesystem manifests when local context is disabled
- preserve the setting through full prompts, prompt rebuilds, post-verification summaries, and Tier-3 minimal context fallbacks
- document the canonical `.agents/agents/<id>/config.json` configuration

## Root cause

DotAgents unconditionally injected its local memory/configuration guidance and runtime filesystem context into every profile. Isolated automation and benchmark profiles therefore received unrelated instructions and paths, encouraging them to inspect DotAgents state instead of focusing on the assigned workspace task.

## Impact

Existing profiles retain current behavior because local context defaults to enabled. Isolated profiles can opt out with:

```json
{
  "promptConfig": {
    "includeLocalContext": false
  }
}
```

Current conversation history, profile system prompts, tools, skills, and normal completion behavior are unaffected.

## Validation

- `pnpm --filter @dotagents/core test` — 84 tests passed
- targeted desktop prompt/profile tests — 25 tests passed
- `pnpm --filter @dotagents/core typecheck`
- `pnpm --filter @dotagents/desktop typecheck`
- `git diff --check`
